### PR TITLE
Add syntax highlighting to API Basics documentation

### DIFF
--- a/docs/Advanced-Topics-Block-Components.md
+++ b/docs/Advanced-Topics-Block-Components.md
@@ -34,7 +34,7 @@ criteria.
 For instance, we may wish to render `ContentBlock` objects of type `'media'` using
 a custom `MediaComponent`.
 
-```
+```js
 function myBlockRenderer(contentBlock) {
   const type = contentBlock.getType();
   if (type === 'media') {
@@ -76,7 +76,7 @@ key to the text within a `'media'` block during `EditorState` management,
 then retrieve the metadata for that key in your custom component `render()`
 code.
 
-```
+```js
 import {Entity} from 'draft-js';
 const MediaComponent = React.createClass({
   render() {

--- a/docs/Advanced-Topics-Block-Styling.md
+++ b/docs/Advanced-Topics-Block-Styling.md
@@ -30,7 +30,7 @@ The `blockStyleFn` prop on `Editor` allows you to define CSS classes to
 style blocks at render time. For instance, you may wish to style `'blockquote'`
 type blocks with fancy italic text.
 
-```
+```js
 function myBlockStyleFn(contentBlock) {
   const type = contentBlock.getType();
   if (type === 'blockquote') {
@@ -49,7 +49,7 @@ const EditorWithFancyBlockquotes = React.createClass({
 
 Then in your own CSS:
 
-```
+```css
 .superFancyBlockquote {
   color: #999;
   font-family: 'Hoefler Text', Georgia, serif;

--- a/docs/Advanced-Topics-Decorators.md
+++ b/docs/Advanced-Topics-Decorators.md
@@ -43,7 +43,7 @@ optionally be provided.
 In the "Tweet" editor example, for instance, we use a `CompositeDecorator` that
 searches for @-handle strings as well as hashtag strings:
 
-```
+```js
 const compositeDecorator = new CompositeDecorator([
   {
     strategy: handleStrategy,
@@ -59,7 +59,7 @@ const compositeDecorator = new CompositeDecorator([
 This composite decorator will first scan a given block of text for @-handle
 matches, then for hashtag matches.
 
-```
+```js
 // Note: these aren't very good regexes, don't use them!
 const HANDLE_REGEX = /\@[\w]+/g;
 const HASHTAG_REGEX = /\#[\w\u0590-\u05ff]+/g;
@@ -95,7 +95,7 @@ In our current example, the `CompositeDecorator` object names `HandleSpan` and
 `HashtagSpan` as the components to use for decoration. These are just basic
 stateless components:
 
-```
+```js
 const HandleSpan = (props) => {
   return <span {...props} style={styles.handle}>{props.children}</span>;
 };
@@ -134,7 +134,7 @@ For example, if for some reason we wished to disable the creation of @-handle
 decorations while the user interacts with the editor, it would be fine to do the
 following:
 
-```
+```js
 function turnOffHandleDecorations(editorState) {
   const onlyHashtags = new CompositeDecorator([{
     strategy: hashtagStrategy,

--- a/docs/Advanced-Topics-Entities.md
+++ b/docs/Advanced-Topics-Entities.md
@@ -56,7 +56,7 @@ be used to refer to the entity.
 This key is the value that should be used when applying entities to your
 content. For instance, the `Modifier` module contains an `applyEntity` method:
 
-```
+```js
 const key = Entity.create('LINK', 'MUTABLE', {href: 'http://www.zombo.com'});
 const contentStateWithLink = Modifier.applyEntity(
   contentState,
@@ -69,7 +69,7 @@ For a given range of text, then, you can extract its associated entity key by us
 the `getEntityAt()` method on a `ContentBlock` object, passing in the target
 offset value.
 
-```
+```js
 const blockWithLinkAtBeginning = contentState.getBlockForKey('...');
 const linkKey = blockWithLinkAtBeginning.getEntityAt(0);
 const linkInstance = Entity.get(linkKey);

--- a/docs/Advanced-Topics-Inline-Styles.md
+++ b/docs/Advanced-Topics-Inline-Styles.md
@@ -31,7 +31,7 @@ reuse identical immutable objects.
 
 In essence, our styles are:
 
-```
+```js
 [
   [], // H
   [], // e
@@ -51,7 +51,7 @@ Now let's say that we wish to make the middle range of characters italic as well
 The end result will accommodate the overlap by including `'ITALIC'` in the
 relevant `OrderedSet` objects as well.
 
-```
+```js
 [
   [], // H
   [], // e
@@ -85,7 +85,7 @@ for a live example.)
 For example, you may want to add a `'STRIKETHROUGH'` style. To do so, define a
 custom style map:
 
-```
+```js
 import {Editor} from 'draft-js';
 
 const styleMap = {

--- a/docs/Advanced-Topics-Key-Bindings.md
+++ b/docs/Advanced-Topics-Key-Bindings.md
@@ -44,7 +44,7 @@ write your contents to the server as a draft copy.
 
 First, let's define our key binding function.
 
-```
+```js
 import {KeyBindingUtil} from 'draft-js';
 const {hasCommandModifier} = KeyBindingUtil;
 
@@ -66,7 +66,7 @@ fall through to the default key bindings.
 In our editor component, we can then make use of the command via the
 `handleKeyCommand` prop:
 
-```
+```js
 import {Editor} from 'draft-js';
 class MyEditor extends React.Component {
   // ...

--- a/docs/QuickStart-API-Basics.md
+++ b/docs/QuickStart-API-Basics.md
@@ -26,7 +26,7 @@ This approach allows the component that composes the input to have strict
 control over the state of the input, while still allowing updates to the DOM
 to provide information about the text that the user has written.
 
-```
+```js
 const MyInput = React.createClass({
   onChange(evt) {
     this.setState({value: evt.target.value});
@@ -58,7 +58,7 @@ including contents, cursor, and undo/redo history. All changes to content and
 selection within the editor will create new `EditorState` objects. Note that
 this remains efficient due to data persistence across immutable objects.
 
-```
+```js
 import {Editor} from 'draft-js';
 const MyEditor = React.createClass({
   onChange(editorState) {

--- a/docs/QuickStart-Rich-Styling.md
+++ b/docs/QuickStart-Rich-Styling.md
@@ -43,7 +43,7 @@ such as Cmd+B (bold), Cmd+I (italic), and so on.
 We can observe and handle key commands via the `handleKeyCommand` prop, and
 hook these into `RichUtils` to apply or remove the desired style.
 
-```
+```js
 import {Editor, RichUtils} from 'draft-js';
 const MyEditor = React.createClass({
   onChange(editorState) {
@@ -87,7 +87,7 @@ features.
 
 Here's a super-basic example with a "Bold" button to toggle the `BOLD` style.
 
-```
+```js
 const MyEditor = React.createClass({
   ...
 


### PR DESCRIPTION
This can be done to quite a few more documents. Should I do separate PRs for each or can I group as one larger syntax highlighting addition PR?