### PR TITLE
Fix logState calls in entity and link examples

### DIFF
--- a/examples/entity/entity.html
+++ b/examples/entity/entity.html
@@ -123,7 +123,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           this.focus = () => this.refs.editor.focus();
           this.onChange = (editorState) => this.setState({editorState});
           this.logState = () => {
-            console.log(convertToRaw(this.state.editorState.toJS()));
+            const content = this.state.editorState.getCurrentContent();
+            console.log(convertToRaw(content));
           };
         }
 

--- a/examples/link/link.html
+++ b/examples/link/link.html
@@ -29,6 +29,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       'use strict';
 
       const {
+        convertToRaw,
         CompositeDecorator,
         ContentState,
         Editor,
@@ -55,7 +56,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           this.focus = () => this.refs.editor.focus();
           this.onChange = (editorState) => this.setState({editorState});
           this.logState = () => {
-            console.log(convertToRaw(this.state.editorState.toJS()));
+            const content = this.state.editorState.getCurrentContent();
+            console.log(convertToRaw(content));
           };
 
           this.addLink = this._addLink.bind(this);


### PR DESCRIPTION
`convertToRaw` expects a `ContentState` object.

Note that the `logState` functions in `plaintext.html` and `tweet.html` just call `.toJS()` without a `convertToRaw`.