### PR TITLE
Check devEngines on pretest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- 5
+- 4
 sudo: false
 cache:
   directories:

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "repository": "facebook/draft-js",
   "license": "BSD-3-Clause",
   "scripts": {
-    "prebuild": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json",
+    "pretest": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json",
     "build": "gulp",
     "lint": "eslint .",
     "test": "NODE_ENV=test jest"

--- a/src/.flowconfig
+++ b/src/.flowconfig
@@ -2,6 +2,7 @@
 .*/__tests__.*
 .*/react/node_modules/.*
 .*/fbjs/node_modules/.*
+.*/node_modules/invariant/.*
 
 [include]
 ../node_modules/fbjs/lib/


### PR DESCRIPTION
To support users on 5.x and `npm 3`. All the examples worked for me, including the TeX one.

Follow up to #31.

Thank you so much for this library, I've been wondering about handling `contentEditable` cleanly with React for editor components for some time. :heart: