### PR TITLE
[docs] Change examples to use ES6 Classes

### DIFF
--- a/docs/Advanced-Topics-Block-Components.md
+++ b/docs/Advanced-Topics-Block-Components.md
@@ -49,12 +49,12 @@ function myBlockRenderer(contentBlock) {
 
 // Then...
 import {Editor} from 'draft-js';
-const EditorWithMedia = React.createClass({
+class EditorWithMedia extends React.Component {
   ...
   render() {
     return <Editor ... blockRendererFn={myBlockRenderer} />;
   }
-});
+}
 ```
 
 If no custom renderer object is returned by the `blockRendererFn` function,
@@ -78,13 +78,13 @@ code.
 
 ```js
 import {Entity} from 'draft-js';
-const MediaComponent = React.createClass({
+class MediaComponent extends React.Component {
   render() {
     const {block, foo} = this.props;
     const data = Entity.get(block.getEntityAt(0)).getData();
     // Return a <figure> or some other content using this data.
   }
-});
+}
 ```
 
 The `ContentBlock` object is made available within the custom component, along

--- a/docs/Advanced-Topics-Block-Styling.md
+++ b/docs/Advanced-Topics-Block-Styling.md
@@ -40,11 +40,11 @@ function myBlockStyleFn(contentBlock) {
 
 // Then...
 import {Editor} from 'draft-js';
-const EditorWithFancyBlockquotes = React.createClass({
+class EditorWithFancyBlockquotes extends React.Component {
   render() {
     return <Editor ... blockStyleFn={myBlockStyleFn} />;
   }
-});
+}
 ```
 
 Then in your own CSS:

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -24,17 +24,19 @@ npm install --save draft-js react react-dom
 ```js
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {Editor} from 'draft-js';
+import {Editor, EditorState} from 'draft-js';
 
-const MyEditor = React.createClass({
-  onChange(editorState) {
-    this.setState({editorState});
-  },
+class MyEditor extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {editorState: EditorState.createEmpty()};
+    this.onChange = (editorState) => this.setState({editorState});
+  }
   render() {
     const {editorState} = this.state;
     return <Editor editorState={editorState} onChange={this.onChange} />;
   }
-});
+}
 
 ReactDOM.render(
   <MyEditor />,

--- a/docs/QuickStart-API-Basics.md
+++ b/docs/QuickStart-API-Basics.md
@@ -27,14 +27,15 @@ control over the state of the input, while still allowing updates to the DOM
 to provide information about the text that the user has written.
 
 ```js
-const MyInput = React.createClass({
-  onChange(evt) {
-    this.setState({value: evt.target.value});
-  },
+class MyInput extends React.Component {
+  constructor(props) {
+    super(props);
+    this.onChange = (evt) => this.setState({value: evt.target.value});
+  }
   render() {
     return <input value={this.state.value} onChange={this.onChange} />;
   }
-});
+}
 ```
 
 The top-level component can maintain control over the input state via this
@@ -60,15 +61,16 @@ this remains efficient due to data persistence across immutable objects.
 
 ```js
 import {Editor} from 'draft-js';
-const MyEditor = React.createClass({
-  onChange(editorState) {
-    this.setState({editorState});
-  },
+class MyEditor extends React.Component {
+  constructor(props) {
+    super(props);
+    this.onChange = (editorState) => this.setState({editorState});
+  }
   render() {
     const {editorState} = this.state;
     return <Editor editorState={editorState} onChange={this.onChange} />;
   }
-});
+}
 ```
 
 For any edits or selection changes that occur in the editor DOM, your `onChange`

--- a/docs/QuickStart-Rich-Styling.md
+++ b/docs/QuickStart-Rich-Styling.md
@@ -45,10 +45,11 @@ hook these into `RichUtils` to apply or remove the desired style.
 
 ```js
 import {Editor, RichUtils} from 'draft-js';
-const MyEditor = React.createClass({
-  onChange(editorState) {
-    this.setState({editorState});
-  },
+class MyEditor extends React.Component {
+  constructor(props) {
+    super(props);
+    this.onChange = (editorState) => this.setState({editorState});
+  }
   handleKeyCommand(command) {
     const {editorState} = this.state;
     const newState = RichUtils.handleKeyCommand(editorState, command);
@@ -57,7 +58,7 @@ const MyEditor = React.createClass({
       return true;
     }
     return false;
-  },
+  }
   render() {
     const {editorState} = this.state;
     return (
@@ -68,7 +69,7 @@ const MyEditor = React.createClass({
       />
     );
   }
-});
+}
 ```
 
 > handleKeyCommand
@@ -88,7 +89,7 @@ features.
 Here's a super-basic example with a "Bold" button to toggle the `BOLD` style.
 
 ```js
-const MyEditor = React.createClass({
+class MyEditor extends React.Component {
   ...
 
   _onBoldClick() {
@@ -99,7 +100,7 @@ const MyEditor = React.createClass({
     const {editorState} = this.state;
     return (
       <div>
-        <button onClick={this._onBoldClick}>Bold</button>
+        <button onClick={this._onBoldClick.bind(this)}>Bold</button>
         <Editor
           editorState={editorState}
           handleKeyCommand={this.handleKeyCommand}
@@ -108,5 +109,5 @@ const MyEditor = React.createClass({
       </div>
     );
   }
-});
+}
 ```


### PR DESCRIPTION
Change examples to use ES6 Classes. Closes #7 