### PR TITLE
Fix missing src/draft-js/lib/ dir

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "start": "node server/server.js",
-    "postinstall": "npm install .. && mkdir -p src/draft-js/lib"
+    "postinstall": "npm install .."
   },
   "dependencies": {
     "compression": "1.2.2",

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "start": "node server/server.js",
-    "postinstall": "npm install .."
+    "postinstall": "npm install .. && mkdir -p src/draft-js/lib"
   },
   "dependencies": {
     "compression": "1.2.2",


### PR DESCRIPTION
- git cloned the repo
- npm install && npm build
- went to /website
- npm start
- went to http://localhost:8080/draft-js/index.html :
<img width="994" alt="before" src="https://cloud.githubusercontent.com/assets/1126672/13237451/05f6dbe0-d981-11e5-9547-f492bbb01088.png">

This PR creates src/draft-js/lib/ dir as part of postintall script.
