### PR TITLE
Replace all uses of var with const or let

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,5 +11,6 @@ module.exports = {
   rules: {
     'react/jsx-uses-react': 1,
     'react/react-in-jsx-scope': 1,
+    'no-var': 1
   }
 };

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,22 +9,22 @@
 
 'use strict';
 
-var babel = require('gulp-babel');
-var del = require('del');
-var concatCSS = require('gulp-concat-css');
-var derequire = require('gulp-derequire');
-var flatten = require('gulp-flatten');
-var gulp = require('gulp');
-var gulpUtil = require('gulp-util');
-var runSequence = require('run-sequence');
-var through = require('through2');
-var webpackStream = require('webpack-stream');
+const babel = require('gulp-babel');
+const del = require('del');
+const concatCSS = require('gulp-concat-css');
+const derequire = require('gulp-derequire');
+const flatten = require('gulp-flatten');
+const gulp = require('gulp');
+const gulpUtil = require('gulp-util');
+const runSequence = require('run-sequence');
+const through = require('through2');
+const webpackStream = require('webpack-stream');
 
-var babelOpts = require('./scripts/babel/default-options');
-var babelPluginDEV = require('fbjs-scripts/babel/dev-expression');
-var gulpCheckDependencies = require('fbjs-scripts/gulp/check-dependencies');
+const babelOpts = require('./scripts/babel/default-options');
+const babelPluginDEV = require('fbjs-scripts/babel/dev-expression');
+const gulpCheckDependencies = require('fbjs-scripts/gulp/check-dependencies');
 
-var paths = {
+const paths = {
   dist: 'dist',
   lib: 'lib',
   src: [
@@ -41,8 +41,8 @@ var paths = {
 // options, converting __DEV__.
 babelOpts.plugins.push(babelPluginDEV);
 
-var buildDist = function(opts) {
-  var webpackOpts = {
+const buildDist = function(opts) {
+  const webpackOpts = {
     debug: opts.debug,
     externals: {
       immutable: 'Immutable',
@@ -96,8 +96,8 @@ gulp.task('css', function() {
   return gulp
     .src(paths.css)
     .pipe(through.obj(function(file, encoding, callback) {
-      var contents = file.contents.toString();
-      var replaced = contents.replace(
+      const contents = file.contents.toString();
+      let replaced = contents.replace(
         // Regex based on MakeHasteCssModuleTransform: ignores comments,
         // strings, and URLs
         /\/\*.*?\*\/|'(?:\\.|[^'])*'|"(?:\\.|[^"])*"|url\([^)]*\)|(\.(?:public\/)?[\w-]*\/{1,2}[\w-]+)/g,
@@ -113,7 +113,7 @@ gulp.task('css', function() {
         // MakeHasteCssVariablesTransform
         /\bvar\(([\w-]+)\)/g,
         function(match, name) {
-          var vars = {
+          const vars = {
             'fbui-desktop-text-placeholder': '#9197a3',
             'fbui-desktop-text-placeholder-focused': '#bdc1c9',
           };
@@ -132,7 +132,7 @@ gulp.task('css', function() {
 });
 
 gulp.task('dist', ['modules', 'css'], function() {
-  var opts = {
+  const opts = {
     debug: true,
     output: 'Draft.js'
   };
@@ -143,7 +143,7 @@ gulp.task('dist', ['modules', 'css'], function() {
 });
 
 gulp.task('dist:min', ['modules'], function() {
-  var opts = {
+  const opts = {
     debug: false,
     output: 'Draft.min.js',
   };

--- a/scripts/babel/default-options.js
+++ b/scripts/babel/default-options.js
@@ -1,5 +1,5 @@
-var assign = require('object-assign');
-var babelPluginModules = require('fbjs-scripts/babel/rewrite-modules');
+const assign = require('object-assign');
+const babelPluginModules = require('fbjs-scripts/babel/rewrite-modules');
 
 module.exports = {
   blacklist: [

--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -1,9 +1,9 @@
-var babel = require('babel-core');
-var assign = require('object-assign');
-var babelOpts = require('../babel/default-options');
-var babelInlineRequires = require('fbjs-scripts/babel/inline-requires');
-var createCacheKeyFunction = require('fbjs-scripts/jest/createCacheKeyFunction');
-var path = require('path');
+const babel = require('babel-core');
+const assign = require('object-assign');
+const babelOpts = require('../babel/default-options');
+const babelInlineRequires = require('fbjs-scripts/babel/inline-requires');
+const createCacheKeyFunction = require('fbjs-scripts/jest/createCacheKeyFunction');
+const path = require('path');
 
 // Modify babelOpts to account for our needs. Namely we want to retain line
 // numbers for better stack traces in tests.
@@ -17,7 +17,7 @@ babelOpts.plugins.push({
   transformer: babelInlineRequires,
 });
 
-var cacheKeyFunction = createCacheKeyFunction([
+const cacheKeyFunction = createCacheKeyFunction([
   __filename,
   path.join(__dirname, '..', '..', 'node_modules', 'fbjs', 'package.json'),
   path.join(__dirname, '..', '..', 'node_modules', 'fbjs-scripts', 'package.json'),

--- a/src/component/contents/DraftEditorBlock.react.js
+++ b/src/component/contents/DraftEditorBlock.react.js
@@ -84,21 +84,21 @@ class DraftEditorBlock extends React.Component {
    * scroll parent.
    */
   componentDidMount(): void {
-    var selection = this.props.selection;
-    var endKey = selection.getEndKey();
+    const selection = this.props.selection;
+    const endKey = selection.getEndKey();
     if (!selection.getHasFocus() || endKey !== this.props.block.getKey()) {
       return;
     }
 
-    var blockNode = ReactDOM.findDOMNode(this);
-    var scrollParent = Style.getScrollParent(blockNode);
-    var scrollPosition = getScrollPosition(scrollParent);
-    var scrollDelta;
+    const blockNode = ReactDOM.findDOMNode(this);
+    const scrollParent = Style.getScrollParent(blockNode);
+    const scrollPosition = getScrollPosition(scrollParent);
+    let scrollDelta;
 
     if (scrollParent === window) {
-      var nodePosition = getElementPosition(blockNode);
-      var nodeBottom = nodePosition.y + nodePosition.height;
-      var viewportHeight = getViewportDimensions().height;
+      const nodePosition = getElementPosition(blockNode);
+      const nodeBottom = nodePosition.y + nodePosition.height;
+      const viewportHeight = getViewportDimensions().height;
       scrollDelta = nodeBottom - viewportHeight;
       if (scrollDelta > 0) {
         window.scrollTo(
@@ -107,8 +107,8 @@ class DraftEditorBlock extends React.Component {
         );
       }
     } else {
-      var blockBottom = blockNode.offsetHeight + blockNode.offsetTop;
-      var scrollBottom = scrollParent.offsetHeight + scrollPosition.y;
+      const blockBottom = blockNode.offsetHeight + blockNode.offsetTop;
+      const scrollBottom = scrollParent.offsetHeight + scrollPosition.y;
       scrollDelta = blockBottom - scrollBottom;
       if (scrollDelta > 0) {
         Scroll.setTop(
@@ -120,19 +120,19 @@ class DraftEditorBlock extends React.Component {
   }
 
   _renderChildren(): Array<ReactElement> {
-    var block = this.props.block;
-    var blockKey = block.getKey();
-    var text = block.getText();
-    var lastLeafSet = this.props.tree.size - 1;
-    var hasSelection = isBlockOnSelectionEdge(this.props.selection, blockKey);
+    const block = this.props.block;
+    const blockKey = block.getKey();
+    const text = block.getText();
+    const lastLeafSet = this.props.tree.size - 1;
+    const hasSelection = isBlockOnSelectionEdge(this.props.selection, blockKey);
 
     return this.props.tree.map((leafSet, ii) => {
-      var leavesForLeafSet = leafSet.get('leaves');
-      var lastLeaf = leavesForLeafSet.size - 1;
-      var leaves = leavesForLeafSet.map((leaf, jj) => {
-        var offsetKey = DraftOffsetKey.encode(blockKey, ii, jj);
-        var start = leaf.get('start');
-        var end = leaf.get('end');
+      const leavesForLeafSet = leafSet.get('leaves');
+      const lastLeaf = leavesForLeafSet.size - 1;
+      const leaves = leavesForLeafSet.map((leaf, jj) => {
+        const offsetKey = DraftOffsetKey.encode(blockKey, ii, jj);
+        const start = leaf.get('start');
+        const end = leaf.get('end');
         return (
           <DraftEditorLeaf
             key={offsetKey}
@@ -149,7 +149,7 @@ class DraftEditorBlock extends React.Component {
         );
       }).toArray();
 
-      var decoratorKey = leafSet.get('decoratorKey');
+      const decoratorKey = leafSet.get('decoratorKey');
       if (decoratorKey == null) {
         return leaves;
       }
@@ -158,23 +158,23 @@ class DraftEditorBlock extends React.Component {
         return leaves;
       }
 
-      var decorator = nullthrows(this.props.decorator);
+      const decorator = nullthrows(this.props.decorator);
 
-      var DecoratorComponent = decorator.getComponentForKey(decoratorKey);
+      const DecoratorComponent = decorator.getComponentForKey(decoratorKey);
       if (!DecoratorComponent) {
         return leaves;
       }
 
-      var decoratorProps = decorator.getPropsForKey(decoratorKey);
-      var decoratorOffsetKey = DraftOffsetKey.encode(blockKey, ii, 0);
-      var decoratedText = text.slice(
+      const decoratorProps = decorator.getPropsForKey(decoratorKey);
+      const decoratorOffsetKey = DraftOffsetKey.encode(blockKey, ii, 0);
+      const decoratedText = text.slice(
         leavesForLeafSet.first().get('start'),
         leavesForLeafSet.last().get('end')
       );
 
       // Resetting dir to the same value on a child node makes Chrome/Firefox
       // confused on cursor movement. See http://jsfiddle.net/d157kLck/3/
-      var dir = UnicodeBidiDirection.getHTMLDirIfDifferent(
+      const dir = UnicodeBidiDirection.getHTMLDirIfDifferent(
         UnicodeBidi.getDirection(decoratedText),
         this.props.direction,
       );

--- a/src/component/contents/DraftEditorLeaf.react.js
+++ b/src/component/contents/DraftEditorLeaf.react.js
@@ -13,12 +13,12 @@
 
 'use strict';
 
-var DraftEditorTextNode = require('DraftEditorTextNode.react');
-var React = require('React');
-var ReactDOM = require('ReactDOM');
-var SelectionState = require('SelectionState');
+const DraftEditorTextNode = require('DraftEditorTextNode.react');
+const React = require('React');
+const ReactDOM = require('ReactDOM');
+const SelectionState = require('SelectionState');
 
-var setDraftEditorSelection = require('setDraftEditorSelection');
+const setDraftEditorSelection = require('setDraftEditorSelection');
 
 import type {DraftInlineStyle} from 'DraftInlineStyle';
 

--- a/src/component/contents/__tests__/DraftEditorBlock.react-test.js
+++ b/src/component/contents/__tests__/DraftEditorBlock.react-test.js
@@ -18,33 +18,33 @@ jest.autoMockOff()
   .mock('getScrollPosition')
   .mock('getViewportDimensions');
 
-var BlockTree = require('BlockTree');
-var CharacterMetadata = require('CharacterMetadata');
-var ContentBlock = require('ContentBlock');
-var Immutable = require('immutable');
-var React = require('React');
-var ReactDOM = require('ReactDOM');
-var ReactTestUtils = require('ReactTestUtils');
-var SampleDraftInlineStyle = require('SampleDraftInlineStyle');
-var SelectionState = require('SelectionState');
-var Style = require('Style');
-var UnicodeBidiDirection = require('UnicodeBidiDirection');
+const BlockTree = require('BlockTree');
+const CharacterMetadata = require('CharacterMetadata');
+const ContentBlock = require('ContentBlock');
+const Immutable = require('immutable');
+const React = require('React');
+const ReactDOM = require('ReactDOM');
+const ReactTestUtils = require('ReactTestUtils');
+const SampleDraftInlineStyle = require('SampleDraftInlineStyle');
+const SelectionState = require('SelectionState');
+const Style = require('Style');
+const UnicodeBidiDirection = require('UnicodeBidiDirection');
 
-var getElementPosition = require('getElementPosition');
-var getScrollPosition = require('getScrollPosition');
-var getViewportDimensions = require('getViewportDimensions');
-var reactComponentExpect = require('reactComponentExpect');
-var {BOLD, NONE, ITALIC} = SampleDraftInlineStyle;
+const getElementPosition = require('getElementPosition');
+const getScrollPosition = require('getScrollPosition');
+const getViewportDimensions = require('getViewportDimensions');
+const reactComponentExpect = require('reactComponentExpect');
+const {BOLD, NONE, ITALIC} = SampleDraftInlineStyle;
 
-var mockGetDecorations = jest.genMockFn();
+const mockGetDecorations = jest.genMockFn();
 
-var DecoratorSpan = React.createClass({
+const DecoratorSpan = React.createClass({
   render() {
     return <span>{this.props.children}</span>;
   },
 });
 
-var DraftEditorBlock = require('DraftEditorBlock.react');
+const DraftEditorBlock = require('DraftEditorBlock.react');
 
 // Define a class to satisfy typechecks.
 class Decorator {
@@ -59,7 +59,7 @@ class Decorator {
   }
 }
 
-var mockLeafRender = jest.genMockFn().mockReturnValue(<span />);
+const mockLeafRender = jest.genMockFn().mockReturnValue(<span />);
 jest.setMock(
   'DraftEditorLeaf.react',
   React.createClass({
@@ -69,7 +69,7 @@ jest.setMock(
   })
 );
 
-var DraftEditorLeaf = require('DraftEditorLeaf.react');
+const DraftEditorLeaf = require('DraftEditorLeaf.react');
 
 function returnEmptyString() {
   return '';
@@ -146,12 +146,12 @@ describe('DraftEditorBlock.react', () => {
 
   describe('Basic rendering', () => {
     it('must render a leaf node', () => {
-      var props = getProps(getHelloBlock());
-      var block = ReactTestUtils.renderIntoDocument(
+      const props = getProps(getHelloBlock());
+      const block = ReactTestUtils.renderIntoDocument(
         <DraftEditorBlock {...props} />
       );
 
-      var rendered = reactComponentExpect(block)
+      const rendered = reactComponentExpect(block)
         .expectRenderedChild()
         .toBeComponentOfType('div');
 
@@ -167,9 +167,9 @@ describe('DraftEditorBlock.react', () => {
     });
 
     it('must render multiple leaf nodes', () => {
-      var boldLength = 2;
-      var helloBlock = getHelloBlock();
-      var characters = helloBlock.getCharacterList();
+      const boldLength = 2;
+      let helloBlock = getHelloBlock();
+      let characters = helloBlock.getCharacterList();
       characters = characters
         .slice(0, boldLength)
         .map(c => CharacterMetadata.applyStyle(c, 'BOLD'))
@@ -177,12 +177,12 @@ describe('DraftEditorBlock.react', () => {
 
       helloBlock = helloBlock.set('characterList', characters.toList());
 
-      var props = getProps(helloBlock);
-      var block = ReactTestUtils.renderIntoDocument(
+      const props = getProps(helloBlock);
+      const block = ReactTestUtils.renderIntoDocument(
         <DraftEditorBlock {...props} />
       );
 
-      var rendered = reactComponentExpect(block)
+      const rendered = reactComponentExpect(block)
         .expectRenderedChild()
         .toBeComponentOfType('div');
 
@@ -207,10 +207,10 @@ describe('DraftEditorBlock.react', () => {
 
   describe('Allow/reject component updates', () => {
     it('must allow update when `block` has changed', () => {
-      var helloBlock = getHelloBlock();
-      var props = getProps(helloBlock);
+      const helloBlock = getHelloBlock();
+      const props = getProps(helloBlock);
 
-      var container = document.createElement('div');
+      const container = document.createElement('div');
       ReactDOM.render(
         <DraftEditorBlock {...props} />,
         container
@@ -218,8 +218,8 @@ describe('DraftEditorBlock.react', () => {
 
       expect(mockLeafRender.mock.calls.length).toBe(1);
 
-      var updatedHelloBlock = helloBlock.set('text', 'hxllo');
-      var nextProps = getProps(updatedHelloBlock);
+      const updatedHelloBlock = helloBlock.set('text', 'hxllo');
+      const nextProps = getProps(updatedHelloBlock);
 
       expect(updatedHelloBlock).not.toBe(helloBlock);
       expect(props.block).not.toBe(nextProps.block);
@@ -233,10 +233,10 @@ describe('DraftEditorBlock.react', () => {
     });
 
     it('must allow update when `tree` has changed', () => {
-      var helloBlock = getHelloBlock();
-      var props = getProps(helloBlock);
+      const helloBlock = getHelloBlock();
+      const props = getProps(helloBlock);
 
-      var container = document.createElement('div');
+      const container = document.createElement('div');
       ReactDOM.render(
         <DraftEditorBlock {...props} />,
         container
@@ -247,10 +247,10 @@ describe('DraftEditorBlock.react', () => {
       mockGetDecorations.mockReturnValue(
         Immutable.List.of('x', 'x', null, null, null)
       );
-      var decorator = new Decorator();
+      const decorator = new Decorator();
 
-      var newTree = BlockTree.generate(helloBlock, decorator);
-      var nextProps = {...props, tree: newTree, decorator};
+      const newTree = BlockTree.generate(helloBlock, decorator);
+      const nextProps = {...props, tree: newTree, decorator};
 
       expect(props.tree).not.toBe(nextProps.tree);
 
@@ -263,10 +263,10 @@ describe('DraftEditorBlock.react', () => {
     });
 
     it('must allow update when `direction` has changed', () => {
-      var helloBlock = getHelloBlock();
-      var props = getProps(helloBlock);
+      const helloBlock = getHelloBlock();
+      const props = getProps(helloBlock);
 
-      var container = document.createElement('div');
+      const container = document.createElement('div');
       ReactDOM.render(
         <DraftEditorBlock {...props} />,
         container
@@ -274,7 +274,7 @@ describe('DraftEditorBlock.react', () => {
 
       expect(mockLeafRender.mock.calls.length).toBe(1);
 
-      var nextProps = {...props, direction: UnicodeBidiDirection.RTL};
+      const nextProps = {...props, direction: UnicodeBidiDirection.RTL};
       expect(props.direction).not.toBe(nextProps.direction);
 
       ReactDOM.render(
@@ -286,10 +286,10 @@ describe('DraftEditorBlock.react', () => {
     });
 
     it('must allow update when forcing selection', () => {
-      var helloBlock = getHelloBlock();
-      var props = getProps(helloBlock);
+      const helloBlock = getHelloBlock();
+      const props = getProps(helloBlock);
 
-      var container = document.createElement('div');
+      const container = document.createElement('div');
       ReactDOM.render(
         <DraftEditorBlock {...props} />,
         container
@@ -298,7 +298,7 @@ describe('DraftEditorBlock.react', () => {
       expect(mockLeafRender.mock.calls.length).toBe(1);
 
       // The default selection state in this test is on a selection edge.
-      var nextProps = {
+      const nextProps = {
         ...props,
         forceSelection: true,
       };
@@ -312,10 +312,10 @@ describe('DraftEditorBlock.react', () => {
     });
 
     it('must reject update if conditions are not met', () => {
-      var helloBlock = getHelloBlock();
-      var props = getProps(helloBlock);
+      const helloBlock = getHelloBlock();
+      const props = getProps(helloBlock);
 
-      var container = document.createElement('div');
+      const container = document.createElement('div');
       ReactDOM.render(
         <DraftEditorBlock {...props} />,
         container
@@ -334,10 +334,10 @@ describe('DraftEditorBlock.react', () => {
     });
 
     it('must reject update if selection is not on an edge', () => {
-      var helloBlock = getHelloBlock();
-      var props = getProps(helloBlock);
+      const helloBlock = getHelloBlock();
+      const props = getProps(helloBlock);
 
-      var container = document.createElement('div');
+      const container = document.createElement('div');
       ReactDOM.render(
         <DraftEditorBlock {...props} />,
         container
@@ -346,12 +346,12 @@ describe('DraftEditorBlock.react', () => {
       expect(mockLeafRender.mock.calls.length).toBe(1);
 
       // Move selection state to some other block.
-      var nonEdgeSelection = props.selection.merge({
+      const nonEdgeSelection = props.selection.merge({
         anchorKey: 'z',
         focusKey: 'z',
       });
 
-      var newProps = {...props, selection: nonEdgeSelection};
+      const newProps = {...props, selection: nonEdgeSelection};
 
       // Render again with selection now moved elsewhere and the contents
       // unchanged.
@@ -367,23 +367,23 @@ describe('DraftEditorBlock.react', () => {
 
   describe('Complex rendering with a decorator', () => {
     it('must split apart two decorated and undecorated', () => {
-      var helloBlock = getHelloBlock();
+      const helloBlock = getHelloBlock();
 
       mockGetDecorations.mockReturnValue(
         Immutable.List.of('x', 'x', null, null, null)
       );
-      var decorator = new Decorator();
-      var props = getProps(helloBlock, decorator);
+      const decorator = new Decorator();
+      const props = getProps(helloBlock, decorator);
 
-      var container = document.createElement('div');
-      var block = ReactDOM.render(
+      const container = document.createElement('div');
+      const block = ReactDOM.render(
         <DraftEditorBlock {...props} />,
         container
       );
 
       expect(mockLeafRender.mock.calls.length).toBe(2);
 
-      var rendered = reactComponentExpect(block)
+      const rendered = reactComponentExpect(block)
         .expectRenderedChild()
         .toBeComponentOfType('div');
 
@@ -401,24 +401,24 @@ describe('DraftEditorBlock.react', () => {
     });
 
     it('must split apart two decorators', () => {
-      var helloBlock = getHelloBlock();
+      const helloBlock = getHelloBlock();
 
       mockGetDecorations.mockReturnValue(
         Immutable.List.of('x', 'x', 'y', 'y', 'y')
       );
 
-      var decorator = new Decorator();
-      var props = getProps(helloBlock, decorator);
+      const decorator = new Decorator();
+      const props = getProps(helloBlock, decorator);
 
-      var container = document.createElement('div');
-      var block = ReactDOM.render(
+      const container = document.createElement('div');
+      const block = ReactDOM.render(
         <DraftEditorBlock {...props} />,
         container
       );
 
       expect(mockLeafRender.mock.calls.length).toBe(2);
 
-      var rendered = reactComponentExpect(block)
+      const rendered = reactComponentExpect(block)
         .expectRenderedChild()
         .toBeComponentOfType('div');
 
@@ -436,24 +436,24 @@ describe('DraftEditorBlock.react', () => {
 
   describe('Complex rendering with inline styles', () => {
     it('must split apart styled spans', () => {
-      var helloBlock = getHelloBlock();
-      var characters = helloBlock.getCharacterList();
-      var newChars = characters.slice(0, 2).map(ch => {
+      let helloBlock = getHelloBlock();
+      const characters = helloBlock.getCharacterList();
+      const newChars = characters.slice(0, 2).map(ch => {
         return CharacterMetadata.applyStyle(ch, 'BOLD');
       }).concat(characters.slice(2));
 
       helloBlock = helloBlock.set('characterList', Immutable.List(newChars));
-      var props = getProps(helloBlock);
+      const props = getProps(helloBlock);
 
-      var container = document.createElement('div');
-      var block = ReactDOM.render(
+      const container = document.createElement('div');
+      const block = ReactDOM.render(
         <DraftEditorBlock {...props} />,
         container
       );
 
       expect(mockLeafRender.mock.calls.length).toBe(2);
 
-      var rendered = reactComponentExpect(block)
+      const rendered = reactComponentExpect(block)
         .expectRenderedChild()
         .toBeComponentOfType('div');
 
@@ -467,9 +467,9 @@ describe('DraftEditorBlock.react', () => {
     });
 
     it('must split styled spans apart within decorator', () => {
-      var helloBlock = getHelloBlock();
-      var characters = helloBlock.getCharacterList();
-      var newChars = Immutable.List([
+      let helloBlock = getHelloBlock();
+      const characters = helloBlock.getCharacterList();
+      const newChars = Immutable.List([
         CharacterMetadata.applyStyle(characters.get(0), 'BOLD'),
         CharacterMetadata.applyStyle(characters.get(1), 'ITALIC'),
       ]).concat(characters.slice(2));
@@ -479,22 +479,22 @@ describe('DraftEditorBlock.react', () => {
       mockGetDecorations.mockReturnValue(
         Immutable.List.of('x', 'x', null, null, null)
       );
-      var decorator = new Decorator();
-      var props = getProps(helloBlock, decorator);
+      const decorator = new Decorator();
+      const props = getProps(helloBlock, decorator);
 
-      var container = document.createElement('div');
-      var block = ReactDOM.render(
+      const container = document.createElement('div');
+      const block = ReactDOM.render(
         <DraftEditorBlock {...props} />,
         container
       );
 
       expect(mockLeafRender.mock.calls.length).toBe(3);
 
-      var rendered = reactComponentExpect(block)
+      const rendered = reactComponentExpect(block)
         .expectRenderedChild()
         .toBeComponentOfType('div');
 
-      var decoratedSpan = rendered
+      const decoratedSpan = rendered
         .expectRenderedChildAt(0)
         .scalarPropsEqual({offsetKey: 'a-0-0'})
         .toBeComponentOfType(DecoratorSpan)
@@ -515,7 +515,7 @@ describe('DraftEditorBlock.react', () => {
   });
 
   describe('Scroll-to-cursor on mount', () => {
-    var props = getProps(getHelloBlock());
+    const props = getProps(getHelloBlock());
 
     describe('Scroll parent is `window`', () => {
       it('must scroll the window if needed', () => {
@@ -526,13 +526,13 @@ describe('DraftEditorBlock.react', () => {
           height: 16,
         });
 
-        var container = document.createElement('div');
+        const container = document.createElement('div');
         ReactDOM.render(
           <DraftEditorBlock {...props} />,
           container
         );
 
-        var scrollCalls = window.scrollTo.mock.calls;
+        const scrollCalls = window.scrollTo.mock.calls;
         expect(scrollCalls.length).toBe(1);
         expect(scrollCalls[0][0]).toBe(0);
 
@@ -541,13 +541,13 @@ describe('DraftEditorBlock.react', () => {
       });
 
       it('must not scroll the window if unnecessary', () => {
-        var container = document.createElement('div');
+        const container = document.createElement('div');
         ReactDOM.render(
           <DraftEditorBlock {...props} />,
           container
         );
 
-        var scrollCalls = window.scrollTo.mock.calls;
+        const scrollCalls = window.scrollTo.mock.calls;
         expect(scrollCalls.length).toBe(0);
       });
     });

--- a/src/component/contents/__tests__/DraftEditorTextNode-test.js
+++ b/src/component/contents/__tests__/DraftEditorTextNode-test.js
@@ -13,17 +13,17 @@
 
 jest.dontMock('DraftEditorTextNode.react');
 
-var BLOCK_DELIMITER_CHAR = '\n';
-var TEST_A = 'Hello';
-var TEST_B = ' World!';
+const BLOCK_DELIMITER_CHAR = '\n';
+const TEST_A = 'Hello';
+const TEST_B = ' World!';
 
-var DraftEditorTextNode = require('DraftEditorTextNode.react');
-var React = require('React');
-var ReactDOM = require('ReactDOM');
-var UserAgent = require('UserAgent');
+const DraftEditorTextNode = require('DraftEditorTextNode.react');
+const React = require('React');
+const ReactDOM = require('ReactDOM');
+const UserAgent = require('UserAgent');
 
 describe('DraftEditorTextNode', function() {
-  var container;
+  let container;
 
   beforeEach(function() {
     jest.resetModuleRegistry();
@@ -43,7 +43,7 @@ describe('DraftEditorTextNode', function() {
   }
 
   function expectPopulatedSpan(stub, testString) {
-    var node = ReactDOM.findDOMNode(stub);
+    const node = ReactDOM.findDOMNode(stub);
     expect(node.tagName).toBe('SPAN');
     expect(node.childNodes.length).toBe(1);
     expect(node.firstChild.textContent).toBe(testString);
@@ -51,7 +51,7 @@ describe('DraftEditorTextNode', function() {
 
   it('must initialize correctly with an empty string, non-IE', function() {
     initializeAsNonIE();
-    var stub = renderIntoContainer(
+    const stub = renderIntoContainer(
       <DraftEditorTextNode>{''}</DraftEditorTextNode>
     );
     expect(ReactDOM.findDOMNode(stub).tagName).toBe('BR');
@@ -59,7 +59,7 @@ describe('DraftEditorTextNode', function() {
 
   it('must initialize correctly with an empty string, IE', function() {
     initializeAsIE();
-    var stub = renderIntoContainer(
+    const stub = renderIntoContainer(
       <DraftEditorTextNode>{''}</DraftEditorTextNode>
     );
     expectPopulatedSpan(stub, BLOCK_DELIMITER_CHAR);
@@ -67,7 +67,7 @@ describe('DraftEditorTextNode', function() {
 
   it('must initialize correctly with a string, non-IE', function() {
     initializeAsNonIE();
-    var stub = renderIntoContainer(
+    const stub = renderIntoContainer(
       <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>
     );
     expectPopulatedSpan(stub, TEST_A);
@@ -75,7 +75,7 @@ describe('DraftEditorTextNode', function() {
 
   it('must initialize correctly with a string, IE', function() {
     initializeAsIE();
-    var stub = renderIntoContainer(
+    const stub = renderIntoContainer(
       <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>
     );
     expectPopulatedSpan(stub, TEST_A);
@@ -83,7 +83,7 @@ describe('DraftEditorTextNode', function() {
 
   it('must update from empty to non-empty, non-IE', function() {
     initializeAsNonIE();
-    var stub = renderIntoContainer(
+    const stub = renderIntoContainer(
       <DraftEditorTextNode>{''}</DraftEditorTextNode>
     );
 
@@ -93,7 +93,7 @@ describe('DraftEditorTextNode', function() {
 
   it('must update from empty to non-empty, IE', function() {
     initializeAsIE();
-    var stub = renderIntoContainer(
+    const stub = renderIntoContainer(
       <DraftEditorTextNode>{''}</DraftEditorTextNode>
     );
 
@@ -103,7 +103,7 @@ describe('DraftEditorTextNode', function() {
 
   it('must update from non-empty to non-empty, non-IE', function() {
     initializeAsNonIE();
-    var stub = renderIntoContainer(
+    const stub = renderIntoContainer(
       <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>
     );
 
@@ -119,7 +119,7 @@ describe('DraftEditorTextNode', function() {
 
   it('must update from non-empty to non-empty, non-IE', function() {
     initializeAsIE();
-    var stub = renderIntoContainer(
+    const stub = renderIntoContainer(
       <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>
     );
 
@@ -134,7 +134,7 @@ describe('DraftEditorTextNode', function() {
 
   it('must skip updates if text already matches DOM, non-IE', function() {
     initializeAsNonIE();
-    var stub = renderIntoContainer(
+    const stub = renderIntoContainer(
       <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>
     );
 
@@ -152,7 +152,7 @@ describe('DraftEditorTextNode', function() {
 
   it('must skip updates if text already matches DOM, IE', function() {
     initializeAsIE();
-    var stub = renderIntoContainer(
+    const stub = renderIntoContainer(
       <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>
     );
 
@@ -170,7 +170,7 @@ describe('DraftEditorTextNode', function() {
 
   it('must update from non-empty to empty, non-IE', function() {
     initializeAsNonIE();
-    var stub = renderIntoContainer(
+    const stub = renderIntoContainer(
       <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>
     );
 
@@ -181,7 +181,7 @@ describe('DraftEditorTextNode', function() {
 
   it('must update from non-empty to empty, IE', function() {
     initializeAsIE();
-    var stub = renderIntoContainer(
+    const stub = renderIntoContainer(
       <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>
     );
 
@@ -199,7 +199,7 @@ describe('DraftEditorTextNode', function() {
 
   it('must force unchanged text back into the DOM', function() {
     initializeAsNonIE();
-    var stub = renderIntoContainer(
+    const stub = renderIntoContainer(
       <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>
     );
 

--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -41,7 +41,7 @@ let resolved = false;
 let stillComposing = false;
 let textInputData = '';
 
-var DraftEditorCompositionHandler = {
+const DraftEditorCompositionHandler = {
   onBeforeInput: function(e: SyntheticInputEvent): void {
     textInputData = (textInputData || '') + e.data;
   },

--- a/src/component/handlers/drag/DraftEditorDragHandler.js
+++ b/src/component/handlers/drag/DraftEditorDragHandler.js
@@ -35,7 +35,7 @@ function getSelectionForEvent(
   let offset: ?number = null;
 
   if (document.caretRangeFromPoint) {
-    var dropRange = document.caretRangeFromPoint(event.x, event.y);
+    const dropRange = document.caretRangeFromPoint(event.x, event.y);
     node = dropRange.startContainer;
     offset = dropRange.startOffset;
   } else if (event.rangeParent) {
@@ -58,7 +58,7 @@ function getSelectionForEvent(
   );
 }
 
-var DraftEditorDragHandler = {
+const DraftEditorDragHandler = {
   /**
    * Drag originating from input terminated.
    */

--- a/src/component/handlers/edit/commands/SecondaryClipboard.js
+++ b/src/component/handlers/edit/commands/SecondaryClipboard.js
@@ -12,30 +12,30 @@
 
 'use strict';
 
-var DraftModifier = require('DraftModifier');
-var EditorState = require('EditorState');
+const DraftModifier = require('DraftModifier');
+const EditorState = require('EditorState');
 
-var getContentStateFragment = require('getContentStateFragment');
-var nullthrows = require('nullthrows');
+const getContentStateFragment = require('getContentStateFragment');
+const nullthrows = require('nullthrows');
 
 import type {BlockMap} from 'BlockMap';
 import type SelectionState from 'SelectionState';
 
-var clipboard: ?BlockMap = null;
+let clipboard: ?BlockMap = null;
 
 /**
  * Some systems offer a "secondary" clipboard to allow quick internal cut
  * and paste behavior. For instance, Ctrl+K (cut) and Ctrl+Y (paste).
  */
-var SecondaryClipboard = {
+const SecondaryClipboard = {
   cut: function(editorState: EditorState): EditorState {
-    var content = editorState.getCurrentContent();
-    var selection = editorState.getSelection();
-    var targetRange: ?SelectionState = null;
+    const content = editorState.getCurrentContent();
+    const selection = editorState.getSelection();
+    let targetRange: ?SelectionState = null;
 
     if (selection.isCollapsed()) {
-      var anchorKey = selection.getAnchorKey();
-      var blockEnd = content.getBlockForKey(anchorKey).getLength();
+      const anchorKey = selection.getAnchorKey();
+      const blockEnd = content.getBlockForKey(anchorKey).getLength();
 
       if (blockEnd === selection.getAnchorOffset()) {
         return editorState;
@@ -49,7 +49,7 @@ var SecondaryClipboard = {
     targetRange = nullthrows(targetRange);
     clipboard = getContentStateFragment(content, targetRange);
 
-    var afterRemoval = DraftModifier.removeRange(
+    const afterRemoval = DraftModifier.removeRange(
       content,
       targetRange,
       'forward'
@@ -67,7 +67,7 @@ var SecondaryClipboard = {
       return editorState;
     }
 
-    var newContent = DraftModifier.replaceWithFragment(
+    const newContent = DraftModifier.replaceWithFragment(
       editorState.getCurrentContent(),
       editorState.getSelection(),
       clipboard

--- a/src/component/handlers/edit/commands/keyCommandBackspaceToStartOfLine.js
+++ b/src/component/handlers/edit/commands/keyCommandBackspaceToStartOfLine.js
@@ -12,23 +12,23 @@
 
 'use strict';
 
-var EditorState = require('EditorState');
+const EditorState = require('EditorState');
 
-var expandRangeToStartOfLine = require('expandRangeToStartOfLine');
-var getDraftEditorSelectionWithNodes = require('getDraftEditorSelectionWithNodes');
-var removeTextWithStrategy = require('removeTextWithStrategy');
+const expandRangeToStartOfLine = require('expandRangeToStartOfLine');
+const getDraftEditorSelectionWithNodes = require('getDraftEditorSelectionWithNodes');
+const removeTextWithStrategy = require('removeTextWithStrategy');
 
 function keyCommandBackspaceToStartOfLine(
   editorState: EditorState
 ): EditorState {
-  var afterRemoval = removeTextWithStrategy(
+  const afterRemoval = removeTextWithStrategy(
     editorState,
     strategyState => {
-      var domSelection = global.getSelection();
-      var range = domSelection.getRangeAt(0);
+      const domSelection = global.getSelection();
+      let range = domSelection.getRangeAt(0);
       range = expandRangeToStartOfLine(range);
 
-      var selection = getDraftEditorSelectionWithNodes(
+      const selection = getDraftEditorSelectionWithNodes(
         strategyState,
         null,
         range.endContainer,

--- a/src/component/handlers/edit/commands/keyCommandBackspaceWord.js
+++ b/src/component/handlers/edit/commands/keyCommandBackspaceWord.js
@@ -12,30 +12,30 @@
 
 'use strict';
 
-var DraftRemovableWord = require('DraftRemovableWord');
-var EditorState = require('EditorState');
+const DraftRemovableWord = require('DraftRemovableWord');
+const EditorState = require('EditorState');
 
-var moveSelectionBackward = require('moveSelectionBackward');
-var removeTextWithStrategy = require('removeTextWithStrategy');
+const moveSelectionBackward = require('moveSelectionBackward');
+const removeTextWithStrategy = require('removeTextWithStrategy');
 
 /**
  * Delete the word that is left of the cursor, as well as any spaces or
  * punctuation after the word.
  */
 function keyCommandBackspaceWord(editorState: EditorState): EditorState {
-  var afterRemoval = removeTextWithStrategy(
+  const afterRemoval = removeTextWithStrategy(
     editorState,
     strategyState => {
-      var selection = strategyState.getSelection();
-      var offset = selection.getStartOffset();
+      const selection = strategyState.getSelection();
+      const offset = selection.getStartOffset();
       // If there are no words before the cursor, remove the preceding newline.
       if (offset === 0) {
         return moveSelectionBackward(strategyState, 1);
       }
-      var key = selection.getStartKey();
-      var content = strategyState.getCurrentContent();
-      var text = content.getBlockForKey(key).getText().slice(0, offset);
-      var toRemove = DraftRemovableWord.getBackward(text);
+      const key = selection.getStartKey();
+      const content = strategyState.getCurrentContent();
+      const text = content.getBlockForKey(key).getText().slice(0, offset);
+      const toRemove = DraftRemovableWord.getBackward(text);
       return moveSelectionBackward(
         strategyState,
         toRemove.length || 1

--- a/src/component/handlers/edit/commands/keyCommandDeleteWord.js
+++ b/src/component/handlers/edit/commands/keyCommandDeleteWord.js
@@ -12,26 +12,26 @@
 
 'use strict';
 
-var DraftRemovableWord = require('DraftRemovableWord');
-var EditorState = require('EditorState');
+const DraftRemovableWord = require('DraftRemovableWord');
+const EditorState = require('EditorState');
 
-var moveSelectionForward = require('moveSelectionForward');
-var removeTextWithStrategy = require('removeTextWithStrategy');
+const moveSelectionForward = require('moveSelectionForward');
+const removeTextWithStrategy = require('removeTextWithStrategy');
 
 /**
  * Delete the word that is right of the cursor, as well as any spaces or
  * punctuation before the word.
  */
 function keyCommandDeleteWord(editorState: EditorState): EditorState {
-  var afterRemoval = removeTextWithStrategy(
+  const afterRemoval = removeTextWithStrategy(
     editorState,
     strategyState => {
-      var selection = strategyState.getSelection();
-      var offset = selection.getStartOffset();
-      var key = selection.getStartKey();
-      var content = strategyState.getCurrentContent();
-      var text = content.getBlockForKey(key).getText().slice(offset);
-      var toRemove = DraftRemovableWord.getForward(text);
+      const selection = strategyState.getSelection();
+      const offset = selection.getStartOffset();
+      const key = selection.getStartKey();
+      const content = strategyState.getCurrentContent();
+      const text = content.getBlockForKey(key).getText().slice(offset);
+      const toRemove = DraftRemovableWord.getForward(text);
 
       // If there are no words in front of the cursor, remove the newline.
       return moveSelectionForward(

--- a/src/component/handlers/edit/commands/keyCommandInsertNewline.js
+++ b/src/component/handlers/edit/commands/keyCommandInsertNewline.js
@@ -12,11 +12,11 @@
 
 'use strict';
 
-var DraftModifier = require('DraftModifier');
-var EditorState = require('EditorState');
+const DraftModifier = require('DraftModifier');
+const EditorState = require('EditorState');
 
 function keyCommandInsertNewline(editorState: EditorState): EditorState {
-  var contentState = DraftModifier.splitBlock(
+  const contentState = DraftModifier.splitBlock(
     editorState.getCurrentContent(),
     editorState.getSelection()
   );

--- a/src/component/handlers/edit/commands/keyCommandMoveSelectionToEndOfBlock.js
+++ b/src/component/handlers/edit/commands/keyCommandMoveSelectionToEndOfBlock.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var EditorState = require('EditorState');
+const EditorState = require('EditorState');
 
 /**
  * See comment for `moveSelectionToStartOfBlock`.
@@ -20,10 +20,10 @@ var EditorState = require('EditorState');
 function keyCommandMoveSelectionToEndOfBlock(
   editorState: EditorState
 ): EditorState {
-  var selection = editorState.getSelection();
-  var endKey = selection.getEndKey();
-  var content = editorState.getCurrentContent();
-  var textLength = content.getBlockForKey(endKey).getLength();
+  const selection = editorState.getSelection();
+  const endKey = selection.getEndKey();
+  const content = editorState.getCurrentContent();
+  const textLength = content.getBlockForKey(endKey).getLength();
   return EditorState.set(editorState, {
     selection: selection.merge({
       anchorKey: endKey,

--- a/src/component/handlers/edit/commands/keyCommandMoveSelectionToStartOfBlock.js
+++ b/src/component/handlers/edit/commands/keyCommandMoveSelectionToStartOfBlock.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var EditorState = require('EditorState');
+const EditorState = require('EditorState');
 
 /**
  * Collapse selection at the start of the first selected block. This is used
@@ -22,8 +22,8 @@ var EditorState = require('EditorState');
 function keyCommandMoveSelectionToStartOfBlock(
   editorState: EditorState
 ): EditorState {
-  var selection = editorState.getSelection();
-  var startKey = selection.getStartKey();
+  const selection = editorState.getSelection();
+  const startKey = selection.getStartKey();
   return EditorState.set(editorState, {
     selection: selection.merge({
       anchorKey: startKey,

--- a/src/component/handlers/edit/commands/keyCommandPlainBackspace.js
+++ b/src/component/handlers/edit/commands/keyCommandPlainBackspace.js
@@ -12,11 +12,11 @@
 
 'use strict';
 
-var EditorState = require('EditorState');
-var UnicodeUtils = require('UnicodeUtils');
+const EditorState = require('EditorState');
+const UnicodeUtils = require('UnicodeUtils');
 
-var moveSelectionBackward = require('moveSelectionBackward');
-var removeTextWithStrategy = require('removeTextWithStrategy');
+const moveSelectionBackward = require('moveSelectionBackward');
+const removeTextWithStrategy = require('removeTextWithStrategy');
 
 /**
  * Remove the selected range. If the cursor is collapsed, remove the preceding
@@ -24,14 +24,14 @@ var removeTextWithStrategy = require('removeTextWithStrategy');
  * will remove a surrogate pair properly as well.
  */
 function keyCommandPlainBackspace(editorState: EditorState): EditorState {
-  var afterRemoval = removeTextWithStrategy(
+  const afterRemoval = removeTextWithStrategy(
     editorState,
     strategyState => {
-      var selection = strategyState.getSelection();
-      var content = strategyState.getCurrentContent();
-      var key = selection.getAnchorKey();
-      var offset = selection.getAnchorOffset();
-      var charBehind = content.getBlockForKey(key).getText()[offset - 1];
+      const selection = strategyState.getSelection();
+      const content = strategyState.getCurrentContent();
+      const key = selection.getAnchorKey();
+      const offset = selection.getAnchorOffset();
+      const charBehind = content.getBlockForKey(key).getText()[offset - 1];
       return moveSelectionBackward(
         strategyState,
         charBehind ? UnicodeUtils.getUTF16Length(charBehind, 0) : 1
@@ -44,7 +44,7 @@ function keyCommandPlainBackspace(editorState: EditorState): EditorState {
     return editorState;
   }
 
-  var selection = editorState.getSelection();
+  const selection = editorState.getSelection();
   return EditorState.push(
     editorState,
     afterRemoval.set('selectionBefore', selection),

--- a/src/component/handlers/edit/commands/keyCommandPlainDelete.js
+++ b/src/component/handlers/edit/commands/keyCommandPlainDelete.js
@@ -12,11 +12,11 @@
 
 'use strict';
 
-var EditorState = require('EditorState');
-var UnicodeUtils = require('UnicodeUtils');
+const EditorState = require('EditorState');
+const UnicodeUtils = require('UnicodeUtils');
 
-var moveSelectionForward = require('moveSelectionForward');
-var removeTextWithStrategy = require('removeTextWithStrategy');
+const moveSelectionForward = require('moveSelectionForward');
+const removeTextWithStrategy = require('removeTextWithStrategy');
 
 /**
  * Remove the selected range. If the cursor is collapsed, remove the following
@@ -24,14 +24,14 @@ var removeTextWithStrategy = require('removeTextWithStrategy');
  * will remove a surrogate pair properly as well.
  */
 function keyCommandPlainDelete(editorState: EditorState): EditorState {
-  var afterRemoval = removeTextWithStrategy(
+  const afterRemoval = removeTextWithStrategy(
     editorState,
     strategyState => {
-      var selection = strategyState.getSelection();
-      var content = strategyState.getCurrentContent();
-      var key = selection.getAnchorKey();
-      var offset = selection.getAnchorOffset();
-      var charAhead = content.getBlockForKey(key).getText()[offset];
+      const selection = strategyState.getSelection();
+      const content = strategyState.getCurrentContent();
+      const key = selection.getAnchorKey();
+      const offset = selection.getAnchorOffset();
+      const charAhead = content.getBlockForKey(key).getText()[offset];
       return moveSelectionForward(
         strategyState,
         charAhead ? UnicodeUtils.getUTF16Length(charAhead, 0) : 1
@@ -44,7 +44,7 @@ function keyCommandPlainDelete(editorState: EditorState): EditorState {
     return editorState;
   }
 
-  var selection = editorState.getSelection();
+  const selection = editorState.getSelection();
 
   return EditorState.push(
     editorState,

--- a/src/component/handlers/edit/commands/keyCommandTransposeCharacters.js
+++ b/src/component/handlers/edit/commands/keyCommandTransposeCharacters.js
@@ -12,10 +12,10 @@
 
 'use strict';
 
-var DraftModifier = require('DraftModifier');
-var EditorState = require('EditorState');
+const DraftModifier = require('DraftModifier');
+const EditorState = require('EditorState');
 
-var getContentStateFragment = require('getContentStateFragment');
+const getContentStateFragment = require('getContentStateFragment');
 
 /**
  * Transpose the characters on either side of a collapsed cursor, or
@@ -23,28 +23,28 @@ var getContentStateFragment = require('getContentStateFragment');
  * characters.
  */
 function keyCommandTransposeCharacters(editorState: EditorState): EditorState {
-  var selection = editorState.getSelection();
+  const selection = editorState.getSelection();
   if (!selection.isCollapsed()) {
     return editorState;
   }
 
-  var offset = selection.getAnchorOffset();
+  const offset = selection.getAnchorOffset();
   if (offset === 0) {
     return editorState;
   }
 
-  var blockKey = selection.getAnchorKey();
-  var content = editorState.getCurrentContent();
-  var block = content.getBlockForKey(blockKey);
-  var length = block.getLength();
+  const blockKey = selection.getAnchorKey();
+  const content = editorState.getCurrentContent();
+  const block = content.getBlockForKey(blockKey);
+  const length = block.getLength();
 
   // Nothing to transpose if there aren't two characters.
   if (length <= 1) {
     return editorState;
   }
 
-  var removalRange;
-  var finalSelection;
+  let removalRange;
+  let finalSelection;
 
   if (offset === length) {
     // The cursor is at the end of the block. Swap the last two characters.
@@ -57,28 +57,28 @@ function keyCommandTransposeCharacters(editorState: EditorState): EditorState {
 
   // Extract the character to move as a fragment. This preserves its
   // styling and entity, if any.
-  var movedFragment = getContentStateFragment(content, removalRange);
-  var afterRemoval = DraftModifier.removeRange(
+  const movedFragment = getContentStateFragment(content, removalRange);
+  const afterRemoval = DraftModifier.removeRange(
     content,
     removalRange,
     'backward'
   );
 
   // After the removal, the insertion target is one character back.
-  var selectionAfter = afterRemoval.getSelectionAfter();
-  var targetOffset = selectionAfter.getAnchorOffset() - 1;
-  var targetRange = selectionAfter.merge({
+  const selectionAfter = afterRemoval.getSelectionAfter();
+  const targetOffset = selectionAfter.getAnchorOffset() - 1;
+  const targetRange = selectionAfter.merge({
     anchorOffset: targetOffset,
     focusOffset: targetOffset,
   });
 
-  var afterInsert = DraftModifier.replaceWithFragment(
+  const afterInsert = DraftModifier.replaceWithFragment(
     afterRemoval,
     targetRange,
     movedFragment
   );
 
-  var newEditorState = EditorState.push(
+  const newEditorState = EditorState.push(
     editorState,
     afterInsert,
     'insert-fragment'

--- a/src/component/handlers/edit/commands/keyCommandUndo.js
+++ b/src/component/handlers/edit/commands/keyCommandUndo.js
@@ -12,21 +12,21 @@
 
 'use strict';
 
-var EditorState = require('EditorState');
+const EditorState = require('EditorState');
 
 function keyCommandUndo(
   e: SyntheticKeyboardEvent,
   editorState: EditorState,
   updateFn: (editorState: EditorState) => void
 ): void {
-  var undoneState = EditorState.undo(editorState);
+  const undoneState = EditorState.undo(editorState);
 
   // If the last change to occur was a spellcheck change, allow the undo
   // event to fall through to the browser. This allows the browser to record
   // the unwanted change, which should soon lead it to learn not to suggest
   // the correction again.
   if (editorState.getLastChangeType() === 'spellcheck-change') {
-    var nativelyRenderedContent = undoneState.getCurrentContent();
+    const nativelyRenderedContent = undoneState.getCurrentContent();
     updateFn(EditorState.set(undoneState, {nativelyRenderedContent}));
     return;
   }

--- a/src/component/handlers/edit/commands/moveSelectionBackward.js
+++ b/src/component/handlers/edit/commands/moveSelectionBackward.js
@@ -27,21 +27,21 @@ function moveSelectionBackward(
   editorState: EditorState,
   maxDistance: number
 ): SelectionState {
-  var selection = editorState.getSelection();
-  var content = editorState.getCurrentContent();
-  var key = selection.getStartKey();
-  var offset = selection.getStartOffset();
+  const selection = editorState.getSelection();
+  const content = editorState.getCurrentContent();
+  const key = selection.getStartKey();
+  const offset = selection.getStartOffset();
 
-  var focusKey = key;
-  var focusOffset = 0;
+  let focusKey = key;
+  let focusOffset = 0;
 
   if (maxDistance > offset) {
-    var keyBefore = content.getKeyBefore(key);
+    const keyBefore = content.getKeyBefore(key);
     if (keyBefore == null) {
       focusKey = key;
     } else {
       focusKey = keyBefore;
-      var blockBefore = content.getBlockForKey(keyBefore);
+      const blockBefore = content.getBlockForKey(keyBefore);
       focusOffset = blockBefore.getText().length;
     }
   } else {

--- a/src/component/handlers/edit/commands/moveSelectionForward.js
+++ b/src/component/handlers/edit/commands/moveSelectionForward.js
@@ -27,15 +27,15 @@ function moveSelectionForward(
   editorState: EditorState,
   maxDistance: number
 ): SelectionState {
-  var selection = editorState.getSelection();
-  var key = selection.getStartKey();
-  var offset = selection.getStartOffset();
-  var content = editorState.getCurrentContent();
+  const selection = editorState.getSelection();
+  const key = selection.getStartKey();
+  const offset = selection.getStartOffset();
+  const content = editorState.getCurrentContent();
 
-  var focusKey = key;
-  var focusOffset;
+  let focusKey = key;
+  let focusOffset;
 
-  var block = content.getBlockForKey(key);
+  const block = content.getBlockForKey(key);
 
   if (maxDistance > (block.getText().length - offset)) {
     focusKey = content.getKeyAfter(key);

--- a/src/component/handlers/edit/commands/removeTextWithStrategy.js
+++ b/src/component/handlers/edit/commands/removeTextWithStrategy.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var DraftModifier = require('DraftModifier');
+const DraftModifier = require('DraftModifier');
 
 import type ContentState from 'ContentState';
 import type {DraftRemovalDirection} from 'DraftRemovalDirection';
@@ -28,9 +28,9 @@ function removeTextWithStrategy(
   strategy: (editorState: EditorState) => SelectionState,
   direction: DraftRemovalDirection
 ): ContentState {
-  var selection = editorState.getSelection();
-  var content = editorState.getCurrentContent();
-  var target = selection;
+  const selection = editorState.getSelection();
+  const content = editorState.getCurrentContent();
+  let target = selection;
   if (selection.isCollapsed()) {
     if (direction === 'forward') {
       if (editorState.isSelectionAtEndOfContent()) {

--- a/src/component/handlers/edit/editOnBeforeInput.js
+++ b/src/component/handlers/edit/editOnBeforeInput.js
@@ -12,14 +12,14 @@
 
 'use strict';
 
-var BlockTree = require('BlockTree');
-var DraftModifier = require('DraftModifier');
-var EditorState = require('EditorState');
-var UserAgent = require('UserAgent');
+const BlockTree = require('BlockTree');
+const DraftModifier = require('DraftModifier');
+const EditorState = require('EditorState');
+const UserAgent = require('UserAgent');
 
-var getEntityKeyForSelection = require('getEntityKeyForSelection');
-var isSelectionAtLeafStart = require('isSelectionAtLeafStart');
-var nullthrows = require('nullthrows');
+const getEntityKeyForSelection = require('getEntityKeyForSelection');
+const isSelectionAtLeafStart = require('isSelectionAtLeafStart');
+const nullthrows = require('nullthrows');
 
 import type {DraftInlineStyle} from 'DraftInlineStyle';
 
@@ -30,9 +30,9 @@ import type {DraftInlineStyle} from 'DraftInlineStyle';
 // This breaks the input. Special case these characters to ensure that when
 // they are typed, we prevent default on the event to make sure not to
 // trigger quickfind.
-var FF_QUICKFIND_CHAR = '\'';
-var FF_QUICKFIND_LINK_CHAR = '\/';
-var isFirefox = UserAgent.isBrowser('Firefox');
+const FF_QUICKFIND_CHAR = '\'';
+const FF_QUICKFIND_LINK_CHAR = '\/';
+const isFirefox = UserAgent.isBrowser('Firefox');
 
 function mustPreventDefaultForCharacter(character: string): boolean {
   return (
@@ -53,7 +53,7 @@ function replaceText(
   inlineStyle: DraftInlineStyle,
   entityKey: ?string
 ): EditorState {
-  var contentState = DraftModifier.replaceText(
+  const contentState = DraftModifier.replaceText(
     editorState.getCurrentContent(),
     editorState.getSelection(),
     text,
@@ -73,7 +73,7 @@ function replaceText(
  * occurs on the relevant text nodes.
  */
 function editOnBeforeInput(e: SyntheticInputEvent): void {
-  var chars = e.data;
+  const chars = e.data;
 
   // In some cases (ex: IE ideographic space insertion) no character data
   // is provided. There's nothing to do when this happens.
@@ -94,8 +94,8 @@ function editOnBeforeInput(e: SyntheticInputEvent): void {
   // If selection is collapsed, conditionally allow native behavior. This
   // reduces re-renders and preserves spellcheck highlighting. If the selection
   // is not collapsed, we will re-render.
-  var editorState = this.props.editorState;
-  var selection = editorState.getSelection();
+  const editorState = this.props.editorState;
+  const selection = editorState.getSelection();
 
   if (!selection.isCollapsed()) {
     e.preventDefault();
@@ -113,8 +113,8 @@ function editOnBeforeInput(e: SyntheticInputEvent): void {
     return;
   }
 
-  var mayAllowNative = !isSelectionAtLeafStart(editorState);
-  var newEditorState = replaceText(
+  const mayAllowNative = !isSelectionAtLeafStart(editorState);
+  let newEditorState = replaceText(
     editorState,
     chars,
     editorState.getCurrentInlineStyle(),
@@ -130,14 +130,14 @@ function editOnBeforeInput(e: SyntheticInputEvent): void {
     return;
   }
 
-  var anchorKey = selection.getAnchorKey();
-  var anchorTree = editorState.getBlockTree(anchorKey);
+  const anchorKey = selection.getAnchorKey();
+  const anchorTree = editorState.getBlockTree(anchorKey);
 
   // Check the old and new "fingerprints" of the current block to determine
   // whether this insertion requires any addition or removal of text nodes,
   // in which case we would prevent the native character insertion.
-  var originalFingerprint = BlockTree.getFingerprint(anchorTree);
-  var newFingerprint = BlockTree.getFingerprint(
+  const originalFingerprint = BlockTree.getFingerprint(anchorTree);
+  const newFingerprint = BlockTree.getFingerprint(
     newEditorState.getBlockTree(anchorKey)
   );
 

--- a/src/component/handlers/edit/editOnBlur.js
+++ b/src/component/handlers/edit/editOnBlur.js
@@ -12,12 +12,12 @@
 
 'use strict';
 
-var EditorState = require('EditorState');
-var UserAgent = require('UserAgent');
+const EditorState = require('EditorState');
+const UserAgent = require('UserAgent');
 
-var getActiveElement = require('getActiveElement');
+const getActiveElement = require('getActiveElement');
 
-var isWebKit = UserAgent.isEngine('WebKit');
+const isWebKit = UserAgent.isEngine('WebKit');
 
 function editOnBlur(e: SyntheticEvent): void {
   // Webkit has a bug in which blurring a contenteditable by clicking on
@@ -30,13 +30,13 @@ function editOnBlur(e: SyntheticEvent): void {
     global.getSelection().removeAllRanges();
   }
 
-  var editorState = this.props.editorState;
-  var currentSelection = editorState.getSelection();
+  const editorState = this.props.editorState;
+  const currentSelection = editorState.getSelection();
   if (!currentSelection.getHasFocus()) {
     return;
   }
 
-  var selection = currentSelection.set('hasFocus', false);
+  const selection = currentSelection.set('hasFocus', false);
   this.props.onBlur && this.props.onBlur(e);
   this.update(EditorState.acceptSelection(editorState, selection));
 }

--- a/src/component/handlers/edit/editOnCompositionStart.js
+++ b/src/component/handlers/edit/editOnCompositionStart.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var EditorState = require('EditorState');
+const EditorState = require('EditorState');
 
 /**
  * The user has begun using an IME input system. Switching to `composite` mode

--- a/src/component/handlers/edit/editOnCopy.js
+++ b/src/component/handlers/edit/editOnCopy.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var getFragmentFromSelection = require('getFragmentFromSelection');
+const getFragmentFromSelection = require('getFragmentFromSelection');
 
 /**
  * If we have a selection, create a ContentState fragment and store
@@ -20,8 +20,8 @@ var getFragmentFromSelection = require('getFragmentFromSelection');
  * fragment if no external clipboard data is supplied.
  */
 function editOnCopy(e: SyntheticClipboardEvent): void {
-  var editorState = this.props.editorState;
-  var selection = editorState.getSelection();
+  const editorState = this.props.editorState;
+  const selection = editorState.getSelection();
 
   // No selection, so there's nothing to copy.
   if (selection.isCollapsed()) {

--- a/src/component/handlers/edit/editOnFocus.js
+++ b/src/component/handlers/edit/editOnFocus.js
@@ -12,16 +12,16 @@
 
 'use strict';
 
-var EditorState = require('EditorState');
+const EditorState = require('EditorState');
 
 function editOnFocus(e: SyntheticFocusEvent): void {
-  var editorState = this.props.editorState;
-  var currentSelection = editorState.getSelection();
+  const editorState = this.props.editorState;
+  const currentSelection = editorState.getSelection();
   if (currentSelection.getHasFocus()) {
     return;
   }
 
-  var selection = currentSelection.set('hasFocus', true);
+  const selection = currentSelection.set('hasFocus', true);
   this.props.onFocus && this.props.onFocus(e);
 
   // When the tab containing this text editor is hidden and the user does a

--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -12,17 +12,17 @@
 
 'use strict';
 
-var DraftModifier = require('DraftModifier');
-var DraftOffsetKey = require('DraftOffsetKey');
-var EditorState = require('EditorState');
-var UserAgent = require('UserAgent');
+const DraftModifier = require('DraftModifier');
+const DraftOffsetKey = require('DraftOffsetKey');
+const EditorState = require('EditorState');
+const UserAgent = require('UserAgent');
 
-var findAncestorOffsetKey = require('findAncestorOffsetKey');
-var nullthrows = require('nullthrows');
+const findAncestorOffsetKey = require('findAncestorOffsetKey');
+const nullthrows = require('nullthrows');
 
-var isGecko = UserAgent.isEngine('Gecko');
+const isGecko = UserAgent.isEngine('Gecko');
 
-var DOUBLE_NEWLINE = '\n\n';
+const DOUBLE_NEWLINE = '\n\n';
 
 /**
  * This function is intended to handle spellcheck and autocorrect changes,
@@ -31,31 +31,31 @@ var DOUBLE_NEWLINE = '\n\n';
  *
  * The `input` event fires in contentEditable elements reliably for non-IE
  * browsers, immediately after changes occur to the editor DOM. Since our other
- * handlers override or otherwise handle cover other varieties of text input,
+ * handlers override or otherwise handle cover other constieties of text input,
  * the DOM state should match the model in all controlled input cases. Thus,
  * when an `input` change leads to a DOM/model mismatch, the change should be
  * due to a spellcheck change, and we can incorporate it into our model.
  */
 function editOnInput(): void {
-  var domSelection = global.getSelection();
+  const domSelection = global.getSelection();
 
-  var {anchorNode, isCollapsed} = domSelection;
+  const {anchorNode, isCollapsed} = domSelection;
   if (anchorNode.nodeType !== Node.TEXT_NODE) {
     return;
   }
 
-  var domText = anchorNode.textContent;
-  var {editorState} = this.props;
-  var offsetKey = nullthrows(findAncestorOffsetKey(anchorNode));
-  var {blockKey, decoratorKey, leafKey} = DraftOffsetKey.decode(offsetKey);
+  let domText = anchorNode.textContent;
+  const {editorState} = this.props;
+  const offsetKey = nullthrows(findAncestorOffsetKey(anchorNode));
+  const {blockKey, decoratorKey, leafKey} = DraftOffsetKey.decode(offsetKey);
 
-  var {start, end} = editorState
+  const {start, end} = editorState
     .getBlockTree(blockKey)
     .getIn([decoratorKey, 'leaves', leafKey]);
 
-  var content = editorState.getCurrentContent();
-  var block = content.getBlockForKey(blockKey);
-  var modelText = block.getText().slice(start, end);
+  const content = editorState.getCurrentContent();
+  const block = content.getBlockForKey(blockKey);
+  const modelText = block.getText().slice(start, end);
 
   // Special-case soft newlines here. If the DOM text ends in a soft newline,
   // we will have manually inserted an extra soft newline in DraftEditorLeaf.
@@ -70,23 +70,23 @@ function editOnInput(): void {
     return;
   }
 
-  var selection = editorState.getSelection();
+  const selection = editorState.getSelection();
 
   // We'll replace the entire leaf with the text content of the target.
-  var targetRange = selection.merge({
+  const targetRange = selection.merge({
     anchorOffset: start,
     focusOffset: end,
     isBackward: false,
   });
 
-  var newContent = DraftModifier.replaceText(
+  const newContent = DraftModifier.replaceText(
     content,
     targetRange,
     domText,
     block.getInlineStyleAt(start)
   );
 
-  var anchorOffset, focusOffset, startOffset, endOffset;
+  let anchorOffset, focusOffset, startOffset, endOffset;
 
   if (isGecko) {
     // Firefox selection does not change while the context menu is open, so
@@ -103,7 +103,7 @@ function editOnInput(): void {
     // DOM selection. Don't trust it. Instead, use our existing SelectionState
     // and adjust it based on the number of characters changed during the
     // mutation.
-    var charDelta = domText.length - modelText.length;
+    const charDelta = domText.length - modelText.length;
     startOffset = selection.getStartOffset();
     endOffset = selection.getEndOffset();
 
@@ -111,7 +111,7 @@ function editOnInput(): void {
     focusOffset = endOffset + charDelta;
   }
 
-  var contentWithAdjustedDOMSelection = newContent.merge({
+  const contentWithAdjustedDOMSelection = newContent.merge({
     selectionBefore: content.getSelectionAfter(),
     selectionAfter: selection.merge({anchorOffset, focusOffset}),
   });

--- a/src/component/handlers/edit/editOnKeyDown.js
+++ b/src/component/handlers/edit/editOnKeyDown.js
@@ -12,20 +12,20 @@
 
 'use strict';
 
-var EditorState = require('EditorState');
-var Keys = require('Keys');
-var SecondaryClipboard = require('SecondaryClipboard');
+const EditorState = require('EditorState');
+const Keys = require('Keys');
+const SecondaryClipboard = require('SecondaryClipboard');
 
-var keyCommandBackspaceToStartOfLine = require('keyCommandBackspaceToStartOfLine');
-var keyCommandBackspaceWord = require('keyCommandBackspaceWord');
-var keyCommandDeleteWord = require('keyCommandDeleteWord');
-var keyCommandInsertNewline = require('keyCommandInsertNewline');
-var keyCommandPlainBackspace = require('keyCommandPlainBackspace');
-var keyCommandPlainDelete = require('keyCommandPlainDelete');
-var keyCommandMoveSelectionToEndOfBlock = require('keyCommandMoveSelectionToEndOfBlock');
-var keyCommandMoveSelectionToStartOfBlock = require('keyCommandMoveSelectionToStartOfBlock');
-var keyCommandTransposeCharacters = require('keyCommandTransposeCharacters');
-var keyCommandUndo = require('keyCommandUndo');
+const keyCommandBackspaceToStartOfLine = require('keyCommandBackspaceToStartOfLine');
+const keyCommandBackspaceWord = require('keyCommandBackspaceWord');
+const keyCommandDeleteWord = require('keyCommandDeleteWord');
+const keyCommandInsertNewline = require('keyCommandInsertNewline');
+const keyCommandPlainBackspace = require('keyCommandPlainBackspace');
+const keyCommandPlainDelete = require('keyCommandPlainDelete');
+const keyCommandMoveSelectionToEndOfBlock = require('keyCommandMoveSelectionToEndOfBlock');
+const keyCommandMoveSelectionToStartOfBlock = require('keyCommandMoveSelectionToStartOfBlock');
+const keyCommandTransposeCharacters = require('keyCommandTransposeCharacters');
+const keyCommandUndo = require('keyCommandUndo');
 
 import type {DraftEditorCommand} from 'DraftEditorCommand';
 
@@ -76,8 +76,8 @@ function onKeyCommand(
  * component may provide a custom mapping via the `keyBindingFn` prop.
  */
 function editOnKeyDown(e: SyntheticKeyboardEvent): void {
-  var keyCode = e.which;
-  var editorState = this.props.editorState;
+  const keyCode = e.which;
+  const editorState = this.props.editorState;
 
   switch (keyCode) {
     case Keys.RETURN:
@@ -103,7 +103,7 @@ function editOnKeyDown(e: SyntheticKeyboardEvent): void {
       return;
   }
 
-  var command = this.props.keyBindingFn(e);
+  const command = this.props.keyBindingFn(e);
 
   // If no command is specified, allow keydown event to continue.
   if (!command) {
@@ -126,7 +126,7 @@ function editOnKeyDown(e: SyntheticKeyboardEvent): void {
     return;
   }
 
-  var newState = onKeyCommand(command, editorState);
+  const newState = onKeyCommand(command, editorState);
   if (newState !== editorState) {
     this.update(newState);
   }

--- a/src/component/handlers/edit/editOnPaste.js
+++ b/src/component/handlers/edit/editOnPaste.js
@@ -12,17 +12,17 @@
 
 'use strict';
 
-var BlockMapBuilder = require('BlockMapBuilder');
-var CharacterMetadata = require('CharacterMetadata');
-var DataTransfer = require('DataTransfer');
-var DraftModifier = require('DraftModifier');
-var DraftPasteProcessor = require('DraftPasteProcessor');
-var EditorState = require('EditorState');
+const BlockMapBuilder = require('BlockMapBuilder');
+const CharacterMetadata = require('CharacterMetadata');
+const DataTransfer = require('DataTransfer');
+const DraftModifier = require('DraftModifier');
+const DraftPasteProcessor = require('DraftPasteProcessor');
+const EditorState = require('EditorState');
 
-var getEntityKeyForSelection = require('getEntityKeyForSelection');
-var getTextContentFromFiles = require('getTextContentFromFiles');
-var nullthrows = require('nullthrows');
-var splitTextIntoTextBlocks = require('splitTextIntoTextBlocks');
+const getEntityKeyForSelection = require('getEntityKeyForSelection');
+const getTextContentFromFiles = require('getTextContentFromFiles');
+const nullthrows = require('nullthrows');
+const splitTextIntoTextBlocks = require('splitTextIntoTextBlocks');
 
 import type {BlockMap} from 'BlockMap';
 
@@ -31,12 +31,12 @@ import type {BlockMap} from 'BlockMap';
  */
 function editOnPaste(e: SyntheticClipboardEvent): void {
   e.preventDefault();
-  var data = new DataTransfer(e.clipboardData);
+  const data = new DataTransfer(e.clipboardData);
 
   // Get files, unless this is likely to be a string the user wants inline.
   if (!data.isRichText()) {
-    var files = data.getFiles();
-    var defaultFileText = data.getText();
+    const files = data.getFiles();
+    const defaultFileText = data.getText();
     if (files.length > 0) {
       // Allow customized paste handling for images, etc. Otherwise, fall
       // through to insert text contents into the editor.
@@ -53,9 +53,9 @@ function editOnPaste(e: SyntheticClipboardEvent): void {
           return;
         }
 
-        var {editorState} = this.props;
-        var blocks = splitTextIntoTextBlocks(fileText);
-        var character = CharacterMetadata.create({
+        const {editorState} = this.props;
+        const blocks = splitTextIntoTextBlocks(fileText);
+        const character = CharacterMetadata.create({
           style: editorState.getCurrentInlineStyle(),
           entity: getEntityKeyForSelection(
             editorState.getCurrentContent(),
@@ -63,10 +63,10 @@ function editOnPaste(e: SyntheticClipboardEvent): void {
           ),
         });
 
-        var text = DraftPasteProcessor.processText(blocks, character);
-        var fragment = BlockMapBuilder.createFromArray(text);
+        const text = DraftPasteProcessor.processText(blocks, character);
+        const fragment = BlockMapBuilder.createFromArray(text);
 
-        var withInsertedText = DraftModifier.replaceWithFragment(
+        const withInsertedText = DraftModifier.replaceWithFragment(
           editorState.getCurrentContent(),
           editorState.getSelection(),
           fragment
@@ -85,8 +85,8 @@ function editOnPaste(e: SyntheticClipboardEvent): void {
     }
   }
 
-  var textBlocks: ?Array<string> = null;
-  var text = data.getText();
+  let textBlocks: ?Array<string> = null;
+  const text = data.getText();
   this.props.onPasteRawText && this.props.onPasteRawText(text);
   if (text) {
     textBlocks = splitTextIntoTextBlocks(text);
@@ -102,15 +102,15 @@ function editOnPaste(e: SyntheticClipboardEvent): void {
     // paste will preserve the newlines correctly.
     if (data.isRichText() && this.getClipboard()) {
       textBlocks = nullthrows(textBlocks);
-      var textBlocksWithoutNewlines = textBlocks.filter(filterOutNewlines);
-      var currentClipboard = this.getClipboard();
-      var clipboardWithoutNewlines = currentClipboard
+      const textBlocksWithoutNewlines = textBlocks.filter(filterOutNewlines);
+      const currentClipboard = this.getClipboard();
+      const clipboardWithoutNewlines = currentClipboard
         .toSeq()
         .map(clipBlock => clipBlock.getText())
         .filter(filterOutNewlines)
         .toArray();
 
-      var clipboardMatch = textBlocksWithoutNewlines.every(
+      const clipboardMatch = textBlocksWithoutNewlines.every(
         (line, ii) => line === clipboardWithoutNewlines[ii]
       );
 
@@ -123,14 +123,14 @@ function editOnPaste(e: SyntheticClipboardEvent): void {
     }
 
     // If there is html paste data, try to parse that.
-    var htmlData = data.getHTML();
+    const htmlData = data.getHTML();
     if (htmlData) {
-      var htmlFragment = DraftPasteProcessor.processHTML(
+      const htmlFragment = DraftPasteProcessor.processHTML(
         htmlData,
       );
 
       if (htmlFragment) {
-        var htmlMap = BlockMapBuilder.createFromArray(htmlFragment);
+        const htmlMap = BlockMapBuilder.createFromArray(htmlFragment);
         this.update(insertFragment(this.props.editorState, htmlMap));
         return;
       }
@@ -141,8 +141,8 @@ function editOnPaste(e: SyntheticClipboardEvent): void {
   }
 
   if (textBlocks) {
-    var {editorState} = this.props;
-    var character = CharacterMetadata.create({
+    const {editorState} = this.props;
+    const character = CharacterMetadata.create({
       style: editorState.getCurrentInlineStyle(),
       entity: getEntityKeyForSelection(
         editorState.getCurrentContent(),
@@ -150,12 +150,12 @@ function editOnPaste(e: SyntheticClipboardEvent): void {
       ),
     });
 
-    var textFragment = DraftPasteProcessor.processText(
+    const textFragment = DraftPasteProcessor.processText(
       textBlocks,
       character
     );
 
-    var textMap = BlockMapBuilder.createFromArray(textFragment);
+    const textMap = BlockMapBuilder.createFromArray(textFragment);
     this.update(insertFragment(this.props.editorState, textMap));
   }
 }
@@ -168,7 +168,7 @@ function insertFragment(
   editorState: EditorState,
   fragment: BlockMap
 ): EditorState {
-  var newContent = DraftModifier.replaceWithFragment(
+  const newContent = DraftModifier.replaceWithFragment(
     editorState.getCurrentContent(),
     editorState.getSelection(),
     fragment

--- a/src/component/handlers/edit/editOnSelect.js
+++ b/src/component/handlers/edit/editOnSelect.js
@@ -12,22 +12,22 @@
 
 'use strict';
 
-var EditorState = require('EditorState');
-var ReactDOM = require('ReactDOM');
+const EditorState = require('EditorState');
+const ReactDOM = require('ReactDOM');
 
-var getDraftEditorSelection = require('getDraftEditorSelection');
+const getDraftEditorSelection = require('getDraftEditorSelection');
 
 function editOnSelect(): void {
   if (this._blockSelectEvents) {
     return;
   }
 
-  var editorState = this.props.editorState;
-  var documentSelection = getDraftEditorSelection(
+  let editorState = this.props.editorState;
+  const documentSelection = getDraftEditorSelection(
     editorState,
     ReactDOM.findDOMNode(this.refs.editorContainer).firstChild
   );
-  var updatedSelectionState = documentSelection.selectionState;
+  const updatedSelectionState = documentSelection.selectionState;
 
   if (updatedSelectionState !== editorState.getSelection()) {
     if (documentSelection.needsRecovery) {

--- a/src/component/handlers/edit/getFragmentFromSelection.js
+++ b/src/component/handlers/edit/getFragmentFromSelection.js
@@ -12,13 +12,13 @@
 
 'use strict';
 
-var getContentStateFragment = require('getContentStateFragment');
+const getContentStateFragment = require('getContentStateFragment');
 
 import type {BlockMap} from 'BlockMap';
 import type EditorState from 'EditorState';
 
 function getFragmentFromSelection(editorState: EditorState): ?BlockMap {
-  var selectionState = editorState.getSelection();
+  const selectionState = editorState.getSelection();
   if (!selectionState.isCollapsed()) {
     return getContentStateFragment(
       editorState.getCurrentContent(),

--- a/src/component/selection/DraftOffsetKey.js
+++ b/src/component/selection/DraftOffsetKey.js
@@ -14,9 +14,9 @@
 
 import type {DraftOffsetKeyPath} from 'DraftOffsetKeyPath';
 
-var KEY_DELIMITER = '-';
+const KEY_DELIMITER = '-';
 
-var DraftOffsetKey = {
+const DraftOffsetKey = {
   encode: function(
     blockKey: string,
     decoratorKey: number,
@@ -26,7 +26,7 @@ var DraftOffsetKey = {
   },
 
   decode: function(offsetKey: string): DraftOffsetKeyPath {
-    var [blockKey, decoratorKey, leafKey] = offsetKey.split(KEY_DELIMITER);
+    const [blockKey, decoratorKey, leafKey] = offsetKey.split(KEY_DELIMITER);
     return {
       blockKey,
       decoratorKey: parseInt(decoratorKey, 10),

--- a/src/component/selection/__tests__/getDraftEditorSelection-test.js
+++ b/src/component/selection/__tests__/getDraftEditorSelection-test.js
@@ -13,17 +13,17 @@
 
 jest.autoMockOff();
 
-var CharacterMetadata = require('CharacterMetadata');
-var ContentBlock = require('ContentBlock');
-var ContentState = require('ContentState');
-var EditorState = require('EditorState');
-var Immutable = require('immutable');
-var SelectionState = require('SelectionState');
+const CharacterMetadata = require('CharacterMetadata');
+const ContentBlock = require('ContentBlock');
+const ContentState = require('ContentState');
+const EditorState = require('EditorState');
+const Immutable = require('immutable');
+const SelectionState = require('SelectionState');
 
-var {BOLD} = require('SampleDraftInlineStyle');
-var {EMPTY} = CharacterMetadata;
+const {BOLD} = require('SampleDraftInlineStyle');
+const {EMPTY} = CharacterMetadata;
 
-var getDraftEditorSelection = require('getDraftEditorSelection');
+const getDraftEditorSelection = require('getDraftEditorSelection');
 
 /**
  * Test possible selection states for the text editor. This is based on
@@ -34,14 +34,14 @@ var getDraftEditorSelection = require('getDraftEditorSelection');
  * Welcome to the jungle.
  */
 describe('getDraftEditorSelection', function() {
-  var editorState;
-  var root;
-  var contents;
-  var blocks;
-  var decorators;
-  var leafs;
-  var leafChildren;
-  var textNodes;
+  let editorState;
+  let root;
+  let contents;
+  let blocks;
+  let decorators;
+  let leafs;
+  let leafChildren;
+  let textNodes;
 
   beforeEach(function() {
     window.getSelection = jest.genMockFunction();
@@ -50,7 +50,7 @@ describe('getDraftEditorSelection', function() {
     contents.setAttribute('data-contents', 'true');
     root.appendChild(contents);
 
-    var text = [
+    const text = [
       'Washington',
       'Jefferson',
       'Lincoln',
@@ -59,28 +59,28 @@ describe('getDraftEditorSelection', function() {
       'Obama',
     ];
 
-    var textA = text[0] + text[1];
-    var textB = text[2] + text[3];
-    var textC = text[4] + text[5];
+    const textA = text[0] + text[1];
+    const textB = text[2] + text[3];
+    const textC = text[4] + text[5];
 
-    var boldChar = CharacterMetadata.create({style: BOLD});
-    var aChars = Immutable.List(
+    const boldChar = CharacterMetadata.create({style: BOLD});
+    const aChars = Immutable.List(
       Immutable.Repeat(EMPTY, text[0].length).concat(
         Immutable.Repeat(boldChar, text[1].length)
       )
     );
-    var bChars = Immutable.List(
+    const bChars = Immutable.List(
       Immutable.Repeat(EMPTY, text[2].length).concat(
         Immutable.Repeat(boldChar, text[3].length)
       )
     );
-    var cChars = Immutable.List(
+    const cChars = Immutable.List(
       Immutable.Repeat(EMPTY, text[4].length).concat(
         Immutable.Repeat(boldChar, text[5].length)
       )
     );
 
-    var contentBlocks = [
+    const contentBlocks = [
       new ContentBlock({
         key: 'a',
         type: 'unstyled',
@@ -101,7 +101,7 @@ describe('getDraftEditorSelection', function() {
       }),
     ];
 
-    var contentState = ContentState.createFromBlockArray(contentBlocks);
+    const contentState = ContentState.createFromBlockArray(contentBlocks);
     editorState = EditorState.createWithContent(contentState);
 
     textNodes = text
@@ -113,7 +113,7 @@ describe('getDraftEditorSelection', function() {
     leafChildren = textNodes
       .map(
         function(textNode) {
-          var span = document.createElement('span');
+          const span = document.createElement('span');
           span.appendChild(textNode);
           return span;
         }
@@ -121,7 +121,7 @@ describe('getDraftEditorSelection', function() {
     leafs = ['a-0-0', 'a-0-1', 'b-0-0', 'b-0-1', 'c-0-0', 'c-0-1']
       .map(
         function(blockKey, ii) {
-          var span = document.createElement('span');
+          const span = document.createElement('span');
           span.setAttribute('data-offset-key', '' + blockKey);
           span.appendChild(leafChildren[ii]);
           return span;
@@ -130,7 +130,7 @@ describe('getDraftEditorSelection', function() {
     decorators = ['a-0-0', 'b-0-0', 'c-0-0']
       .map(
         function(decoratorKey, ii) {
-          var span = document.createElement('span');
+          const span = document.createElement('span');
           span.setAttribute('data-offset-key', '' + decoratorKey);
           span.appendChild(leafs[(ii * 2)]);
           span.appendChild(leafs[(ii * 2) + 1]);
@@ -140,7 +140,7 @@ describe('getDraftEditorSelection', function() {
     blocks = ['a-0-0', 'b-0-0', 'c-0-0']
       .map(
         function(blockKey, ii) {
-          var blockElement = document.createElement('div');
+          const blockElement = document.createElement('div');
           blockElement.setAttribute('data-offset-key', '' + blockKey);
           blockElement.appendChild(decorators[ii]);
           return blockElement;
@@ -154,10 +154,10 @@ describe('getDraftEditorSelection', function() {
   });
 
   function assertEquals(result, assert) {
-    var resultSelection = result.selectionState;
-    var resultRecovery = result.needsRecovery;
-    var assertSelection = assert.selectionState;
-    var assertRecovery = assert.needsRecovery;
+    const resultSelection = result.selectionState;
+    const resultRecovery = result.needsRecovery;
+    const assertSelection = assert.selectionState;
+    const assertRecovery = assert.needsRecovery;
     expect(resultSelection.getAnchorKey())
       .toBe(assertSelection.getAnchorKey());
     expect(resultSelection.getAnchorOffset())
@@ -179,7 +179,7 @@ describe('getDraftEditorSelection', function() {
     describe('Selection is entirely within a single text node', function() {
 
       it('must find offsets when collapsed at start', function() {
-        var textNode = textNodes[0];
+        const textNode = textNodes[0];
         window.getSelection.mockReturnValueOnce({
           rangeCount: 1,
           anchorNode: textNode,
@@ -188,7 +188,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: 0,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -202,7 +202,7 @@ describe('getDraftEditorSelection', function() {
       });
 
       it('must find offsets when collapsed at end', function() {
-        var textNode = textNodes[0];
+        const textNode = textNodes[0];
         window.getSelection.mockReturnValueOnce({
           rangeCount: 1,
           anchorNode: textNode,
@@ -211,7 +211,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: textNode.length,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -225,7 +225,7 @@ describe('getDraftEditorSelection', function() {
       });
 
       it('must find offsets for non-collapsed selection', function() {
-        var textNode = textNodes[0];
+        const textNode = textNodes[0];
         window.getSelection.mockReturnValueOnce({
           rangeCount: 1,
           anchorNode: textNode,
@@ -234,7 +234,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: 6,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -248,7 +248,7 @@ describe('getDraftEditorSelection', function() {
       });
 
       it('must find offsets for reversed selection', function() {
-        var textNode = textNodes[0];
+        const textNode = textNodes[0];
         window.getSelection.mockReturnValueOnce({
           rangeCount: 1,
           anchorNode: textNode,
@@ -257,7 +257,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: 1,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -271,7 +271,7 @@ describe('getDraftEditorSelection', function() {
       });
 
       it('must find offsets for selection on entire text node', function() {
-        var textNode = textNodes[0];
+        const textNode = textNodes[0];
         window.getSelection.mockReturnValueOnce({
           rangeCount: 1,
           anchorNode: textNode,
@@ -280,7 +280,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: textNode.length,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -305,7 +305,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: 0,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -327,7 +327,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: textNodes[2].textContent.length,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -349,7 +349,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: 6,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -371,7 +371,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: 6,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'c',
@@ -396,7 +396,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: 0,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -410,7 +410,7 @@ describe('getDraftEditorSelection', function() {
       });
 
       it('starts at head of text node, ends at end of leaf child', function() {
-        var leaf = leafChildren[4];
+        const leaf = leafChildren[4];
         window.getSelection.mockReturnValueOnce({
           rangeCount: 1,
           anchorNode: textNodes[0],
@@ -419,7 +419,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: leaf.childNodes.length,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -434,7 +434,7 @@ describe('getDraftEditorSelection', function() {
 
 
       it('starts within text node, ends at start of leaf child', function() {
-        var leaf = leafChildren[4];
+        const leaf = leafChildren[4];
         window.getSelection.mockReturnValueOnce({
           rangeCount: 1,
           anchorNode: textNodes[0],
@@ -443,7 +443,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: 0,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -457,7 +457,7 @@ describe('getDraftEditorSelection', function() {
       });
 
       it('starts within text node, ends at end of leaf child', function() {
-        var leaf = leafChildren[4];
+        const leaf = leafChildren[4];
         window.getSelection.mockReturnValueOnce({
           rangeCount: 1,
           anchorNode: textNodes[0],
@@ -466,7 +466,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: leaf.childNodes.length,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -480,7 +480,7 @@ describe('getDraftEditorSelection', function() {
       });
 
       it('is a reversed text-to-leaf-child selection', function() {
-        var leaf = leafChildren[4];
+        const leaf = leafChildren[4];
         window.getSelection.mockReturnValueOnce({
           rangeCount: 1,
           anchorNode: leaf,
@@ -489,7 +489,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: 4,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'c',
@@ -513,7 +513,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: 0,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -527,7 +527,7 @@ describe('getDraftEditorSelection', function() {
       });
 
       it('starts at head of text node, ends at end of leaf span', function() {
-        var leaf = leafs[4];
+        const leaf = leafs[4];
         window.getSelection.mockReturnValueOnce({
           rangeCount: 1,
           anchorNode: textNodes[0],
@@ -536,7 +536,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: leaf.childNodes.length,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -551,7 +551,7 @@ describe('getDraftEditorSelection', function() {
 
 
       it('starts within text node, ends at start of leaf span', function() {
-        var leaf = leafs[4];
+        const leaf = leafs[4];
         window.getSelection.mockReturnValueOnce({
           rangeCount: 1,
           anchorNode: textNodes[0],
@@ -560,7 +560,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: 0,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -574,7 +574,7 @@ describe('getDraftEditorSelection', function() {
       });
 
       it('starts within text node, ends at end of leaf span', function() {
-        var leaf = leafs[4];
+        const leaf = leafs[4];
         window.getSelection.mockReturnValueOnce({
           rangeCount: 1,
           anchorNode: textNodes[0],
@@ -583,7 +583,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: leaf.childNodes.length,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -597,7 +597,7 @@ describe('getDraftEditorSelection', function() {
       });
 
       it('is a reversed text-to-leaf selection', function() {
-        var leaf = leafs[4];
+        const leaf = leafs[4];
         window.getSelection.mockReturnValueOnce({
           rangeCount: 1,
           anchorNode: leaf,
@@ -606,7 +606,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: 4,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'c',
@@ -622,7 +622,7 @@ describe('getDraftEditorSelection', function() {
 
     describe('A single leaf span is selected', function() {
       it('is collapsed at start', function() {
-        var leaf = leafs[0];
+        const leaf = leafs[0];
         window.getSelection.mockReturnValueOnce({
           rangeCount: 1,
           anchorNode: leaf,
@@ -631,7 +631,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: 0,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -645,7 +645,7 @@ describe('getDraftEditorSelection', function() {
       });
 
       it('is collapsed at end', function() {
-        var leaf = leafs[0];
+        const leaf = leafs[0];
         window.getSelection.mockReturnValueOnce({
           rangeCount: 1,
           anchorNode: leaf,
@@ -654,7 +654,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: leaf.childNodes.length,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -669,7 +669,7 @@ describe('getDraftEditorSelection', function() {
 
 
       it('contains an entire leaf', function() {
-        var leaf = leafs[4];
+        const leaf = leafs[4];
         window.getSelection.mockReturnValueOnce({
           rangeCount: 1,
           anchorNode: leaf,
@@ -678,7 +678,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: leaf.childNodes.length,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'c',
@@ -692,7 +692,7 @@ describe('getDraftEditorSelection', function() {
       });
 
       it('is reversed on entire leaf', function() {
-        var leaf = leafs[4];
+        const leaf = leafs[4];
         window.getSelection.mockReturnValueOnce({
           rangeCount: 1,
           anchorNode: leaf,
@@ -701,7 +701,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: 0,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'c',
@@ -725,7 +725,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: 0,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -747,7 +747,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: leafs[4].childNodes.length,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -770,7 +770,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: 0,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'c',
@@ -786,7 +786,7 @@ describe('getDraftEditorSelection', function() {
 
     describe('A single block is selected', function() {
       it('is collapsed at start', function() {
-        var block = blocks[0];
+        const block = blocks[0];
         window.getSelection.mockReturnValueOnce({
           rangeCount: 1,
           anchorNode: block,
@@ -795,7 +795,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: 0,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -809,9 +809,9 @@ describe('getDraftEditorSelection', function() {
       });
 
       it('is collapsed at end', function() {
-        var block = blocks[0];
-        var decorators = block.childNodes;
-        var leafs = decorators[0].childNodes;
+        const block = blocks[0];
+        const decorators = block.childNodes;
+        const leafs = decorators[0].childNodes;
         window.getSelection.mockReturnValueOnce({
           rangeCount: 1,
           anchorNode: block,
@@ -820,12 +820,12 @@ describe('getDraftEditorSelection', function() {
           focusOffset: decorators.length,
         });
 
-        var textLength = 0;
-        for (var ii = 0; ii < leafs.length; ii++) {
+        let textLength = 0;
+        for (let ii = 0; ii < leafs.length; ii++) {
           textLength += leafs[ii].textContent.length;
         }
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -839,9 +839,9 @@ describe('getDraftEditorSelection', function() {
       });
 
       it('is entirely selected', function() {
-        var block = blocks[0];
-        var decorators = block.childNodes;
-        var leafs = decorators[0].childNodes;
+        const block = blocks[0];
+        const decorators = block.childNodes;
+        const leafs = decorators[0].childNodes;
         window.getSelection.mockReturnValueOnce({
           rangeCount: 1,
           anchorNode: block,
@@ -850,12 +850,12 @@ describe('getDraftEditorSelection', function() {
           focusOffset: decorators.length,
         });
 
-        var textLength = 0;
-        for (var ii = 0; ii < leafs.length; ii++) {
+        let textLength = 0;
+        for (let ii = 0; ii < leafs.length; ii++) {
           textLength += leafs[ii].textContent.length;
         }
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -876,8 +876,8 @@ describe('getDraftEditorSelection', function() {
      */
     describe('Selection with text node and block', function() {
       it('begins at text node zero, ends at end of block', function() {
-        var textNode = textNodes[0];
-        var block = blocks[0];
+        const textNode = textNodes[0];
+        const block = blocks[0];
         window.getSelection.mockReturnValueOnce({
           rangeCount: 1,
           anchorNode: textNode,
@@ -886,7 +886,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: block.childNodes.length,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -901,8 +901,8 @@ describe('getDraftEditorSelection', function() {
 
       // No idea if this is possible.
       it('begins within text node, ends at end of block', function() {
-        var textNode = textNodes[0];
-        var block = blocks[0];
+        const textNode = textNodes[0];
+        const block = blocks[0];
         window.getSelection.mockReturnValueOnce({
           rangeCount: 1,
           anchorNode: textNode,
@@ -911,7 +911,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: block.childNodes.length,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -926,8 +926,8 @@ describe('getDraftEditorSelection', function() {
 
       // No idea if this is possible.
       it('is reversed from the first case', function() {
-        var textNode = textNodes[0];
-        var block = blocks[0];
+        const textNode = textNodes[0];
+        const block = blocks[0];
         window.getSelection.mockReturnValueOnce({
           rangeCount: 1,
           anchorNode: block,
@@ -936,7 +936,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: 0,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -960,7 +960,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: blocks[2].childNodes.length,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -982,7 +982,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: 0,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -1004,7 +1004,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: blocks[2].childNodes.length,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -1026,7 +1026,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: 1,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -1048,7 +1048,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: 1,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'c',
@@ -1072,7 +1072,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: 0,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -1094,7 +1094,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: 1,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -1116,7 +1116,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: 1,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -1138,7 +1138,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: 3,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -1165,7 +1165,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: 0,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -1187,7 +1187,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: root.childNodes.length,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'c',
@@ -1209,7 +1209,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: root.childNodes.length,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',
@@ -1231,7 +1231,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: 0,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'c',
@@ -1260,7 +1260,7 @@ describe('getDraftEditorSelection', function() {
           focusOffset: root.childNodes.length,
         });
 
-        var selection = getDraftEditorSelection(editorState, root);
+        const selection = getDraftEditorSelection(editorState, root);
         assertEquals(selection, {
           selectionState: new SelectionState({
             anchorKey: 'a',

--- a/src/component/selection/expandRangeToStartOfLine.js
+++ b/src/component/selection/expandRangeToStartOfLine.js
@@ -11,17 +11,17 @@
  * @flow
  */
 
-var UnicodeUtils = require('UnicodeUtils');
+const UnicodeUtils = require('UnicodeUtils');
 
-var getRangeClientRects = require('getRangeClientRects');
-var invariant = require('invariant');
+const getRangeClientRects = require('getRangeClientRects');
+const invariant = require('invariant');
 
 /**
  * Return the computed line height, in pixels, for the provided element.
  */
 function getLineHeightPx(element: Element): number {
-  var computed = getComputedStyle(element);
-  var div = document.createElement('div');
+  const computed = getComputedStyle(element);
+  const div = document.createElement('div');
   div.style.fontFamily = computed.fontFamily;
   div.style.fontSize = computed.fontSize;
   div.style.fontStyle = computed.fontStyle;
@@ -32,7 +32,7 @@ function getLineHeightPx(element: Element): number {
 
   // forced layout here
   document.body.appendChild(div);
-  var rect = div.getBoundingClientRect();
+  const rect = div.getBoundingClientRect();
   document.body.removeChild(div);
 
   return rect.height;
@@ -54,13 +54,13 @@ function areRectsOnOneLine(
   rects: Array<ClientRect>,
   lineHeight: number
 ): boolean {
-  var minTop = Infinity;
-  var minBottom = Infinity;
-  var maxTop = -Infinity;
-  var maxBottom = -Infinity;
+  let minTop = Infinity;
+  let minBottom = Infinity;
+  let maxTop = -Infinity;
+  let maxBottom = -Infinity;
 
-  for (var ii = 0; ii < rects.length; ii++) {
-    var rect = rects[ii];
+  for (let ii = 0; ii < rects.length; ii++) {
+    const rect = rects[ii];
     if (rect.width === 0 || rect.width === 1) {
       // When a range starts or ends a soft wrap, many browsers (Chrome, IE,
       // Safari) include an empty rect on the previous or next line. When the
@@ -111,11 +111,11 @@ function expandRangeToStartOfLine(range: Range): Range {
   );
   range = range.cloneRange();
 
-  var containingElement = range.startContainer;
+  let containingElement = range.startContainer;
   if (containingElement.nodeType !== 1) {
     containingElement = containingElement.parentNode;
   }
-  var lineHeight = getLineHeightPx((containingElement: any));
+  const lineHeight = getLineHeightPx((containingElement: any));
 
   // Imagine our text looks like:
   //   <div><span>once upon a time, there was a <em>boy
@@ -128,8 +128,8 @@ function expandRangeToStartOfLine(range: Range): Range {
   // the break point is inside the span, then inside the <em>, then in its text
   // node child, the actual break point before "who".
 
-  var bestContainer = range.endContainer;
-  var bestOffset = range.endOffset;
+  let bestContainer = range.endContainer;
+  let bestOffset = range.endOffset;
   range.setStart(range.startContainer, 0);
 
   while (areRectsOnOneLine(getRangeClientRects(range), lineHeight)) {
@@ -156,13 +156,14 @@ function expandRangeToStartOfLine(range: Range): Range {
 
   // At all times, (bestContainer, bestOffset) is the latest single-line start
   // point that we know of.
-  var currentContainer = bestContainer;
-  var maxIndexToConsider = bestOffset - 1;
+  let currentContainer = bestContainer;
+  let maxIndexToConsider = bestOffset - 1;
 
   do {
-    var nodeValue = currentContainer.nodeValue;
+    let ii;
+    const nodeValue = currentContainer.nodeValue;
 
-    for (var ii = maxIndexToConsider; ii >= 0; ii--) {
+    for (ii = maxIndexToConsider; ii >= 0; ii--) {
       if (nodeValue != null && ii > 0 &&
           UnicodeUtils.isSurrogatePair(nodeValue, ii - 1)) {
         // We're in the middle of a surrogate pair -- skip over so we never

--- a/src/component/selection/findAncestorOffsetKey.js
+++ b/src/component/selection/findAncestorOffsetKey.js
@@ -13,14 +13,14 @@
 
 'use strict';
 
-var getSelectionOffsetKeyForNode = require('getSelectionOffsetKeyForNode');
+const getSelectionOffsetKeyForNode = require('getSelectionOffsetKeyForNode');
 
 /**
  * Get the key from the node's nearest offset-aware ancestor.
  */
 function findAncestorOffsetKey(node: Node): ?string {
   while (node && node !== document.documentElement) {
-    var key = getSelectionOffsetKeyForNode(node);
+    const key = getSelectionOffsetKeyForNode(node);
     if (key != null) {
       return key;
     }

--- a/src/component/selection/getDraftEditorSelection.js
+++ b/src/component/selection/getDraftEditorSelection.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-var getDraftEditorSelectionWithNodes = require('getDraftEditorSelectionWithNodes');
+const getDraftEditorSelectionWithNodes = require('getDraftEditorSelectionWithNodes');
 
 import type {DOMDerivedSelection} from 'DOMDerivedSelection';
 import type EditorState from 'EditorState';
@@ -26,7 +26,7 @@ function getDraftEditorSelection(
   editorState: EditorState,
   root: HTMLElement
 ): DOMDerivedSelection {
-  var selection = global.getSelection();
+  const selection = global.getSelection();
 
   // No active selection.
   if (selection.rangeCount === 0) {

--- a/src/component/selection/getDraftEditorSelectionWithNodes.js
+++ b/src/component/selection/getDraftEditorSelectionWithNodes.js
@@ -13,11 +13,11 @@
 
 'use strict';
 
-var findAncestorOffsetKey = require('findAncestorOffsetKey');
-var getSelectionOffsetKeyForNode = require('getSelectionOffsetKeyForNode');
-var getUpdatedSelectionState = require('getUpdatedSelectionState');
-var invariant = require('invariant');
-var nullthrows = require('nullthrows');
+const findAncestorOffsetKey = require('findAncestorOffsetKey');
+const getSelectionOffsetKeyForNode = require('getSelectionOffsetKeyForNode');
+const getUpdatedSelectionState = require('getUpdatedSelectionState');
+const invariant = require('invariant');
+const nullthrows = require('nullthrows');
 
 import type {DOMDerivedSelection} from 'DOMDerivedSelection';
 import type EditorState from 'EditorState';
@@ -39,8 +39,8 @@ function getDraftEditorSelectionWithNodes(
   focusNode: Node,
   focusOffset: number
 ): DOMDerivedSelection {
-  var anchorIsTextNode = anchorNode.nodeType === Node.TEXT_NODE;
-  var focusIsTextNode = focusNode.nodeType === Node.TEXT_NODE;
+  const anchorIsTextNode = anchorNode.nodeType === Node.TEXT_NODE;
+  const focusIsTextNode = focusNode.nodeType === Node.TEXT_NODE;
 
   // If the selection range lies only on text nodes, the task is simple.
   // Find the nearest offset-aware elements and use the
@@ -58,9 +58,9 @@ function getDraftEditorSelectionWithNodes(
     };
   }
 
-  var anchorPoint = null;
-  var focusPoint = null;
-  var needsRecovery = true;
+  let anchorPoint = null;
+  let focusPoint = null;
+  let needsRecovery = true;
 
   // An element is selected. Convert this selection range into leaf offset
   // keys and offset values for consumption at the component level. This
@@ -142,7 +142,7 @@ function getPointForNonTextNode(
   node: Node,
   childOffset: number
 ): SelectionPoint {
-  var offsetKey: ?string = findAncestorOffsetKey(node);
+  const offsetKey: ?string = findAncestorOffsetKey(node);
 
   invariant(
     offsetKey != null ||
@@ -168,19 +168,19 @@ function getPointForNonTextNode(
   // find the leftmost ("first") leaf in the tree and use that as the offset
   // key.
   if (childOffset === 0) {
-    var key: ?string = null;
+    let key: ?string = null;
     if (offsetKey != null) {
       key = offsetKey;
     } else {
-      var firstLeaf = getFirstLeaf(node);
+      const firstLeaf = getFirstLeaf(node);
       key = nullthrows(getSelectionOffsetKeyForNode(firstLeaf));
     }
     return {key, offset: 0};
   }
 
-  var nodeBeforeCursor = node.childNodes[childOffset - 1];
-  var leafKey: ?string = null;
-  var textLength: ?number = null;
+  const nodeBeforeCursor = node.childNodes[childOffset - 1];
+  let leafKey: ?string = null;
+  let textLength: ?number = null;
 
   if (!getSelectionOffsetKeyForNode(nodeBeforeCursor)) {
     // Our target node may be a leaf or a text node, in which case we're
@@ -191,7 +191,7 @@ function getPointForNonTextNode(
   } else {
     // Otherwise, we'll look at the child to the left of the cursor and find
     // the last leaf node in its subtree.
-    var lastLeaf = getLastLeaf(nodeBeforeCursor);
+    const lastLeaf = getLastLeaf(nodeBeforeCursor);
     leafKey = nullthrows(getSelectionOffsetKeyForNode(lastLeaf));
     textLength = getTextContentLength(lastLeaf);
   }
@@ -209,7 +209,7 @@ function getPointForNonTextNode(
  * render newlines instead of break tags.
  */
 function getTextContentLength(node: Node): number {
-  var textContent = node.textContent;
+  const textContent = node.textContent;
   return textContent === '\n' ? 0 : textContent.length;
 }
 

--- a/src/component/selection/getRangeBoundingClientRect.js
+++ b/src/component/selection/getRangeBoundingClientRect.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-var getRangeClientRects = require('getRangeClientRects');
+const getRangeClientRects = require('getRangeClientRects');
 
 /**
  * Like range.getBoundingClientRect() but normalizes for browser bugs.
@@ -23,16 +23,16 @@ function getRangeBoundingClientRect(range: Range): ClientRect {
   // the first rectangle in list and all of the remaining rectangles of which
   // the height or width is not zero."
   // http://www.w3.org/TR/cssom-view/#dom-range-getboundingclientrect
-  var rects = getRangeClientRects(range);
-  var top = 0;
-  var right = 0;
-  var bottom = 0;
-  var left = 0;
+  const rects = getRangeClientRects(range);
+  let top = 0;
+  let right = 0;
+  let bottom = 0;
+  let left = 0;
 
   if (rects.length) {
     ({top, right, bottom, left} = rects[0]);
-    for (var ii = 1; ii < rects.length; ii++) {
-      var rect = rects[ii];
+    for (let ii = 1; ii < rects.length; ii++) {
+      const rect = rects[ii];
       if (rect.height !== 0 || rect.width !== 0) {
         top = Math.min(top, rect.top);
         right = Math.max(right, rect.right);

--- a/src/component/selection/getRangeClientRects.js
+++ b/src/component/selection/getRangeClientRects.js
@@ -13,11 +13,11 @@
 
 'use strict';
 
-var UserAgent = require('UserAgent');
+const UserAgent = require('UserAgent');
 
-var invariant = require('invariant');
+const invariant = require('invariant');
 
-var isChrome = UserAgent.isBrowser('Chrome');
+const isChrome = UserAgent.isBrowser('Chrome');
 
 // In Chrome, the client rects will include the entire bounds of all nodes that
 // begin (have a start tag) within the selection, even if the selection does
@@ -25,23 +25,23 @@ var isChrome = UserAgent.isBrowser('Chrome');
 // start tag and join the client rects together.
 // https://code.google.com/p/chromium/issues/detail?id=324437
 function getRangeClientRectsChrome(range: Range): Array<ClientRect> {
-  var tempRange = range.cloneRange();
-  var clientRects = [];
+  const tempRange = range.cloneRange();
+  const clientRects = [];
 
   for (
-    var ancestor = range.endContainer;
+    let ancestor = range.endContainer;
     ancestor != null;
     ancestor = ancestor.parentNode
   ) {
     // If we've climbed up to the common ancestor, we can now use the
     // original start point and stop climbing the tree.
-    var atCommonAncestor = ancestor === range.commonAncestorContainer;
+    const atCommonAncestor = ancestor === range.commonAncestorContainer;
     if (atCommonAncestor) {
       tempRange.setStart(range.startContainer, range.startOffset);
     } else {
       tempRange.setStart(tempRange.endContainer, 0);
     }
-    var rects = Array.from(tempRange.getClientRects());
+    const rects = Array.from(tempRange.getClientRects());
     clientRects.push(rects);
     if (atCommonAncestor) {
       clientRects.reverse();
@@ -59,7 +59,7 @@ function getRangeClientRectsChrome(range: Range): Array<ClientRect> {
 /**
  * Like range.getClientRects() but normalizes for browser bugs.
  */
-var getRangeClientRects = isChrome ?
+const getRangeClientRects = isChrome ?
   getRangeClientRectsChrome :
   function(range: Range): Array<ClientRect> {
     return Array.from(range.getClientRects());

--- a/src/component/selection/getUpdatedSelectionState.js
+++ b/src/component/selection/getUpdatedSelectionState.js
@@ -12,9 +12,9 @@
 
 'use strict';
 
-var DraftOffsetKey = require('DraftOffsetKey');
+const DraftOffsetKey = require('DraftOffsetKey');
 
-var nullthrows = require('nullthrows');
+const nullthrows = require('nullthrows');
 
 import type EditorState from 'EditorState';
 import type SelectionState from 'SelectionState';
@@ -26,7 +26,7 @@ function getUpdatedSelectionState(
   focusKey: string,
   focusOffset: number
 ): SelectionState {
-  var selection: SelectionState = nullthrows(editorState.getSelection());
+  const selection: SelectionState = nullthrows(editorState.getSelection());
   if (__DEV__) {
     if (!anchorKey || !focusKey) {
       /*eslint-disable no-console */
@@ -41,9 +41,9 @@ function getUpdatedSelectionState(
     }
   }
 
-  var anchorPath = DraftOffsetKey.decode(anchorKey);
-  var anchorBlockKey = anchorPath.blockKey;
-  var anchorLeaf = editorState
+  const anchorPath = DraftOffsetKey.decode(anchorKey);
+  const anchorBlockKey = anchorPath.blockKey;
+  const anchorLeaf = editorState
     .getBlockTree(anchorBlockKey)
     .getIn([
       anchorPath.decoratorKey,
@@ -51,9 +51,9 @@ function getUpdatedSelectionState(
       anchorPath.leafKey,
     ]);
 
-  var focusPath = DraftOffsetKey.decode(focusKey);
-  var focusBlockKey = focusPath.blockKey;
-  var focusLeaf = editorState
+  const focusPath = DraftOffsetKey.decode(focusKey);
+  const focusBlockKey = focusPath.blockKey;
+  const focusLeaf = editorState
     .getBlockTree(focusBlockKey)
     .getIn([
       focusPath.decoratorKey,
@@ -61,13 +61,13 @@ function getUpdatedSelectionState(
       focusPath.leafKey,
     ]);
 
-  var anchorLeafStart: number = anchorLeaf.get('start');
-  var focusLeafStart: number = focusLeaf.get('start');
+  const anchorLeafStart: number = anchorLeaf.get('start');
+  const focusLeafStart: number = focusLeaf.get('start');
 
-  var anchorBlockOffset = anchorLeaf ? anchorLeafStart + anchorOffset : null;
-  var focusBlockOffset = focusLeaf ? focusLeafStart + focusOffset : null;
+  const anchorBlockOffset = anchorLeaf ? anchorLeafStart + anchorOffset : null;
+  const focusBlockOffset = focusLeaf ? focusLeafStart + focusOffset : null;
 
-  var areEqual = (
+  const areEqual = (
     selection.getAnchorKey() === anchorBlockKey &&
     selection.getAnchorOffset() === anchorBlockOffset &&
     selection.getFocusKey() === focusBlockKey &&
@@ -78,10 +78,10 @@ function getUpdatedSelectionState(
     return selection;
   }
 
-  var isBackward = false;
+  let isBackward = false;
   if (anchorBlockKey === focusBlockKey) {
-    var anchorLeafEnd: number = anchorLeaf.get('end');
-    var focusLeafEnd: number = focusLeaf.get('end');
+    const anchorLeafEnd: number = anchorLeaf.get('end');
+    const focusLeafEnd: number = focusLeaf.get('end');
     if (
       focusLeafStart === anchorLeafStart &&
       focusLeafEnd === anchorLeafEnd
@@ -91,7 +91,7 @@ function getUpdatedSelectionState(
       isBackward = focusLeafStart < anchorLeafStart;
     }
   } else {
-    var startKey = editorState
+    const startKey = editorState
       .getCurrentContent()
       .getBlockMap()
       .keySeq()

--- a/src/component/selection/isSelectionAtLeafStart.js
+++ b/src/component/selection/isSelectionAtLeafStart.js
@@ -16,12 +16,12 @@
 import type EditorState from 'EditorState';
 
 function isSelectionAtLeafStart(editorState: EditorState): boolean {
-  var selection = editorState.getSelection();
-  var anchorKey = selection.getAnchorKey();
-  var blockTree = editorState.getBlockTree(anchorKey);
-  var offset = selection.getStartOffset();
+  const selection = editorState.getSelection();
+  const anchorKey = selection.getAnchorKey();
+  const blockTree = editorState.getBlockTree(anchorKey);
+  const offset = selection.getStartOffset();
 
-  var isAtStart = false;
+  let isAtStart = false;
 
   blockTree.some(leafSet => {
     if (offset === leafSet.get('start')) {
@@ -31,7 +31,7 @@ function isSelectionAtLeafStart(editorState: EditorState): boolean {
 
     if (offset < leafSet.get('end')) {
       return leafSet.get('leaves').some(leaf => {
-        var leafStart = leaf.get('start');
+        const leafStart = leaf.get('start');
         if (offset === leafStart) {
           isAtStart = true;
           return true;

--- a/src/component/selection/setDraftEditorSelection.js
+++ b/src/component/selection/setDraftEditorSelection.js
@@ -13,8 +13,8 @@
 
 'use strict';
 
-var containsNode = require('containsNode');
-var getActiveElement = require('getActiveElement');
+const containsNode = require('containsNode');
+const getActiveElement = require('getActiveElement');
 
 import type SelectionState from 'SelectionState';
 
@@ -41,17 +41,17 @@ function setDraftEditorSelection(
     return;
   }
 
-  var selection = global.getSelection();
-  var anchorKey = selectionState.getAnchorKey();
-  var anchorOffset = selectionState.getAnchorOffset();
-  var focusKey = selectionState.getFocusKey();
-  var focusOffset = selectionState.getFocusOffset();
-  var isBackward = selectionState.getIsBackward();
+  const selection = global.getSelection();
+  let anchorKey = selectionState.getAnchorKey();
+  let anchorOffset = selectionState.getAnchorOffset();
+  let focusKey = selectionState.getFocusKey();
+  let focusOffset = selectionState.getFocusOffset();
+  let isBackward = selectionState.getIsBackward();
 
   // IE doesn't support backward selection. Swap key/offset pairs.
   if (!selection.extend && isBackward) {
-    var tempKey = anchorKey;
-    var tempOffset = anchorOffset;
+    const tempKey = anchorKey;
+    const tempOffset = anchorOffset;
     anchorKey = focusKey;
     anchorOffset = focusOffset;
     focusKey = tempKey;
@@ -59,13 +59,13 @@ function setDraftEditorSelection(
     isBackward = false;
   }
 
-  var hasAnchor = (
+  const hasAnchor = (
     anchorKey === blockKey &&
     nodeStart <= anchorOffset &&
     nodeEnd >= anchorOffset
   );
 
-  var hasFocus = (
+  const hasFocus = (
     focusKey === blockKey &&
     nodeStart <= focusOffset &&
     nodeEnd >= focusOffset
@@ -107,8 +107,8 @@ function setDraftEditorSelection(
     // We keep track of it, reset the selection range, and extend it
     // back to the focus point.
     if (hasAnchor) {
-      var storedFocusNode = selection.focusNode;
-      var storedFocusOffset = selection.focusOffset;
+      const storedFocusNode = selection.focusNode;
+      const storedFocusOffset = selection.focusOffset;
 
       selection.removeAllRanges();
       addPointToSelection(selection, node, anchorOffset - nodeStart);
@@ -138,7 +138,7 @@ function addFocusToSelection(
     // Additionally, clone the selection range. IE11 throws an
     // InvalidStateError when attempting to access selection properties
     // after the range is detached.
-    var range = selection.getRangeAt(0);
+    const range = selection.getRangeAt(0);
     range.setEnd(node, offset);
     selection.addRange(range.cloneRange());
   }
@@ -149,7 +149,7 @@ function addPointToSelection(
   node: Node,
   offset: number
 ): void {
-  var range = document.createRange();
+  const range = document.createRange();
   range.setStart(node, offset);
   selection.addRange(range);
 }

--- a/src/component/utils/KeyBindingUtil.js
+++ b/src/component/utils/KeyBindingUtil.js
@@ -13,11 +13,11 @@
 
 'use strict';
 
-var UserAgent = require('UserAgent');
+const UserAgent = require('UserAgent');
 
-var isOSX = UserAgent.isPlatform('Mac OS X');
+const isOSX = UserAgent.isPlatform('Mac OS X');
 
-var KeyBindingUtil = {
+const KeyBindingUtil = {
   /**
    * Check whether the ctrlKey modifier is *not* being used in conjunction with
    * the altKey modifier. If they are combined, the result is an `altGraph`

--- a/src/component/utils/getDefaultKeyBinding.js
+++ b/src/component/utils/getDefaultKeyBinding.js
@@ -13,21 +13,21 @@
 
 'use strict';
 
-var KeyBindingUtil = require('KeyBindingUtil');
-var Keys = require('Keys');
-var UserAgent = require('UserAgent');
+const KeyBindingUtil = require('KeyBindingUtil');
+const Keys = require('Keys');
+const UserAgent = require('UserAgent');
 
 import type {DraftEditorCommand} from 'DraftEditorCommand';
 
-var isOSX = UserAgent.isPlatform('Mac OS X');
-var isWindows = UserAgent.isPlatform('Windows');
+const isOSX = UserAgent.isPlatform('Mac OS X');
+const isWindows = UserAgent.isPlatform('Windows');
 
 // Firefox on OSX had a bug resulting in navigation instead of cursor movement.
 // This bug was fixed in Firefox 29. Feature detection is virtually impossible
 // so we just check the version number. See #342765.
-var shouldFixFirefoxMovement = isOSX && UserAgent.isBrowser('Firefox < 29');
+const shouldFixFirefoxMovement = isOSX && UserAgent.isBrowser('Firefox < 29');
 
-var {
+const {
   hasCommandModifier,
   isCtrlKeyCommand,
 } = KeyBindingUtil;

--- a/src/component/utils/getTextContentFromFiles.js
+++ b/src/component/utils/getTextContentFromFiles.js
@@ -12,16 +12,16 @@
 
 'use strict';
 
-var TEXT_CLIPPING_REGEX = /\.textClipping$/;
+const TEXT_CLIPPING_REGEX = /\.textClipping$/;
 
-var TEXT_TYPES = {
+const TEXT_TYPES = {
   'text/plain': true,
   'text/html': true,
   'text/rtf': true,
 };
 
 // Somewhat arbitrary upper bound on text size. Let's not lock up the browser.
-var TEXT_SIZE_UPPER_BOUND = 5000;
+const TEXT_SIZE_UPPER_BOUND = 5000;
 
 /**
  * Extract the text content from a file list.
@@ -30,8 +30,8 @@ function getTextContentFromFiles(
   files: Array<File>,
   callback: (contents: string) => void
 ): void {
-  var readCount = 0;
-  var results = [];
+  let readCount = 0;
+  const results = [];
   files.forEach(function(/*blob*/ file) {
     readFile(file, function(/*string*/ text) {
       readCount++;
@@ -56,7 +56,7 @@ function readFile(
   }
 
   if (file.type === '') {
-    var contents = '';
+    let contents = '';
     // Special-case text clippings, which have an empty type but include
     // `.textClipping` in the file name. `readAsText` results in an empty
     // string for text clippings, so we force the file name to serve
@@ -68,7 +68,7 @@ function readFile(
     return;
   }
 
-  var reader = new FileReader();
+  const reader = new FileReader();
   reader.onload = function() {
     callback(reader.result);
   };

--- a/src/component/utils/isSoftNewlineEvent.js
+++ b/src/component/utils/isSoftNewlineEvent.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-var Keys = require('Keys');
+const Keys = require('Keys');
 
 function isSoftNewlineEvent(e: SyntheticKeyboardEvent): boolean {
   return e.which === Keys.RETURN && (

--- a/src/component/utils/splitTextIntoTextBlocks.js
+++ b/src/component/utils/splitTextIntoTextBlocks.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var NEWLINE_REGEX = /\r\n?|\n/g;
+const NEWLINE_REGEX = /\r\n?|\n/g;
 
 function splitTextIntoTextBlocks(text: string): Array<string> {
   return text.split(NEWLINE_REGEX);

--- a/src/model/decorators/CompositeDraftDecorator.js
+++ b/src/model/decorators/CompositeDraftDecorator.js
@@ -13,14 +13,14 @@
 
 'use strict';
 
-var Immutable = require('immutable');
+const Immutable = require('immutable');
 
 import type ContentBlock from 'ContentBlock';
 import type {DraftDecorator} from 'DraftDecorator';
 
-var {List} = Immutable;
+const {List} = Immutable;
 
-var DELIMITER = '.';
+const DELIMITER = '.';
 
 /**
  * A CompositeDraftDecorator traverses through a list of DraftDecorator
@@ -52,12 +52,12 @@ class CompositeDraftDecorator {
   }
 
   getDecorations(block: ContentBlock): List<?string> {
-    var decorations = Array(block.getText().length).fill(null);
+    const decorations = Array(block.getText().length).fill(null);
 
     this._decorators.forEach(
       (/*object*/ decorator, /*number*/ ii) => {
-        var counter = 0;
-        var strategy = decorator.strategy;
+        let counter = 0;
+        const strategy = decorator.strategy;
         strategy(block, (/*number*/ start, /*number*/ end) => {
           // Find out if any of our matching range is already occupied
           // by another decorator. If so, discard the match. Otherwise, store
@@ -74,12 +74,12 @@ class CompositeDraftDecorator {
   }
 
   getComponentForKey(key: string): Function {
-    var componentKey = parseInt(key.split(DELIMITER)[0], 10);
+    const componentKey = parseInt(key.split(DELIMITER)[0], 10);
     return this._decorators[componentKey].component;
   }
 
   getPropsForKey(key: string): ?Object {
-    var componentKey = parseInt(key.split(DELIMITER)[0], 10);
+    const componentKey = parseInt(key.split(DELIMITER)[0], 10);
     return this._decorators[componentKey].props;
   }
 }
@@ -93,7 +93,7 @@ function canOccupySlice(
   start: number,
   end: number
 ): boolean {
-  for (var ii = start; ii < end; ii++) {
+  for (let ii = start; ii < end; ii++) {
     if (decorations[ii] != null) {
       return false;
     }
@@ -111,7 +111,7 @@ function occupySlice(
   end: number,
   componentKey: string
 ): void {
-  for (var ii = start; ii < end; ii++) {
+  for (let ii = start; ii < end; ii++) {
     targetArr[ii] = componentKey;
   }
 }

--- a/src/model/decorators/__tests__/CompositeDraftDecorator-test.js
+++ b/src/model/decorators/__tests__/CompositeDraftDecorator-test.js
@@ -12,7 +12,7 @@
 
 jest.dontMock('CompositeDraftDecorator');
 
-var CompositeDraftDecorator = require('CompositeDraftDecorator');
+const CompositeDraftDecorator = require('CompositeDraftDecorator');
 
 describe('CompositeDraftDecorator', () => {
   class ContentBlock {
@@ -26,7 +26,7 @@ describe('CompositeDraftDecorator', () => {
 
   function searchWith(regex) {
     return function(block, callback) {
-      var text = block.getText();
+      const text = block.getText();
       text.replace(
         regex,
         function(/*string*/ match, /*number*/ offset) {
@@ -36,31 +36,31 @@ describe('CompositeDraftDecorator', () => {
     };
   }
 
-  var FooSpan = jest.genMockFn();
-  var FooDecorator = {
+  const FooSpan = jest.genMockFn();
+  const FooDecorator = {
     strategy: searchWith(/foo/gi),
     component: FooSpan,
   };
 
-  var BarSpan = jest.genMockFn();
-  var BarDecorator = {
+  const BarSpan = jest.genMockFn();
+  const BarDecorator = {
     strategy: searchWith(/bar/gi),
     component: BarSpan,
   };
 
-  var BartSpan = jest.genMockFn();
-  var BartDecorator = {
+  const BartSpan = jest.genMockFn();
+  const BartDecorator = {
     strategy: searchWith(/bart/gi),
     component: BartSpan,
   };
 
   function getCompositeDecorator() {
-    var decorators = [FooDecorator, BarDecorator];
+    const decorators = [FooDecorator, BarDecorator];
     return new CompositeDraftDecorator(decorators);
   }
 
   function isOccupied(arr) {
-    for (var ii = 0; ii < arr.length; ii++) {
+    for (let ii = 0; ii < arr.length; ii++) {
       if (arr[ii] == null) {
         return false;
       }
@@ -69,7 +69,7 @@ describe('CompositeDraftDecorator', () => {
   }
 
   function isEntirelyNull(arr) {
-    for (var ii = 0; ii < arr.length; ii++) {
+    for (let ii = 0; ii < arr.length; ii++) {
       if (arr[ii] != null) {
         return false;
       }
@@ -78,19 +78,19 @@ describe('CompositeDraftDecorator', () => {
   }
 
   it('must behave correctly if there are no matches', () => {
-    var composite = getCompositeDecorator();
-    var text = 'take a sad song and make it better';
-    var content = new ContentBlock(text);
-    var decorations = composite.getDecorations(content).toArray();
+    const composite = getCompositeDecorator();
+    const text = 'take a sad song and make it better';
+    const content = new ContentBlock(text);
+    const decorations = composite.getDecorations(content).toArray();
     expect(decorations.length).toBe(text.length);
     expect(decorations).toEqual(Array(text.length).fill(null));
   });
 
   it('must find decoration matches', () => {
-    var composite = getCompositeDecorator();
-    var text = 'a footballing fool';
-    var content = new ContentBlock(text);
-    var decorations = composite.getDecorations(content).toArray();
+    const composite = getCompositeDecorator();
+    const text = 'a footballing fool';
+    const content = new ContentBlock(text);
+    const decorations = composite.getDecorations(content).toArray();
     expect(decorations.length).toBe(text.length);
 
     expect(isOccupied(decorations.slice(2, 5))).toBe(true);
@@ -105,10 +105,10 @@ describe('CompositeDraftDecorator', () => {
   });
 
   it('must find matches for multiple decorators', () => {
-    var composite = getCompositeDecorator();
-    var text = 'a foosball bar';
-    var content = new ContentBlock(text);
-    var decorations = composite.getDecorations(content).toArray();
+    const composite = getCompositeDecorator();
+    const text = 'a foosball bar';
+    const content = new ContentBlock(text);
+    const decorations = composite.getDecorations(content).toArray();
 
     // Match the "Foo" decorator.
     expect(isOccupied(decorations.slice(2, 5))).toBe(true);
@@ -126,10 +126,10 @@ describe('CompositeDraftDecorator', () => {
   // Reverse the order of the matches from above. "foo" comes after "bar" in
   // the document text.
   it('must find matches regardless of text location', () => {
-    var composite = getCompositeDecorator();
-    var text = 'some bar food';
-    var content = new ContentBlock(text);
-    var decorations = composite.getDecorations(content).toArray();
+    const composite = getCompositeDecorator();
+    const text = 'some bar food';
+    const content = new ContentBlock(text);
+    const decorations = composite.getDecorations(content).toArray();
 
     // Match the "Foo" decorator.
     expect(isOccupied(decorations.slice(9, 12))).toBe(true);
@@ -143,12 +143,12 @@ describe('CompositeDraftDecorator', () => {
   });
 
   it('must throw out overlaps with existing decorations', () => {
-    var decorators = [BartDecorator, BarDecorator];
-    var composite = new CompositeDraftDecorator(decorators);
+    const decorators = [BartDecorator, BarDecorator];
+    const composite = new CompositeDraftDecorator(decorators);
 
-    var text = 'bart has a bar';
-    var content = new ContentBlock(text);
-    var decorations = composite.getDecorations(content).toArray();
+    const text = 'bart has a bar';
+    const content = new ContentBlock(text);
+    const decorations = composite.getDecorations(content).toArray();
 
     // Even though "bart" matches our "bar" strategy, "bart" comes first
     // in our decoration order and will claim those letters first.
@@ -167,12 +167,12 @@ describe('CompositeDraftDecorator', () => {
 
   // Swap the order of "bar" and "bart".
   it('must throw out matches if earlier match is shorter', () => {
-    var decorators = [BarDecorator, BartDecorator];
-    var composite = new CompositeDraftDecorator(decorators);
+    const decorators = [BarDecorator, BartDecorator];
+    const composite = new CompositeDraftDecorator(decorators);
 
-    var text = 'bart has a bar';
-    var content = new ContentBlock(text);
-    var decorations = composite.getDecorations(content).toArray();
+    const text = 'bart has a bar';
+    const content = new ContentBlock(text);
+    const decorations = composite.getDecorations(content).toArray();
 
     // "bar" comes first and claims two strings.
     expect(isOccupied(decorations.slice(0, 3))).toBe(true);
@@ -189,12 +189,12 @@ describe('CompositeDraftDecorator', () => {
   });
 
   it('must separate adjacent ranges that have the same decorator', () => {
-    var decorators = [BarDecorator];
-    var composite = new CompositeDraftDecorator(decorators);
+    const decorators = [BarDecorator];
+    const composite = new CompositeDraftDecorator(decorators);
 
-    var text = 'barbarbar';
-    var content = new ContentBlock(text);
-    var decorations = composite.getDecorations(content).toArray();
+    const text = 'barbarbar';
+    const content = new ContentBlock(text);
+    const decorations = composite.getDecorations(content).toArray();
 
     expect(isOccupied(decorations.slice(0, 3))).toBe(true);
     expect(decorations[0]).toEqual(decorations[2]);

--- a/src/model/encoding/DraftStringKey.js
+++ b/src/model/encoding/DraftStringKey.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-var DraftStringKey = {
+const DraftStringKey = {
   stringify: function(key: mixed): string {
     return '_' + String(key);
   },

--- a/src/model/encoding/__tests__/decodeEntityRanges-test.js
+++ b/src/model/encoding/__tests__/decodeEntityRanges-test.js
@@ -13,16 +13,16 @@
 
 jest.autoMockOff();
 
-var decodeEntityRanges = require('decodeEntityRanges');
+const decodeEntityRanges = require('decodeEntityRanges');
 
 describe('decodeEntityRanges', () => {
   it('must decode when no entities present', () => {
-    var decoded = decodeEntityRanges(' '.repeat(20), []);
+    const decoded = decodeEntityRanges(' '.repeat(20), []);
     expect(decoded).toEqual(Array(20).fill(null));
   });
 
   it('must decode when an entity is present', () => {
-    var decoded = decodeEntityRanges(
+    const decoded = decodeEntityRanges(
       ' '.repeat(5),
       [{
         offset: 2,
@@ -34,7 +34,7 @@ describe('decodeEntityRanges', () => {
   });
 
   it('must decode when multiple entities present', () => {
-    var decoded = decodeEntityRanges(
+    const decoded = decodeEntityRanges(
       ' '.repeat(8),
       [
         {
@@ -53,7 +53,7 @@ describe('decodeEntityRanges', () => {
   });
 
   it('must decode when an entity is present more than once', () => {
-    var decoded = decodeEntityRanges(
+    const decoded = decodeEntityRanges(
       ' '.repeat(8),
       [
         {
@@ -72,7 +72,7 @@ describe('decodeEntityRanges', () => {
   });
 
   it('must handle ranges that include surrogate pairs', () => {
-    var decoded = decodeEntityRanges(
+    const decoded = decodeEntityRanges(
       'Take a \uD83D\uDCF7 #selfie',
       [
         {
@@ -88,7 +88,7 @@ describe('decodeEntityRanges', () => {
       ]
     );
 
-    var entities = [
+    const entities = [
       null, null, null, null, null, null, // `Take a`
       '6', '6', '6', '6', '6', '6',       // ` [camera] #s`
       null, null, '8', '8', null,         // `elfie`

--- a/src/model/encoding/__tests__/decodeInlineStyleRanges-test.js
+++ b/src/model/encoding/__tests__/decodeInlineStyleRanges-test.js
@@ -13,9 +13,9 @@
 
 jest.autoMockOff();
 
-var decodeInlineStyleRanges = require('decodeInlineStyleRanges');
+const decodeInlineStyleRanges = require('decodeInlineStyleRanges');
 
-var {
+const {
   BOLD,
   BOLD_ITALIC,
   BOLD_ITALIC_UNDERLINE,
@@ -24,7 +24,7 @@ var {
   NONE,
 } = require('SampleDraftInlineStyle');
 
-var {List} = require('immutable');
+const {List} = require('immutable');
 
 function areEqual(a, b) {
   expect(List(a).equals(List(b))).toBeTruthy();
@@ -32,19 +32,19 @@ function areEqual(a, b) {
 
 describe('decodeInlineStyleRanges', function() {
   it('must decode for an unstyled block', function() {
-    var block = {text: 'Hello'};
-    var decoded = decodeInlineStyleRanges(block.text);
+    const block = {text: 'Hello'};
+    const decoded = decodeInlineStyleRanges(block.text);
     areEqual(decoded, Array(block.text.length).fill(NONE));
   });
 
   it('must decode for a flat styled block', function() {
-    var block = {
+    const block = {
       text: 'Hello',
       inlineStyleRanges: [
         {style: 'BOLD', offset: 0, length: 5},
       ],
     };
-    var decoded = decodeInlineStyleRanges(
+    const decoded = decodeInlineStyleRanges(
       block.text,
       block.inlineStyleRanges
     );
@@ -52,7 +52,7 @@ describe('decodeInlineStyleRanges', function() {
   });
 
   it('must decode for a mixed-style block', function() {
-    var block = {
+    const block = {
       text: 'Hello',
       inlineStyleRanges: [
         {style: 'BOLD', offset: 0, length: 3},
@@ -61,7 +61,7 @@ describe('decodeInlineStyleRanges', function() {
         {style: 'BOLD', offset: 4, length: 1},
       ],
     };
-    var decoded = decodeInlineStyleRanges(
+    const decoded = decodeInlineStyleRanges(
       block.text,
       block.inlineStyleRanges
     );
@@ -75,7 +75,7 @@ describe('decodeInlineStyleRanges', function() {
   });
 
   it('must decode for strings that contain surrogate pairs in UTF-16', () => {
-    var block = {
+    const block = {
       text: 'Take a \uD83D\uDCF7 #selfie',
       inlineStyleRanges: [
         {offset: 4, length: 4, style: 'BOLD'},
@@ -83,7 +83,7 @@ describe('decodeInlineStyleRanges', function() {
       ],
     };
 
-    var decoded = decodeInlineStyleRanges(
+    const decoded = decodeInlineStyleRanges(
       block.text,
       block.inlineStyleRanges
     );

--- a/src/model/encoding/__tests__/encodeEntityRanges-test.js
+++ b/src/model/encoding/__tests__/encodeEntityRanges-test.js
@@ -13,13 +13,13 @@
 
 jest.autoMockOff();
 
-var ContentBlock = require('ContentBlock');
-var Immutable = require('immutable');
+const ContentBlock = require('ContentBlock');
+const Immutable = require('immutable');
 
-var createCharacterList = require('createCharacterList');
-var encodeEntityRanges = require('encodeEntityRanges');
+const createCharacterList = require('createCharacterList');
+const encodeEntityRanges = require('encodeEntityRanges');
 
-var {OrderedSet, Repeat} = Immutable;
+const {OrderedSet, Repeat} = Immutable;
 
 describe('encodeEntityRanges', () => {
   function createBlock(text, entities) {
@@ -36,8 +36,8 @@ describe('encodeEntityRanges', () => {
   }
 
   it('must return an empty array if no entities present', () => {
-    var block = createBlock(' '.repeat(20), Repeat(null, 20).toArray());
-    var encoded = encodeEntityRanges(block, {});
+    const block = createBlock(' '.repeat(20), Repeat(null, 20).toArray());
+    let encoded = encodeEntityRanges(block, {});
     expect(encoded).toEqual([]);
 
     encoded = encodeEntityRanges(block, {'0': '0'});
@@ -45,9 +45,9 @@ describe('encodeEntityRanges', () => {
   });
 
   it('must return ranges with the storage-mapped key', () => {
-    var entities = [null, null, '6', '6', null];
-    var block = createBlock(' '.repeat(entities.length), entities);
-    var encoded = encodeEntityRanges(block, {'_6': '0'});
+    const entities = [null, null, '6', '6', null];
+    const block = createBlock(' '.repeat(entities.length), entities);
+    const encoded = encodeEntityRanges(block, {'_6': '0'});
     expect(encoded).toEqual([
       {
         offset: 2,
@@ -58,9 +58,9 @@ describe('encodeEntityRanges', () => {
   });
 
   it('must return ranges with multiple entities present', () => {
-    var entities = [null, null, '6', '6', null, '8', '8', null];
-    var block = createBlock(' '.repeat(entities.length), entities);
-    var encoded = encodeEntityRanges(block, {'_6': '0', '_8': '1'});
+    const entities = [null, null, '6', '6', null, '8', '8', null];
+    const block = createBlock(' '.repeat(entities.length), entities);
+    const encoded = encodeEntityRanges(block, {'_6': '0', '_8': '1'});
     expect(encoded).toEqual([
       {
         offset: 2,
@@ -76,9 +76,9 @@ describe('encodeEntityRanges', () => {
   });
 
   it('must return ranges with an entity present more than once', () => {
-    var entities = [null, null, '6', '6', null, '6', '6', null];
-    var block = createBlock(' '.repeat(entities.length), entities);
-    var encoded = encodeEntityRanges(block, {'_6': '0', '_8': '1'});
+    const entities = [null, null, '6', '6', null, '6', '6', null];
+    const block = createBlock(' '.repeat(entities.length), entities);
+    const encoded = encodeEntityRanges(block, {'_6': '0', '_8': '1'});
     expect(encoded).toEqual([
       {
         offset: 2,
@@ -94,15 +94,15 @@ describe('encodeEntityRanges', () => {
   });
 
   it('must handle ranges that include surrogate pairs', () => {
-    var str = 'Take a \uD83D\uDCF7 #selfie';
-    var entities = [
+    const str = 'Take a \uD83D\uDCF7 #selfie';
+    const entities = [
       null, null, null, null, null, null, // `Take a`
       '6', '6', '6', '6', '6', '6',       // ` [camera] #s`
       null, null, '8', '8', null,         // `elfie`
     ];
 
-    var block = createBlock(str, entities);
-    var encoded = encodeEntityRanges(block, {'_6': '0', '_8': '1'});
+    const block = createBlock(str, entities);
+    const encoded = encodeEntityRanges(block, {'_6': '0', '_8': '1'});
     expect(encoded).toEqual([
       {
         offset: 6,

--- a/src/model/encoding/__tests__/encodeInlineStyleRanges-test.js
+++ b/src/model/encoding/__tests__/encodeInlineStyleRanges-test.js
@@ -13,14 +13,14 @@
 
 jest.autoMockOff();
 
-var ContentBlock = require('ContentBlock');
-var Immutable = require('immutable');
-var SampleDraftInlineStyle = require('SampleDraftInlineStyle');
+const ContentBlock = require('ContentBlock');
+const Immutable = require('immutable');
+const SampleDraftInlineStyle = require('SampleDraftInlineStyle');
 
-var createCharacterList = require('createCharacterList');
-var encodeInlineStyleRanges = require('encodeInlineStyleRanges');
+const createCharacterList = require('createCharacterList');
+const encodeInlineStyleRanges = require('encodeInlineStyleRanges');
 
-var {
+const {
   BOLD,
   BOLD_ITALIC,
   BOLD_UNDERLINE,
@@ -30,7 +30,7 @@ var {
   NONE,
 } = SampleDraftInlineStyle;
 
-var {
+const {
   List,
   Repeat,
 } = Immutable;
@@ -81,7 +81,7 @@ describe('encodeInlineStyleRanges', () => {
       {offset: 0, length: 20, style: 'ITALIC'},
     ]);
 
-    var all = BOLD_ITALIC_UNDERLINE;
+    const all = BOLD_ITALIC_UNDERLINE;
     expect(
       encodeInlineStyleRanges(createBlock(' '.repeat(20), Repeat(all, 20)))
     ).toEqual([
@@ -92,7 +92,7 @@ describe('encodeInlineStyleRanges', () => {
   });
 
   it('must encode for a complex styled document', () => {
-    var complex = List([
+    const complex = List([
       BOLD, BOLD, BOLD, BOLD, NONE,         // "four "
       BOLD_ITALIC, BOLD_ITALIC,         // "sc"
       ITALIC_UNDERLINE, BOLD_UNDERLINE, // "or"
@@ -112,8 +112,8 @@ describe('encodeInlineStyleRanges', () => {
   });
 
   it('must encode for strings with surrogate pairs', () => {
-    var str = 'Take a \uD83D\uDCF7 #selfie';
-    var styles = List([
+    const str = 'Take a \uD83D\uDCF7 #selfie';
+    const styles = List([
       NONE, NONE, NONE, NONE, // `Take`
       BOLD, BOLD, BOLD_ITALIC, BOLD_ITALIC, BOLD_ITALIC, // ` a [camera]`
       ITALIC, ITALIC, ITALIC, ITALIC, ITALIC, ITALIC,  // ` #self`

--- a/src/model/encoding/__tests__/sanitizeDraftText-test.js
+++ b/src/model/encoding/__tests__/sanitizeDraftText-test.js
@@ -12,17 +12,17 @@
 jest.autoMockOff();
 
 describe('sanitizeDraftText', () => {
-  var sanitizeDraftText = require('sanitizeDraftText');
+  const sanitizeDraftText = require('sanitizeDraftText');
   it('must strip carriage returns', () => {
-    var trailing = 'test\u000d';
+    const trailing = 'test\u000d';
     expect(sanitizeDraftText(trailing)).toBe('test');
-    var twoTrailing = 'test\u000d\u000d';
+    const twoTrailing = 'test\u000d\u000d';
     expect(sanitizeDraftText(twoTrailing)).toBe('test');
-    var within = 'te\u000dst';
+    const within = 'te\u000dst';
     expect(sanitizeDraftText(within)).toBe('test');
-    var leading = '\u000dtest';
+    const leading = '\u000dtest';
     expect(sanitizeDraftText(leading)).toBe('test');
-    var all = '\u000dt\u000des\u000dt\u000d\u000d';
+    const all = '\u000dt\u000des\u000dt\u000d\u000d';
     expect(sanitizeDraftText(all)).toBe('test');
   });
 });

--- a/src/model/encoding/convertFromDraftStateToRaw.js
+++ b/src/model/encoding/convertFromDraftStateToRaw.js
@@ -12,11 +12,11 @@
 
 'use strict';
 
-var DraftEntity = require('DraftEntity');
-var DraftStringKey = require('DraftStringKey');
+const DraftEntity = require('DraftEntity');
+const DraftStringKey = require('DraftStringKey');
 
-var encodeEntityRanges = require('encodeEntityRanges');
-var encodeInlineStyleRanges = require('encodeInlineStyleRanges');
+const encodeEntityRanges = require('encodeEntityRanges');
+const encodeInlineStyleRanges = require('encodeInlineStyleRanges');
 
 import type ContentBlock from 'ContentBlock';
 import type ContentState from 'ContentState';
@@ -25,16 +25,16 @@ import type {RawDraftContentState} from 'RawDraftContentState';
 function convertFromDraftStateToRaw(
   contentState: ContentState
 ): RawDraftContentState {
-  var entityStorageKey = 0;
-  var entityStorageMap = {};
-  var rawBlocks = [];
+  let entityStorageKey = 0;
+  const entityStorageMap = {};
+  const rawBlocks = [];
 
   contentState.getBlockMap().forEach((block, blockKey) => {
     block.findEntityRanges(
       character => character.getEntity() !== null,
       start => {
         // Stringify to maintain order of otherwise numeric keys.
-        var stringifiedEntityKey = DraftStringKey.stringify(
+        const stringifiedEntityKey = DraftStringKey.stringify(
           block.getEntityAt(start)
         );
         if (!entityStorageMap.hasOwnProperty(stringifiedEntityKey)) {
@@ -55,10 +55,10 @@ function convertFromDraftStateToRaw(
 
   // Flip storage map so that our storage keys map to global
   // DraftEntity keys.
-  var entityKeys = Object.keys(entityStorageMap);
-  var flippedStorageMap = {};
+  const entityKeys = Object.keys(entityStorageMap);
+  const flippedStorageMap = {};
   entityKeys.forEach((key, jj) => {
-    var entity = DraftEntity.get(DraftStringKey.unstringify(key));
+    const entity = DraftEntity.get(DraftStringKey.unstringify(key));
     flippedStorageMap[jj] = {
       type: entity.getType(),
       mutability: entity.getMutability(),
@@ -73,7 +73,7 @@ function convertFromDraftStateToRaw(
 }
 
 function canHaveDepth(block: ContentBlock): boolean {
-  var type = block.getType();
+  const type = block.getType();
   return type === 'ordered-list-item' || type === 'unordered-list-item';
 }
 

--- a/src/model/encoding/convertFromRawToDraftState.js
+++ b/src/model/encoding/convertFromRawToDraftState.js
@@ -12,50 +12,51 @@
 
 'use strict';
 
-var ContentBlock = require('ContentBlock');
-var DraftEntity = require('DraftEntity');
+const ContentBlock = require('ContentBlock');
+const DraftEntity = require('DraftEntity');
 
-var createCharacterList = require('createCharacterList');
-var decodeEntityRanges = require('decodeEntityRanges');
-var decodeInlineStyleRanges = require('decodeInlineStyleRanges');
-var generateBlockKey = require('generateBlockKey');
+const createCharacterList = require('createCharacterList');
+const decodeEntityRanges = require('decodeEntityRanges');
+const decodeInlineStyleRanges = require('decodeInlineStyleRanges');
+const generateBlockKey = require('generateBlockKey');
 
 import type {RawDraftContentState} from 'RawDraftContentState';
 
 function convertFromRawToDraftState(
   rawState: RawDraftContentState
 ): Array<ContentBlock> {
-  var {blocks, entityMap} = rawState;
+  const {blocks, entityMap} = rawState;
 
-  var fromStorageToLocal = {};
+  const fromStorageToLocal = {};
   Object.keys(entityMap).forEach(
     storageKey => {
-      var encodedEntity = entityMap[storageKey];
-      var {type, mutability, data} = encodedEntity;
-      var newKey = DraftEntity.create(type, mutability, data || {});
+      const encodedEntity = entityMap[storageKey];
+      const {type, mutability, data} = encodedEntity;
+      const newKey = DraftEntity.create(type, mutability, data || {});
       fromStorageToLocal[storageKey] = newKey;
     }
   );
 
   return blocks.map(
     block => {
-      var {key, type, text, depth, inlineStyleRanges, entityRanges} = block;
+      const {type, text} = block
+      let {key, depth, inlineStyleRanges, entityRanges} = block;
       key = key || generateBlockKey();
       depth = depth || 0;
       inlineStyleRanges = inlineStyleRanges || [];
       entityRanges = entityRanges || [];
 
-      var inlineStyles = decodeInlineStyleRanges(text, inlineStyleRanges);
+      const inlineStyles = decodeInlineStyleRanges(text, inlineStyleRanges);
 
       // Translate entity range keys to the DraftEntity map.
-      var filteredEntityRanges = entityRanges
+      const filteredEntityRanges = entityRanges
         .filter(range => fromStorageToLocal.hasOwnProperty(range.key))
         .map(range => {
           return {...range, key: fromStorageToLocal[range.key]};
         });
 
-      var entities = decodeEntityRanges(text, filteredEntityRanges);
-      var characterList = createCharacterList(inlineStyles, entities);
+      const entities = decodeEntityRanges(text, filteredEntityRanges);
+      const characterList = createCharacterList(inlineStyles, entities);
 
       return new ContentBlock({key, type, text, depth, characterList});
     }

--- a/src/model/encoding/createCharacterList.js
+++ b/src/model/encoding/createCharacterList.js
@@ -13,19 +13,19 @@
 
 'use strict';
 
-var CharacterMetadata = require('CharacterMetadata');
-var Immutable = require('immutable');
+const CharacterMetadata = require('CharacterMetadata');
+const Immutable = require('immutable');
 
 import type {DraftInlineStyle} from 'DraftInlineStyle';
 
-var {List} = Immutable;
+const {List} = Immutable;
 
 function createCharacterList(
   inlineStyles: Array<DraftInlineStyle>,
   entities: Array<?string>
 ): List<CharacterMetadata> {
-  var characterArray = inlineStyles.map((style, ii) => {
-    var entity = entities[ii];
+  const characterArray = inlineStyles.map((style, ii) => {
+    const entity = entities[ii];
     return CharacterMetadata.create({style, entity});
   });
   return List(characterArray);

--- a/src/model/encoding/decodeEntityRanges.js
+++ b/src/model/encoding/decodeEntityRanges.js
@@ -13,9 +13,9 @@
 
 'use strict';
 
-var UnicodeUtils = require('UnicodeUtils');
+const UnicodeUtils = require('UnicodeUtils');
 
-var {substr} = UnicodeUtils;
+const {substr} = UnicodeUtils;
 
 /**
  * Convert to native JavaScript string lengths to determine ranges.
@@ -24,15 +24,15 @@ function decodeEntityRanges(
   text: string,
   ranges: Array<Object>
 ): Array<?string> {
-  var entities = Array(text.length).fill(null);
+  const entities = Array(text.length).fill(null);
   if (ranges) {
     ranges.forEach(
       range => {
         // Using Unicode-enabled substrings converted to JavaScript lengths,
         // fill the output array with entity keys.
-        var start = substr(text, 0, range.offset).length;
-        var end = start + substr(text, range.offset, range.length).length;
-        for (var ii = start; ii < end; ii++) {
+        const start = substr(text, 0, range.offset).length;
+        const end = start + substr(text, range.offset, range.length).length;
+        for (let ii = start; ii < end; ii++) {
           entities[ii] = range.key;
         }
       }

--- a/src/model/encoding/decodeInlineStyleRanges.js
+++ b/src/model/encoding/decodeInlineStyleRanges.js
@@ -13,11 +13,11 @@
 
 'use strict';
 
-var UnicodeUtils = require('UnicodeUtils');
+const UnicodeUtils = require('UnicodeUtils');
 
-var {OrderedSet} = require('immutable');
+const {OrderedSet} = require('immutable');
 
-var {substr} = UnicodeUtils;
+const {substr} = UnicodeUtils;
 
 import type {DraftInlineStyle} from 'DraftInlineStyle';
 
@@ -30,11 +30,11 @@ function decodeInlineStyleRanges(
   text: string,
   ranges?: Array<Object>
 ): Array<DraftInlineStyle> {
-  var styles = Array(text.length).fill(EMPTY_SET);
+  const styles = Array(text.length).fill(EMPTY_SET);
   if (ranges) {
     ranges.forEach((/*object*/ range) => {
-      var cursor = substr(text, 0, range.offset).length;
-      var end = cursor + substr(text, range.offset, range.length).length;
+      let cursor = substr(text, 0, range.offset).length;
+      const end = cursor + substr(text, range.offset, range.length).length;
       while (cursor < end) {
         styles[cursor] = styles[cursor].add(range.style);
         cursor++;

--- a/src/model/encoding/encodeEntityRanges.js
+++ b/src/model/encoding/encodeEntityRanges.js
@@ -13,13 +13,13 @@
 
 'use strict';
 
-var DraftStringKey = require('DraftStringKey');
-var UnicodeUtils = require('UnicodeUtils');
+const DraftStringKey = require('DraftStringKey');
+const UnicodeUtils = require('UnicodeUtils');
 
 import type ContentBlock from 'ContentBlock';
 import type {EntityRange} from 'EntityRange';
 
-var {strlen} = UnicodeUtils;
+const {strlen} = UnicodeUtils;
 
 /**
  * Convert to UTF-8 character counts for storage.
@@ -28,12 +28,12 @@ function encodeEntityRanges(
   block: ContentBlock,
   storageMap: Object
 ): Array<EntityRange> {
-  var encoded = [];
+  const encoded = [];
   block.findEntityRanges(
     character => !!character.getEntity(),
     (/*number*/ start, /*number*/ end) => {
-      var text = block.getText();
-      var key = block.getEntityAt(start);
+      const text = block.getText();
+      const key = block.getEntityAt(start);
       encoded.push({
         offset: strlen(text.slice(0, start)),
         length: strlen(text.slice(start, end)),

--- a/src/model/encoding/encodeInlineStyleRanges.js
+++ b/src/model/encoding/encodeInlineStyleRanges.js
@@ -12,19 +12,19 @@
 
 'use strict';
 
-var DefaultDraftInlineStyle = require('DefaultDraftInlineStyle');
-var UnicodeUtils = require('UnicodeUtils');
+const DefaultDraftInlineStyle = require('DefaultDraftInlineStyle');
+const UnicodeUtils = require('UnicodeUtils');
 
-var findRangesImmutable = require('findRangesImmutable');
+const findRangesImmutable = require('findRangesImmutable');
 
 import type ContentBlock from 'ContentBlock';
 import type {DraftInlineStyle} from 'DraftInlineStyle';
 import type {InlineStyleRange} from 'InlineStyleRange';
 import type {List} from 'immutable';
 
-var areEqual = (a, b) => a === b;
-var isTruthy = a => !!a;
-var EMPTY_ARRAY = [];
+const areEqual = (a, b) => a === b;
+const isTruthy = a => !!a;
+const EMPTY_ARRAY = [];
 
 /**
  * Helper function for getting encoded styles for each inline style. Convert
@@ -35,10 +35,10 @@ function getEncodedInlinesForType(
   styleList: List<DraftInlineStyle>,
   styleToEncode: string
 ): Array<InlineStyleRange> {
-  var ranges = [];
+  const ranges = [];
 
   // Obtain an array with ranges for only the specified style.
-  var filteredInlines = styleList
+  const filteredInlines = styleList
     .map(style => style.has(styleToEncode))
     .toList();
 
@@ -48,7 +48,7 @@ function getEncodedInlinesForType(
     // We only want to keep ranges with nonzero style values.
     isTruthy,
     (start, end) => {
-      var text = block.getText();
+      const text = block.getText();
       ranges.push({
         offset: UnicodeUtils.strlen(text.slice(0, start)),
         length: UnicodeUtils.strlen(text.slice(start, end)),
@@ -67,9 +67,9 @@ function getEncodedInlinesForType(
 function encodeInlineStyleRanges(
   block: ContentBlock
 ): Array<InlineStyleRange> {
-  var styleList = block.getCharacterList().map(c => c.getStyle()).toList();
-  var styles = Object.keys(DefaultDraftInlineStyle);
-  var ranges: Array<Array<InlineStyleRange>> = styles
+  const styleList = block.getCharacterList().map(c => c.getStyle()).toList();
+  const styles = Object.keys(DefaultDraftInlineStyle);
+  const ranges: Array<Array<InlineStyleRange>> = styles
     .map(style => getEncodedInlinesForType(block, styleList, style));
 
   return Array.prototype.concat.apply(EMPTY_ARRAY, ranges);

--- a/src/model/encoding/sanitizeDraftText.js
+++ b/src/model/encoding/sanitizeDraftText.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var REGEX_BLOCK_DELIMITER = new RegExp('\r', 'g');
+const REGEX_BLOCK_DELIMITER = new RegExp('\r', 'g');
 
 function sanitizeDraftText(input: string): string {
   return input.replace(REGEX_BLOCK_DELIMITER, '');

--- a/src/model/entity/DraftEntity.js
+++ b/src/model/entity/DraftEntity.js
@@ -11,18 +11,18 @@
  * @flow
  */
 
-var DraftEntityInstance = require('DraftEntityInstance');
-var Immutable = require('immutable');
+const DraftEntityInstance = require('DraftEntityInstance');
+const Immutable = require('immutable');
 
-var invariant = require('invariant');
+const invariant = require('invariant');
 
 import type {DraftEntityMutability} from 'DraftEntityMutability';
 import type {DraftEntityType} from 'DraftEntityType';
 
-var {Map} = Immutable;
+const {Map} = Immutable;
 
-var instances: Map<string, DraftEntityInstance> = Map();
-var instanceKey = 0;
+let instances: Map<string, DraftEntityInstance> = Map();
+let instanceKey = 0;
 
 /**
  * A "document entity" is an object containing metadata associated with a
@@ -37,7 +37,7 @@ var instanceKey = 0;
  * generated via DraftEntity.create() and used to obtain entity metadata
  * via DraftEntity.get().
  */
-var DraftEntity = {
+const DraftEntity = {
   /**
    * Create a DraftEntityInstance and store it for later retrieval.
    *
@@ -60,7 +60,7 @@ var DraftEntity = {
    * useful when restoring instances from the server.
    */
   add: function(instance: DraftEntityInstance): string {
-    var key = '' + (++instanceKey);
+    const key = '' + (++instanceKey);
     instances = instances.set(key, instance);
     return key;
   },
@@ -69,7 +69,7 @@ var DraftEntity = {
    * Retrieve the entity corresponding to the supplied key string.
    */
   get: function(key: string): DraftEntityInstance {
-    var instance = instances.get(key);
+    const instance = instances.get(key);
     invariant(!!instance, 'Unknown DraftEntity key.');
     return instance;
   },
@@ -83,9 +83,9 @@ var DraftEntity = {
     key: string,
     toMerge: {[key: string]: any}
   ): DraftEntityInstance {
-    var instance = DraftEntity.get(key);
-    var newData = {...instance.getData(), ...toMerge};
-    var newInstance = instance.set('data', newData);
+    const instance = DraftEntity.get(key);
+    const newData = {...instance.getData(), ...toMerge};
+    const newInstance = instance.set('data', newData);
     instances = instances.set(key, newInstance);
     return newInstance;
   },

--- a/src/model/entity/DraftEntityInstance.js
+++ b/src/model/entity/DraftEntityInstance.js
@@ -12,14 +12,14 @@
 
 'use strict';
 
-var Immutable = require('immutable');
+const Immutable = require('immutable');
 
 import type {DraftEntityType} from 'DraftEntityType';
 import type {DraftEntityMutability} from 'DraftEntityMutability';
 
-var {Record} = Immutable;
+const {Record} = Immutable;
 
-var DraftEntityInstanceRecord = Record({
+const DraftEntityInstanceRecord = Record({
   type: 'TOKEN',
   mutability: 'IMMUTABLE',
   data: Object,

--- a/src/model/entity/DraftEntityMutability.js
+++ b/src/model/entity/DraftEntityMutability.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var ComposedEntityMutability = require('ComposedEntityMutability');
+const ComposedEntityMutability = require('ComposedEntityMutability');
 
 /**
  * An enum representing the possible "mutability" options for an entity.

--- a/src/model/entity/__mocks__/DraftEntity.js
+++ b/src/model/entity/__mocks__/DraftEntity.js
@@ -7,15 +7,15 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-var DraftEntity = jest.genMockFromModule('DraftEntity');
+const DraftEntity = jest.genMockFromModule('DraftEntity');
 
-var DraftEntityInstance = {
+const DraftEntityInstance = {
   getType: jest.genMockFn().mockReturnValue(''),
   getMutability: jest.genMockFn().mockReturnValue(''),
   getData: jest.genMockFn().mockReturnValue({}),
 };
 
-var count = 0;
+let count = 0;
 
 DraftEntity.create = jest.genMockFn().mockImplementation(function() {
   count++;

--- a/src/model/entity/__tests__/DraftEntity-test.js
+++ b/src/model/entity/__tests__/DraftEntity-test.js
@@ -13,7 +13,7 @@
 
 jest.autoMockOff();
 
-var DraftEntity = require('DraftEntity');
+const DraftEntity = require('DraftEntity');
 
 describe('DraftEntity', () => {
   beforeEach(() => {
@@ -25,13 +25,13 @@ describe('DraftEntity', () => {
   }
 
   it('must create instances', () => {
-    var key = createLink();
+    const key = createLink();
     expect(typeof key).toBe('string');
   });
 
   it('must retrieve an instance given a key', () => {
-    var key = createLink();
-    var retrieved = DraftEntity.get(key);
+    const key = createLink();
+    const retrieved = DraftEntity.get(key);
     expect(retrieved.getType()).toBe('LINK');
     expect(retrieved.getMutability()).toBe('MUTABLE');
     expect(retrieved.getData()).toEqual({uri: 'zombo.com'});
@@ -44,21 +44,21 @@ describe('DraftEntity', () => {
   });
 
   it('must merge data', () => {
-    var key = createLink();
+    const key = createLink();
 
     // Merge new property.
-    var newData = {foo: 'bar'};
+    const newData = {foo: 'bar'};
     DraftEntity.mergeData(key, newData);
-    var newEntity = DraftEntity.get(key);
+    const newEntity = DraftEntity.get(key);
     expect(newEntity.getData()).toEqual({
       uri: 'zombo.com',
       foo: 'bar',
     });
 
     // Replace existing property.
-    var withNewURI = {uri: 'homestarrunner.com'};
+    const withNewURI = {uri: 'homestarrunner.com'};
     DraftEntity.mergeData(key, withNewURI);
-    var entityWithNewURI = DraftEntity.get(key);
+    const entityWithNewURI = DraftEntity.get(key);
     expect(entityWithNewURI.getData()).toEqual({
       uri: 'homestarrunner.com',
       foo: 'bar',

--- a/src/model/entity/__tests__/getEntityKeyForSelection-test.js
+++ b/src/model/entity/__tests__/getEntityKeyForSelection-test.js
@@ -13,24 +13,22 @@ jest.autoMockOff();
 
 jest.mock('DraftEntity');
 
-var getEntityKeyForSelection = require('getEntityKeyForSelection');
-var getSampleStateForTesting = require('getSampleStateForTesting');
+const getEntityKeyForSelection = require('getEntityKeyForSelection');
+const getSampleStateForTesting = require('getSampleStateForTesting');
 
-var {
-  contentState,
-  selectionState,
-} = getSampleStateForTesting();
+const state = getSampleStateForTesting();
+const {contentState} = state;
 
-selectionState = selectionState.merge({
+const selectionState = state.selectionState.merge({
   anchorKey: 'b',
   focusKey: 'b',
 });
 
-var DraftEntity = require('DraftEntity');
+const DraftEntity = require('DraftEntity');
 
 describe('getEntityKeyForSelection', () => {
   describe('collapsed selection', () => {
-    var collapsed = selectionState.merge({
+    const collapsed = selectionState.merge({
       anchorOffset: 2,
       focusOffset: 2,
     });
@@ -40,7 +38,7 @@ describe('getEntityKeyForSelection', () => {
     });
 
     it('must return null at start of block', () => {
-      var key = getEntityKeyForSelection(contentState, selectionState);
+      const key = getEntityKeyForSelection(contentState, selectionState);
       expect(key).toBe(null);
     });
 
@@ -48,7 +46,7 @@ describe('getEntityKeyForSelection', () => {
       DraftEntity.get.mockImplementation(() => {
         return {getMutability: () => 'MUTABLE'};
       });
-      var key = getEntityKeyForSelection(contentState, collapsed);
+      const key = getEntityKeyForSelection(contentState, collapsed);
       expect(key).toBe('123');
     });
 
@@ -56,7 +54,7 @@ describe('getEntityKeyForSelection', () => {
       DraftEntity.get.mockImplementation(() => {
         return {getMutability: () => 'IMMUTABLE'};
       });
-      var key = getEntityKeyForSelection(contentState, collapsed);
+      const key = getEntityKeyForSelection(contentState, collapsed);
       expect(key).toBe(null);
     });
 
@@ -64,13 +62,13 @@ describe('getEntityKeyForSelection', () => {
       DraftEntity.get.mockImplementation(() => {
         return {getMutability: () => 'SEGMENTED'};
       });
-      var key = getEntityKeyForSelection(contentState, collapsed);
+      const key = getEntityKeyForSelection(contentState, collapsed);
       expect(key).toBe(null);
     });
   });
 
   describe('non-collapsed selection', () => {
-    var nonCollapsed = selectionState.merge({
+    const nonCollapsed = selectionState.merge({
       anchorOffset: 2,
       focusKey: 'c',
       focusOffset: 2,
@@ -81,10 +79,10 @@ describe('getEntityKeyForSelection', () => {
     });
 
     it('must return null if start is at end of block', () => {
-      var startsAtEnd = nonCollapsed.merge({
+      const startsAtEnd = nonCollapsed.merge({
         anchorOffset: contentState.getBlockForKey('b').getLength(),
       });
-      var key = getEntityKeyForSelection(contentState, startsAtEnd);
+      const key = getEntityKeyForSelection(contentState, startsAtEnd);
       expect(key).toBe(null);
     });
 
@@ -92,7 +90,7 @@ describe('getEntityKeyForSelection', () => {
       DraftEntity.get.mockImplementation(() => {
         return {getMutability: () => 'MUTABLE'};
       });
-      var key = getEntityKeyForSelection(contentState, nonCollapsed);
+      const key = getEntityKeyForSelection(contentState, nonCollapsed);
       expect(key).toBe('123');
     });
 
@@ -100,7 +98,7 @@ describe('getEntityKeyForSelection', () => {
       DraftEntity.get.mockImplementation(() => {
         return {getMutability: () => 'IMMUTABLE'};
       });
-      var key = getEntityKeyForSelection(contentState, nonCollapsed);
+      const key = getEntityKeyForSelection(contentState, nonCollapsed);
       expect(key).toBe(null);
     });
 
@@ -108,7 +106,7 @@ describe('getEntityKeyForSelection', () => {
       DraftEntity.get.mockImplementation(() => {
         return {getMutability: () => 'SEGMENTED'};
       });
-      var key = getEntityKeyForSelection(contentState, nonCollapsed);
+      const key = getEntityKeyForSelection(contentState, nonCollapsed);
       expect(key).toBe(null);
     });
   });

--- a/src/model/entity/getEntityKeyForSelection.js
+++ b/src/model/entity/getEntityKeyForSelection.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-var DraftEntity = require('DraftEntity');
+const DraftEntity = require('DraftEntity');
 
 import type ContentState from 'ContentState';
 import type SelectionState from 'SelectionState';
@@ -27,11 +27,11 @@ function getEntityKeyForSelection(
   contentState: ContentState,
   targetSelection: SelectionState
 ): ?string {
-  var entityKey;
+  let entityKey;
 
   if (targetSelection.isCollapsed()) {
-    var key = targetSelection.getAnchorKey();
-    var offset = targetSelection.getAnchorOffset();
+    const key = targetSelection.getAnchorKey();
+    const offset = targetSelection.getAnchorOffset();
     if (offset > 0) {
       entityKey = contentState.getBlockForKey(key).getEntityAt(offset - 1);
       return filterKey(entityKey);
@@ -39,9 +39,9 @@ function getEntityKeyForSelection(
     return null;
   }
 
-  var startKey = targetSelection.getStartKey();
-  var startOffset = targetSelection.getStartOffset();
-  var startBlock = contentState.getBlockForKey(startKey);
+  const startKey = targetSelection.getStartKey();
+  const startOffset = targetSelection.getStartOffset();
+  const startBlock = contentState.getBlockForKey(startKey);
 
   entityKey = startOffset === startBlock.getLength() ?
     null :
@@ -58,7 +58,7 @@ function filterKey(
   entityKey: ?string
 ): ?string {
   if (entityKey) {
-    var entity = DraftEntity.get(entityKey);
+    const entity = DraftEntity.get(entityKey);
     return entity.getMutability() === 'MUTABLE' ? entityKey : null;
   }
   return null;

--- a/src/model/entity/getTextAfterNearestEntity.js
+++ b/src/model/entity/getTextAfterNearestEntity.js
@@ -23,7 +23,7 @@ function getTextAfterNearestEntity(
   block: ContentBlock,
   offset: number
 ): string {
-  var start = offset;
+  let start = offset;
 
   // Get start based on where the last entity ended.
   while (start > 0 && block.getEntityAt(start - 1) === null) {

--- a/src/model/immutable/BlockMapBuilder.js
+++ b/src/model/immutable/BlockMapBuilder.js
@@ -12,14 +12,14 @@
 
 'use strict';
 
-var Immutable = require('immutable');
+const Immutable = require('immutable');
 
 import type {BlockMap} from 'BlockMap';
 import type ContentBlock from 'ContentBlock';
 
-var {OrderedMap} = Immutable;
+const {OrderedMap} = Immutable;
 
-var BlockMapBuilder = {
+const BlockMapBuilder = {
   createFromArray: function(
     blocks: Array<ContentBlock>
   ): BlockMap {

--- a/src/model/immutable/BlockTree.js
+++ b/src/model/immutable/BlockTree.js
@@ -12,26 +12,26 @@
 
 'use strict';
 
-var Immutable = require('immutable');
+const Immutable = require('immutable');
 
-var emptyFunction = require('emptyFunction');
-var findRangesImmutable = require('findRangesImmutable');
+const emptyFunction = require('emptyFunction');
+const findRangesImmutable = require('findRangesImmutable');
 
 import type CharacterMetadata from 'CharacterMetadata';
 import type ContentBlock from 'ContentBlock';
 import type {DraftDecoratorType} from 'DraftDecoratorType';
 
-var {
+const {
   List,
   Repeat,
   Record,
 } = Immutable;
 
-var returnTrue = emptyFunction.thatReturnsTrue;
+const returnTrue = emptyFunction.thatReturnsTrue;
 
-var FINGERPRINT_DELIMITER = '-';
+const FINGERPRINT_DELIMITER = '-';
 
-var defaultLeafRange: {
+const defaultLeafRange: {
   start: ?number;
   end: ?number;
 } = {
@@ -39,9 +39,9 @@ var defaultLeafRange: {
   end: null,
 };
 
-var LeafRange = Record(defaultLeafRange);
+const LeafRange = Record(defaultLeafRange);
 
-var defaultDecoratorRange: {
+const defaultDecoratorRange: {
   start: ?number;
   end: ?number;
   decoratorKey: ?string;
@@ -53,9 +53,9 @@ var defaultDecoratorRange: {
   leaves: null,
 };
 
-var DecoratorRange = Record(defaultDecoratorRange);
+const DecoratorRange = Record(defaultDecoratorRange);
 
-var BlockTree = {
+const BlockTree = {
   /**
    * Generate a block tree for a given ContentBlock/decorator pair.
    */
@@ -63,7 +63,7 @@ var BlockTree = {
     block: ContentBlock,
     decorator: ?DraftDecoratorType
   ): List<DecoratorRange> {
-    var textLength = block.getLength();
+    const textLength = block.getLength();
     if (!textLength) {
       return List.of(
         new DecoratorRange({
@@ -77,12 +77,12 @@ var BlockTree = {
       );
     }
 
-    var leafSets = [];
-    var decorations = decorator ?
+    const leafSets = [];
+    const decorations = decorator ?
       decorator.getDecorations(block) :
       List(Repeat(null, textLength));
 
-    var chars = block.getCharacterList();
+    const chars = block.getCharacterList();
 
     findRangesImmutable(
       decorations,
@@ -114,8 +114,8 @@ var BlockTree = {
   getFingerprint: function(tree: List<DecoratorRange>): string {
     return tree.map(
       leafSet => {
-        var decoratorKey = leafSet.get('decoratorKey');
-        var fingerprintString = decoratorKey !== null ?
+        const decoratorKey = leafSet.get('decoratorKey');
+        const fingerprintString = decoratorKey !== null ?
           decoratorKey + '.' + (leafSet.get('end') - leafSet.get('start')) :
           '';
         return '' + fingerprintString + '.' + leafSet.get('leaves').size;
@@ -131,8 +131,8 @@ function generateLeaves(
   characters: List<CharacterMetadata>,
   offset: number
 ): List<LeafRange> {
-  var leaves = [];
-  var inlineStyles = characters.map(c => c.getStyle()).toList();
+  const leaves = [];
+  const inlineStyles = characters.map(c => c.getStyle()).toList();
   findRangesImmutable(
     inlineStyles,
     areEqual,

--- a/src/model/immutable/CharacterMetadata.js
+++ b/src/model/immutable/CharacterMetadata.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-var {
+const {
   Map,
   OrderedSet,
   Record,
@@ -28,12 +28,12 @@ type CharacterMetadataConfig = {
 
 const EMPTY_SET = OrderedSet();
 
-var defaultRecord: CharacterMetadataConfig = {
+const defaultRecord: CharacterMetadataConfig = {
   style: EMPTY_SET,
   entity: null,
 };
 
-var CharacterMetadataRecord = Record(defaultRecord);
+const CharacterMetadataRecord = Record(defaultRecord);
 
 class CharacterMetadata extends CharacterMetadataRecord {
   getStyle(): DraftInlineStyle {
@@ -52,7 +52,7 @@ class CharacterMetadata extends CharacterMetadataRecord {
     record: CharacterMetadata,
     style: string
   ): CharacterMetadata {
-    var withStyle = record.set('style', record.getStyle().add(style));
+    const withStyle = record.set('style', record.getStyle().add(style));
     return CharacterMetadata.create(withStyle);
   }
 
@@ -60,7 +60,7 @@ class CharacterMetadata extends CharacterMetadataRecord {
     record: CharacterMetadata,
     style: string
   ): CharacterMetadata {
-    var withoutStyle = record.set('style', record.getStyle().remove(style));
+    const withoutStyle = record.set('style', record.getStyle().remove(style));
     return CharacterMetadata.create(withoutStyle);
   }
 
@@ -68,7 +68,7 @@ class CharacterMetadata extends CharacterMetadataRecord {
     record: CharacterMetadata,
     entityKey: ?string
   ): CharacterMetadata {
-    var withEntity = record.getEntity() === entityKey ?
+    const withEntity = record.getEntity() === entityKey ?
       record :
       record.set('entity', entityKey);
     return CharacterMetadata.create(withEntity);
@@ -86,22 +86,22 @@ class CharacterMetadata extends CharacterMetadataRecord {
     }
 
     // Fill in unspecified properties, if necessary.
-    var configMap =
+    const configMap =
       Map({style: EMPTY_SET, entity: (null: ?string)}).merge(config);
 
-    var existing: ?CharacterMetadata = pool.get(configMap);
+    const existing: ?CharacterMetadata = pool.get(configMap);
     if (existing) {
       return existing;
     }
 
-    var newCharacter = new CharacterMetadata(configMap);
+    const newCharacter = new CharacterMetadata(configMap);
     pool = pool.set(configMap, newCharacter);
     return newCharacter;
   }
 }
 
-var EMPTY = new CharacterMetadata();
-var pool: Map<Map, CharacterMetadata> = Map([[Map(defaultRecord), EMPTY]]);
+const EMPTY = new CharacterMetadata();
+let pool: Map<Map, CharacterMetadata> = Map([[Map(defaultRecord), EMPTY]]);
 
 CharacterMetadata.EMPTY = EMPTY;
 

--- a/src/model/immutable/ContentBlock.js
+++ b/src/model/immutable/ContentBlock.js
@@ -13,15 +13,15 @@
 
 'use strict';
 
-var Immutable = require('immutable');
+const Immutable = require('immutable');
 
-var findRangesImmutable = require('findRangesImmutable');
+const findRangesImmutable = require('findRangesImmutable');
 
 import type CharacterMetadata from 'CharacterMetadata';
 import type {DraftBlockType} from 'DraftBlockType';
 import type {DraftInlineStyle} from 'DraftInlineStyle';
 
-var {
+const {
   List,
   OrderedSet,
   Record,
@@ -29,7 +29,7 @@ var {
 
 const EMPTY_SET = OrderedSet();
 
-var defaultRecord: {
+const defaultRecord: {
   key: string;
   type: DraftBlockType;
   text: string;
@@ -43,7 +43,7 @@ var defaultRecord: {
   depth: 0,
 };
 
-var ContentBlockRecord = Record(defaultRecord);
+const ContentBlockRecord = Record(defaultRecord);
 
 class ContentBlock extends ContentBlockRecord {
   getKey(): string {
@@ -71,12 +71,12 @@ class ContentBlock extends ContentBlockRecord {
   }
 
   getInlineStyleAt(offset: number): DraftInlineStyle {
-    var character = this.getCharacterList().get(offset);
+    const character = this.getCharacterList().get(offset);
     return character ? character.getStyle() : EMPTY_SET;
   }
 
   getEntityAt(offset: number): ?string {
-    var character = this.getCharacterList().get(offset);
+    const character = this.getCharacterList().get(offset);
     return character ? character.getEntity() : null;
   }
 

--- a/src/model/immutable/ContentState.js
+++ b/src/model/immutable/ContentState.js
@@ -52,7 +52,7 @@ class ContentState extends ContentStateRecord {
   }
 
   getBlockForKey(key: string): ContentBlock {
-    var block: ContentBlock = this.getBlockMap().get(key);
+    const block: ContentBlock = this.getBlockMap().get(key);
     return block;
   }
 
@@ -103,7 +103,7 @@ class ContentState extends ContentStateRecord {
   }
 
   hasText(): boolean {
-    var blockMap = this.getBlockMap();
+    const blockMap = this.getBlockMap();
     return (
       blockMap.size > 1 ||
       blockMap.first().getLength() > 0
@@ -113,8 +113,8 @@ class ContentState extends ContentStateRecord {
   static createFromBlockArray(
     blocks: Array<ContentBlock>
   ): ContentState {
-    var blockMap = BlockMapBuilder.createFromArray(blocks);
-    var selectionState = SelectionState.createEmpty(blockMap.first().getKey());
+    const blockMap = BlockMapBuilder.createFromArray(blocks);
+    const selectionState = SelectionState.createEmpty(blockMap.first().getKey());
     return new ContentState({
       blockMap,
       selectionBefore: selectionState,

--- a/src/model/immutable/EditorBidiService.js
+++ b/src/model/immutable/EditorBidiService.js
@@ -13,18 +13,18 @@
 
 'use strict';
 
-var Immutable = require('immutable');
-var UnicodeBidiService = require('UnicodeBidiService');
+const Immutable = require('immutable');
+const UnicodeBidiService = require('UnicodeBidiService');
 
-var nullthrows = require('nullthrows');
+const nullthrows = require('nullthrows');
 
 import type ContentState from 'ContentState';
 
-var {OrderedMap} = Immutable;
+const {OrderedMap} = Immutable;
 
-var bidiService;
+let bidiService;
 
-var EditorBidiService = {
+const EditorBidiService = {
   getDirectionMap: function(
     content: ContentState,
     prevBidiMap: ?OrderedMap
@@ -35,11 +35,11 @@ var EditorBidiService = {
       bidiService.reset();
     }
 
-    var blockMap = content.getBlockMap();
-    var nextBidi = blockMap
+    const blockMap = content.getBlockMap();
+    const nextBidi = blockMap
       .valueSeq()
       .map(block => nullthrows(bidiService).getDirection(block.getText()));
-    var bidiMap = OrderedMap(blockMap.keySeq().zip(nextBidi));
+    const bidiMap = OrderedMap(blockMap.keySeq().zip(nextBidi));
 
     if (prevBidiMap != null && Immutable.is(prevBidiMap, bidiMap)) {
       return prevBidiMap;

--- a/src/model/immutable/EditorState.js
+++ b/src/model/immutable/EditorState.js
@@ -12,11 +12,11 @@
 
 'use strict';
 
-var BlockTree = require('BlockTree');
-var ContentState = require('ContentState');
-var EditorBidiService = require('EditorBidiService');
-var Immutable = require('immutable');
-var SelectionState = require('SelectionState');
+const BlockTree = require('BlockTree');
+const ContentState = require('ContentState');
+const EditorBidiService = require('EditorBidiService');
+const Immutable = require('immutable');
+const SelectionState = require('SelectionState');
 
 import type {BlockMap} from 'BlockMap';
 import type {DraftDecoratorType} from 'DraftDecoratorType';
@@ -24,7 +24,7 @@ import type {DraftInlineStyle} from 'DraftInlineStyle';
 import type {List, OrderedMap} from 'immutable';
 import type {EditorChangeType} from 'EditorChangeType';
 
-var {
+const {
   OrderedSet,
   Record,
   Stack,
@@ -46,7 +46,7 @@ type EditorStateRecordType = {
   undoStack: Stack<ContentState>;
 };
 
-var defaultRecord: EditorStateRecordType = {
+const defaultRecord: EditorStateRecordType = {
   allowUndo: true,
   currentContent: null,
   decorator: null,
@@ -62,7 +62,7 @@ var defaultRecord: EditorStateRecordType = {
   undoStack: Stack(),
 };
 
-var EditorStateRecord = Record(defaultRecord);
+const EditorStateRecord = Record(defaultRecord);
 
 class EditorState {
   _immutable: EditorStateRecord;
@@ -80,7 +80,7 @@ class EditorState {
     contentState: ContentState,
     decorator?: DraftDecoratorType
   ): EditorState {
-    var firstKey = contentState.getBlockMap().first().getKey();
+    const firstKey = contentState.getBlockMap().first().getKey();
     return EditorState.create({
       currentContent: contentState,
       undoStack: Stack(),
@@ -91,8 +91,8 @@ class EditorState {
   }
 
   static create(config: Object): EditorState {
-    var {currentContent, decorator} = config;
-    var recordConfig = {
+    const {currentContent, decorator} = config;
+    const recordConfig = {
       ...config,
       treeMap: generateNewTreeMap(currentContent, decorator),
       directionMap: EditorBidiService.getDirectionMap(currentContent),
@@ -103,20 +103,20 @@ class EditorState {
   }
 
   static set(editorState: EditorState, put: Object): EditorState {
-    var map = editorState.getImmutable().withMutations(state => {
-      var existingDecorator = state.get('decorator');
-      var decorator = existingDecorator;
+    const map = editorState.getImmutable().withMutations(state => {
+      const existingDecorator = state.get('decorator');
+      let decorator = existingDecorator;
       if (put.decorator === null) {
         decorator = null;
       } else if (put.decorator) {
         decorator = put.decorator;
       }
 
-      var newContent = put.currentContent || editorState.getCurrentContent();
+      const newContent = put.currentContent || editorState.getCurrentContent();
 
       if (decorator !== existingDecorator) {
-        var treeMap: OrderedMap = state.get('treeMap');
-        var newTreeMap;
+        const treeMap: OrderedMap = state.get('treeMap');
+        let newTreeMap;
         if (decorator && existingDecorator) {
           newTreeMap = regenerateTreeForNewDecorator(
             newContent.getBlockMap(),
@@ -136,7 +136,7 @@ class EditorState {
         return;
       }
 
-      var existingContent = editorState.getCurrentContent();
+      const existingContent = editorState.getCurrentContent();
       if (newContent !== existingContent) {
         state.set(
           'treeMap',
@@ -216,13 +216,13 @@ class EditorState {
    * based on the location of the selection state.
    */
   getCurrentInlineStyle(): DraftInlineStyle {
-    var override = this.getInlineStyleOverride();
+    const override = this.getInlineStyleOverride();
     if (override != null) {
       return override;
     }
 
-    var content = this.getCurrentContent();
-    var selection = this.getSelection();
+    const content = this.getCurrentContent();
+    const selection = this.getSelection();
 
     if (selection.isCollapsed()) {
       return getInlineStyleForCollapsedSelection(content, selection);
@@ -236,15 +236,15 @@ class EditorState {
   }
 
   isSelectionAtStartOfContent(): boolean {
-    var firstKey = this.getCurrentContent().getBlockMap().first().getKey();
+    const firstKey = this.getCurrentContent().getBlockMap().first().getKey();
     return this.getSelection().hasEdgeWithin(firstKey, 0, 0);
   }
 
   isSelectionAtEndOfContent(): boolean {
-    var content = this.getCurrentContent();
-    var blockMap = content.getBlockMap();
-    var last = blockMap.last();
-    var end = last.getLength();
+    const content = this.getCurrentContent();
+    const blockMap = content.getBlockMap();
+    const last = blockMap.last();
+    const end = last.getLength();
     return this.getSelection().hasEdgeWithin(last.getKey(), end, end);
   }
 
@@ -293,10 +293,10 @@ class EditorState {
    * Move selection to the end of the editor without forcing focus.
    */
   static moveSelectionToEnd(editorState: EditorState): EditorState {
-    var content = editorState.getCurrentContent();
-    var lastBlock = content.getLastBlock();
-    var lastKey = lastBlock.getKey();
-    var length = lastBlock.getLength();
+    const content = editorState.getCurrentContent();
+    const lastBlock = content.getLastBlock();
+    const lastKey = lastBlock.getKey();
+    const length = lastBlock.getLength();
 
     return EditorState.acceptSelection(
       editorState,
@@ -316,7 +316,7 @@ class EditorState {
    * to allow the user to continue working seamlessly.
    */
   static moveFocusToEnd(editorState: EditorState): EditorState {
-    var afterSelectionMove = EditorState.moveSelectionToEnd(editorState);
+    const afterSelectionMove = EditorState.moveSelectionToEnd(editorState);
     return EditorState.forceSelection(
       afterSelectionMove,
       afterSelectionMove.getSelection()
@@ -337,8 +337,8 @@ class EditorState {
       return editorState;
     }
 
-    var forceSelection = changeType !== 'insert-characters';
-    var directionMap = EditorBidiService.getDirectionMap(
+    const forceSelection = changeType !== 'insert-characters';
+    const directionMap = EditorBidiService.getDirectionMap(
       contentState,
       editorState.getDirectionMap()
     );
@@ -354,10 +354,10 @@ class EditorState {
       });
     }
 
-    var selection = editorState.getSelection();
-    var currentContent = editorState.getCurrentContent();
-    var undoStack = editorState.getUndoStack();
-    var newContent = contentState;
+    const selection = editorState.getSelection();
+    const currentContent = editorState.getCurrentContent();
+    let undoStack = editorState.getUndoStack();
+    let newContent = contentState;
 
     if (
       selection !== currentContent.getSelectionAfter() ||
@@ -398,14 +398,14 @@ class EditorState {
       return editorState;
     }
 
-    var undoStack = editorState.getUndoStack();
-    var newCurrentContent = undoStack.peek();
+    const undoStack = editorState.getUndoStack();
+    const newCurrentContent = undoStack.peek();
     if (!newCurrentContent) {
       return editorState;
     }
 
-    var currentContent = editorState.getCurrentContent();
-    var directionMap = EditorBidiService.getDirectionMap(
+    const currentContent = editorState.getCurrentContent();
+    const directionMap = EditorBidiService.getDirectionMap(
       newCurrentContent,
       editorState.getDirectionMap()
     );
@@ -432,14 +432,14 @@ class EditorState {
       return editorState;
     }
 
-    var redoStack = editorState.getRedoStack();
-    var newCurrentContent = redoStack.peek();
+    const redoStack = editorState.getRedoStack();
+    const newCurrentContent = redoStack.peek();
     if (!newCurrentContent) {
       return editorState;
     }
 
-    var currentContent = editorState.getCurrentContent();
-    var directionMap = EditorBidiService.getDirectionMap(
+    const currentContent = editorState.getCurrentContent();
+    const directionMap = EditorBidiService.getDirectionMap(
       newCurrentContent,
       editorState.getDirectionMap()
     );
@@ -513,8 +513,8 @@ function regenerateTreeForNewBlocks(
   newBlockMap: BlockMap,
   decorator: ?DraftDecoratorType
 ): OrderedMap<string, List> {
-  var prevBlockMap = editorState.getCurrentContent().getBlockMap();
-  var prevTreeMap = editorState.getImmutable().get('treeMap');
+  const prevBlockMap = editorState.getCurrentContent().getBlockMap();
+  const prevTreeMap = editorState.getImmutable().get('treeMap');
   return prevTreeMap.merge(
     newBlockMap
       .toSeq()
@@ -559,7 +559,7 @@ function mustBecomeBoundary(
   editorState: EditorState,
   changeType: EditorChangeType
 ): boolean {
-  var lastChangeType = editorState.getLastChangeType();
+  const lastChangeType = editorState.getLastChangeType();
   return (
     changeType !== lastChangeType ||
     (
@@ -574,9 +574,9 @@ function getInlineStyleForCollapsedSelection(
   content: ContentState,
   selection: SelectionState
 ): DraftInlineStyle {
-  var startKey = selection.getStartKey();
-  var startOffset = selection.getStartOffset();
-  var startBlock = content.getBlockForKey(startKey);
+  const startKey = selection.getStartKey();
+  const startOffset = selection.getStartOffset();
+  const startBlock = content.getBlockForKey(startKey);
 
   // If the cursor is not at the start of the block, look backward to
   // preserve the style of the preceding character.
@@ -598,9 +598,9 @@ function getInlineStyleForNonCollapsedSelection(
   content: ContentState,
   selection: SelectionState
 ): DraftInlineStyle {
-  var startKey = selection.getStartKey();
-  var startOffset = selection.getStartOffset();
-  var startBlock = content.getBlockForKey(startKey);
+  const startKey = selection.getStartKey();
+  const startOffset = selection.getStartOffset();
+  const startBlock = content.getBlockForKey(startKey);
 
   // If there is a character just inside the selection, use its style.
   if (startOffset < startBlock.getLength()) {
@@ -621,8 +621,8 @@ function lookUpwardForInlineStyle(
   content: ContentState,
   fromKey: string
 ): DraftInlineStyle {
-  var previousBlock = content.getBlockBefore(fromKey);
-  var previousLength;
+  let previousBlock = content.getBlockBefore(fromKey);
+  let previousLength;
 
   while (previousBlock) {
     previousLength = previousBlock.getLength();

--- a/src/model/immutable/SelectionState.js
+++ b/src/model/immutable/SelectionState.js
@@ -13,11 +13,11 @@
 
 'use strict';
 
-var Immutable = require('immutable');
+const Immutable = require('immutable');
 
-var {Record} = Immutable;
+const {Record} = Immutable;
 
-var defaultRecord: {
+const defaultRecord: {
   anchorKey: string;
   anchorOffset: number;
   focusKey: string;
@@ -33,7 +33,7 @@ var defaultRecord: {
   hasFocus: false,
 };
 
-var SelectionStateRecord = Record(defaultRecord);
+const SelectionStateRecord = Record(defaultRecord);
 
 class SelectionState extends SelectionStateRecord {
   serialize(): string {
@@ -78,12 +78,12 @@ class SelectionState extends SelectionStateRecord {
     start: number,
     end: number
   ): boolean {
-    var anchorKey = this.getAnchorKey();
-    var focusKey = this.getFocusKey();
+    const anchorKey = this.getAnchorKey();
+    const focusKey = this.getFocusKey();
 
     if (anchorKey === focusKey && anchorKey === blockKey) {
-      var selectionStart = this.getStartOffset();
-      var selectionEnd = this.getEndOffset();
+      const selectionStart = this.getStartOffset();
+      const selectionEnd = this.getEndOffset();
       return start <= selectionEnd && selectionStart <= end;
     }
 
@@ -91,7 +91,7 @@ class SelectionState extends SelectionStateRecord {
       return false;
     }
 
-    var offsetToCheck = blockKey === anchorKey ?
+    const offsetToCheck = blockKey === anchorKey ?
       this.getAnchorOffset() :
       this.getFocusOffset();
 

--- a/src/model/immutable/__tests__/BlockTree-test.js
+++ b/src/model/immutable/__tests__/BlockTree-test.js
@@ -13,38 +13,38 @@
 
 jest.autoMockOff();
 
-var BlockTree = require('BlockTree');
-var CharacterMetadata = require('CharacterMetadata');
-var ContentBlock = require('ContentBlock');
-var Immutable = require('immutable');
-var {BOLD} = require('SampleDraftInlineStyle');
+const BlockTree = require('BlockTree');
+const CharacterMetadata = require('CharacterMetadata');
+const ContentBlock = require('ContentBlock');
+const Immutable = require('immutable');
+const {BOLD} = require('SampleDraftInlineStyle');
 
-var {EMPTY} = CharacterMetadata;
+const {EMPTY} = CharacterMetadata;
 
-var {
+const {
   Repeat,
 } = Immutable;
 
-var PLAIN_BLOCK = {
+const PLAIN_BLOCK = {
   key: 'a',
   text: 'Lincoln',
   characterList: Repeat(EMPTY, 7).toList(),
 };
 
-var boldChar = CharacterMetadata.create({style: BOLD});
-var styledChars = Repeat(EMPTY, 4).concat(
+const boldChar = CharacterMetadata.create({style: BOLD});
+const styledChars = Repeat(EMPTY, 4).concat(
   Repeat(boldChar, 4),
   Repeat(EMPTY, 2)
 );
 
-var STYLED_BLOCK = {
+const STYLED_BLOCK = {
   key: 'b',
   text: 'Washington',
   characterList: styledChars,
 };
 
 function assertLeafSetValues(leafSet, values) {
-  var {start, end, decoratorKey} = values;
+  const {start, end, decoratorKey} = values;
   expect(leafSet.get('start')).toBe(start);
   expect(leafSet.get('end')).toBe(end);
   expect(leafSet.get('decoratorKey')).toBe(decoratorKey);
@@ -72,38 +72,38 @@ describe('BlockTree', () => {
     }
 
     it('must generate for unstyled block', () => {
-      var block = new ContentBlock(PLAIN_BLOCK);
-      var length = PLAIN_BLOCK.text.length;
-      var decorator = getDecorator(length);
-      var tree = BlockTree.generate(block, decorator);
+      const block = new ContentBlock(PLAIN_BLOCK);
+      const length = PLAIN_BLOCK.text.length;
+      const decorator = getDecorator(length);
+      const tree = BlockTree.generate(block, decorator);
 
       // No decorations, so only one leaf set.
       expect(tree.size).toBe(1);
-      var leafSet = tree.get(0);
+      const leafSet = tree.get(0);
       assertLeafSetValues(leafSet, {
         start: 0,
         end: length,
         decoratorKey: null,
       });
 
-      var leaves = leafSet.get('leaves');
+      const leaves = leafSet.get('leaves');
       expect(leaves.size).toBe(1);
 
-      var leaf = leaves.get(0);
+      const leaf = leaves.get(0);
       assertLeafValues(leaf, {start: 0, end: length});
 
       expect(BlockTree.getFingerprint(tree)).toBe('.1');
     });
 
     it('must generate for styled block', () => {
-      var block = new ContentBlock(STYLED_BLOCK);
-      var length = STYLED_BLOCK.text.length;
-      var decorator = getDecorator(length);
-      var tree = BlockTree.generate(block, decorator);
+      const block = new ContentBlock(STYLED_BLOCK);
+      const length = STYLED_BLOCK.text.length;
+      const decorator = getDecorator(length);
+      const tree = BlockTree.generate(block, decorator);
 
       // No decorations, so only one leaf set.
       expect(tree.size).toBe(1);
-      var leafSet = tree.get(0);
+      const leafSet = tree.get(0);
       assertLeafSetValues(leafSet, {
         start: 0,
         end: length,
@@ -111,7 +111,7 @@ describe('BlockTree', () => {
       });
 
       // Three styled sections, so three leaves in this leaf set.
-      var leaves = leafSet.get('leaves');
+      const leaves = leafSet.get('leaves');
       expect(leaves.size).toBe(3);
 
       assertLeafValues(leaves.get(0), {start: 0, end: 4});
@@ -123,8 +123,8 @@ describe('BlockTree', () => {
   });
 
   describe('generate tree with single decoration', () => {
-    var DECORATOR_KEY = 'x';
-    var RANGE_LENGTH = 3;
+    const DECORATOR_KEY = 'x';
+    const RANGE_LENGTH = 3;
 
     function getDecorator(length) {
       Decorator.prototype.getDecorations.mockImplementation(
@@ -139,10 +139,10 @@ describe('BlockTree', () => {
     }
 
     it('must generate for unstyled block', () => {
-      var block = new ContentBlock(PLAIN_BLOCK);
-      var length = PLAIN_BLOCK.text.length;
-      var decorator = getDecorator(length);
-      var tree = BlockTree.generate(block, decorator);
+      const block = new ContentBlock(PLAIN_BLOCK);
+      const length = PLAIN_BLOCK.text.length;
+      const decorator = getDecorator(length);
+      const tree = BlockTree.generate(block, decorator);
 
       // One leaf set for each decoration range.
       expect(tree.size).toBe(3);
@@ -170,10 +170,10 @@ describe('BlockTree', () => {
     });
 
     it('must generate for styled block', () => {
-      var block = new ContentBlock(STYLED_BLOCK);
-      var length = STYLED_BLOCK.text.length;
-      var decorator = getDecorator(length);
-      var tree = BlockTree.generate(block, decorator);
+      const block = new ContentBlock(STYLED_BLOCK);
+      const length = STYLED_BLOCK.text.length;
+      const decorator = getDecorator(length);
+      const tree = BlockTree.generate(block, decorator);
 
       // Leaf Sets: ['Was', 'hin', 'gton']
       // Set 0 leaves (null entity): ['Was'] with NONE
@@ -207,9 +207,9 @@ describe('BlockTree', () => {
   });
 
   describe('generate tree with multiple decorations', () => {
-    var DECORATOR_KEY_A = 'y';
-    var DECORATOR_KEY_B = 'z';
-    var RANGE_LENGTH = 3;
+    const DECORATOR_KEY_A = 'y';
+    const DECORATOR_KEY_B = 'z';
+    const RANGE_LENGTH = 3;
 
     function getDecorator(length) {
       Decorator.prototype.getDecorations.mockImplementation(
@@ -224,10 +224,10 @@ describe('BlockTree', () => {
     }
 
     it('must generate for unstyled block', () => {
-      var block = new ContentBlock(PLAIN_BLOCK);
-      var length = PLAIN_BLOCK.text.length;
-      var decorator = getDecorator(length);
-      var tree = BlockTree.generate(block, decorator);
+      const block = new ContentBlock(PLAIN_BLOCK);
+      const length = PLAIN_BLOCK.text.length;
+      const decorator = getDecorator(length);
+      const tree = BlockTree.generate(block, decorator);
 
       // One leaf set for each decoration range.
       expect(tree.size).toBe(3);
@@ -255,10 +255,10 @@ describe('BlockTree', () => {
     });
 
     it('must generate for styled block', () => {
-      var block = new ContentBlock(STYLED_BLOCK);
-      var length = STYLED_BLOCK.text.length;
-      var decorator = getDecorator(length);
-      var tree = BlockTree.generate(block, decorator);
+      const block = new ContentBlock(STYLED_BLOCK);
+      const length = STYLED_BLOCK.text.length;
+      const decorator = getDecorator(length);
+      const tree = BlockTree.generate(block, decorator);
 
       // Leaf Sets: ['Was', 'hin', 'gton']
       // Set 0 leaves ('y' entity): ['Was'] with NONE

--- a/src/model/immutable/__tests__/CharacterMetadata-test.js
+++ b/src/model/immutable/__tests__/CharacterMetadata-test.js
@@ -13,8 +13,8 @@
 
 jest.autoMockOff();
 
-var CharacterMetadata = require('CharacterMetadata');
-var {
+const CharacterMetadata = require('CharacterMetadata');
+const {
   BOLD,
   BOLD_ITALIC,
   NONE,
@@ -23,15 +23,15 @@ var {
 
 describe('CharacterMetadata', () => {
   it('must have appropriate default values', () => {
-    var character = CharacterMetadata.create();
+    const character = CharacterMetadata.create();
     expect(character.getStyle().size).toBe(0);
     expect(character.getEntity()).toBe(null);
   });
 
   describe('Style handling', () => {
-    var plain = CharacterMetadata.create();
-    var bold = CharacterMetadata.create({style: BOLD});
-    var fancy = CharacterMetadata.create({style: BOLD_ITALIC});
+    const plain = CharacterMetadata.create();
+    const bold = CharacterMetadata.create({style: BOLD});
+    const fancy = CharacterMetadata.create({style: BOLD_ITALIC});
 
     it('must run `hasStyle` correctly', () => {
       expect(plain.hasStyle('BOLD')).toBe(false);
@@ -43,49 +43,49 @@ describe('CharacterMetadata', () => {
     });
 
     it('must apply style', () => {
-      var newlyBold = CharacterMetadata.applyStyle(plain, 'BOLD');
+      const newlyBold = CharacterMetadata.applyStyle(plain, 'BOLD');
       expect(newlyBold.hasStyle('BOLD')).toBe(true);
-      var alsoItalic = CharacterMetadata.applyStyle(newlyBold, 'ITALIC');
+      const alsoItalic = CharacterMetadata.applyStyle(newlyBold, 'ITALIC');
       expect(alsoItalic.hasStyle('BOLD')).toBe(true);
       expect(alsoItalic.hasStyle('ITALIC')).toBe(true);
     });
 
     it('must remove style', () => {
-      var justBold = CharacterMetadata.removeStyle(fancy, 'ITALIC');
+      const justBold = CharacterMetadata.removeStyle(fancy, 'ITALIC');
       expect(justBold.hasStyle('BOLD')).toBe(true);
       expect(justBold.hasStyle('ITALIC')).toBe(false);
-      var justPlain = CharacterMetadata.removeStyle(justBold, 'BOLD');
+      const justPlain = CharacterMetadata.removeStyle(justBold, 'BOLD');
       expect(justPlain.hasStyle('BOLD')).toBe(false);
       expect(justPlain.hasStyle('ITALIC')).toBe(false);
     });
   });
 
   describe('Entity handling', () => {
-    var withoutEntity = CharacterMetadata.create();
-    var withEntity = CharacterMetadata.create({entity: 'a'});
+    const withoutEntity = CharacterMetadata.create();
+    const withEntity = CharacterMetadata.create({entity: 'a'});
 
     it('must apply entity correctly', () => {
-      var newKey = 'x';
-      var modifiedA = CharacterMetadata.applyEntity(withoutEntity, newKey);
-      var modifiedB = CharacterMetadata.applyEntity(withEntity, newKey);
+      const newKey = 'x';
+      const modifiedA = CharacterMetadata.applyEntity(withoutEntity, newKey);
+      const modifiedB = CharacterMetadata.applyEntity(withEntity, newKey);
       expect(modifiedA.getEntity()).toBe(newKey);
       expect(modifiedB.getEntity()).toBe(newKey);
     });
 
     it('must remove entity correctly', () => {
-      var modifiedA = CharacterMetadata.applyEntity(withoutEntity, null);
-      var modifiedB = CharacterMetadata.applyEntity(withEntity, null);
+      const modifiedA = CharacterMetadata.applyEntity(withoutEntity, null);
+      const modifiedB = CharacterMetadata.applyEntity(withEntity, null);
       expect(modifiedA.getEntity()).toBe(null);
       expect(modifiedB.getEntity()).toBe(null);
     });
   });
 
   describe('Metadata Reuse', () => {
-    var empty = CharacterMetadata.create();
-    var withStyle = CharacterMetadata.create({style: BOLD});
-    var withTwoStyles = CharacterMetadata.create({style: BOLD_ITALIC});
-    var withEntity = CharacterMetadata.create({entity: '1234'});
-    var withStyleAndEntity = CharacterMetadata.create({
+    const empty = CharacterMetadata.create();
+    const withStyle = CharacterMetadata.create({style: BOLD});
+    const withTwoStyles = CharacterMetadata.create({style: BOLD_ITALIC});
+    const withEntity = CharacterMetadata.create({entity: '1234'});
+    const withStyleAndEntity = CharacterMetadata.create({
       entity: '1234',
       style: BOLD,
     });
@@ -118,7 +118,7 @@ describe('CharacterMetadata', () => {
         withEntity
       );
 
-      var underlined = CharacterMetadata.create({
+      const underlined = CharacterMetadata.create({
         style: UNDERLINE,
         entity: null,
       });

--- a/src/model/immutable/__tests__/ContentBlock-test.js
+++ b/src/model/immutable/__tests__/ContentBlock-test.js
@@ -13,17 +13,17 @@
 
 jest.autoMockOff();
 
-var CharacterMetadata = require('CharacterMetadata');
-var ContentBlock = require('ContentBlock');
-var Immutable = require('immutable');
+const CharacterMetadata = require('CharacterMetadata');
+const ContentBlock = require('ContentBlock');
+const Immutable = require('immutable');
 
-var {
+const {
   NONE,
   BOLD,
 } = require('SampleDraftInlineStyle');
 
 describe('ContentBlock', () => {
-  var ENTITY_KEY = 'x';
+  const ENTITY_KEY = 'x';
 
   function getSampleBlock() {
     return new ContentBlock({
@@ -42,7 +42,7 @@ describe('ContentBlock', () => {
 
   describe('basic retrieval', () => {
     it('must provide default values', () => {
-      var block = new ContentBlock();
+      const block = new ContentBlock();
       expect(block.getType()).toBe('unstyled');
       expect(block.getText()).toBe('');
       expect(
@@ -51,7 +51,7 @@ describe('ContentBlock', () => {
     });
 
     it('must retrieve properties', () => {
-      var block = getSampleBlock();
+      const block = getSampleBlock();
       expect(block.getKey()).toBe('a');
       expect(block.getText()).toBe('Alpha');
       expect(block.getType()).toBe('unstyled');
@@ -62,7 +62,7 @@ describe('ContentBlock', () => {
 
   describe('style retrieval', () => {
     it('must properly retrieve style at offset', () => {
-      var block = getSampleBlock();
+      const block = getSampleBlock();
       expect(block.getInlineStyleAt(0)).toBe(BOLD);
       expect(block.getInlineStyleAt(1)).toBe(NONE);
       expect(block.getInlineStyleAt(2)).toBe(NONE);
@@ -71,11 +71,11 @@ describe('ContentBlock', () => {
     });
 
     it('must correctly identify ranges of styles', () => {
-      var block = getSampleBlock();
-      var cb = jest.genMockFn();
+      const block = getSampleBlock();
+      const cb = jest.genMockFn();
       block.findStyleRanges(() => true, cb);
 
-      var calls = cb.mock.calls;
+      const calls = cb.mock.calls;
       expect(calls.length).toBe(4);
       expect(calls[0]).toEqual([0, 1]);
       expect(calls[1]).toEqual([1, 3]);
@@ -86,7 +86,7 @@ describe('ContentBlock', () => {
 
   describe('entity retrieval', () => {
     it('must properly retrieve entity at offset', () => {
-      var block = getSampleBlock();
+      const block = getSampleBlock();
       expect(block.getEntityAt(0)).toBe(ENTITY_KEY);
       expect(block.getEntityAt(1)).toBe(null);
       expect(block.getEntityAt(2)).toBe(null);
@@ -95,11 +95,11 @@ describe('ContentBlock', () => {
     });
 
     it('must correctly identify ranges of entities', () => {
-      var block = getSampleBlock();
-      var cb = jest.genMockFn();
+      const block = getSampleBlock();
+      const cb = jest.genMockFn();
       block.findEntityRanges(() => true, cb);
 
-      var calls = cb.mock.calls;
+      const calls = cb.mock.calls;
       expect(calls.length).toBe(3);
       expect(calls[0]).toEqual([0, 1]);
       expect(calls[1]).toEqual([1, 4]);

--- a/src/model/immutable/__tests__/ContentState-test.js
+++ b/src/model/immutable/__tests__/ContentState-test.js
@@ -15,19 +15,19 @@ jest
   .autoMockOff()
   .mock('SelectionState');
 
-var BlockMapBuilder = require('BlockMapBuilder');
-var ContentBlock = require('ContentBlock');
-var ContentState = require('ContentState');
+const BlockMapBuilder = require('BlockMapBuilder');
+const ContentBlock = require('ContentBlock');
+const ContentState = require('ContentState');
 
-var SINGLE_BLOCK = [
+const SINGLE_BLOCK = [
   {text: 'Lorem ipsum', key: 'a'},
 ];
-var MULTI_BLOCK = [
+const MULTI_BLOCK = [
   {text: 'Four score', key: 'b'},
   {text: 'and seven', key: 'c'},
 ];
 
-var SelectionState = require('SelectionState');
+const SelectionState = require('SelectionState');
 
 describe('ContentState', () => {
   function getContentBlocks(textBlocks) {
@@ -35,8 +35,8 @@ describe('ContentState', () => {
   }
 
   function getConfigForText(textBlocks) {
-    var contentBlocks = getContentBlocks(textBlocks);
-    var blockMap = BlockMapBuilder.createFromArray(contentBlocks);
+    const contentBlocks = getContentBlocks(textBlocks);
+    const blockMap = BlockMapBuilder.createFromArray(contentBlocks);
     return {
       blockMap,
       selectionBefore: new SelectionState(),
@@ -56,21 +56,21 @@ describe('ContentState', () => {
 
   describe('creation and retrieval', () => {
     it('must create a new instance', () => {
-      var state = getSample(SINGLE_BLOCK);
+      const state = getSample(SINGLE_BLOCK);
       expect(state instanceof ContentState).toBe(true);
     });
   });
 
   describe('key fetching', () => {
     it('must succeed or fail properly', () => {
-      var singleBlock = getSample(SINGLE_BLOCK);
-      var key = SINGLE_BLOCK[0].key;
+      const singleBlock = getSample(SINGLE_BLOCK);
+      const key = SINGLE_BLOCK[0].key;
       expect(singleBlock.getKeyBefore(key)).toBe(undefined);
       expect(singleBlock.getKeyAfter(key)).toBe(undefined);
 
-      var multiBlock = getSample(MULTI_BLOCK);
-      var firstKey = MULTI_BLOCK[0].key;
-      var secondKey = MULTI_BLOCK[1].key;
+      const multiBlock = getSample(MULTI_BLOCK);
+      const firstKey = MULTI_BLOCK[0].key;
+      const secondKey = MULTI_BLOCK[1].key;
 
       expect(multiBlock.getKeyBefore(firstKey)).toBe(undefined);
       expect(multiBlock.getKeyAfter(firstKey)).toBe(secondKey);
@@ -81,8 +81,8 @@ describe('ContentState', () => {
 
   describe('block fetching', () => {
     it('must retrieve or fail fetching block for key', () => {
-      var state = getSample(SINGLE_BLOCK);
-      var block = state.getBlockForKey('a');
+      const state = getSample(SINGLE_BLOCK);
+      const block = state.getBlockForKey('a');
       expect(block instanceof ContentBlock).toBe(true);
       expect(block.getText()).toBe(SINGLE_BLOCK[0].text);
       expect(state.getBlockForKey('x')).toBe(undefined);

--- a/src/model/immutable/__tests__/EditorBidiService-test.js
+++ b/src/model/immutable/__tests__/EditorBidiService-test.js
@@ -13,46 +13,46 @@
 
 jest.autoMockOff();
 
-var ContentBlock = require('ContentBlock');
-var ContentState = require('ContentState');
-var EditorBidiService = require('EditorBidiService');
-var Immutable = require('immutable');
-var UnicodeBidiDirection = require('UnicodeBidiDirection');
+const ContentBlock = require('ContentBlock');
+const ContentState = require('ContentState');
+const EditorBidiService = require('EditorBidiService');
+const Immutable = require('immutable');
+const UnicodeBidiDirection = require('UnicodeBidiDirection');
 
-var {
+const {
   OrderedMap,
   Seq,
 } = Immutable;
 
-var {
+const {
   LTR,
   RTL,
 } = UnicodeBidiDirection;
 
-var ltr = new ContentBlock({
+const ltr = new ContentBlock({
   key: 'a',
   text: 'hello',
 });
-var rtl = new ContentBlock({
+const rtl = new ContentBlock({
   key: 'b',
   text: '\u05e9\u05d1\u05ea',
 });
-var empty = new ContentBlock({
+const empty = new ContentBlock({
   key: 'c',
   text: '',
 });
 
 describe('EditorBidiService', () => {
   function getContentState(blocks) {
-    var keys = Seq(blocks.map(b => b.getKey()));
-    var values = Seq(blocks);
-    var blockMap = OrderedMap(keys.zip(values));
+    const keys = Seq(blocks.map(b => b.getKey()));
+    const values = Seq(blocks);
+    const blockMap = OrderedMap(keys.zip(values));
     return new ContentState({blockMap});
   }
 
   it('must create a new map', () => {
-    var state = getContentState([ltr]);
-    var directions = EditorBidiService.getDirectionMap(state);
+    const state = getContentState([ltr]);
+    const directions = EditorBidiService.getDirectionMap(state);
     expect(
       directions.keySeq().toArray()
     ).toEqual(
@@ -66,11 +66,11 @@ describe('EditorBidiService', () => {
   });
 
   it('must return the same map if no changes', () => {
-    var state = getContentState([ltr]);
-    var directions = EditorBidiService.getDirectionMap(state);
+    const state = getContentState([ltr]);
+    const directions = EditorBidiService.getDirectionMap(state);
 
-    var nextState = getContentState([ltr]);
-    var nextDirections = EditorBidiService.getDirectionMap(
+    const nextState = getContentState([ltr]);
+    const nextDirections = EditorBidiService.getDirectionMap(
       nextState,
       directions
     );
@@ -80,17 +80,17 @@ describe('EditorBidiService', () => {
   });
 
   it('must return the same map if no text changes', () => {
-    var state = getContentState([ltr]);
-    var directions = EditorBidiService.getDirectionMap(state);
+    const state = getContentState([ltr]);
+    const directions = EditorBidiService.getDirectionMap(state);
 
-    var newLTR = new ContentBlock({
+    const newLTR = new ContentBlock({
       key: 'a',
       text: 'hello',
     });
     expect(newLTR).not.toBe(ltr);
 
-    var nextState = getContentState([newLTR]);
-    var nextDirections = EditorBidiService.getDirectionMap(
+    const nextState = getContentState([newLTR]);
+    const nextDirections = EditorBidiService.getDirectionMap(
       nextState,
       directions
     );
@@ -100,17 +100,17 @@ describe('EditorBidiService', () => {
   });
 
   it('must return the same map if no directions change', () => {
-    var state = getContentState([ltr]);
-    var directions = EditorBidiService.getDirectionMap(state);
+    const state = getContentState([ltr]);
+    const directions = EditorBidiService.getDirectionMap(state);
 
-    var newLTR = new ContentBlock({
+    const newLTR = new ContentBlock({
       key: 'a',
       text: 'asdf',
     });
     expect(newLTR).not.toBe(ltr);
 
-    var nextState = getContentState([newLTR]);
-    var nextDirections = EditorBidiService.getDirectionMap(
+    const nextState = getContentState([newLTR]);
+    const nextDirections = EditorBidiService.getDirectionMap(
       nextState,
       directions
     );
@@ -120,16 +120,16 @@ describe('EditorBidiService', () => {
   });
 
   it('must return a new map if block keys change', () => {
-    var state = getContentState([ltr]);
-    var directions = EditorBidiService.getDirectionMap(state);
+    const state = getContentState([ltr]);
+    const directions = EditorBidiService.getDirectionMap(state);
 
-    var newLTR = new ContentBlock({
+    const newLTR = new ContentBlock({
       key: 'asdf',
       text: 'asdf',
     });
 
-    var nextState = getContentState([newLTR]);
-    var nextDirections = EditorBidiService.getDirectionMap(
+    const nextState = getContentState([newLTR]);
+    const nextDirections = EditorBidiService.getDirectionMap(
       nextState,
       directions
     );
@@ -150,8 +150,8 @@ describe('EditorBidiService', () => {
   });
 
   it('must return a new map if direction changes', () => {
-    var state = getContentState([ltr, empty]);
-    var directions = EditorBidiService.getDirectionMap(state);
+    const state = getContentState([ltr, empty]);
+    const directions = EditorBidiService.getDirectionMap(state);
 
     expect(
       directions.valueSeq().toArray()
@@ -159,8 +159,8 @@ describe('EditorBidiService', () => {
       [LTR, LTR]
     );
 
-    var nextState = getContentState([ltr, rtl]);
-    var nextDirections = EditorBidiService.getDirectionMap(
+    const nextState = getContentState([ltr, rtl]);
+    const nextDirections = EditorBidiService.getDirectionMap(
       nextState,
       directions
     );

--- a/src/model/immutable/__tests__/EditorState-test.js
+++ b/src/model/immutable/__tests__/EditorState-test.js
@@ -13,60 +13,60 @@
 
 jest.autoMockOff();
 
-var CharacterMetadata = require('CharacterMetadata');
-var ContentBlock = require('ContentBlock');
-var ContentState = require('ContentState');
-var EditorState = require('EditorState');
-var Immutable = require('immutable');
-var SelectionState = require('SelectionState');
+const CharacterMetadata = require('CharacterMetadata');
+const ContentBlock = require('ContentBlock');
+const ContentState = require('ContentState');
+const EditorState = require('EditorState');
+const Immutable = require('immutable');
+const SelectionState = require('SelectionState');
 
-var {
+const {
   NONE,
   BOLD,
   ITALIC,
 } = require('SampleDraftInlineStyle');
 
-var {EMPTY} = CharacterMetadata;
+const {EMPTY} = CharacterMetadata;
 
-var {
+const {
   List,
   Repeat,
 } = Immutable;
 
-var plainBlock = new ContentBlock({
+const plainBlock = new ContentBlock({
   key: 'a',
   text: 'Arsenal',
   characterList: List(Repeat(EMPTY, 7)),
 });
 
-var boldChar = CharacterMetadata.create({style: BOLD});
-var boldBlock = new ContentBlock({
+const boldChar = CharacterMetadata.create({style: BOLD});
+const boldBlock = new ContentBlock({
   key: 'b',
   text: 'Burnley',
   characterList: List(Repeat(boldChar, 7)),
 });
 
-var emptyBlockA = new ContentBlock({
+const emptyBlockA = new ContentBlock({
   key: 'emptyA',
   text: '',
   characterList: List(),
 });
 
-var emptyBlockB = new ContentBlock({
+const emptyBlockB = new ContentBlock({
   key: 'emptyB',
   text: '',
   characterList: List(),
 });
 
-var italicChar = CharacterMetadata.create({style: ITALIC});
-var italicBlock = new ContentBlock({
+const italicChar = CharacterMetadata.create({style: ITALIC});
+const italicBlock = new ContentBlock({
   key: 'c',
   text: 'Chelsea',
   characterList: List(Repeat(italicChar, 7)),
 });
 
 function getUndecoratedEditorState() {
-  var contentState = ContentState.createFromBlockArray([
+  const contentState = ContentState.createFromBlockArray([
     plainBlock,
     boldBlock,
     emptyBlockA,
@@ -77,7 +77,7 @@ function getUndecoratedEditorState() {
 }
 
 function getEmptyLedMultiBlockEditorState() {
-  var contentState = ContentState.createFromBlockArray([
+  const contentState = ContentState.createFromBlockArray([
     emptyBlockA,
     emptyBlockB,
     boldBlock,
@@ -86,7 +86,7 @@ function getEmptyLedMultiBlockEditorState() {
 }
 
 function getDecoratedEditorState(decorator) {
-  var contentState = ContentState.createFromBlockArray([
+  const contentState = ContentState.createFromBlockArray([
     boldBlock,
     italicBlock,
   ]);
@@ -96,10 +96,10 @@ function getDecoratedEditorState(decorator) {
 describe('EditorState', () => {
 
   describe('getCurrentInlineStyle', () => {
-    var mainEditor = getUndecoratedEditorState();
+    const mainEditor = getUndecoratedEditorState();
 
     describe('Collapsed selection', () => {
-      var mainSelection = new SelectionState({
+      const mainSelection = new SelectionState({
         anchorKey: 'a',
         anchorOffset: 0,
         focusKey: 'a',
@@ -108,49 +108,49 @@ describe('EditorState', () => {
       });
 
       it('uses right of the caret at document start', () => {
-        var editor = EditorState.acceptSelection(mainEditor, mainSelection);
+        const editor = EditorState.acceptSelection(mainEditor, mainSelection);
         expect(editor.getCurrentInlineStyle()).toBe(NONE);
       });
 
       it('uses left of the caret, at position `1+`', () => {
-        var selection = mainSelection.merge({
+        const selection = mainSelection.merge({
           anchorOffset: 1,
           focusOffset: 1,
         });
-        var editor = EditorState.acceptSelection(mainEditor, selection);
+        const editor = EditorState.acceptSelection(mainEditor, selection);
         expect(editor.getCurrentInlineStyle()).toBe(NONE);
       });
 
       it('uses right of the caret at offset `0` within document', () => {
-        var selection = mainSelection.merge({
+        const selection = mainSelection.merge({
           anchorKey: 'b',
           focusKey: 'b',
         });
-        var editor = EditorState.acceptSelection(mainEditor, selection);
+        const editor = EditorState.acceptSelection(mainEditor, selection);
         expect(editor.getCurrentInlineStyle()).toBe(BOLD);
       });
 
       it('uses previous block at offset `0` within empty block', () => {
-        var selection = mainSelection.merge({
+        const selection = mainSelection.merge({
           anchorKey: 'emptyA',
           focusKey: 'emptyA',
         });
-        var editor = EditorState.acceptSelection(mainEditor, selection);
+        const editor = EditorState.acceptSelection(mainEditor, selection);
         expect(editor.getCurrentInlineStyle()).toBe(BOLD);
       });
 
       it('looks upward through empty blocks to find a character', () => {
-        var selection = mainSelection.merge({
+        const selection = mainSelection.merge({
           anchorKey: 'emptyB',
           focusKey: 'emptyB',
         });
-        var editor = EditorState.acceptSelection(mainEditor, selection);
+        const editor = EditorState.acceptSelection(mainEditor, selection);
         expect(editor.getCurrentInlineStyle()).toBe(BOLD);
       });
     });
 
     describe('Non-collapsed selection', () => {
-      var selectionState = new SelectionState({
+      const selectionState = new SelectionState({
         anchorKey: 'a',
         anchorOffset: 0,
         focusKey: 'a',
@@ -159,37 +159,37 @@ describe('EditorState', () => {
       });
 
       it('uses right of the start for blocks with text', () => {
-        var selection = selectionState.set('focusKey', 'b');
-        var editor = EditorState.acceptSelection(mainEditor, selection);
+        const selection = selectionState.set('focusKey', 'b');
+        const editor = EditorState.acceptSelection(mainEditor, selection);
         expect(editor.getCurrentInlineStyle()).toBe(NONE);
       });
 
       it('uses left of the start if starting at end of block', () => {
-        var blockB = mainEditor.getCurrentContent().getBlockForKey('b');
-        var selection = selectionState.merge({
+        const blockB = mainEditor.getCurrentContent().getBlockForKey('b');
+        const selection = selectionState.merge({
           anchorKey: 'b',
           anchorOffset: blockB.getLength(),
           focusKey: 'c',
           focusOffset: 3,
         });
 
-        var editor = EditorState.acceptSelection(mainEditor, selection);
+        const editor = EditorState.acceptSelection(mainEditor, selection);
         expect(editor.getCurrentInlineStyle()).toBe(BOLD);
       });
 
       it('looks upward through empty blocks to find a character', () => {
-        var selection = selectionState.merge({
+        const selection = selectionState.merge({
           anchorKey: 'emptyA',
           anchorOffset: 0,
           focusKey: 'c',
           focusOffset: 3,
         });
-        var editor = EditorState.acceptSelection(mainEditor, selection);
+        const editor = EditorState.acceptSelection(mainEditor, selection);
         expect(editor.getCurrentInlineStyle()).toBe(BOLD);
       });
 
       it('falls back to no style if in empty block at document start', () => {
-        var editor = getEmptyLedMultiBlockEditorState(
+        const editor = getEmptyLedMultiBlockEditorState(
           new SelectionState({
             anchorKey: 'emptyA',
             anchorOffset: 0,
@@ -204,8 +204,8 @@ describe('EditorState', () => {
   });
 
   describe('Decorator handling', () => {
-    var boldA = List(Repeat('x', boldBlock.getLength()));
-    var boldB = List(Repeat('y', boldBlock.getLength()));
+    const boldA = List(Repeat('x', boldBlock.getLength()));
+    const boldB = List(Repeat('y', boldBlock.getLength()));
 
     function Decorator() {}
     Decorator.prototype.getDecorations = jest.genMockFn();
@@ -221,19 +221,19 @@ describe('EditorState', () => {
     });
 
     it('must set a new decorator', () => {
-      var decorator = new Decorator();
-      var editorState = getDecoratedEditorState(decorator);
+      const decorator = new Decorator();
+      const editorState = getDecoratedEditorState(decorator);
       expect(decorator.getDecorations.mock.calls.length).toBe(2);
 
       Decorator.prototype.getDecorations.mockImplementation(
         v => v === boldBlock ? boldB : List(Repeat(undefined, v.getLength()))
       );
-      var newDecorator = new NextDecorator();
+      const newDecorator = new NextDecorator();
       NextDecorator.prototype.getDecorations.mockImplementation(
         v => v === boldBlock ? boldB : List(Repeat(undefined, v.getLength()))
       );
 
-      var withNewDecorator = EditorState.set(editorState, {
+      const withNewDecorator = EditorState.set(editorState, {
         decorator: newDecorator,
       });
       expect(withNewDecorator).not.toBe(editorState);
@@ -263,10 +263,10 @@ describe('EditorState', () => {
     });
 
     it('must correctly remove a decorator', () => {
-      var decorator = new Decorator();
-      var editorState = getDecoratedEditorState(decorator);
+      const decorator = new Decorator();
+      const editorState = getDecoratedEditorState(decorator);
       expect(decorator.getDecorations.mock.calls.length).toBe(2);
-      var withNewDecorator = EditorState.set(editorState, {decorator: null});
+      const withNewDecorator = EditorState.set(editorState, {decorator: null});
       expect(withNewDecorator).not.toBe(editorState);
       expect(withNewDecorator.getDecorator()).toBe(null);
       expect(decorator.getDecorations.mock.calls.length).toBe(2);

--- a/src/model/immutable/__tests__/SelectionState-test.js
+++ b/src/model/immutable/__tests__/SelectionState-test.js
@@ -13,9 +13,9 @@
 
 jest.autoMockOff();
 
-var SelectionState = require('SelectionState');
+const SelectionState = require('SelectionState');
 
-var COLLAPSED = {
+const COLLAPSED = {
   anchorKey: 'a',
   anchorOffset: 0,
   focusKey: 'a',
@@ -24,7 +24,7 @@ var COLLAPSED = {
   hasFocus: true,
 };
 
-var WITHIN_BLOCK = {
+const WITHIN_BLOCK = {
   anchorKey: 'a',
   anchorOffset: 10,
   focusKey: 'a',
@@ -33,7 +33,7 @@ var WITHIN_BLOCK = {
   hasFocus: true,
 };
 
-var MULTIBLOCK = {
+const MULTIBLOCK = {
   anchorKey: 'b',
   anchorOffset: 10,
   focusKey: 'c',
@@ -47,7 +47,7 @@ function getSample(config) {
 }
 
 function verifyValues(state, values) {
-  var {
+  const {
     anchorKey,
     anchorOffset,
     focusKey,
@@ -67,12 +67,12 @@ function verifyValues(state, values) {
 describe('SelectionState', () => {
   describe('creation and retrieval', () => {
     it('must create a new instance', () => {
-      var state = getSample(COLLAPSED);
+      const state = getSample(COLLAPSED);
       expect(state instanceof SelectionState).toBe(true);
     });
 
     it('must retrieve properties correctly', () => {
-      var state = getSample(COLLAPSED);
+      const state = getSample(COLLAPSED);
       verifyValues(state, COLLAPSED);
     });
   });
@@ -152,8 +152,8 @@ describe('SelectionState', () => {
     });
 
     it('properly identifies start end end keys when backward', () => {
-      var withinBlock = flip(getSample(WITHIN_BLOCK));
-      var multiBlock = getSample({...MULTIBLOCK, isBackward: true});
+      const withinBlock = flip(getSample(WITHIN_BLOCK));
+      const multiBlock = getSample({...MULTIBLOCK, isBackward: true});
       expect(withinBlock.getStartKey()).toBe('a');
       expect(multiBlock.getStartKey()).toBe('c');
       expect(withinBlock.getEndKey()).toBe('a');
@@ -161,8 +161,8 @@ describe('SelectionState', () => {
     });
 
     it('properly identifies start end end offsets when backward', () => {
-      var withinBlock = flip(getSample(WITHIN_BLOCK));
-      var multiBlock = getSample({...MULTIBLOCK, isBackward: true});
+      const withinBlock = flip(getSample(WITHIN_BLOCK));
+      const multiBlock = getSample({...MULTIBLOCK, isBackward: true});
       expect(withinBlock.getStartOffset()).toBe(10);
       expect(multiBlock.getStartOffset()).toBe(15);
       expect(withinBlock.getEndOffset()).toBe(20);

--- a/src/model/immutable/__tests__/findRangesImmutable-test.js
+++ b/src/model/immutable/__tests__/findRangesImmutable-test.js
@@ -13,14 +13,14 @@
 
 jest.autoMockOff();
 
-var Immutable = require('immutable');
-var findRangesImmutable = require('findRangesImmutable');
+const Immutable = require('immutable');
+const findRangesImmutable = require('findRangesImmutable');
 
 describe('findRangesImmutable', () => {
-  var returnTrue = () => true;
+  const returnTrue = () => true;
 
   it('must be a no-op for an empty list', () => {
-    var cb = jest.genMockFn();
+    const cb = jest.genMockFn();
     findRangesImmutable(
       Immutable.List(),
       returnTrue,
@@ -31,26 +31,26 @@ describe('findRangesImmutable', () => {
   });
 
   describe('Function usage', () => {
-    var list = Immutable.List.of(1, 1, 1, 1, 1);
+    const list = Immutable.List.of(1, 1, 1, 1, 1);
 
     it('must identify the full list as a single range', () => {
-      var cb = jest.genMockFn();
+      const cb = jest.genMockFn();
       findRangesImmutable(list, returnTrue, returnTrue, cb);
-      var calls = cb.mock.calls;
+      const calls = cb.mock.calls;
       expect(calls.length).toBe(1);
       expect(calls[0]).toEqual([0, 5]);
     });
 
     it('must properly use `areEqualFn`', () => {
-      var cb = jest.genMockFn();
-      var areEqual = () => false;
+      const cb = jest.genMockFn();
+      const areEqual = () => false;
       findRangesImmutable(
         list,
         areEqual, // never equal
         returnTrue,
         cb
       );
-      var calls = cb.mock.calls;
+      const calls = cb.mock.calls;
       expect(calls.length).toBe(5);
       expect(calls[0]).toEqual([0, 1]);
       expect(calls[1]).toEqual([1, 2]);
@@ -60,30 +60,30 @@ describe('findRangesImmutable', () => {
     });
 
     it('must properly use `filterFn`', () => {
-      var cb = jest.genMockFn();
+      const cb = jest.genMockFn();
       findRangesImmutable(
         list,
         returnTrue,
         () => false, // never an accepted filter result
         cb
       );
-      var calls = cb.mock.calls;
+      const calls = cb.mock.calls;
       expect(calls.length).toBe(0);
     });
   });
 
   describe('Range finding for multi-value list', () => {
-    var list = Immutable.List.of(0, 0, 1, 1, 0, 0, 2, 2);
+    const list = Immutable.List.of(0, 0, 1, 1, 0, 0, 2, 2);
 
     it('must identify each range', () => {
-      var cb = jest.genMockFn();
+      const cb = jest.genMockFn();
       findRangesImmutable(
         list,
         (a, b) => a === b,
         returnTrue,
         cb
       );
-      var calls = cb.mock.calls;
+      const calls = cb.mock.calls;
       expect(calls.length).toBe(4);
       expect(calls[0]).toEqual([0, 2]);
       expect(calls[1]).toEqual([2, 4]);

--- a/src/model/immutable/findRangesImmutable.js
+++ b/src/model/immutable/findRangesImmutable.js
@@ -31,7 +31,7 @@ function findRangesImmutable<T>(
     return;
   }
 
-  var cursor: number = 0;
+  let cursor: number = 0;
 
   haystack.reduce((value, nextValue, nextIndex) => {
     if (!areEqualFn(value, nextValue)) {

--- a/src/model/keys/generateBlockKey.js
+++ b/src/model/keys/generateBlockKey.js
@@ -13,11 +13,11 @@
 
 'use strict';
 
-var seenKeys = {};
-var MULTIPLIER = Math.pow(2, 24);
+const seenKeys = {};
+const MULTIPLIER = Math.pow(2, 24);
 
 function generateBlockKey(): string {
-  var key;
+  let key;
   while (key === undefined || seenKeys.hasOwnProperty(key) || !isNaN(+key)) {
     key = Math.floor(Math.random() * MULTIPLIER).toString(32);
   }

--- a/src/model/modifier/DraftEntitySegments.js
+++ b/src/model/modifier/DraftEntitySegments.js
@@ -39,7 +39,7 @@ import type {DraftRange} from 'DraftRange';
  *       'John F. Kennedy' -> 'F. Kennedy'
  *            ^
  */
-var DraftEntitySegments = {
+const DraftEntitySegments = {
   getRemovalRange: function(
     selectionStart: number,
     selectionEnd: number,
@@ -47,7 +47,7 @@ var DraftEntitySegments = {
     entityStart: number,
     direction: DraftRemovalDirection
   ): DraftRange {
-    var segments = text.split(' ');
+    let segments = text.split(' ');
     segments = segments.map((/*string*/ segment, /*number*/ ii) => {
       if (direction === 'forward') {
         if (ii > 0) {
@@ -59,13 +59,13 @@ var DraftEntitySegments = {
       return segment;
     });
 
-    var segmentStart = entityStart;
-    var segmentEnd;
-    var segment;
-    var removalStart: any = null;
-    var removalEnd: any = null;
+    let segmentStart = entityStart;
+    let segmentEnd;
+    let segment;
+    let removalStart: any = null;
+    let removalEnd: any = null;
 
-    for (var jj = 0; jj < segments.length; jj++) {
+    for (let jj = 0; jj < segments.length; jj++) {
       segment = segments[jj];
       segmentEnd = segmentStart + segment.length;
 
@@ -84,9 +84,9 @@ var DraftEntitySegments = {
       segmentStart = segmentEnd;
     }
 
-    var entityEnd = entityStart + text.length;
-    var atStart = removalStart === entityStart;
-    var atEnd = removalEnd === entityEnd;
+    const entityEnd = entityStart + text.length;
+    const atStart = removalStart === entityStart;
+    const atEnd = removalEnd === entityEnd;
 
     if ((!atStart && atEnd) || (atStart && !atEnd)) {
       if (direction === 'forward') {

--- a/src/model/modifier/DraftModifier.js
+++ b/src/model/modifier/DraftModifier.js
@@ -13,20 +13,20 @@
 
 'use strict';
 
-var CharacterMetadata = require('CharacterMetadata');
-var ContentStateInlineStyle = require('ContentStateInlineStyle');
-var {OrderedSet} = require('immutable');
+const CharacterMetadata = require('CharacterMetadata');
+const ContentStateInlineStyle = require('ContentStateInlineStyle');
+const {OrderedSet} = require('immutable');
 
-var applyEntityToContentState = require('applyEntityToContentState');
-var getCharacterRemovalRange = require('getCharacterRemovalRange');
-var getContentStateFragment = require('getContentStateFragment');
-var insertFragmentIntoContentState = require('insertFragmentIntoContentState');
-var insertTextIntoContentState = require('insertTextIntoContentState');
-var invariant = require('invariant');
-var removeEntitiesAtEdges = require('removeEntitiesAtEdges');
-var removeRangeFromContentState = require('removeRangeFromContentState');
-var setBlockTypeForContentState = require('setBlockTypeForContentState');
-var splitBlockInContentState = require('splitBlockInContentState');
+const applyEntityToContentState = require('applyEntityToContentState');
+const getCharacterRemovalRange = require('getCharacterRemovalRange');
+const getContentStateFragment = require('getContentStateFragment');
+const insertFragmentIntoContentState = require('insertFragmentIntoContentState');
+const insertTextIntoContentState = require('insertTextIntoContentState');
+const invariant = require('invariant');
+const removeEntitiesAtEdges = require('removeEntitiesAtEdges');
+const removeRangeFromContentState = require('removeRangeFromContentState');
+const setBlockTypeForContentState = require('setBlockTypeForContentState');
+const splitBlockInContentState = require('splitBlockInContentState');
 
 import type {BlockMap} from 'BlockMap';
 import type ContentState from 'ContentState';
@@ -45,7 +45,7 @@ import type SelectionState from 'SelectionState';
  *
  * These functions encapsulate some of the most common transaction sequences.
  */
-var DraftModifier = {
+const DraftModifier = {
   replaceText: function(
     contentState: ContentState,
     rangeToReplace: SelectionState,
@@ -53,13 +53,13 @@ var DraftModifier = {
     inlineStyle?: DraftInlineStyle,
     entityKey?: ?string
   ): ContentState {
-    var withoutEntities = removeEntitiesAtEdges(contentState, rangeToReplace);
-    var withoutText = removeRangeFromContentState(
+    const withoutEntities = removeEntitiesAtEdges(contentState, rangeToReplace);
+    const withoutText = removeRangeFromContentState(
       withoutEntities,
       rangeToReplace
     );
 
-    var character = CharacterMetadata.create({
+    const character = CharacterMetadata.create({
       style: inlineStyle || OrderedSet(),
       entity: entityKey || null,
     });
@@ -97,9 +97,9 @@ var DraftModifier = {
     removalRange: SelectionState,
     targetRange: SelectionState
   ): ContentState {
-    var movedFragment = getContentStateFragment(contentState, removalRange);
+    const movedFragment = getContentStateFragment(contentState, removalRange);
 
-    var afterRemoval = DraftModifier.removeRange(
+    const afterRemoval = DraftModifier.removeRange(
       contentState,
       removalRange,
       'backward'
@@ -117,8 +117,8 @@ var DraftModifier = {
     targetRange: SelectionState,
     fragment: BlockMap
   ): ContentState {
-    var withoutEntities = removeEntitiesAtEdges(contentState, targetRange);
-    var withoutText = removeRangeFromContentState(
+    const withoutEntities = removeEntitiesAtEdges(contentState, targetRange);
+    const withoutText = removeRangeFromContentState(
       withoutEntities,
       targetRange
     );
@@ -138,15 +138,15 @@ var DraftModifier = {
     // Check whether the selection state overlaps with a single entity.
     // If so, try to remove the appropriate substring of the entity text.
     if (rangeToRemove.getAnchorKey() === rangeToRemove.getFocusKey()) {
-      var key = rangeToRemove.getAnchorKey();
-      var startOffset = rangeToRemove.getStartOffset();
-      var endOffset = rangeToRemove.getEndOffset();
-      var block = contentState.getBlockForKey(key);
+      const key = rangeToRemove.getAnchorKey();
+      const startOffset = rangeToRemove.getStartOffset();
+      const endOffset = rangeToRemove.getEndOffset();
+      const block = contentState.getBlockForKey(key);
 
-      var startEntity = block.getEntityAt(startOffset);
-      var endEntity = block.getEntityAt(endOffset - 1);
+      const startEntity = block.getEntityAt(startOffset);
+      const endEntity = block.getEntityAt(endOffset - 1);
       if (startEntity && startEntity === endEntity) {
-        var adjustedRemovalRange = getCharacterRemovalRange(
+        const adjustedRemovalRange = getCharacterRemovalRange(
           block,
           rangeToRemove,
           removalDirection
@@ -155,7 +155,7 @@ var DraftModifier = {
       }
     }
 
-    var withoutEntities = removeEntitiesAtEdges(contentState, rangeToRemove);
+    const withoutEntities = removeEntitiesAtEdges(contentState, rangeToRemove);
     return removeRangeFromContentState(withoutEntities, rangeToRemove);
   },
 
@@ -163,8 +163,8 @@ var DraftModifier = {
     contentState: ContentState,
     selectionState: SelectionState
   ): ContentState {
-    var withoutEntities = removeEntitiesAtEdges(contentState, selectionState);
-    var withoutText = removeRangeFromContentState(
+    const withoutEntities = removeEntitiesAtEdges(contentState, selectionState);
+    const withoutText = removeRangeFromContentState(
       withoutEntities,
       selectionState
     );
@@ -216,7 +216,7 @@ var DraftModifier = {
     selectionState: SelectionState,
     entityKey: ?string
   ): ContentState {
-    var withoutEntities = removeEntitiesAtEdges(contentState, selectionState);
+    const withoutEntities = removeEntitiesAtEdges(contentState, selectionState);
     return applyEntityToContentState(
       withoutEntities,
       selectionState,

--- a/src/model/modifier/DraftRemovableWord.js
+++ b/src/model/modifier/DraftRemovableWord.js
@@ -13,45 +13,45 @@
 
 'use strict';
 
-var TokenizeUtil = require('TokenizeUtil');
+const TokenizeUtil = require('TokenizeUtil');
 
-var punctuation = TokenizeUtil.getPunctuation();
+const punctuation = TokenizeUtil.getPunctuation();
 
 // The apostrophe and curly single quotes behave in a curious way: when
 // surrounded on both sides by word characters, they behave as word chars; when
 // either neighbor is punctuation or an end of the string, they behave as
 // punctuation.
-var CHAMELEON_CHARS = '[\'\u2018\u2019]';
+const CHAMELEON_CHARS = '[\'\u2018\u2019]';
 
 // Remove the underscore, which should count as part of the removable word. The
 // "chameleon chars" also count as punctuation in this regex.
-var WHITESPACE_AND_PUNCTUATION = '\\s|(?![_])' + punctuation;
+const WHITESPACE_AND_PUNCTUATION = '\\s|(?![_])' + punctuation;
 
-var DELETE_STRING =
+const DELETE_STRING =
   '^' +
   '(?:' + WHITESPACE_AND_PUNCTUATION + ')*' +
   '(?:' + CHAMELEON_CHARS + '|(?!' + WHITESPACE_AND_PUNCTUATION + ').)*' +
   '(?:(?!' + WHITESPACE_AND_PUNCTUATION + ').)';
-var DELETE_REGEX = new RegExp(DELETE_STRING);
+const DELETE_REGEX = new RegExp(DELETE_STRING);
 
-var BACKSPACE_STRING =
+const BACKSPACE_STRING =
   '(?:(?!' + WHITESPACE_AND_PUNCTUATION + ').)' +
   '(?:' + CHAMELEON_CHARS + '|(?!' + WHITESPACE_AND_PUNCTUATION + ').)*' +
   '(?:' + WHITESPACE_AND_PUNCTUATION + ')*' +
   '$';
-var BACKSPACE_REGEX = new RegExp(BACKSPACE_STRING);
+const BACKSPACE_REGEX = new RegExp(BACKSPACE_STRING);
 
 function getRemovableWord(
   text: string,
   isBackward: boolean
 ): string {
-  var matches = isBackward ?
+  const matches = isBackward ?
     BACKSPACE_REGEX.exec(text) :
     DELETE_REGEX.exec(text);
   return matches ? matches[0] : text;
 }
 
-var DraftRemovableWord = {
+const DraftRemovableWord = {
   getBackward: function(text: string): string {
     return getRemovableWord(text, true);
   },

--- a/src/model/modifier/RichTextEditorUtil.js
+++ b/src/model/modifier/RichTextEditorUtil.js
@@ -13,11 +13,11 @@
 
 'use strict';
 
-var DraftEntity = require('DraftEntity');
-var DraftModifier = require('DraftModifier');
-var EditorState = require('EditorState');
+const DraftEntity = require('DraftEntity');
+const DraftModifier = require('DraftModifier');
+const EditorState = require('EditorState');
 
-var adjustBlockDepthForContentState = require('adjustBlockDepthForContentState');
+const adjustBlockDepthForContentState = require('adjustBlockDepthForContentState');
 
 import type ContentState from 'ContentState';
 import type {DraftBlockType} from 'DraftBlockType';
@@ -25,23 +25,23 @@ import type {DraftEditorCommand} from 'DraftEditorCommand';
 import type SelectionState from 'SelectionState';
 import type URI from 'URI';
 
-var RichTextEditorUtil = {
+const RichTextEditorUtil = {
   currentBlockContainsLink: function(
     editorState: EditorState
   ): boolean {
-    var selection = editorState.getSelection();
+    const selection = editorState.getSelection();
     return editorState.getCurrentContent()
       .getBlockForKey(selection.getAnchorKey())
       .getCharacterList()
       .slice(selection.getStartOffset(), selection.getEndOffset())
       .some(v => {
-        var entity = v.getEntity();
+        const entity = v.getEntity();
         return !!entity && DraftEntity.get(entity).getType() === 'LINK';
       });
   },
 
   getCurrentBlockType: function(editorState: EditorState): DraftBlockType {
-    var selection = editorState.getSelection();
+    const selection = editorState.getSelection();
     return editorState.getCurrentContent()
       .getBlockForKey(selection.getStartKey())
       .getType();
@@ -78,7 +78,7 @@ var RichTextEditorUtil = {
   },
 
   insertSoftNewline: function(editorState: EditorState): EditorState {
-    var contentState = DraftModifier.insertText(
+    const contentState = DraftModifier.insertText(
       editorState.getCurrentContent(),
       editorState.getSelection(),
       '\n',
@@ -98,7 +98,7 @@ var RichTextEditorUtil = {
    * just remove the existing style.
    */
   onBackspace: function(editorState: EditorState): ?EditorState {
-    var selection = editorState.getSelection();
+    const selection = editorState.getSelection();
     if (
       !selection.isCollapsed() ||
       selection.getAnchorOffset() ||
@@ -108,28 +108,28 @@ var RichTextEditorUtil = {
     }
 
     // First, try to remove a preceding media block.
-    var content = editorState.getCurrentContent();
-    var startKey = selection.getStartKey();
-    var blockAfter = content.getBlockAfter(startKey);
+    const content = editorState.getCurrentContent();
+    const startKey = selection.getStartKey();
+    const blockAfter = content.getBlockAfter(startKey);
 
     // If the current block is empty, just delete it.
     if (blockAfter && content.getBlockForKey(startKey).getLength() === 0) {
       return null;
     }
 
-    var blockBefore = content.getBlockBefore(startKey);
+    const blockBefore = content.getBlockBefore(startKey);
 
     if (blockBefore && blockBefore.getType() === 'media') {
-      var mediaBlockTarget = selection.merge({
+      const mediaBlockTarget = selection.merge({
         anchorKey: blockBefore.getKey(),
         anchorOffset: 0,
       });
-      var asCurrentStyle = DraftModifier.setBlockType(
+      const asCurrentStyle = DraftModifier.setBlockType(
         content,
         mediaBlockTarget,
         content.getBlockForKey(startKey).getType()
       );
-      var withoutMedia = DraftModifier.removeRange(
+      const withoutMedia = DraftModifier.removeRange(
         asCurrentStyle,
         mediaBlockTarget,
         'backward'
@@ -144,7 +144,7 @@ var RichTextEditorUtil = {
     }
 
     // If that doesn't succeed, try to remove the current block style.
-    var withoutBlockStyle = RichTextEditorUtil.tryToRemoveBlockStyle(
+    const withoutBlockStyle = RichTextEditorUtil.tryToRemoveBlockStyle(
       editorState
     );
 
@@ -160,22 +160,22 @@ var RichTextEditorUtil = {
   },
 
   onDelete: function(editorState: EditorState): ?EditorState {
-    var selection = editorState.getSelection();
+    const selection = editorState.getSelection();
     if (!selection.isCollapsed()) {
       return null;
     }
 
-    var content = editorState.getCurrentContent();
-    var startKey = selection.getStartKey();
-    var block = content.getBlockForKey(startKey);
-    var length = block.getLength();
+    const content = editorState.getCurrentContent();
+    const startKey = selection.getStartKey();
+    const block = content.getBlockForKey(startKey);
+    const length = block.getLength();
 
     // The cursor is somewhere within the text. Behave normally.
     if (selection.getStartOffset() < length) {
       return null;
     }
 
-    var blockAfter = content.getBlockAfter(startKey);
+    const blockAfter = content.getBlockAfter(startKey);
 
     if (!blockAfter || blockAfter.getType() !== 'media') {
       return null;
@@ -183,18 +183,18 @@ var RichTextEditorUtil = {
 
     // If the current block is empty, delete it.
     if (length === 0) {
-      var target = selection.merge({
+      const target = selection.merge({
         focusKey: blockAfter.getKey(),
         focusOffset: 0,
       });
 
-      var withoutEmptyBlock = DraftModifier.removeRange(
+      const withoutEmptyBlock = DraftModifier.removeRange(
         content,
         target,
         'forward'
       );
 
-      var preserveMedia = DraftModifier.setBlockType(
+      const preserveMedia = DraftModifier.setBlockType(
         withoutEmptyBlock,
         withoutEmptyBlock.getSelectionAfter(),
         'media'
@@ -204,12 +204,12 @@ var RichTextEditorUtil = {
     }
 
     // Otherwise, delete the media block.
-    var mediaBlockTarget = selection.merge({
+    const mediaBlockTarget = selection.merge({
       focusKey: blockAfter.getKey(),
       focusOffset: blockAfter.getLength(),
     });
 
-    var withoutMedia = DraftModifier.removeRange(
+    const withoutMedia = DraftModifier.removeRange(
       content,
       mediaBlockTarget,
       'forward'
@@ -231,15 +231,15 @@ var RichTextEditorUtil = {
     editorState: EditorState,
     maxDepth: number
   ): EditorState {
-    var selection = editorState.getSelection();
-    var key = selection.getAnchorKey();
+    const selection = editorState.getSelection();
+    const key = selection.getAnchorKey();
     if (key !== selection.getFocusKey()) {
       return editorState;
     }
 
-    var content = editorState.getCurrentContent();
-    var block = content.getBlockForKey(key);
-    var type = block.getType();
+    const content = editorState.getCurrentContent();
+    const block = content.getBlockForKey(key);
+    const type = block.getType();
     if (type !== 'unordered-list-item' && type !== 'ordered-list-item') {
       return editorState;
     }
@@ -248,12 +248,12 @@ var RichTextEditorUtil = {
 
     // Only allow indenting one level beyond the block above, and only if
     // the block above is a list item as well.
-    var blockAbove = content.getBlockBefore(key);
+    const blockAbove = content.getBlockBefore(key);
     if (!blockAbove) {
       return editorState;
     }
 
-    var typeAbove = blockAbove.getType();
+    const typeAbove = blockAbove.getType();
     if (
       typeAbove !== 'unordered-list-item' &&
       typeAbove !== 'ordered-list-item'
@@ -261,14 +261,14 @@ var RichTextEditorUtil = {
       return editorState;
     }
 
-    var depth = block.getDepth();
+    const depth = block.getDepth();
     if (!event.shiftKey && depth === maxDepth) {
       return editorState;
     }
 
     maxDepth = Math.min(blockAbove.getDepth() + 1, maxDepth);
 
-    var withAdjustment = adjustBlockDepthForContentState(
+    const withAdjustment = adjustBlockDepthForContentState(
       content,
       selection,
       event.shiftKey ? -1 : 1,
@@ -286,12 +286,12 @@ var RichTextEditorUtil = {
     editorState: EditorState,
     blockType: DraftBlockType
   ): EditorState {
-    var selection = editorState.getSelection();
-    var startKey = selection.getStartKey();
-    var endKey = selection.getEndKey();
-    var content = editorState.getCurrentContent();
+    const selection = editorState.getSelection();
+    const startKey = selection.getStartKey();
+    const endKey = selection.getEndKey();
+    const content = editorState.getCurrentContent();
 
-    var hasMedia = content.getBlockMap()
+    const hasMedia = content.getBlockMap()
       .skipWhile((_, k) => k !== startKey)
       .takeWhile((_, k) => k !== endKey)
       .some(v => v.getType() === 'media');
@@ -300,7 +300,7 @@ var RichTextEditorUtil = {
       return editorState;
     }
 
-    var typeToSet = content.getBlockForKey(startKey).getType() === blockType ?
+    const typeToSet = content.getBlockForKey(startKey).getType() === blockType ?
       'unstyled' :
       blockType;
 
@@ -312,9 +312,9 @@ var RichTextEditorUtil = {
   },
 
   toggleCode: function(editorState: EditorState): EditorState {
-    var selection = editorState.getSelection();
-    var anchorKey = selection.getAnchorKey();
-    var focusKey = selection.getFocusKey();
+    const selection = editorState.getSelection();
+    const anchorKey = selection.getAnchorKey();
+    const focusKey = selection.getFocusKey();
 
     if (selection.isCollapsed() || anchorKey !== focusKey) {
       return RichTextEditorUtil.toggleBlockType(editorState, 'code-block');
@@ -333,8 +333,8 @@ var RichTextEditorUtil = {
     editorState: EditorState,
     inlineStyle: string
   ): EditorState {
-    var selection = editorState.getSelection();
-    var currentStyle = editorState.getCurrentInlineStyle();
+    const selection = editorState.getSelection();
+    const currentStyle = editorState.getCurrentInlineStyle();
 
     // If the selection is collapsed, toggle the specified style on or off and
     // set the result as the new inline style override. This will then be
@@ -350,8 +350,8 @@ var RichTextEditorUtil = {
 
     // If characters are selected, immediately apply or remove the
     // inline style on the document state itself.
-    var content = editorState.getCurrentContent();
-    var newContent;
+    const content = editorState.getCurrentContent();
+    let newContent;
 
     // If the style is already present for the selection range, remove it.
     // Otherwise, apply it.
@@ -381,7 +381,7 @@ var RichTextEditorUtil = {
     targetSelection: SelectionState,
     entityKey: ?string
   ): EditorState {
-    var withoutLink = DraftModifier.applyEntity(
+    const withoutLink = DraftModifier.applyEntity(
       editorState.getCurrentContent(),
       targetSelection,
       entityKey
@@ -400,17 +400,17 @@ var RichTextEditorUtil = {
    * style of the block instead of the default behavior.
    */
   tryToRemoveBlockStyle: function(editorState: EditorState): ?ContentState {
-    var selection = editorState.getSelection();
-    var offset = selection.getAnchorOffset();
+    const selection = editorState.getSelection();
+    const offset = selection.getAnchorOffset();
     if (selection.isCollapsed() && offset === 0) {
-      var key = selection.getAnchorKey();
-      var content = editorState.getCurrentContent();
-      var block = content.getBlockForKey(key);
+      const key = selection.getAnchorKey();
+      const content = editorState.getCurrentContent();
+      const block = content.getBlockForKey(key);
       if (block.getLength() > 0) {
         return null;
       }
 
-      var type = block.getType();
+      const type = block.getType();
       if (type !== 'unstyled' && type !== 'code-block') {
         return DraftModifier.setBlockType(content, selection, 'unstyled');
       }

--- a/src/model/modifier/__tests__/DraftRemovableWord-test.js
+++ b/src/model/modifier/__tests__/DraftRemovableWord-test.js
@@ -13,20 +13,20 @@
 
 jest.autoMockOff();
 
-var DraftRemovableWord = require('DraftRemovableWord');
+const DraftRemovableWord = require('DraftRemovableWord');
 
 describe('DraftRemovableWord', function() {
-  var forward;
-  var backward;
+  let forward;
+  let backward;
 
-  var english = 'the animals';
-  var accents = 'th\u00e9 f\u00e0bregas';
-  var arabic = '\u0637\u0638\u0639 \u063A\u063B\u063C';
-  var japanese = '\u4f1a\u8b70\u4e2d \u30cf\u30c3\u30b7\u30e5';
-  var korean = '\ud2b8\uc704\ud130 \ud2b8\uc704\ud130';
-  var halfWidthHangul = '\uffa3\uffa6\uffb0 \uffa1\uffa2\uffb2';
-  var cyrillic = '\u0430\u0448\u043e\u043a \u0431\u0414\u0416\u0426';
-  var withNumbers = 'f14 tomcat';
+  const english = 'the animals';
+  const accents = 'th\u00e9 f\u00e0bregas';
+  const arabic = '\u0637\u0638\u0639 \u063A\u063B\u063C';
+  const japanese = '\u4f1a\u8b70\u4e2d \u30cf\u30c3\u30b7\u30e5';
+  const korean = '\ud2b8\uc704\ud130 \ud2b8\uc704\ud130';
+  const halfWidthHangul = '\uffa3\uffa6\uffb0 \uffa1\uffa2\uffb2';
+  const cyrillic = '\u0430\u0448\u043e\u043a \u0431\u0414\u0416\u0426';
+  const withNumbers = 'f14 tomcat';
 
   beforeEach(function() {
     jest.resetModuleRegistry();
@@ -77,7 +77,7 @@ describe('DraftRemovableWord', function() {
   });
 
   it('must identify words led by punctuation looking forward', function() {
-    var match = english.split(' ')[0];
+    const match = english.split(' ')[0];
     expect(forward('.' + english)).toBe('.' + match);
     expect(forward('|' + english)).toBe('|' + match);
     expect(forward('^' + english)).toBe('^' + match);
@@ -116,7 +116,7 @@ describe('DraftRemovableWord', function() {
   });
 
   it('must identify words ended by punctuation looking backward', function() {
-    var match = english.split(' ')[1];
+    const match = english.split(' ')[1];
     expect(backward(english + '.')).toBe(match + '.');
     expect(backward(english + '|')).toBe(match + '|');
     expect(backward(english + '^')).toBe(match + '^');

--- a/src/model/modifier/getCharacterRemovalRange.js
+++ b/src/model/modifier/getCharacterRemovalRange.js
@@ -13,11 +13,11 @@
 
 'use strict';
 
-var DraftEntity = require('DraftEntity');
-var DraftEntitySegments = require('DraftEntitySegments');
+const DraftEntity = require('DraftEntity');
+const DraftEntitySegments = require('DraftEntitySegments');
 
-var getRangesForDraftEntity = require('getRangesForDraftEntity');
-var invariant = require('invariant');
+const getRangesForDraftEntity = require('getRangesForDraftEntity');
+const invariant = require('invariant');
 
 import type ContentBlock from 'ContentBlock';
 import type {DraftRemovalDirection} from 'DraftRemovalDirection';
@@ -37,15 +37,15 @@ function getCharacterRemovalRange(
   selectionState: SelectionState,
   direction: DraftRemovalDirection
 ): SelectionState {
-  var start = selectionState.getStartOffset();
-  var end = selectionState.getEndOffset();
-  var entityKey = block.getEntityAt(start);
+  const start = selectionState.getStartOffset();
+  const end = selectionState.getEndOffset();
+  const entityKey = block.getEntityAt(start);
   if (!entityKey) {
     return selectionState;
   }
 
-  var entity = DraftEntity.get(entityKey);
-  var mutability = entity.getMutability();
+  const entity = DraftEntity.get(entityKey);
+  const mutability = entity.getMutability();
 
   // `MUTABLE` entities can just have the specified range of text removed
   // directly. No adjustments are needed.
@@ -54,7 +54,7 @@ function getCharacterRemovalRange(
   }
 
   // Find the entity range that overlaps with our removal range.
-  var entityRanges = getRangesForDraftEntity(block, entityKey).filter(
+  const entityRanges = getRangesForDraftEntity(block, entityKey).filter(
     (range) => start < range.end && end > range.start
   );
 
@@ -63,7 +63,7 @@ function getCharacterRemovalRange(
     'There should only be one entity range within this removal range.'
   );
 
-  var entityRange = entityRanges[0];
+  const entityRange = entityRanges[0];
 
   // For `IMMUTABLE` entity types, we will remove the entire entity range.
   if (mutability === 'IMMUTABLE') {
@@ -76,7 +76,7 @@ function getCharacterRemovalRange(
 
   // For `SEGMENTED` entity types, determine the appropriate segment to
   // remove.
-  var removalRange = DraftEntitySegments.getRemovalRange(
+  const removalRange = DraftEntitySegments.getRemovalRange(
     start,
     end,
     block.getText().slice(entityRange.start, entityRange.end),

--- a/src/model/modifier/getRangesForDraftEntity.js
+++ b/src/model/modifier/getRangesForDraftEntity.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-var invariant = require('invariant');
+const invariant = require('invariant');
 
 import type ContentBlock from 'ContentBlock';
 import type {DraftRange} from 'DraftRange';
@@ -30,7 +30,7 @@ function getRangesForDraftEntity(
   block: ContentBlock,
   key: string
 ): Array<DraftRange> {
-  var ranges = [];
+  const ranges = [];
   block.findEntityRanges(
     c => c.getEntity() === key,
     (start, end) => {

--- a/src/model/paste/__mocks__/getSafeBodyFromHTML.js
+++ b/src/model/paste/__mocks__/getSafeBodyFromHTML.js
@@ -10,8 +10,8 @@
 // THIS IS PURELY A MOCK TO GET AROUND THE TEST FRAMEWORK
 // Never use this for anything else ever.
 function getUnsafeBodyFromHTML(html) {
-  var fragment = document.createElement('body');
-  var match = html.match(/<body>(.*?)<\/body>/);
+  const fragment = document.createElement('body');
+  const match = html.match(/<body>(.*?)<\/body>/);
   fragment.innerHTML = match ? match[1] : html;
   return fragment;
 }

--- a/src/model/paste/__tests__/DraftPasteProcessor-test.js
+++ b/src/model/paste/__tests__/DraftPasteProcessor-test.js
@@ -13,20 +13,20 @@
 
 jest.autoMockOff();
 
-var DraftEntity = require('DraftEntity');
+const DraftEntity = require('DraftEntity');
 
-var DraftPasteProcessor = require('DraftPasteProcessor');
+const DraftPasteProcessor = require('DraftPasteProcessor');
 
 describe('DraftPasteProcessor', function() {
   function assertInlineStyles(block, comparison) {
-    var styles = block.getCharacterList().map(c => c.getStyle());
+    const styles = block.getCharacterList().map(c => c.getStyle());
     expect(styles.toJS()).toEqual(comparison);
   }
 
   // Don't want to couple this to a specific way of generating entity IDs so
   // just checking their existance
   function assertEntities(block, comparison) {
-    var entities = block.getCharacterList().map(c => c.getEntity());
+    const entities = block.getCharacterList().map(c => c.getEntity());
     entities.toJS().forEach((entity, ii) => {
       expect(comparison[ii]).toBe(!!entity);
     });
@@ -49,9 +49,9 @@ describe('DraftPasteProcessor', function() {
   }
 
   it('must identify italics text', function() {
-    var html = '<i>hello</i> hi';
-    var output = DraftPasteProcessor.processHTML(html);
-    var block = output[0];
+    const html = '<i>hello</i> hi';
+    const output = DraftPasteProcessor.processHTML(html);
+    const block = output[0];
     expect(block.getType()).toBe('unstyled');
     assertInlineStyles(block, [
       ['ITALIC'],
@@ -67,9 +67,9 @@ describe('DraftPasteProcessor', function() {
   });
 
   it('must identify overlapping inline styles', function() {
-    var html = '<i><b>he</b>hi</i>';
-    var output = DraftPasteProcessor.processHTML(html);
-    var block = output[0];
+    const html = '<i><b>he</b>hi</i>';
+    const output = DraftPasteProcessor.processHTML(html);
+    const block = output[0];
     expect(block.getType()).toBe('unstyled');
     assertInlineStyles(block, [
       ['ITALIC', 'BOLD'],
@@ -81,8 +81,8 @@ describe('DraftPasteProcessor', function() {
   });
 
   it('must identify block styles', function() {
-    var html = '<ol><li>hi</li><li>there</li></ol>';
-    var output = DraftPasteProcessor.processHTML(html);
+    const html = '<ol><li>hi</li><li>there</li></ol>';
+    const output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, [
       'ordered-list-item',
       'ordered-list-item',
@@ -90,8 +90,8 @@ describe('DraftPasteProcessor', function() {
   });
 
   it('must collapse nested blocks to the topmost level', function() {
-    var html = '<ul><li><h2>what</h2></li></ul>';
-    var output = DraftPasteProcessor.processHTML(html);
+    const html = '<ul><li><h2>what</h2></li></ul>';
+    const output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, [
       'unordered-list-item',
     ]);
@@ -102,8 +102,8 @@ describe('DraftPasteProcessor', function() {
    * Changes to the mocked DOM appear to have broken this.
    *
    * it('must suppress blocks nested inside other blocks', function() {
-   *   var html = '<p><h2>Some text here</h2> more text here </p>';
-   *   var output = DraftPasteProcessor.processHTML(html);
+   *   const html = '<p><h2>Some text here</h2> more text here </p>';
+   *   const output = DraftPasteProcessor.processHTML(html);
    *   assertBlockTypes(output, [
    *     'unstyled',
    *   ]);
@@ -111,8 +111,8 @@ describe('DraftPasteProcessor', function() {
    */
 
   it('must detect two touching blocks', function() {
-    var html = '<h1>hi</h1>        <h2>hi</h2>';
-    var output = DraftPasteProcessor.processHTML(html);
+    const html = '<h1>hi</h1>        <h2>hi</h2>';
+    const output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, [
       'header-one',
       'header-two',
@@ -120,8 +120,8 @@ describe('DraftPasteProcessor', function() {
   });
 
   it('must insert a block when needed', function() {
-    var html = ' <h1> hi </h1><h1> </h1><span> whatever </span> <h2>hi </h2> ';
-    var output = DraftPasteProcessor.processHTML(html);
+    const html = ' <h1> hi </h1><h1> </h1><span> whatever </span> <h2>hi </h2> ';
+    const output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, [
       'header-one',
       'unstyled',
@@ -130,20 +130,20 @@ describe('DraftPasteProcessor', function() {
   });
 
   it('must not generate fake blocks on heavy nesting', function() {
-    var html = '<p><span><span><span>Word</span></span></span>' +
+    const html = '<p><span><span><span>Word</span></span></span>' +
       '<span><span>,</span></span></p>';
-    var output = DraftPasteProcessor.processHTML(html);
+    const output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, ['unstyled']);
   });
 
   it('must preserve spaces', function() {
-    var html, output;
+    let html, output;
 
     html = '<span>hello</span> <span>hi</span>';
     output = DraftPasteProcessor.processHTML(html);
     expect(output.length).toEqual(1);
     assertBlockTypes(output, ['unstyled']);
-    var block = output[0];
+    const block = output[0];
     expect(block.getText()).toBe('hello hi');
 
     html = '<span>hello </span><span>hi</span>';
@@ -156,8 +156,8 @@ describe('DraftPasteProcessor', function() {
   });
 
   it('must treat divs as Ps when we do not have semantic markup', function() {
-    var html = '<div>hi</div><div>hello</div>';
-    var output = DraftPasteProcessor.processHTML(html);
+    const html = '<div>hi</div><div>hello</div>';
+    const output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, [
       'unstyled',
       'unstyled',
@@ -165,8 +165,8 @@ describe('DraftPasteProcessor', function() {
   });
 
   it('must NOT treat divs as Ps when we pave Ps', function() {
-    var html = '<div><p>hi</p><p>hello</p></div>';
-    var output = DraftPasteProcessor.processHTML(html);
+    const html = '<div><p>hi</p><p>hello</p></div>';
+    const output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, [
       'unstyled',
       'unstyled',
@@ -174,14 +174,14 @@ describe('DraftPasteProcessor', function() {
   });
 
   it('must replace br tags with soft newlines', function() {
-    var html = 'hi<br>hello';
-    var output = DraftPasteProcessor.processHTML(html);
+    const html = 'hi<br>hello';
+    const output = DraftPasteProcessor.processHTML(html);
     expect(output[0].getText()).toBe('hi\nhello');
   });
 
   it('must split unstyled blocks on two br tags', function() {
-    var html = 'hi<br><br>hello';
-    var output = DraftPasteProcessor.processHTML(html);
+    let html = 'hi<br><br>hello';
+    let output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, [
       'unstyled',
       'unstyled',
@@ -195,14 +195,14 @@ describe('DraftPasteProcessor', function() {
   });
 
   it('must NOT split unstyled blocks inside a styled block', function() {
-    var html = '<pre>hi<br><br>hello</pre>';
-    var output = DraftPasteProcessor.processHTML(html);
+    const html = '<pre>hi<br><br>hello</pre>';
+    const output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, ['code-block']);
   });
 
   it('must split unstyled blocks on two br tags', function() {
-    var html = 'hi<br><br>hello';
-    var output = DraftPasteProcessor.processHTML(html);
+    const html = 'hi<br><br>hello';
+    const output = DraftPasteProcessor.processHTML(html);
     expect(output[0].getText().length).toBe(3);
     expect(output[1].getText()).toBe('hello');
     assertBlockTypes(output, [
@@ -212,28 +212,28 @@ describe('DraftPasteProcessor', function() {
   });
 
   it('must replace newlines in regular tags', function() {
-    var html = '<div>hello\nthere</div>';
-    var output = DraftPasteProcessor.processHTML(html);
+    const html = '<div>hello\nthere</div>';
+    const output = DraftPasteProcessor.processHTML(html);
     expect(output[0].getText()).toBe('hello there');
   });
 
   it('must preserve newlines in pre tags', function() {
-    var html = '<pre>hello\nthere</pre>';
-    var output = DraftPasteProcessor.processHTML(html);
+    const html = '<pre>hello\nthere</pre>';
+    const output = DraftPasteProcessor.processHTML(html);
     expect(output[0].getText()).toBe('hello\nthere');
   });
 
   it('must preserve newlines in whitespace in pre tags', function() {
-    var html = '<pre><span>hello</span>\n<span>there</span></pre>';
-    var output = DraftPasteProcessor.processHTML(html);
+    const html = '<pre><span>hello</span>\n<span>there</span></pre>';
+    const output = DraftPasteProcessor.processHTML(html);
     expect(output[0].getText()).toBe('hello\nthere');
     assertBlockTypes(output, ['code-block']);
   });
 
   it('must parse based on style attribute', function() {
-    var html = '<span style="font-weight: bold;">Bold '
+    const html = '<span style="font-weight: bold;">Bold '
       + '<span style="font-style: italic;">Italic</span></span>.';
-    var output = DraftPasteProcessor.processHTML(html);
+    const output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, ['unstyled']);
     assertInlineStyles(output[0], [
       ['BOLD'],
@@ -253,22 +253,22 @@ describe('DraftPasteProcessor', function() {
   });
 
   it('must detect links in pasted content', function() {
-    var html = 'This is a <a href="http://www.facebook.com">link</a>, yep.';
-    var output = DraftPasteProcessor.processHTML(html);
+    const html = 'This is a <a href="http://www.facebook.com">link</a>, yep.';
+    const output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, ['unstyled']);
     assertEntities(
       output[0],
       Array(10).fill(false).concat(Array(4).fill(true), Array(6).fill(false))
     );
     expect(output[0].getText()).toBe('This is a link, yep.');
-    var entityId = output[0].getCharacterList().get(12).getEntity();
-    var entity = DraftEntity.get(entityId);
+    const entityId = output[0].getCharacterList().get(12).getEntity();
+    const entity = DraftEntity.get(entityId);
     expect(entity.getData().url).toBe('http://www.facebook.com/');
   });
 
   it('must preserve styles inside links in a good way', function() {
-    var html = 'A <a href="http://www.facebook.com"><i>cool</i> link</a>, yep.';
-    var output = DraftPasteProcessor.processHTML(html);
+    const html = 'A <a href="http://www.facebook.com"><i>cool</i> link</a>, yep.';
+    const output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, ['unstyled']);
     assertInlineStyles(
       output[0],
@@ -282,16 +282,16 @@ describe('DraftPasteProcessor', function() {
   });
 
   it('must ignore links that do not actually link anywhere', function() {
-    var html = 'This is a <a>link</a>, yep.';
-    var output = DraftPasteProcessor.processHTML(html);
+    const html = 'This is a <a>link</a>, yep.';
+    const output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, ['unstyled']);
     assertEntities(output[0], Array(20).fill(false));
     expect(output[0].getText()).toBe('This is a link, yep.');
   });
 
   it('Tolerate doule BR tags separated by whitespace', function() {
-    var html = 'hi<br>  <br>hello';
-    var output = DraftPasteProcessor.processHTML(html);
+    let html = 'hi<br>  <br>hello';
+    let output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, [
       'unstyled',
       'unstyled',
@@ -311,13 +311,13 @@ describe('DraftPasteProcessor', function() {
   });
 
   it('Strip whitespace after block dividers', function() {
-    var html = '<p>hello</p> <p> what</p>';
-    var output = DraftPasteProcessor.processHTML(html);
+    const html = '<p>hello</p> <p> what</p>';
+    const output = DraftPasteProcessor.processHTML(html);
     expect(output[1].getText()).toBe('what');
   });
 
   it('must preserve list formatting', function() {
-    var html = `
+    const html = `
       what
       <ul>
           <li>what</li>
@@ -331,7 +331,7 @@ describe('DraftPasteProcessor', function() {
           <li>what</li>
       </ul>
     `;
-    var output = DraftPasteProcessor.processHTML(html);
+    const output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, [
       'unstyled',
       'unordered-list-item',

--- a/src/model/paste/getSafeBodyFromHTML.js
+++ b/src/model/paste/getSafeBodyFromHTML.js
@@ -12,17 +12,17 @@
 
 'use strict';
 
-var UserAgent = require('UserAgent');
+const UserAgent = require('UserAgent');
 
-var isOldIE = UserAgent.isBrowser('IE <= 9');
+const isOldIE = UserAgent.isBrowser('IE <= 9');
 
 // Provides a dom node that will not execute scripts
 // https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation.createHTMLDocument
 // https://developer.mozilla.org/en-US/Add-ons/Code_snippets/HTML_to_DOM
 
 function getSafeBodyFromHTML(html: string): ?Element {
-  var doc;
-  var root = null;
+  let doc;
+  let root = null;
   // Provides a safe context
   if (
     !isOldIE &&

--- a/src/model/transaction/ContentStateInlineStyle.js
+++ b/src/model/transaction/ContentStateInlineStyle.js
@@ -13,13 +13,13 @@
 
 'use strict';
 
-var CharacterMetadata = require('CharacterMetadata');
-var {Map} = require('immutable');
+const CharacterMetadata = require('CharacterMetadata');
+const {Map} = require('immutable');
 
 import type ContentState from 'ContentState';
 import type SelectionState from 'SelectionState';
 
-var ContentStateInlineStyle = {
+const ContentStateInlineStyle = {
   add: function(
     contentState: ContentState,
     selectionState: SelectionState,
@@ -43,19 +43,19 @@ function modifyInlineStyle(
   inlineStyle: string,
   addOrRemove: boolean
 ): ContentState {
-  var blockMap = contentState.getBlockMap();
-  var startKey = selectionState.getStartKey();
-  var startOffset = selectionState.getStartOffset();
-  var endKey = selectionState.getEndKey();
-  var endOffset = selectionState.getEndOffset();
+  const blockMap = contentState.getBlockMap();
+  const startKey = selectionState.getStartKey();
+  const startOffset = selectionState.getStartOffset();
+  const endKey = selectionState.getEndKey();
+  const endOffset = selectionState.getEndOffset();
 
-  var newBlocks = blockMap
+  const newBlocks = blockMap
     .skipUntil((_, k) => k === startKey)
     .takeUntil((_, k) => k === endKey)
     .concat(Map([[endKey, blockMap.get(endKey)]]))
     .map((block, blockKey) => {
-      var sliceStart;
-      var sliceEnd;
+      let sliceStart;
+      let sliceEnd;
 
       if (startKey === endKey) {
         sliceStart = startOffset;
@@ -65,8 +65,8 @@ function modifyInlineStyle(
         sliceEnd = blockKey === endKey ? endOffset : block.getLength();
       }
 
-      var chars = block.getCharacterList();
-      var current;
+      let chars = block.getCharacterList();
+      let current;
       while (sliceStart < sliceEnd) {
         current = chars.get(sliceStart);
         chars = chars.set(

--- a/src/model/transaction/__tests__/applyEntityToContentBlock-test.js
+++ b/src/model/transaction/__tests__/applyEntityToContentBlock-test.js
@@ -13,17 +13,17 @@
 
 jest.autoMockOff();
 
-var CharacterMetadata = require('CharacterMetadata');
-var ContentBlock = require('ContentBlock');
-var applyEntityToContentBlock = require('applyEntityToContentBlock');
+const CharacterMetadata = require('CharacterMetadata');
+const ContentBlock = require('ContentBlock');
+const applyEntityToContentBlock = require('applyEntityToContentBlock');
 
-var {
+const {
   List,
   Repeat,
 } = require('immutable');
 
 describe('applyEntityToContentBlock', () => {
-  var block = new ContentBlock({
+  const block = new ContentBlock({
     key: 'a',
     text: 'Hello',
     characterList: List(Repeat(CharacterMetadata.EMPTY, 5)),
@@ -34,22 +34,22 @@ describe('applyEntityToContentBlock', () => {
   }
 
   it('must apply from the start', () => {
-    var modified = applyEntityToContentBlock(block, 0, 2, 'x');
+    const modified = applyEntityToContentBlock(block, 0, 2, 'x');
     expect(getEntities(modified)).toEqual(['x', 'x', null, null, null]);
   });
 
   it('must apply within', () => {
-    var modified = applyEntityToContentBlock(block, 1, 4, 'x');
+    const modified = applyEntityToContentBlock(block, 1, 4, 'x');
     expect(getEntities(modified)).toEqual([null, 'x', 'x', 'x', null]);
   });
 
   it('must apply at the end', () => {
-    var modified = applyEntityToContentBlock(block, 3, 5, 'x');
+    const modified = applyEntityToContentBlock(block, 3, 5, 'x');
     expect(getEntities(modified)).toEqual([null, null, null, 'x', 'x']);
   });
 
   it('must apply to the entire text', () => {
-    var modified = applyEntityToContentBlock(block, 0, 5, 'x');
+    const modified = applyEntityToContentBlock(block, 0, 5, 'x');
     expect(getEntities(modified)).toEqual(['x', 'x', 'x', 'x', 'x']);
   });
 });

--- a/src/model/transaction/__tests__/applyEntityToContentState-test.js
+++ b/src/model/transaction/__tests__/applyEntityToContentState-test.js
@@ -13,13 +13,13 @@
 
 jest.autoMockOff();
 
-var Immutable = require('immutable');
-var SelectionState = require('SelectionState');
-var applyEntityToContentState = require('applyEntityToContentState');
-var getSampleStateForTesting = require('getSampleStateForTesting');
+const Immutable = require('immutable');
+const SelectionState = require('SelectionState');
+const applyEntityToContentState = require('applyEntityToContentState');
+const getSampleStateForTesting = require('getSampleStateForTesting');
 
 describe('applyEntityToContentState', () => {
-  var {
+  const {
     contentState,
   } = getSampleStateForTesting();
 
@@ -32,8 +32,8 @@ describe('applyEntityToContentState', () => {
   }
 
   describe('Apply entity within single block', () => {
-    var target = contentState.getBlockMap().first();
-    var targetSelection = new SelectionState({
+    const target = contentState.getBlockMap().first();
+    const targetSelection = new SelectionState({
       anchorKey: target.getKey(),
       anchorOffset: 0,
       focusKey: target.getKey(),
@@ -41,12 +41,12 @@ describe('applyEntityToContentState', () => {
     });
 
     function applyAndCheck(entityKey) {
-      var withNewEntity = applyEntityToContentState(
+      const withNewEntity = applyEntityToContentState(
         contentState,
         targetSelection,
         entityKey
       );
-      var first = withNewEntity.getBlockMap().first();
+      const first = withNewEntity.getBlockMap().first();
 
       checkForCharacterList(first);
       expect(getEntities(first)).toEqual(
@@ -64,11 +64,11 @@ describe('applyEntityToContentState', () => {
   });
 
   describe('Apply entity across multiple blocks', () => {
-    var blockMap = contentState.getBlockMap();
-    var first = blockMap.first();
-    var last = contentState.getBlockAfter(first.getKey());
+    const blockMap = contentState.getBlockMap();
+    const first = blockMap.first();
+    const last = contentState.getBlockAfter(first.getKey());
 
-    var targetSelection = new SelectionState({
+    const targetSelection = new SelectionState({
       anchorKey: first.getKey(),
       anchorOffset: 0,
       focusKey: last.getKey(),
@@ -76,13 +76,13 @@ describe('applyEntityToContentState', () => {
     });
 
     function applyAndCheck(entityKey) {
-      var withNewEntity = applyEntityToContentState(
+      const withNewEntity = applyEntityToContentState(
         contentState,
         targetSelection,
         entityKey
       );
-      var first = withNewEntity.getBlockMap().first();
-      var last = withNewEntity.getBlockAfter(first.getKey());
+      const first = withNewEntity.getBlockMap().first();
+      const last = withNewEntity.getBlockAfter(first.getKey());
 
       checkForCharacterList(first);
       expect(getEntities(first)).toEqual(

--- a/src/model/transaction/__tests__/insertIntoList-test.js
+++ b/src/model/transaction/__tests__/insertIntoList-test.js
@@ -13,14 +13,14 @@
 
 jest.autoMockOff();
 
-var Immutable = require('immutable');
-var insertIntoList = require('insertIntoList');
+const Immutable = require('immutable');
+const insertIntoList = require('insertIntoList');
 
 describe('insertIntoList', () => {
-  var list = Immutable.List.of(0, 1, 2, 3, 4);
+  const list = Immutable.List.of(0, 1, 2, 3, 4);
 
   it('must insert at end of list', () => {
-    var result = insertIntoList(
+    const result = insertIntoList(
       list,
       Immutable.List.of(100, 101, 102),
       list.size
@@ -30,7 +30,7 @@ describe('insertIntoList', () => {
   });
 
   it('must insert at beginning of list', () => {
-    var result = insertIntoList(
+    const result = insertIntoList(
       list,
       Immutable.List.of(100, 101, 102),
       0
@@ -40,7 +40,7 @@ describe('insertIntoList', () => {
   });
 
   it('must insert within a list', () => {
-    var result = insertIntoList(
+    const result = insertIntoList(
       list,
       Immutable.List.of(100, 101, 102),
       3

--- a/src/model/transaction/__tests__/insertTextIntoContentState-test.js
+++ b/src/model/transaction/__tests__/insertTextIntoContentState-test.js
@@ -13,43 +13,43 @@
 
 jest.autoMockOff();
 
-var CharacterMetadata = require('CharacterMetadata');
-var Immutable = require('immutable');
-var insertTextIntoContentState = require('insertTextIntoContentState');
-var getSampleStateForTesting = require('getSampleStateForTesting');
-var {BOLD} = require('SampleDraftInlineStyle');
+const CharacterMetadata = require('CharacterMetadata');
+const Immutable = require('immutable');
+const insertTextIntoContentState = require('insertTextIntoContentState');
+const getSampleStateForTesting = require('getSampleStateForTesting');
+const {BOLD} = require('SampleDraftInlineStyle');
 
 describe('insertTextIntoContentState', () => {
-  var sample = getSampleStateForTesting();
-  var content = sample.contentState;
-  var selection = sample.selectionState;
+  const sample = getSampleStateForTesting();
+  const content = sample.contentState;
+  const selection = sample.selectionState;
 
-  var EMPTY = CharacterMetadata.EMPTY;
+  const EMPTY = CharacterMetadata.EMPTY;
 
-  var block = content.getBlockMap().first();
+  const block = content.getBlockMap().first();
 
   it('must throw if selection is not collapsed', () => {
-    var target = selection.set('focusOffset', 2);
+    const target = selection.set('focusOffset', 2);
     expect(() => {
       insertTextIntoContentState(content, target, 'hey', EMPTY);
     }).toThrow();
   });
 
   it('must return early if no text is provided', () => {
-    var modified = insertTextIntoContentState(content, selection, '', EMPTY);
+    const modified = insertTextIntoContentState(content, selection, '', EMPTY);
     expect(modified).toBe(content);
   });
 
   it('must insert at the start', () => {
-    var character = CharacterMetadata.create({style: BOLD});
-    var modified = insertTextIntoContentState(
+    const character = CharacterMetadata.create({style: BOLD});
+    const modified = insertTextIntoContentState(
       content,
       selection,
       'xx',
       character
     );
 
-    var newBlock = modified.getBlockMap().first();
+    const newBlock = modified.getBlockMap().first();
     expect(newBlock.getText().slice(0, 2)).toBe('xx');
     expect(newBlock.getText().slice(2)).toBe(block.getText());
 
@@ -64,14 +64,14 @@ describe('insertTextIntoContentState', () => {
   });
 
   it('must insert within block', () => {
-    var target = selection.merge({
+    const target = selection.merge({
       focusOffset: 2,
       anchorOffset: 2,
       isBackward: false,
     });
-    var character = CharacterMetadata.create({style: BOLD});
-    var modified = insertTextIntoContentState(content, target, 'xx', character);
-    var newBlock = modified.getBlockMap().first();
+    const character = CharacterMetadata.create({style: BOLD});
+    const modified = insertTextIntoContentState(content, target, 'xx', character);
+    const newBlock = modified.getBlockMap().first();
 
     expect(newBlock.getText().slice(2, 4)).toBe('xx');
     expect(newBlock.getText().slice(0, 2)).toBe(block.getText().slice(0, 2));
@@ -88,16 +88,16 @@ describe('insertTextIntoContentState', () => {
   });
 
   it('must insert at the end', () => {
-    var target = selection.merge({
+    const target = selection.merge({
       focusOffset: block.getLength(),
       anchorOffset: block.getLength(),
       isBackward: false,
     });
 
-    var character = CharacterMetadata.create({style: BOLD});
-    var modified = insertTextIntoContentState(content, target, 'xx', character);
+    const character = CharacterMetadata.create({style: BOLD});
+    const modified = insertTextIntoContentState(content, target, 'xx', character);
 
-    var newBlock = modified.getBlockMap().first();
+    const newBlock = modified.getBlockMap().first();
     expect(newBlock.getText().slice(5, 7)).toBe('xx');
     expect(newBlock.getText().slice(0, 5)).toBe(block.getText());
 

--- a/src/model/transaction/__tests__/removeEntitiesAtEdges-test.js
+++ b/src/model/transaction/__tests__/removeEntitiesAtEdges-test.js
@@ -15,24 +15,24 @@ jest
   .autoMockOff()
   .mock('DraftEntity');
 
-var DraftEntity = require('DraftEntity');
-var Immutable = require('immutable');
-var applyEntityToContentBlock = require('applyEntityToContentBlock');
-var getSampleStateForTesting = require('getSampleStateForTesting');
-var removeEntitiesAtEdges = require('removeEntitiesAtEdges');
+const DraftEntity = require('DraftEntity');
+const Immutable = require('immutable');
+const applyEntityToContentBlock = require('applyEntityToContentBlock');
+const getSampleStateForTesting = require('getSampleStateForTesting');
+const removeEntitiesAtEdges = require('removeEntitiesAtEdges');
 
 describe('removeEntitiesAtEdges', () => {
-  var {
+  const {
     List,
     Repeat,
   } = Immutable;
 
-  var {
+  const {
     contentState,
     selectionState,
   } = getSampleStateForTesting();
 
-  var selectionOnEntity = selectionState.merge({
+  const selectionOnEntity = selectionState.merge({
     anchorKey: 'b',
     anchorOffset: 2,
     focusKey: 'b',
@@ -63,27 +63,27 @@ describe('removeEntitiesAtEdges', () => {
 
   describe('Within a single block', () => {
     it('must not affect blockMap if there are no entities', () => {
-      var result = removeEntitiesAtEdges(contentState, selectionState);
+      const result = removeEntitiesAtEdges(contentState, selectionState);
       expectSameBlockMap(contentState, result);
     });
 
     describe('Handling different mutability types', () => {
       it('must not remove mutable entities', () => {
         setEntityMutability('MUTABLE');
-        var result = removeEntitiesAtEdges(contentState, selectionOnEntity);
+        const result = removeEntitiesAtEdges(contentState, selectionOnEntity);
         expectSameBlockMap(contentState, result);
       });
 
       it('must remove immutable entities', () => {
         setEntityMutability('IMMUTABLE');
-        var result = removeEntitiesAtEdges(contentState, selectionOnEntity);
+        const result = removeEntitiesAtEdges(contentState, selectionOnEntity);
         expect(result.getBlockMap()).not.toBe(contentState.getBlockMap());
         expectNullEntities(result.getBlockForKey('b'));
       });
 
       it('must remove segmented entities', () => {
         setEntityMutability('SEGMENTED');
-        var result = removeEntitiesAtEdges(contentState, selectionOnEntity);
+        const result = removeEntitiesAtEdges(contentState, selectionOnEntity);
         expect(result.getBlockMap()).not.toBe(contentState.getBlockMap());
         expectNullEntities(result.getBlockForKey('b'));
       });
@@ -93,26 +93,26 @@ describe('removeEntitiesAtEdges', () => {
       setEntityMutability('IMMUTABLE');
 
       it('must not remove if cursor is at start of entity', () => {
-        var selection = selectionOnEntity.merge({
+        const selection = selectionOnEntity.merge({
           anchorOffset: 0,
           focusOffset: 0,
         });
-        var result = removeEntitiesAtEdges(contentState, selection);
+        const result = removeEntitiesAtEdges(contentState, selection);
         expectSameBlockMap(contentState, result);
       });
 
       it('must remove if cursor is within entity', () => {
-        var result = removeEntitiesAtEdges(contentState, selectionOnEntity);
+        const result = removeEntitiesAtEdges(contentState, selectionOnEntity);
         expectNullEntities(result.getBlockForKey('b'));
       });
 
       it('must not remove if cursor is at end of entity', () => {
-        var length = contentState.getBlockForKey('b').getLength();
-        var selection = selectionOnEntity.merge({
+        const length = contentState.getBlockForKey('b').getLength();
+        const selection = selectionOnEntity.merge({
           anchorOffset: length,
           focusOffset: length,
         });
-        var result = removeEntitiesAtEdges(contentState, selection);
+        const result = removeEntitiesAtEdges(contentState, selection);
         expectSameBlockMap(contentState, result);
       });
     });
@@ -122,38 +122,38 @@ describe('removeEntitiesAtEdges', () => {
 
       it('must remove for non-collapsed cursor within a single entity', () => {
         setEntityMutability('IMMUTABLE');
-        var selection = selectionOnEntity.set('anchorOffset', 1);
-        var result = removeEntitiesAtEdges(contentState, selection);
+        const selection = selectionOnEntity.set('anchorOffset', 1);
+        const result = removeEntitiesAtEdges(contentState, selection);
         expectNullEntities(result.getBlockForKey('b'));
       });
 
       it('must remove for non-collapsed cursor on multiple entities', () => {
-        var block = contentState.getBlockForKey('b');
-        var newBlock = applyEntityToContentBlock(block, 3, 5, '456');
-        var newBlockMap = contentState.getBlockMap().set('b', newBlock);
-        var newContent = contentState.set('blockMap', newBlockMap);
-        var selection = selectionOnEntity.merge({
+        const block = contentState.getBlockForKey('b');
+        const newBlock = applyEntityToContentBlock(block, 3, 5, '456');
+        const newBlockMap = contentState.getBlockMap().set('b', newBlock);
+        const newContent = contentState.set('blockMap', newBlockMap);
+        const selection = selectionOnEntity.merge({
           anchorOffset: 1,
           focusOffset: 4,
         });
-        var result = removeEntitiesAtEdges(newContent, selection);
+        const result = removeEntitiesAtEdges(newContent, selection);
         expectNullEntities(result.getBlockForKey('b'));
       });
 
       it('must ignore an entity that is entirely within the selection', () => {
-        var block = contentState.getBlockForKey('b');
+        const block = contentState.getBlockForKey('b');
 
         // Remove entity from beginning and end of block.
-        var newBlock = applyEntityToContentBlock(block, 0, 1, null);
+        let newBlock = applyEntityToContentBlock(block, 0, 1, null);
         newBlock = applyEntityToContentBlock(newBlock, 4, 5, null);
 
-        var newBlockMap = contentState.getBlockMap().set('b', newBlock);
-        var newContent = contentState.set('blockMap', newBlockMap);
-        var selection = selectionOnEntity.merge({
+        const newBlockMap = contentState.getBlockMap().set('b', newBlock);
+        const newContent = contentState.set('blockMap', newBlockMap);
+        const selection = selectionOnEntity.merge({
           anchorOffset: 0,
           focusOffset: 5,
         });
-        var result = removeEntitiesAtEdges(newContent, selection);
+        const result = removeEntitiesAtEdges(newContent, selection);
         expectSameBlockMap(newContent, result);
       });
     });
@@ -163,42 +163,42 @@ describe('removeEntitiesAtEdges', () => {
     setEntityMutability('IMMUTABLE');
 
     it('must remove entity at start of selection', () => {
-      var selection = selectionState.merge({
+      const selection = selectionState.merge({
         anchorKey: 'b',
         anchorOffset: 3,
         focusKey: 'c',
         focusOffset: 3,
       });
-      var result = removeEntitiesAtEdges(contentState, selection);
+      const result = removeEntitiesAtEdges(contentState, selection);
       expectNullEntities(result.getBlockForKey('b'));
       expectNullEntities(result.getBlockForKey('c'));
     });
 
     it('must remove entity at end of selection', () => {
-      var selection = selectionState.merge({
+      const selection = selectionState.merge({
         anchorKey: 'a',
         anchorOffset: 3,
         focusKey: 'b',
         focusOffset: 3,
       });
-      var result = removeEntitiesAtEdges(contentState, selection);
+      const result = removeEntitiesAtEdges(contentState, selection);
       expectNullEntities(result.getBlockForKey('a'));
       expectNullEntities(result.getBlockForKey('b'));
     });
 
     it('must remove entities at both ends of selection', () => {
-      var cBlock = contentState.getBlockForKey('c');
-      var len = cBlock.getLength();
-      var modifiedC = applyEntityToContentBlock(cBlock, 0, len, '456');
-      var newBlockMap = contentState.getBlockMap().set('c', modifiedC);
-      var newContent = contentState.set('blockMap', newBlockMap);
-      var selection = selectionState.merge({
+      const cBlock = contentState.getBlockForKey('c');
+      const len = cBlock.getLength();
+      const modifiedC = applyEntityToContentBlock(cBlock, 0, len, '456');
+      const newBlockMap = contentState.getBlockMap().set('c', modifiedC);
+      const newContent = contentState.set('blockMap', newBlockMap);
+      const selection = selectionState.merge({
         anchorKey: 'b',
         anchorOffset: 3,
         focusKey: 'c',
         focusOffset: 3,
       });
-      var result = removeEntitiesAtEdges(newContent, selection);
+      const result = removeEntitiesAtEdges(newContent, selection);
       expectNullEntities(result.getBlockForKey('b'));
       expectNullEntities(result.getBlockForKey('c'));
     });

--- a/src/model/transaction/__tests__/removeRangeFromContentState-test.js
+++ b/src/model/transaction/__tests__/removeRangeFromContentState-test.js
@@ -13,13 +13,13 @@
 
 jest.autoMockOff();
 
-var Immutable = require('immutable');
-var getSampleStateForTesting = require('getSampleStateForTesting');
-var removeRangeFromContentState = require('removeRangeFromContentState');
-var ContentBlock = require('ContentBlock');
+const Immutable = require('immutable');
+const getSampleStateForTesting = require('getSampleStateForTesting');
+const removeRangeFromContentState = require('removeRangeFromContentState');
+const ContentBlock = require('ContentBlock');
 
 describe('removeRangeFromContentState', () => {
-  var {
+  const {
     contentState,
     selectionState,
   } = getSampleStateForTesting();
@@ -61,25 +61,25 @@ describe('removeRangeFromContentState', () => {
   describe('Removal within a single block', () => {
     it('must remove from the beginning of the block', () => {
       // Remove from 0 to 3.
-      var selection = selectionState.set('focusOffset', 3);
-      var afterRemoval = removeRangeFromContentState(contentState, selection);
-      var afterBlockMap = afterRemoval.getBlockMap();
-      var alteredBlock = afterBlockMap.first();
-      var originalBlock = contentState.getBlockMap().first();
+      const selection = selectionState.set('focusOffset', 3);
+      const afterRemoval = removeRangeFromContentState(contentState, selection);
+      const afterBlockMap = afterRemoval.getBlockMap();
+      const alteredBlock = afterBlockMap.first();
+      const originalBlock = contentState.getBlockMap().first();
 
       expectBlockToBeSlice(alteredBlock, originalBlock, 3);
     });
 
     it('must remove from within the block', () => {
       // Remove from 2 to 4.
-      var selection = selectionState.merge({
+      const selection = selectionState.merge({
         anchorOffset: 2,
         focusOffset: 4,
       });
-      var afterRemoval = removeRangeFromContentState(contentState, selection);
-      var afterBlockMap = afterRemoval.getBlockMap();
-      var alteredBlock = afterBlockMap.first();
-      var originalBlock = contentState.getBlockMap().first();
+      const afterRemoval = removeRangeFromContentState(contentState, selection);
+      const afterBlockMap = afterRemoval.getBlockMap();
+      const alteredBlock = afterBlockMap.first();
+      const originalBlock = contentState.getBlockMap().first();
 
       expect(alteredBlock).not.toBe(originalBlock);
       expect(alteredBlock.getType()).toBe(originalBlock.getType());
@@ -88,11 +88,11 @@ describe('removeRangeFromContentState', () => {
         originalBlock.getText().slice(4)
       );
 
-      var stylesToJS = getInlineStyles(originalBlock);
+      const stylesToJS = getInlineStyles(originalBlock);
       expect(getInlineStyles(alteredBlock)).toEqual(
         stylesToJS.slice(0, 2).concat(stylesToJS.slice(4))
       );
-      var entitiesToJS = getEntities(originalBlock);
+      const entitiesToJS = getEntities(originalBlock);
       expect(getEntities(alteredBlock)).toEqual(
         entitiesToJS.slice(0, 2).concat(entitiesToJS.slice(4))
       );
@@ -100,14 +100,14 @@ describe('removeRangeFromContentState', () => {
 
     it('nust remove to the end of the block', () => {
       // Remove from 3 to end.
-      var originalBlock = contentState.getBlockMap().first();
-      var selection = selectionState.merge({
+      const originalBlock = contentState.getBlockMap().first();
+      const selection = selectionState.merge({
         anchorOffset: 3,
         focusOffset: originalBlock.getLength(),
       });
-      var afterRemoval = removeRangeFromContentState(contentState, selection);
-      var afterBlockMap = afterRemoval.getBlockMap();
-      var alteredBlock = afterBlockMap.first();
+      const afterRemoval = removeRangeFromContentState(contentState, selection);
+      const afterBlockMap = afterRemoval.getBlockMap();
+      const alteredBlock = afterBlockMap.first();
 
       expectBlockToBeSlice(alteredBlock, originalBlock, 0, 3);
     });
@@ -116,16 +116,16 @@ describe('removeRangeFromContentState', () => {
   describe('Removal across two blocks', () => {
     describe('Removal from the start of A', () => {
       it('must remove from the start of A to the start of B', () => {
-        var selection = selectionState.set('focusKey', 'b');
-        var afterRemoval = removeRangeFromContentState(contentState, selection);
-        var afterBlockMap = afterRemoval.getBlockMap();
+        const selection = selectionState.set('focusKey', 'b');
+        const afterRemoval = removeRangeFromContentState(contentState, selection);
+        const afterBlockMap = afterRemoval.getBlockMap();
         expect(afterBlockMap.size).toBe(2);
-        var alteredBlock = afterBlockMap.first();
+        const alteredBlock = afterBlockMap.first();
 
         // Block B is removed. Its contents replace the contents of block A,
         // while the `type` of block A is preserved.
-        var blockB = contentState.getBlockMap().skip(1).first();
-        var sameContentDifferentType = blockB.set(
+        const blockB = contentState.getBlockMap().skip(1).first();
+        const sameContentDifferentType = blockB.set(
           'type',
           contentState.getBlockMap().first().getType()
         );
@@ -134,20 +134,20 @@ describe('removeRangeFromContentState', () => {
       });
 
       it('must remove from the start of A to within B', () => {
-        var selection = selectionState.merge({
+        const selection = selectionState.merge({
           focusKey: 'b',
           focusOffset: 3,
         });
 
-        var afterRemoval = removeRangeFromContentState(contentState, selection);
-        var afterBlockMap = afterRemoval.getBlockMap();
+        const afterRemoval = removeRangeFromContentState(contentState, selection);
+        const afterBlockMap = afterRemoval.getBlockMap();
         expect(afterBlockMap.size).toBe(2);
-        var alteredBlock = afterBlockMap.first();
+        const alteredBlock = afterBlockMap.first();
 
         // A slice of block B contents replace the contents of block A,
         // while the `type` of block A is preserved. Block B is removed.
-        var blockB = contentState.getBlockMap().skip(1).first();
-        var sameContentDifferentType = blockB.set(
+        const blockB = contentState.getBlockMap().skip(1).first();
+        const sameContentDifferentType = blockB.set(
           'type',
           contentState.getBlockMap().first().getType()
         );
@@ -156,19 +156,19 @@ describe('removeRangeFromContentState', () => {
       });
 
       it('must remove from the start of A to the end of B', () => {
-        var blockB = contentState.getBlockMap().skip(1).first();
-        var selection = selectionState.merge({
+        const blockB = contentState.getBlockMap().skip(1).first();
+        const selection = selectionState.merge({
           focusKey: 'b',
           focusOffset: blockB.getLength(),
         });
 
-        var afterRemoval = removeRangeFromContentState(contentState, selection);
-        var afterBlockMap = afterRemoval.getBlockMap();
+        const afterRemoval = removeRangeFromContentState(contentState, selection);
+        const afterBlockMap = afterRemoval.getBlockMap();
         expect(afterBlockMap.size).toBe(2);
-        var alteredBlock = afterBlockMap.first();
+        const alteredBlock = afterBlockMap.first();
 
         // Block A is effectively just emptied out, while block B is removed.
-        var emptyBlock = new ContentBlock({
+        const emptyBlock = new ContentBlock({
           text: '',
           type: contentState.getBlockMap().first().getType(),
           characterList: Immutable.List(),
@@ -179,17 +179,17 @@ describe('removeRangeFromContentState', () => {
     });
 
     describe('Removal from within A', () => {
-      var selectionWithinA = selectionState.set('anchorOffset', 3);
+      const selectionWithinA = selectionState.set('anchorOffset', 3);
 
       it('must remove from within A to the start of B', () => {
-        var selection = selectionWithinA.set('focusKey', 'b');
+        const selection = selectionWithinA.set('focusKey', 'b');
 
-        var originalBlockA = contentState.getBlockMap().first();
-        var originalBlockB = contentState.getBlockMap().skip(1).first();
-        var afterRemoval = removeRangeFromContentState(contentState, selection);
-        var afterBlockMap = afterRemoval.getBlockMap();
+        const originalBlockA = contentState.getBlockMap().first();
+        const originalBlockB = contentState.getBlockMap().skip(1).first();
+        const afterRemoval = removeRangeFromContentState(contentState, selection);
+        const afterBlockMap = afterRemoval.getBlockMap();
         expect(afterBlockMap.size).toBe(2);
-        var alteredBlock = afterBlockMap.first();
+        const alteredBlock = afterBlockMap.first();
 
         expect(alteredBlock).not.toBe(originalBlockA);
         expect(alteredBlock).not.toBe(originalBlockB);
@@ -199,11 +199,11 @@ describe('removeRangeFromContentState', () => {
           originalBlockB.getText()
         );
 
-        var stylesToJS = getInlineStyles(originalBlockA);
+        const stylesToJS = getInlineStyles(originalBlockA);
         expect(getInlineStyles(alteredBlock)).toEqual(
           stylesToJS.slice(0, 3).concat(getInlineStyles(originalBlockB))
         );
-        var entitiesToJS = getEntities(originalBlockA);
+        const entitiesToJS = getEntities(originalBlockA);
         expect(getEntities(alteredBlock)).toEqual(
           entitiesToJS.slice(0, 3).concat(getEntities(originalBlockB))
         );
@@ -212,17 +212,17 @@ describe('removeRangeFromContentState', () => {
       });
 
       it('must remove from within A to within B', () => {
-        var selection = selectionWithinA.merge({
+        const selection = selectionWithinA.merge({
           focusKey: 'b',
           focusOffset: 3,
         });
 
-        var originalBlockA = contentState.getBlockMap().first();
-        var originalBlockB = contentState.getBlockMap().skip(1).first();
-        var afterRemoval = removeRangeFromContentState(contentState, selection);
-        var afterBlockMap = afterRemoval.getBlockMap();
+        const originalBlockA = contentState.getBlockMap().first();
+        const originalBlockB = contentState.getBlockMap().skip(1).first();
+        const afterRemoval = removeRangeFromContentState(contentState, selection);
+        const afterBlockMap = afterRemoval.getBlockMap();
         expect(afterBlockMap.size).toBe(2);
-        var alteredBlock = afterBlockMap.first();
+        const alteredBlock = afterBlockMap.first();
 
         expect(alteredBlock).not.toBe(originalBlockA);
         expect(alteredBlock).not.toBe(originalBlockB);
@@ -232,13 +232,13 @@ describe('removeRangeFromContentState', () => {
           originalBlockB.getText().slice(3)
         );
 
-        var stylesToJS = getInlineStyles(originalBlockA);
+        const stylesToJS = getInlineStyles(originalBlockA);
         expect(getInlineStyles(alteredBlock)).toEqual(
           stylesToJS.slice(0, 3).concat(
             getInlineStyles(originalBlockB).slice(3)
           )
         );
-        var entitiesToJS = getEntities(originalBlockA);
+        const entitiesToJS = getEntities(originalBlockA);
         expect(getEntities(alteredBlock)).toEqual(
           entitiesToJS.slice(0, 3).concat(
             getEntities(originalBlockB).slice(3)
@@ -249,18 +249,18 @@ describe('removeRangeFromContentState', () => {
       });
 
       it('must remove from within A to the end of B', () => {
-        var blockB = contentState.getBlockMap().skip(1).first();
-        var selection = selectionWithinA.merge({
+        const blockB = contentState.getBlockMap().skip(1).first();
+        const selection = selectionWithinA.merge({
           focusKey: 'b',
           focusOffset: blockB.getLength(),
         });
 
-        var originalBlockA = contentState.getBlockMap().first();
-        var originalBlockB = contentState.getBlockMap().skip(1).first();
-        var afterRemoval = removeRangeFromContentState(contentState, selection);
-        var afterBlockMap = afterRemoval.getBlockMap();
+        const originalBlockA = contentState.getBlockMap().first();
+        const originalBlockB = contentState.getBlockMap().skip(1).first();
+        const afterRemoval = removeRangeFromContentState(contentState, selection);
+        const afterBlockMap = afterRemoval.getBlockMap();
         expect(afterBlockMap.size).toBe(2);
-        var alteredBlock = afterBlockMap.first();
+        const alteredBlock = afterBlockMap.first();
 
         expect(alteredBlock).not.toBe(originalBlockA);
         expect(alteredBlock).not.toBe(originalBlockB);
@@ -269,11 +269,11 @@ describe('removeRangeFromContentState', () => {
           originalBlockA.getText().slice(0, 3)
         );
 
-        var stylesToJS = getInlineStyles(originalBlockA);
+        const stylesToJS = getInlineStyles(originalBlockA);
         expect(getInlineStyles(alteredBlock)).toEqual(
           stylesToJS.slice(0, 3)
         );
-        var entitiesToJS = getEntities(originalBlockA);
+        const entitiesToJS = getEntities(originalBlockA);
         expect(getEntities(alteredBlock)).toEqual(
           entitiesToJS.slice(0, 3)
         );
@@ -283,24 +283,24 @@ describe('removeRangeFromContentState', () => {
     });
 
     describe('Removal from the end of A', () => {
-      var initialBlock = contentState.getBlockMap().first();
-      var selectionFromEndOfA = selectionState.merge({
+      const initialBlock = contentState.getBlockMap().first();
+      const selectionFromEndOfA = selectionState.merge({
         anchorOffset: initialBlock.getLength(),
         focusOffset: initialBlock.getLength(),
       });
 
       it('must remove from the end of A to the start of B', () => {
-        var selection = selectionFromEndOfA.merge({
+        const selection = selectionFromEndOfA.merge({
           focusKey: 'b',
           focusOffset: 0,
         });
 
-        var originalBlockA = contentState.getBlockMap().first();
-        var originalBlockB = contentState.getBlockMap().skip(1).first();
-        var afterRemoval = removeRangeFromContentState(contentState, selection);
-        var afterBlockMap = afterRemoval.getBlockMap();
+        const originalBlockA = contentState.getBlockMap().first();
+        const originalBlockB = contentState.getBlockMap().skip(1).first();
+        const afterRemoval = removeRangeFromContentState(contentState, selection);
+        const afterBlockMap = afterRemoval.getBlockMap();
         expect(afterBlockMap.size).toBe(2);
-        var alteredBlock = afterBlockMap.first();
+        const alteredBlock = afterBlockMap.first();
 
         expect(alteredBlock).not.toBe(originalBlockA);
         expect(alteredBlock).not.toBe(originalBlockB);
@@ -310,11 +310,11 @@ describe('removeRangeFromContentState', () => {
           originalBlockB.getText()
         );
 
-        var stylesToJS = getInlineStyles(originalBlockA);
+        const stylesToJS = getInlineStyles(originalBlockA);
         expect(getInlineStyles(alteredBlock)).toEqual(
           stylesToJS.concat(getInlineStyles(originalBlockB))
         );
-        var entitiesToJS = getEntities(originalBlockA);
+        const entitiesToJS = getEntities(originalBlockA);
         expect(getEntities(alteredBlock)).toEqual(
           entitiesToJS.concat(getEntities(originalBlockB))
         );
@@ -323,17 +323,17 @@ describe('removeRangeFromContentState', () => {
       });
 
       it('must remove from the end of A to within B', () => {
-        var selection = selectionFromEndOfA.merge({
+        const selection = selectionFromEndOfA.merge({
           focusKey: 'b',
           focusOffset: 3,
         });
 
-        var originalBlockA = contentState.getBlockMap().first();
-        var originalBlockB = contentState.getBlockMap().skip(1).first();
-        var afterRemoval = removeRangeFromContentState(contentState, selection);
-        var afterBlockMap = afterRemoval.getBlockMap();
+        const originalBlockA = contentState.getBlockMap().first();
+        const originalBlockB = contentState.getBlockMap().skip(1).first();
+        const afterRemoval = removeRangeFromContentState(contentState, selection);
+        const afterBlockMap = afterRemoval.getBlockMap();
         expect(afterBlockMap.size).toBe(2);
-        var alteredBlock = afterBlockMap.first();
+        const alteredBlock = afterBlockMap.first();
 
         expect(alteredBlock).not.toBe(originalBlockA);
         expect(alteredBlock).not.toBe(originalBlockB);
@@ -343,13 +343,13 @@ describe('removeRangeFromContentState', () => {
           originalBlockB.getText().slice(3)
         );
 
-        var stylesToJS = getInlineStyles(originalBlockA);
+        const stylesToJS = getInlineStyles(originalBlockA);
         expect(getInlineStyles(alteredBlock)).toEqual(
           stylesToJS.concat(
             getInlineStyles(originalBlockB).slice(3)
           )
         );
-        var entitiesToJS = getEntities(originalBlockA);
+        const entitiesToJS = getEntities(originalBlockA);
         expect(getEntities(alteredBlock)).toEqual(
           entitiesToJS.concat(
             getEntities(originalBlockB).slice(3)
@@ -359,18 +359,18 @@ describe('removeRangeFromContentState', () => {
       });
 
       it('must remove from the end of A to the end of B', () => {
-        var originalBlockA = contentState.getBlockMap().first();
-        var originalBlockB = contentState.getBlockMap().skip(1).first();
+        const originalBlockA = contentState.getBlockMap().first();
+        const originalBlockB = contentState.getBlockMap().skip(1).first();
 
-        var selection = selectionFromEndOfA.merge({
+        const selection = selectionFromEndOfA.merge({
           focusKey: 'b',
           focusOffset: originalBlockB.getLength(),
         });
 
-        var afterRemoval = removeRangeFromContentState(contentState, selection);
-        var afterBlockMap = afterRemoval.getBlockMap();
+        const afterRemoval = removeRangeFromContentState(contentState, selection);
+        const afterBlockMap = afterRemoval.getBlockMap();
         expect(afterBlockMap.size).toBe(2);
-        var alteredBlock = afterBlockMap.first();
+        const alteredBlock = afterBlockMap.first();
 
         // no-op for the first block, since no new content is appended.
         expect(alteredBlock).toBe(originalBlockA);
@@ -384,21 +384,21 @@ describe('removeRangeFromContentState', () => {
   });
 
   describe('Removal across more than two blocks', () => {
-    var selection = selectionState.merge({
+    const selection = selectionState.merge({
       anchorOffset: 3,
       focusKey: 'c',
       focusOffset: 3,
     });
 
     it('must remove blocks entirely within the selection', () => {
-      var originalBlockA = contentState.getBlockMap().first();
-      var originalBlockB = contentState.getBlockMap().skip(1).first();
-      var originalBlockC = contentState.getBlockMap().skip(2).first();
+      const originalBlockA = contentState.getBlockMap().first();
+      const originalBlockB = contentState.getBlockMap().skip(1).first();
+      const originalBlockC = contentState.getBlockMap().skip(2).first();
 
-      var afterRemoval = removeRangeFromContentState(contentState, selection);
-      var afterBlockMap = afterRemoval.getBlockMap();
+      const afterRemoval = removeRangeFromContentState(contentState, selection);
+      const afterBlockMap = afterRemoval.getBlockMap();
       expect(afterBlockMap.size).toBe(1);
-      var alteredBlock = afterBlockMap.first();
+      const alteredBlock = afterBlockMap.first();
 
       expect(alteredBlock).not.toBe(originalBlockA);
       expect(alteredBlock).not.toBe(originalBlockB);
@@ -409,13 +409,13 @@ describe('removeRangeFromContentState', () => {
         originalBlockC.getText().slice(3)
       );
 
-      var stylesToJS = getInlineStyles(originalBlockA);
+      const stylesToJS = getInlineStyles(originalBlockA);
       expect(getInlineStyles(alteredBlock)).toEqual(
         stylesToJS.slice(0, 3).concat(
           getInlineStyles(originalBlockC).slice(3)
         )
       );
-      var entitiesToJS = getEntities(originalBlockA);
+      const entitiesToJS = getEntities(originalBlockA);
       expect(getEntities(alteredBlock)).toEqual(
         entitiesToJS.slice(0, 3).concat(
           getEntities(originalBlockC).slice(3)

--- a/src/model/transaction/__tests__/splitBlockInContentState-test.js
+++ b/src/model/transaction/__tests__/splitBlockInContentState-test.js
@@ -13,12 +13,12 @@
 
 jest.autoMockOff();
 
-var Immutable = require('immutable');
-var getSampleStateForTesting = require('getSampleStateForTesting');
-var splitBlockInContentState = require('splitBlockInContentState');
+const Immutable = require('immutable');
+const getSampleStateForTesting = require('getSampleStateForTesting');
+const splitBlockInContentState = require('splitBlockInContentState');
 
 describe('removeRangeFromContentState', () => {
-  var {
+  const {
     contentState,
     selectionState,
   } = getSampleStateForTesting();
@@ -37,7 +37,7 @@ describe('removeRangeFromContentState', () => {
 
   it('must be restricted to collapsed selections', () => {
     expect(() => {
-      var nonCollapsed = selectionState.set('focusOffset', 1);
+      const nonCollapsed = selectionState.set('focusOffset', 1);
       return splitBlockInContentState(contentState, nonCollapsed);
     }).toThrow();
 
@@ -47,19 +47,19 @@ describe('removeRangeFromContentState', () => {
   });
 
   it('must split at the beginning of a block', () => {
-    var initialBlock = contentState.getBlockMap().first();
-    var afterSplit = splitBlockInContentState(contentState, selectionState);
-    var afterBlockMap = afterSplit.getBlockMap();
+    const initialBlock = contentState.getBlockMap().first();
+    const afterSplit = splitBlockInContentState(contentState, selectionState);
+    const afterBlockMap = afterSplit.getBlockMap();
     expect(afterBlockMap.size).toBe(4);
 
-    var preSplitBlock = afterBlockMap.first();
+    const preSplitBlock = afterBlockMap.first();
 
     expect(preSplitBlock.getKey()).toBe(initialBlock.getKey());
     expect(preSplitBlock.getText()).toBe('');
     expect(getInlineStyles(preSplitBlock)).toEqual([]);
     expect(getEntities(preSplitBlock)).toEqual([]);
 
-    var postSplitBlock = afterBlockMap.skip(1).first();
+    const postSplitBlock = afterBlockMap.skip(1).first();
     expect(preSplitBlock.getKey()).not.toBe(postSplitBlock.getKey());
     expect(preSplitBlock.getType()).toBe(postSplitBlock.getType());
 
@@ -82,19 +82,19 @@ describe('removeRangeFromContentState', () => {
   });
 
   it('must split within a block', () => {
-    var initialBlock = contentState.getBlockMap().first();
-    var SPLIT_OFFSET = 3;
-    var selection = selectionState.merge({
+    const initialBlock = contentState.getBlockMap().first();
+    const SPLIT_OFFSET = 3;
+    const selection = selectionState.merge({
       anchorOffset: SPLIT_OFFSET,
       focusOffset: SPLIT_OFFSET,
     });
 
-    var afterSplit = splitBlockInContentState(contentState, selection);
-    var afterBlockMap = afterSplit.getBlockMap();
+    const afterSplit = splitBlockInContentState(contentState, selection);
+    const afterBlockMap = afterSplit.getBlockMap();
     expect(afterBlockMap.size).toBe(4);
 
-    var preSplitBlock = afterBlockMap.first();
-    var postSplitBlock = afterBlockMap.skip(1).first();
+    const preSplitBlock = afterBlockMap.first();
+    const postSplitBlock = afterBlockMap.skip(1).first();
 
     expect(preSplitBlock.getKey()).toBe(initialBlock.getKey());
     expect(preSplitBlock.getText()).toBe(
@@ -127,19 +127,19 @@ describe('removeRangeFromContentState', () => {
   });
 
   it('must split at the end of a block', () => {
-    var initialBlock = contentState.getBlockMap().first();
-    var end = initialBlock.getLength();
-    var selection = selectionState.merge({
+    const initialBlock = contentState.getBlockMap().first();
+    const end = initialBlock.getLength();
+    const selection = selectionState.merge({
       anchorOffset: end,
       focusOffset: end,
     });
 
-    var afterSplit = splitBlockInContentState(contentState, selection);
-    var afterBlockMap = afterSplit.getBlockMap();
+    const afterSplit = splitBlockInContentState(contentState, selection);
+    const afterBlockMap = afterSplit.getBlockMap();
     expect(afterBlockMap.size).toBe(4);
 
-    var preSplitBlock = afterBlockMap.first();
-    var postSplitBlock = afterBlockMap.skip(1).first();
+    const preSplitBlock = afterBlockMap.first();
+    const postSplitBlock = afterBlockMap.skip(1).first();
 
     expect(preSplitBlock.getKey()).toBe(initialBlock.getKey());
 

--- a/src/model/transaction/adjustBlockDepthForContentState.js
+++ b/src/model/transaction/adjustBlockDepthForContentState.js
@@ -22,16 +22,16 @@ function adjustBlockDepthForContentState(
   adjustment: number,
   maxDepth: number
 ): ContentState {
-  var startKey = selectionState.getStartKey();
-  var endKey = selectionState.getEndKey();
-  var blockMap = contentState.getBlockMap();
-  var blocks = blockMap
+  const startKey = selectionState.getStartKey();
+  const endKey = selectionState.getEndKey();
+  let blockMap = contentState.getBlockMap();
+  const blocks = blockMap
     .toSeq()
     .skipUntil((_, k) => k === startKey)
     .takeUntil((_, k) => k === endKey)
     .concat([[endKey, blockMap.get(endKey)]])
     .map(block => {
-      var depth = block.getDepth() + adjustment;
+      let depth = block.getDepth() + adjustment;
       depth = Math.max(0, Math.min(depth, maxDepth));
       return block.set('depth', depth);
     });

--- a/src/model/transaction/applyEntityToContentBlock.js
+++ b/src/model/transaction/applyEntityToContentBlock.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-var CharacterMetadata = require('CharacterMetadata');
+const CharacterMetadata = require('CharacterMetadata');
 
 import type ContentBlock from 'ContentBlock';
 
@@ -23,7 +23,7 @@ function applyEntityToContentBlock(
   end: number,
   entityKey: ?string
 ): ContentBlock {
-  var characterList = contentBlock.getCharacterList();
+  let characterList = contentBlock.getCharacterList();
   while (start < end) {
     characterList = characterList.set(
       start,

--- a/src/model/transaction/applyEntityToContentState.js
+++ b/src/model/transaction/applyEntityToContentState.js
@@ -13,9 +13,9 @@
 
 'use strict';
 
-var Immutable = require('immutable');
+const Immutable = require('immutable');
 
-var applyEntityToContentBlock = require('applyEntityToContentBlock');
+const applyEntityToContentBlock = require('applyEntityToContentBlock');
 
 import type ContentState from 'ContentState';
 import type SelectionState from 'SelectionState';
@@ -25,20 +25,20 @@ function applyEntityToContentState(
   selectionState: SelectionState,
   entityKey: ?string
 ): ContentState {
-  var blockMap = contentState.getBlockMap();
-  var startKey = selectionState.getStartKey();
-  var startOffset = selectionState.getStartOffset();
-  var endKey = selectionState.getEndKey();
-  var endOffset = selectionState.getEndOffset();
+  const blockMap = contentState.getBlockMap();
+  const startKey = selectionState.getStartKey();
+  const startOffset = selectionState.getStartOffset();
+  const endKey = selectionState.getEndKey();
+  const endOffset = selectionState.getEndOffset();
 
-  var newBlocks = blockMap
+  const newBlocks = blockMap
     .skipUntil((_, k) => k === startKey)
     .takeUntil((_, k) => k === endKey)
     .toOrderedMap()
     .merge(Immutable.OrderedMap([[endKey, blockMap.get(endKey)]]))
     .map((block, blockKey) => {
-      var sliceStart;
-      var sliceEnd;
+      let sliceStart;
+      let sliceEnd;
 
       if (startKey === endKey) {
         sliceStart = startOffset;

--- a/src/model/transaction/getContentStateFragment.js
+++ b/src/model/transaction/getContentStateFragment.js
@@ -13,8 +13,8 @@
 
 'use strict';
 
-var generateBlockKey = require('generateBlockKey');
-var removeEntitiesAtEdges = require('removeEntitiesAtEdges');
+const generateBlockKey = require('generateBlockKey');
+const removeEntitiesAtEdges = require('removeEntitiesAtEdges');
 
 import type {BlockMap} from 'BlockMap';
 import type ContentState from 'ContentState';
@@ -24,29 +24,29 @@ function getContentStateFragment(
   contentState: ContentState,
   selectionState: SelectionState
 ): BlockMap {
-  var startKey = selectionState.getStartKey();
-  var startOffset = selectionState.getStartOffset();
-  var endKey = selectionState.getEndKey();
-  var endOffset = selectionState.getEndOffset();
+  const startKey = selectionState.getStartKey();
+  const startOffset = selectionState.getStartOffset();
+  const endKey = selectionState.getEndKey();
+  const endOffset = selectionState.getEndOffset();
 
   // Edge entities should be stripped to ensure that we don't preserve
   // invalid partial entities when the fragment is reused. We do, however,
   // preserve entities that are entirely within the selection range.
-  var contentWithoutEdgeEntities = removeEntitiesAtEdges(
+  const contentWithoutEdgeEntities = removeEntitiesAtEdges(
     contentState,
     selectionState
   );
 
-  var blockMap = contentWithoutEdgeEntities.getBlockMap();
-  var blockKeys = blockMap.keySeq();
-  var startIndex = blockKeys.indexOf(startKey);
-  var endIndex = blockKeys.indexOf(endKey) + 1;
+  const blockMap = contentWithoutEdgeEntities.getBlockMap();
+  const blockKeys = blockMap.keySeq();
+  const startIndex = blockKeys.indexOf(startKey);
+  const endIndex = blockKeys.indexOf(endKey) + 1;
 
-  var slice = blockMap.slice(startIndex, endIndex).map((block, blockKey) => {
-    var newKey = generateBlockKey();
+  const slice = blockMap.slice(startIndex, endIndex).map((block, blockKey) => {
+    const newKey = generateBlockKey();
 
-    var text = block.getText();
-    var chars = block.getCharacterList();
+    const text = block.getText();
+    const chars = block.getCharacterList();
 
     if (startKey === endKey) {
       return block.merge({

--- a/src/model/transaction/getSampleStateForTesting.js
+++ b/src/model/transaction/getSampleStateForTesting.js
@@ -13,18 +13,18 @@
 
 'use strict';
 
-var BlockMapBuilder = require('BlockMapBuilder');
-var CharacterMetadata = require('CharacterMetadata');
-var ContentBlock = require('ContentBlock');
-var ContentState = require('ContentState');
-var Immutable = require('immutable');
-var SampleDraftInlineStyle = require('SampleDraftInlineStyle');
-var SelectionState = require('SelectionState');
+const BlockMapBuilder = require('BlockMapBuilder');
+const CharacterMetadata = require('CharacterMetadata');
+const ContentBlock = require('ContentBlock');
+const ContentState = require('ContentState');
+const Immutable = require('immutable');
+const SampleDraftInlineStyle = require('SampleDraftInlineStyle');
+const SelectionState = require('SelectionState');
 
-var {BOLD, ITALIC} = SampleDraftInlineStyle;
-var ENTITY_KEY = '123';
+const {BOLD, ITALIC} = SampleDraftInlineStyle;
+const ENTITY_KEY = '123';
 
-var BLOCKS = [
+const BLOCKS = [
   new ContentBlock({
     key: 'a',
     type: 'unstyled',
@@ -57,7 +57,7 @@ var BLOCKS = [
   }),
 ];
 
-var selectionState = new SelectionState({
+const selectionState = new SelectionState({
   anchorKey: 'a',
   anchorOffset: 0,
   focusKey: 'a',
@@ -66,8 +66,8 @@ var selectionState = new SelectionState({
   hasFocus: true,
 });
 
-var blockMap = BlockMapBuilder.createFromArray(BLOCKS);
-var contentState = new ContentState({
+const blockMap = BlockMapBuilder.createFromArray(BLOCKS);
+const contentState = new ContentState({
   blockMap,
   selectionBefore: selectionState,
   selectionAfter: selectionState,

--- a/src/model/transaction/insertFragmentIntoContentState.js
+++ b/src/model/transaction/insertFragmentIntoContentState.js
@@ -13,11 +13,11 @@
 
 'use strict';
 
-var BlockMapBuilder = require('BlockMapBuilder');
+const BlockMapBuilder = require('BlockMapBuilder');
 
-var generateBlockKey = require('generateBlockKey');
-var insertIntoList = require('insertIntoList');
-var invariant = require('invariant');
+const generateBlockKey = require('generateBlockKey');
+const insertIntoList = require('insertIntoList');
+const invariant = require('invariant');
 
 import type {BlockMap} from 'BlockMap';
 import type ContentState from 'ContentState';
@@ -33,22 +33,22 @@ function insertFragmentIntoContentState(
     '`insertFragment` should only be called with a collapsed selection state.'
   );
 
-  var targetKey = selectionState.getStartKey();
-  var targetOffset = selectionState.getStartOffset();
+  const targetKey = selectionState.getStartKey();
+  const targetOffset = selectionState.getStartOffset();
 
-  var blockMap = contentState.getBlockMap();
+  let blockMap = contentState.getBlockMap();
 
-  var fragmentSize = fragment.size;
-  var finalKey;
-  var finalOffset;
+  const fragmentSize = fragment.size;
+  let finalKey;
+  let finalOffset;
 
   if (fragmentSize === 1) {
-    var targetBlock = blockMap.get(targetKey);
-    var pastedBlock = fragment.first();
-    var text = targetBlock.getText();
-    var chars = targetBlock.getCharacterList();
+    const targetBlock = blockMap.get(targetKey);
+    const pastedBlock = fragment.first();
+    const text = targetBlock.getText();
+    const chars = targetBlock.getCharacterList();
 
-    var newBlock = targetBlock.merge({
+    const newBlock = targetBlock.merge({
       text: (
         text.slice(0, targetOffset) +
         pastedBlock.getText() +
@@ -79,7 +79,7 @@ function insertFragmentIntoContentState(
     });
   }
 
-  var newBlockArr = [];
+  const newBlockArr = [];
 
   contentState.getBlockMap().forEach(
     (block, blockKey) => {
@@ -88,16 +88,16 @@ function insertFragmentIntoContentState(
         return;
       }
 
-      var text = block.getText();
-      var chars = block.getCharacterList();
+      const text = block.getText();
+      const chars = block.getCharacterList();
 
       // Modify head portion of block.
-      var blockSize = text.length;
-      var headText = text.slice(0, targetOffset);
-      var headCharacters = chars.slice(0, targetOffset);
-      var appendToHead = fragment.first();
+      const blockSize = text.length;
+      const headText = text.slice(0, targetOffset);
+      const headCharacters = chars.slice(0, targetOffset);
+      const appendToHead = fragment.first();
 
-      var modifiedHead = block.merge({
+      const modifiedHead = block.merge({
         text: headText + appendToHead.getText(),
         characterList: headCharacters.concat(appendToHead.getCharacterList()),
       });
@@ -112,12 +112,12 @@ function insertFragmentIntoContentState(
       );
 
       // Modify tail portion of block.
-      var tailText = text.slice(targetOffset, blockSize);
-      var tailCharacters = chars.slice(targetOffset, blockSize);
-      var prependToTail = fragment.last();
+      const tailText = text.slice(targetOffset, blockSize);
+      const tailCharacters = chars.slice(targetOffset, blockSize);
+      const prependToTail = fragment.last();
       finalKey = generateBlockKey();
 
-      var modifiedTail = prependToTail.merge({
+      const modifiedTail = prependToTail.merge({
         key: finalKey,
         text: prependToTail.getText() + tailText,
         characterList: prependToTail

--- a/src/model/transaction/insertIntoList.js
+++ b/src/model/transaction/insertIntoList.js
@@ -31,8 +31,8 @@ function insertIntoList<T>(
       targetList = targetList.unshift(c);
     });
   } else {
-    var head = targetList.slice(0, offset);
-    var tail = targetList.slice(offset);
+    const head = targetList.slice(0, offset);
+    const tail = targetList.slice(offset);
     targetList = head.concat(toInsert, tail).toList();
   }
   return targetList;

--- a/src/model/transaction/insertTextIntoContentState.js
+++ b/src/model/transaction/insertTextIntoContentState.js
@@ -13,12 +13,12 @@
 
 'use strict';
 
-var Immutable = require('immutable');
+const Immutable = require('immutable');
 
-var insertIntoList = require('insertIntoList');
-var invariant = require('invariant');
+const insertIntoList = require('insertIntoList');
+const invariant = require('invariant');
 
-var {Repeat} = Immutable;
+const {Repeat} = Immutable;
 
 import type CharacterMetadata from 'CharacterMetadata';
 import type ContentState from 'ContentState';
@@ -35,18 +35,18 @@ function insertTextIntoContentState(
     '`insertText` should only be called with a collapsed range.'
   );
 
-  var len = text.length;
+  const len = text.length;
   if (!len) {
     return contentState;
   }
 
-  var blockMap = contentState.getBlockMap();
-  var key = selectionState.getStartKey();
-  var offset = selectionState.getStartOffset();
-  var block = blockMap.get(key);
-  var blockText = block.getText();
+  const blockMap = contentState.getBlockMap();
+  const key = selectionState.getStartKey();
+  const offset = selectionState.getStartOffset();
+  const block = blockMap.get(key);
+  const blockText = block.getText();
 
-  var newBlock = block.merge({
+  const newBlock = block.merge({
     text: (
       blockText.slice(0, offset) +
       text +
@@ -59,7 +59,7 @@ function insertTextIntoContentState(
     ),
   });
 
-  var newOffset = offset + len;
+  const newOffset = offset + len;
 
   return contentState.merge({
     blockMap: blockMap.set(key, newBlock),

--- a/src/model/transaction/removeEntitiesAtEdges.js
+++ b/src/model/transaction/removeEntitiesAtEdges.js
@@ -12,11 +12,11 @@
 
 'use strict';
 
-var CharacterMetadata = require('CharacterMetadata');
-var DraftEntity = require('DraftEntity');
+const CharacterMetadata = require('CharacterMetadata');
+const DraftEntity = require('DraftEntity');
 
-var findRangesImmutable = require('findRangesImmutable');
-var invariant = require('invariant');
+const findRangesImmutable = require('findRangesImmutable');
+const invariant = require('invariant');
 
 import type ContentBlock from 'ContentBlock';
 import type ContentState from 'ContentState';
@@ -27,27 +27,27 @@ function removeEntitiesAtEdges(
   contentState: ContentState,
   selectionState: SelectionState
 ): ContentState {
-  var blockMap = contentState.getBlockMap();
+  const blockMap = contentState.getBlockMap();
 
-  var updatedBlocks = {};
+  const updatedBlocks = {};
 
-  var startKey = selectionState.getStartKey();
-  var startOffset = selectionState.getStartOffset();
-  var startBlock = blockMap.get(startKey);
-  var updatedStart = removeForBlock(startBlock, startOffset);
+  const startKey = selectionState.getStartKey();
+  const startOffset = selectionState.getStartOffset();
+  const startBlock = blockMap.get(startKey);
+  const updatedStart = removeForBlock(startBlock, startOffset);
 
   if (updatedStart !== startBlock) {
     updatedBlocks[startKey] = updatedStart;
   }
 
-  var endKey = selectionState.getEndKey();
-  var endOffset = selectionState.getEndOffset();
-  var endBlock = blockMap.get(endKey);
+  const endKey = selectionState.getEndKey();
+  const endOffset = selectionState.getEndOffset();
+  let endBlock = blockMap.get(endKey);
   if (startKey === endKey) {
     endBlock = updatedStart;
   }
 
-  var updatedEnd = removeForBlock(endBlock, endOffset);
+  const updatedEnd = removeForBlock(endBlock, endOffset);
 
   if (updatedEnd !== endBlock) {
     updatedBlocks[endKey] = updatedEnd;
@@ -68,7 +68,7 @@ function getRemovalRange(
   key: ?string,
   offset: number
 ): Object {
-  var removalRange;
+  let removalRange;
   findRangesImmutable(
     characters,
     (a, b) => a.getEntity() === b.getEntity(),
@@ -90,17 +90,19 @@ function removeForBlock(
   block: ContentBlock,
   offset: number
 ): ContentBlock {
-  var chars = block.getCharacterList();
-  var charBefore = offset > 0 ? chars.get(offset - 1) : undefined;
-  var charAfter = offset < chars.count() ? chars.get(offset) : undefined;
-  var entityBeforeCursor = charBefore ? charBefore.getEntity() : undefined;
-  var entityAfterCursor = charAfter ? charAfter.getEntity() : undefined;
+  let chars = block.getCharacterList();
+  const charBefore = offset > 0 ? chars.get(offset - 1) : undefined;
+  const charAfter = offset < chars.count() ? chars.get(offset) : undefined;
+  const entityBeforeCursor = charBefore ? charBefore.getEntity() : undefined;
+  const entityAfterCursor = charAfter ? charAfter.getEntity() : undefined;
 
   if (entityAfterCursor && entityAfterCursor === entityBeforeCursor) {
-    var entity = DraftEntity.get(entityAfterCursor);
+    const entity = DraftEntity.get(entityAfterCursor);
     if (entity.getMutability() !== 'MUTABLE') {
-      var {start, end} = getRemovalRange(chars, entityAfterCursor, offset);
-      var current;
+      const range = getRemovalRange(chars, entityAfterCursor, offset);
+      const {end} = range;
+      let {start} = range;
+      let current;
       while (start < end) {
         current = chars.get(start);
         chars = chars.set(start, CharacterMetadata.applyEntity(current, null));

--- a/src/model/transaction/removeRangeFromContentState.js
+++ b/src/model/transaction/removeRangeFromContentState.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var Immutable = require('immutable');
+const Immutable = require('immutable');
 
 import type CharacterMetadata from 'CharacterMetadata';
 import type ContentState from 'ContentState';
@@ -27,15 +27,15 @@ function removeRangeFromContentState(
     return contentState;
   }
 
-  var blockMap = contentState.getBlockMap();
-  var startKey = selectionState.getStartKey();
-  var startOffset = selectionState.getStartOffset();
-  var endKey = selectionState.getEndKey();
-  var endOffset = selectionState.getEndOffset();
+  let blockMap = contentState.getBlockMap();
+  const startKey = selectionState.getStartKey();
+  const startOffset = selectionState.getStartOffset();
+  const endKey = selectionState.getEndKey();
+  const endOffset = selectionState.getEndOffset();
 
-  var startBlock = blockMap.get(startKey);
-  var endBlock = blockMap.get(endKey);
-  var characterList;
+  const startBlock = blockMap.get(startKey);
+  const endBlock = blockMap.get(endKey);
+  let characterList;
 
   if (startBlock === endBlock) {
     characterList = removeFromList(
@@ -50,7 +50,7 @@ function removeRangeFromContentState(
       .concat(endBlock.getCharacterList().slice(endOffset));
   }
 
-  var modifiedStart = startBlock.merge({
+  const modifiedStart = startBlock.merge({
     text: (
       startBlock.getText().slice(0, startOffset) +
       endBlock.getText().slice(endOffset)
@@ -58,7 +58,7 @@ function removeRangeFromContentState(
     characterList,
   });
 
-  var newBlocks = blockMap
+  const newBlocks = blockMap
     .toSeq()
     .skipUntil((_, k) => k === startKey)
     .takeUntil((_, k) => k === endKey)
@@ -100,8 +100,8 @@ function removeFromList(
       endOffset--;
     }
   } else {
-    var head = targetList.slice(0, startOffset);
-    var tail = targetList.slice(endOffset);
+    const head = targetList.slice(0, startOffset);
+    const tail = targetList.slice(endOffset);
     targetList = head.concat(tail).toList();
   }
   return targetList;

--- a/src/model/transaction/setBlockTypeForContentState.js
+++ b/src/model/transaction/setBlockTypeForContentState.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-var Immutable = require('immutable');
+const Immutable = require('immutable');
 
 import type ContentState from 'ContentState';
 import type {DraftBlockType} from 'DraftBlockType';
@@ -24,10 +24,10 @@ function setBlockTypeForContentState(
   selectionState: SelectionState,
   blockType: DraftBlockType,
 ): ContentState {
-  var startKey = selectionState.getStartKey();
-  var endKey = selectionState.getEndKey();
-  var blockMap = contentState.getBlockMap();
-  var newBlocks = blockMap
+  const startKey = selectionState.getStartKey();
+  const endKey = selectionState.getEndKey();
+  const blockMap = contentState.getBlockMap();
+  const newBlocks = blockMap
     .toSeq()
     .skipUntil((_, k) => k === startKey)
     .takeUntil((_, k) => k === endKey)

--- a/src/model/transaction/splitBlockInContentState.js
+++ b/src/model/transaction/splitBlockInContentState.js
@@ -13,8 +13,8 @@
 
 'use strict';
 
-var generateBlockKey = require('generateBlockKey');
-var invariant = require('invariant');
+const generateBlockKey = require('generateBlockKey');
+const invariant = require('invariant');
 
 import type ContentState from 'ContentState';
 import type SelectionState from 'SelectionState';
@@ -28,29 +28,29 @@ function splitBlockInContentState(
     'Selection range must be collapsed.'
   );
 
-  var key = selectionState.getAnchorKey();
-  var offset = selectionState.getAnchorOffset();
-  var blockMap = contentState.getBlockMap();
-  var blockToSplit = blockMap.get(key);
+  const key = selectionState.getAnchorKey();
+  const offset = selectionState.getAnchorOffset();
+  const blockMap = contentState.getBlockMap();
+  const blockToSplit = blockMap.get(key);
 
-  var text = blockToSplit.getText();
-  var chars = blockToSplit.getCharacterList();
+  const text = blockToSplit.getText();
+  const chars = blockToSplit.getCharacterList();
 
-  var blockAbove = blockToSplit.merge({
+  const blockAbove = blockToSplit.merge({
     text: text.slice(0, offset),
     characterList: chars.slice(0, offset),
   });
 
-  var keyBelow = generateBlockKey();
-  var blockBelow = blockAbove.merge({
+  const keyBelow = generateBlockKey();
+  const blockBelow = blockAbove.merge({
     key: keyBelow,
     text: text.slice(offset),
     characterList: chars.slice(offset),
   });
 
-  var blocksBefore = blockMap.toSeq().takeUntil(v => v === blockToSplit);
-  var blocksAfter = blockMap.toSeq().skipUntil(v => v === blockToSplit).rest();
-  var newBlocks = blocksBefore.concat(
+  const blocksBefore = blockMap.toSeq().takeUntil(v => v === blockToSplit);
+  const blocksAfter = blockMap.toSeq().skipUntil(v => v === blockToSplit).rest();
+  const newBlocks = blocksBefore.concat(
       [[blockAbove.getKey(), blockAbove], [blockBelow.getKey(), blockBelow]],
       blocksAfter
     ).toOrderedMap();

--- a/src/stubs/ComposedEntityMutability.js
+++ b/src/stubs/ComposedEntityMutability.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var ComposedEntityMutability = {
+const ComposedEntityMutability = {
   'MUTABLE': true,
   'IMMUTABLE': true,
   'SEGMENTED': true,

--- a/src/stubs/ComposedEntityType.js
+++ b/src/stubs/ComposedEntityType.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var ComposedEntityType = {
+const ComposedEntityType = {
   'LINK': true,
   'TOKEN': true,
   'PHOTO': true,


### PR DESCRIPTION
Variable declaration is inconsistent across the project. Most places using `var` but some using `const`/`let`.

PR removes all uses of `var` in favor of `const` or `let` (depending on whether a variable changes reference).