### PR TITLE
[WIP] Only delete current block if blockBefore is media

### DIFF
--- a/src/model/modifier/RichTextEditorUtil.js
+++ b/src/model/modifier/RichTextEditorUtil.js
@@ -111,15 +111,13 @@ var RichTextEditorUtil = {
     var content = editorState.getCurrentContent();
     var startKey = selection.getStartKey();
     var blockAfter = content.getBlockAfter(startKey);
-
-    // If the current block is empty, just delete it.
-    if (blockAfter && content.getBlockForKey(startKey).getLength() === 0) {
-      return null;
-    }
-
     var blockBefore = content.getBlockBefore(startKey);
 
     if (blockBefore && blockBefore.getType() === 'media') {
+      // If the current block is empty, just delete it.
+      if (blockAfter && content.getBlockForKey(startKey).getLength() === 0) {
+        return null;
+      }
       var mediaBlockTarget = selection.merge({
         anchorKey: blockBefore.getKey(),
         anchorOffset: 0,


### PR DESCRIPTION
- [x] Move the `getBlockForKey` check within the `if` block checking if the `blockBefore` is of the type `'media'`.
- [ ] Check that the block is unstyled so that when backspacing a blockquote/heading following a media block the style is stripped when backspacing once (and the block is completely deleted the second time).

Fixes #35