### PR TITLE
Only make code-block unstyled if blockBefore isn't a code-block

### DIFF
--- a/src/model/modifier/RichTextEditorUtil.js
+++ b/src/model/modifier/RichTextEditorUtil.js
@@ -415,7 +415,16 @@ var RichTextEditorUtil = {
       }
 
       var type = block.getType();
-      if (type !== 'unstyled' && type !== 'code-block') {
+      var blockBefore = content.getBlockBefore(key);
+      if (
+        type === 'code-block' &&
+        blockBefore &&
+        blockBefore.getType() === 'code-block'
+      ) {
+        return null;
+      }
+
+      if (type !== 'unstyled') {
         return DraftModifier.setBlockType(content, selection, 'unstyled');
       }
     }


### PR DESCRIPTION
Fixes https://github.com/facebook/draft-js/issues/54 using suggestion.