### PR TITLE
Suppress contentEditable warning

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -238,6 +238,7 @@ class DraftEditor
             aria-owns={readOnly ? null : this.props.ariaOwneeID}
             className={cx('public/DraftEditor/content')}
             contentEditable={!readOnly}
+            suppressContentEditableWarning={true}
             data-testid={this.props.webDriverTestID}
             onBeforeInput={this._onBeforeInput}
             onBlur={this._onBlur}


### PR DESCRIPTION
This will come into effect with the 15.0 release of React, see https://github.com/facebook/react/pull/6112

> Note: I wasn't entirely sure if you want to specify the `={true}`, since it can be omitted, and I couldn't find an example with/without it. Let me know if you want me to remove it

/cc @spicyj