### PR TITLE
Fix typo in QuickStart-Rich-Styling.md

### DIFF
--- a/docs/QuickStart-Rich-Styling.md
+++ b/docs/QuickStart-Rich-Styling.md
@@ -93,6 +93,7 @@ class MyEditor extends React.Component {
   ...
 
   _onBoldClick() {
+    const {editorState} = this.state;
     this.onChange(RichUtils.toggleInlineStyle(editorState, 'BOLD'));
   }
 


### PR DESCRIPTION
In `_onBoldClick`, `editorState` wasn't defined and caused the Bold button to become inoperable.