### PR TITLE
Add a media example

### DIFF
--- a/docs/Advanced-Topics-Block-Components.md
+++ b/docs/Advanced-Topics-Block-Components.md
@@ -21,6 +21,9 @@ in the Draft repository provides a live example of custom block rendering, with
 TeX syntax translated on the fly into editable embedded formula rendering via the
 [KaTeX library](https://khan.github.io/KaTeX/).
 
+A [media example](https://github.com/facebook/draft-js/tree/master/examples/media) is also
+available, which showcases custom block rendering of audio, image, and video.
+
 By using a custom block renderer, it is possible to introduce complex rich
 interactions within the frame of your editor.
 

--- a/examples/media/media.html
+++ b/examples/media/media.html
@@ -29,15 +29,12 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       'use strict';
 
       const {
-        BlockMapBuilder,
-        CharacterMetadata,
-        ContentBlock,
         Editor,
         EditorState,
         Entity,
-        Modifier,
+        MediaUtils,
+        RichUtils,
         convertToRaw,
-        genKey,
       } = Draft;
 
       const {List, Repeat} = Immutable;
@@ -57,21 +54,44 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             console.log(convertToRaw(content));
           };
 
+          this.handleKeyCommand = this._handleKeyCommand.bind(this);
+          this.addMedia = this._addMedia.bind(this);
           this.addAudio = this._addAudio.bind(this);
           this.addImage = this._addImage.bind(this);
           this.addVideo = this._addVideo.bind(this);
         }
 
-        _addAudio(e) {
-          this.onChange(insertMedia(this.state.editorState, 'audio'));
+        _handleKeyCommand(command) {
+          const {editorState} = this.state;
+          const newState = RichUtils.handleKeyCommand(editorState, command);
+          if (newState) {
+            this.onChange(newState);
+            return true;
+          }
+          return false;
         }
 
-        _addImage(e) {
-          this.onChange(insertMedia(this.state.editorState, 'image'));
+        _addMedia(type) {
+          const src = window.prompt('Enter a URL');
+          if (!src) {
+            return;
+          }
+
+          const entityKey = Entity.create(type, 'IMMUTABLE', {src});
+
+          return MediaUtils.insertMedia(this.state.editorState, entityKey, ' ');
         }
 
-        _addVideo(e) {
-          this.onChange(insertMedia(this.state.editorState, 'video'));
+        _addAudio() {
+          this.onChange(this._addMedia('audio'));
+        }
+
+        _addImage() {
+          this.onChange(this._addMedia('image'));
+        }
+
+        _addVideo() {
+          this.onChange(this._addMedia('video'));
         }
 
         render() {
@@ -95,6 +115,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 <Editor
                   blockRendererFn={mediaBlockRenderer}
                   editorState={this.state.editorState}
+                  handleKeyCommand={this.handleKeyCommand}
                   onChange={this.onChange}
                   placeholder="Enter some text..."
                   ref="editor"
@@ -109,65 +130,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             </div>
           );
         }
-      }
-
-      function insertMedia(editorState, type) {
-        const src = window.prompt('Enter a URL');
-        if (!src) {
-          return;
-        }
-
-        const entityKey = Entity.create(type, 'IMMUTABLE', {src});
-
-        const contentState = editorState.getCurrentContent();
-        const selectionState = editorState.getSelection();
-
-        const afterRemoval = Modifier.removeRange(
-          contentState,
-          selectionState,
-          'backward'
-        );
-
-        const targetSelection = afterRemoval.getSelectionAfter();
-        const afterSplit = Modifier.splitBlock(afterRemoval, targetSelection);
-        const insertionTarget = afterSplit.getSelectionAfter();
-
-        const asMedia = Modifier.setBlockType(
-          afterSplit,
-          insertionTarget,
-          'media'
-        );
-        const charData = CharacterMetadata.create({entity: entityKey});
-
-        const fragmentArray = [
-          new ContentBlock({
-            key: genKey(),
-            type: 'media',
-            text: '',
-            characterList: List(Repeat(charData, 1)),
-          }),
-          new ContentBlock({
-            key: genKey(),
-            type: 'unstyled',
-            text: '',
-            characterList: List(),
-          }),
-        ];
-
-        const fragment = BlockMapBuilder.createFromArray(fragmentArray);
-
-        const withMedia = Modifier.replaceWithFragment(
-          asMedia,
-          insertionTarget,
-          fragment
-        );
-
-        const newContent = withMedia.merge({
-          selectionBefore: selectionState,
-          selectionAfter: withMedia.getSelectionAfter().set('hasFocus', true),
-        });
-
-        return EditorState.push(editorState, newContent, 'insert-fragment');
       }
 
       function mediaBlockRenderer(block) {

--- a/examples/media/media.html
+++ b/examples/media/media.html
@@ -159,15 +159,17 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         const entity = Entity.get(props.block.getEntityAt(0));
         const {src} = entity.getData();
         const type = entity.getType();
+
+        let media;
         if (type === 'audio') {
-          return <Audio src={src} />;
+          media = <Audio src={src} />;
         } else if (type === 'image') {
-          return <Image src={src} />;
+          media = <Image src={src} />;
         } else if (type === 'video') {
-          return <Video src={src} />;
+          media = <Video src={src} />;
         }
 
-        return null;
+        return <div>{media}</div>;
       };
 
       const styles = {

--- a/examples/media/media.html
+++ b/examples/media/media.html
@@ -1,0 +1,241 @@
+<!--
+Copyright (c) 2013-present, Facebook, Inc. All rights reserved.
+
+This file provided by Facebook is for non-commercial testing and evaluation
+purposes only. Facebook reserves all rights not expressly granted.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+-->
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Draft • Media Editor</title>
+    <link rel="stylesheet" href="../../dist/Draft.css" />
+  </head>
+  <body>
+    <div id="target"></div>
+    <script src="../../node_modules/react/dist/react.js"></script>
+    <script src="../../node_modules/react-dom/dist/react-dom.js"></script>
+    <script src="../../node_modules/immutable/dist/immutable.js"></script>
+    <script src="../../node_modules/babel-core/browser.js"></script>
+    <script src="../../dist/Draft.js"></script>
+    <script type="text/babel">
+      'use strict';
+
+      const {
+        BlockMapBuilder,
+        CharacterMetadata,
+        ContentBlock,
+        Editor,
+        EditorState,
+        Entity,
+        Modifier,
+        convertToRaw,
+        genKey,
+      } = Draft;
+
+      const {List, Repeat} = Immutable;
+
+      class MediaEditorExample extends React.Component {
+        constructor(props) {
+          super(props);
+
+          this.state = {
+            editorState: EditorState.createEmpty(),
+          };
+
+          this.focus = () => this.refs.editor.focus();
+          this.onChange = (editorState) => this.setState({editorState});
+          this.logState = () => {
+            const content = this.state.editorState.getCurrentContent();
+            console.log(convertToRaw(content));
+          };
+
+          this.addAudio = this._addAudio.bind(this);
+          this.addImage = this._addImage.bind(this);
+          this.addVideo = this._addVideo.bind(this);
+        }
+
+        _addAudio(e) {
+          this.onChange(insertMedia(this.state.editorState, 'audio'));
+        }
+
+        _addImage(e) {
+          this.onChange(insertMedia(this.state.editorState, 'image'));
+        }
+
+        _addVideo(e) {
+          this.onChange(insertMedia(this.state.editorState, 'video'));
+        }
+
+        render() {
+          return (
+            <div style={styles.root}>
+              <div style={{marginBottom: 10}}>
+                Use the buttons to add audio, image, or video.
+              </div>
+              <div style={styles.buttons}>
+                <button onMouseDown={this.addAudio} style={{marginRight: 10}}>
+                  Add Audio
+                </button>
+                <button onMouseDown={this.addImage} style={{marginRight: 10}}>
+                  Add Image
+                </button>
+                <button onMouseDown={this.addVideo} style={{marginRight: 10}}>
+                  Add Video
+                </button>
+              </div>
+              <div style={styles.editor} onClick={this.focus}>
+                <Editor
+                  blockRendererFn={mediaBlockRenderer}
+                  editorState={this.state.editorState}
+                  onChange={this.onChange}
+                  placeholder="Enter some text..."
+                  ref="editor"
+                />
+              </div>
+              <input
+                onClick={this.logState}
+                style={styles.button}
+                type="button"
+                value="Log State"
+              />
+            </div>
+          );
+        }
+      }
+
+      function insertMedia(editorState, type) {
+        const src = window.prompt('Enter a URL');
+        if (!src) {
+          return;
+        }
+
+        const entityKey = Entity.create(type, 'IMMUTABLE', {src});
+
+        const contentState = editorState.getCurrentContent();
+        const selectionState = editorState.getSelection();
+
+        const afterRemoval = Modifier.removeRange(
+          contentState,
+          selectionState,
+          'backward'
+        );
+
+        const targetSelection = afterRemoval.getSelectionAfter();
+        const afterSplit = Modifier.splitBlock(afterRemoval, targetSelection);
+        const insertionTarget = afterSplit.getSelectionAfter();
+
+        const asMedia = Modifier.setBlockType(
+          afterSplit,
+          insertionTarget,
+          'media'
+        );
+        const charData = CharacterMetadata.create({entity: entityKey});
+
+        const fragmentArray = [
+          new ContentBlock({
+            key: genKey(),
+            type: 'media',
+            text: '',
+            characterList: List(Repeat(charData, 1)),
+          }),
+          new ContentBlock({
+            key: genKey(),
+            type: 'unstyled',
+            text: '',
+            characterList: List(),
+          }),
+        ];
+
+        const fragment = BlockMapBuilder.createFromArray(fragmentArray);
+
+        const withMedia = Modifier.replaceWithFragment(
+          asMedia,
+          insertionTarget,
+          fragment
+        );
+
+        const newContent = withMedia.merge({
+          selectionBefore: selectionState,
+          selectionAfter: withMedia.getSelectionAfter().set('hasFocus', true),
+        });
+
+        return EditorState.push(editorState, newContent, 'insert-fragment');
+      }
+
+      function mediaBlockRenderer(block) {
+        if (block.getType() === 'media') {
+          return {
+            component: Media,
+            props: {},
+          };
+        }
+
+        return null;
+      }
+
+      const Audio = (props) => {
+        return <audio controls src={props.src} style={styles.media} />;
+      };
+
+      const Image = (props) => {
+        return <img src={props.src} style={styles.media} />;
+      };
+
+      const Video = (props) => {
+        return <video controls src={props.src} style={styles.media} />;
+      };
+
+      const Media = (props) => {
+        const entity = Entity.get(props.block.getEntityAt(0));
+        const {src} = entity.getData();
+        const type = entity.getType();
+        if (type === 'audio') {
+          return <Audio src={src} />;
+        } else if (type === 'image') {
+          return <Image src={src} />;
+        } else if (type === 'video') {
+          return <Video src={src} />;
+        }
+
+        return null;
+      };
+
+      const styles = {
+        root: {
+          fontFamily: '\'Georgia\', serif',
+          padding: 20,
+          width: 600,
+        },
+        buttons: {
+          marginBottom: 10,
+        },
+        editor: {
+          border: '1px solid #ccc',
+          cursor: 'text',
+          minHeight: 80,
+          padding: 10,
+        },
+        button: {
+          marginTop: 10,
+          textAlign: 'center',
+        },
+        media: {
+          width: '100%',
+        },
+      };
+
+      ReactDOM.render(
+        <MediaEditorExample />,
+        document.getElementById('target')
+      );
+    </script>
+  </body>
+</html>

--- a/examples/tex/js/modifiers/insertTeXBlock.js
+++ b/examples/tex/js/modifiers/insertTeXBlock.js
@@ -14,19 +14,13 @@
 
 'use strict';
 
-import {List, Repeat} from 'immutable';
 import {
-  BlockMapBuilder,
-  CharacterMetadata,
-  ContentBlock,
-  EditorState,
   Entity,
-  Modifier,
-  genKey,
+  MediaUtils,
 } from 'draft-js';
 
-var count = 0;
-var examples = [
+let count = 0;
+const examples = [
   '\\int_a^bu\\frac{d^2v}{dx^2}\\,dx\n' +
   '=\\left.u\\frac{dv}{dx}\\right|_a^b\n' +
   '-\\int_a^b\\frac{du}{dx}\\frac{dv}{dx}\\,dx',
@@ -42,57 +36,12 @@ var examples = [
 ];
 
 export function insertTeXBlock(editorState) {
-  var contentState = editorState.getCurrentContent();
-  var selectionState = editorState.getSelection();
-
-  var afterRemoval = Modifier.removeRange(
-    contentState,
-    selectionState,
-    'backward'
-  );
-
-  var targetSelection = afterRemoval.getSelectionAfter();
-  var afterSplit = Modifier.splitBlock(afterRemoval, targetSelection);
-  var insertionTarget = afterSplit.getSelectionAfter();
-
-  var asMedia = Modifier.setBlockType(afterSplit, insertionTarget, 'media');
-  var nextFormula = count++ % examples.length;
-
-  var entityKey = Entity.create(
+  const nextFormula = count++ % examples.length;
+  const entityKey = Entity.create(
     'TOKEN',
     'IMMUTABLE',
     {content: examples[nextFormula]}
   );
 
-  var charData = CharacterMetadata.create({entity: entityKey});
-
-  var fragmentArray = [
-    new ContentBlock({
-      key: genKey(),
-      type: 'media',
-      text: ' ',
-      characterList: List(Repeat(charData, 1)),
-    }),
-    new ContentBlock({
-      key: genKey(),
-      type: 'unstyled',
-      text: '',
-      characterList: List(),
-    }),
-  ];
-
-  var fragment = BlockMapBuilder.createFromArray(fragmentArray);
-
-  var withMedia = Modifier.replaceWithFragment(
-    asMedia,
-    insertionTarget,
-    fragment
-  );
-
-  var newContent = withMedia.merge({
-    selectionBefore: selectionState,
-    selectionAfter: withMedia.getSelectionAfter().set('hasFocus', true),
-  });
-
-  return EditorState.push(editorState, newContent, 'insert-fragment');
+  return MediaUtils.insertMedia(editorState, entityKey, ' ');
 }

--- a/src/Draft.js
+++ b/src/Draft.js
@@ -22,6 +22,7 @@ const DraftEntity = require('DraftEntity');
 const DraftEntityInstance = require('DraftEntityInstance');
 const EditorState = require('EditorState');
 const KeyBindingUtil = require('KeyBindingUtil');
+const MediaUtils = require('MediaUtils');
 const RichTextEditorUtil = require('RichTextEditorUtil');
 const SelectionState = require('SelectionState');
 
@@ -45,6 +46,7 @@ const DraftPublic = {
   SelectionState,
 
   KeyBindingUtil: KeyBindingUtil,
+  MediaUtils,
   Modifier: DraftModifier,
   RichUtils: RichTextEditorUtil,
 

--- a/src/model/modifier/MediaUtils.js
+++ b/src/model/modifier/MediaUtils.js
@@ -27,7 +27,7 @@ const MediaUtils = {
     editorState: EditorState,
     entityKey: string,
     character: string
-  ): ?EditorState {
+  ): EditorState {
     const contentState = editorState.getCurrentContent();
     const selectionState = editorState.getSelection();
 

--- a/src/model/modifier/MediaUtils.js
+++ b/src/model/modifier/MediaUtils.js
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule MediaUtils
+ * @typechecks
+ * @flow
+ */
+
+'use strict';
+
+const BlockMapBuilder = require('BlockMapBuilder');
+const CharacterMetadata = require('CharacterMetadata');
+const ContentBlock = require('ContentBlock');
+const DraftModifier = require('DraftModifier');
+const EditorState = require('EditorState');
+const {List, Repeat} = require('immutable');
+
+const genKey = require('generateBlockKey');
+
+const MediaUtils = {
+  insertMedia: function(
+    editorState: EditorState,
+    entityKey: string,
+    character: string
+  ): ?EditorState {
+    const contentState = editorState.getCurrentContent();
+    const selectionState = editorState.getSelection();
+
+    const afterRemoval = DraftModifier.removeRange(
+      contentState,
+      selectionState,
+      'backward'
+    );
+
+    const targetSelection = afterRemoval.getSelectionAfter();
+    const afterSplit = DraftModifier.splitBlock(afterRemoval, targetSelection);
+    const insertionTarget = afterSplit.getSelectionAfter();
+
+    const asMedia = DraftModifier.setBlockType(
+      afterSplit,
+      insertionTarget,
+      'media'
+    );
+
+    const charData = CharacterMetadata.create({entity: entityKey});
+
+    const fragmentArray = [
+      new ContentBlock({
+        key: genKey(),
+        type: 'media',
+        text: character,
+        characterList: List(Repeat(charData, character.length)),
+      }),
+      new ContentBlock({
+        key: genKey(),
+        type: 'unstyled',
+        text: '',
+        characterList: List(),
+      }),
+    ];
+
+    const fragment = BlockMapBuilder.createFromArray(fragmentArray);
+
+    const withMedia = DraftModifier.replaceWithFragment(
+      asMedia,
+      insertionTarget,
+      fragment
+    );
+
+    const newContent = withMedia.merge({
+      selectionBefore: selectionState,
+      selectionAfter: withMedia.getSelectionAfter().set('hasFocus', true),
+    });
+
+    return EditorState.push(editorState, newContent, 'insert-fragment');
+  },
+};
+
+module.exports = MediaUtils;


### PR DESCRIPTION
Looks like people were interested in seeing an example using media (https://github.com/facebook/draft-js/issues/46).

I created an example that shows how to use Custom Block Components to attach audio, image, and video into the editor.

Side note:

The docs (http://facebook.github.io/draft-js/docs/advanced-topics-block-components.html) led me to believe it's much simpler to render custom blocks. However, more steps (see `insertMedia(...)`) were needed to wrap around the media for it to work well. The `tex` example (https://github.com/facebook/draft-js/blob/master/examples/tex/js/modifiers/insertTeXBlock.js) has the same code to handle this. Can we provide this as a utility function?

