### PR TITLE
removed two instances of unused content constants.

### DIFF
--- a/examples/link/link.html
+++ b/examples/link/link.html
@@ -72,7 +72,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           }
           const href = window.prompt('Enter a URL');
           const entityKey = Entity.create('link', 'MUTABLE', {href});
-          const content = editorState.getCurrentContent();
           this.setState({
             editorState: RichUtils.toggleLink(editorState, selection, entityKey),
           });
@@ -84,7 +83,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           if (selection.isCollapsed()) {
             return;
           }
-          const content = editorState.getCurrentContent();
           this.setState({
             editorState: RichUtils.toggleLink(editorState, selection, null),
           });


### PR DESCRIPTION
The `content` constant is defined but never used inside `_removeLink` and `_addLink` 