### PR TITLE
Fix typos in docs

### DIFF
--- a/docs/APIReference-Editor.md
+++ b/docs/APIReference-Editor.md
@@ -169,7 +169,7 @@ Handle files that have been pasted directly into the editor.
 
 ### Key Handlers (Optional)
 
-These prop functions expose common useful key events. Example: at Facebook, these are
+These prop functions expose common useful key events. Example: At Facebook, these are
 used to provide keyboard interaction for mention results in inputs.
 
 #### onEscape

--- a/docs/Advanced-Topics-Block-Styling.md
+++ b/docs/Advanced-Topics-Block-Styling.md
@@ -11,7 +11,7 @@ Within `Editor`, some block types are given default CSS styles to limit the amou
 of basic configuration required to get engineers up and running with custom
 editors.
 
-By defining a `blockStyleFn` prop function for a `Editor`, it is possible
+By defining a `blockStyleFn` prop function for an `Editor`, it is possible
 to specify classes that should be applied to blocks at render time.
 
 ## DraftStyleDefault.css
@@ -47,7 +47,7 @@ class EditorWithFancyBlockquotes extends React.Component {
 }
 ```
 
-Then in your own CSS:
+Then, in your own CSS:
 
 ```css
 .superFancyBlockquote {

--- a/docs/Advanced-Topics-Key-Bindings.md
+++ b/docs/Advanced-Topics-Key-Bindings.md
@@ -42,7 +42,7 @@ handled. If it returns `false`, the command will fall through
 Let's say we have an editor that should have a "Save" mechanism to periodically
 write your contents to the server as a draft copy.
 
-First, let's define our key binding function.
+First, let's define our key binding function:
 
 ```js
 import {KeyBindingUtil} from 'draft-js';
@@ -85,6 +85,7 @@ class MyEditor extends React.Component {
       <Editor
         editorState={this.state.editorState}
         handleKeyCommand={this.handleKeyCommand.bind(this)}
+        keyBindingFn={myKeyBindingFn}
         ...
       />
     );

--- a/docs/Advanced-Topics-Key-Bindings.md
+++ b/docs/Advanced-Topics-Key-Bindings.md
@@ -35,7 +35,7 @@ fall-through case, so that your editor may benefit from default commands.
 With your custom command string, you may then implement the `handleKeyCommand`
 prop function, which allows you to map that command string to your desired
 behavior. If `handleKeyCommand` returns `true`, the command is considered
-handled. If it returns `false`, the command will fall through
+handled. If it returns `false`, the command will fall through.
 
 ### Example
 

--- a/docs/Advanced-Topics-Text-Direction.md
+++ b/docs/Advanced-Topics-Text-Direction.md
@@ -14,7 +14,7 @@ For example, we want input behavior for RTL languages such as Arabic and Hebrew
 to meet users' expectations. We also want to be able to support editor contents
 with a mixture of LTR and RTL text.
 
-To that end, Draft uses a bidi direction algorithm to determine appropriate
+To that end, Draft uses a bidi algorithm to determine appropriate
 text alignment and direction on a per-block basis.
 
 Text is rendered with an LTR or RTL direction automatically as the user types.


### PR DESCRIPTION
I found a few typos in the docs that I though needed some fixing :)