### PR TITLE
Correct and clarify docs for handleBeforeInput

### DIFF
--- a/docs/APIReference-Editor.md
+++ b/docs/APIReference-Editor.md
@@ -152,9 +152,11 @@ for details on usage.
 
 #### handleBeforeInput
 ```
-handleBeforeInput?: (e: SyntheticInputEvent) => boolean
+handleBeforeInput?: (chars: string) => boolean
 ```
-Handle a `beforeInput` event before character insertion occurs within the editor.
+Handle the characters to be inserted from a `beforeInput` event. Returning `true`
+causes the default behavior of the `beforeInput` event to be prevented (i.e. it is
+the same as calling the `preventDefault` method on the event).
 Example usage: After a user has typed `- ` at the start of a new block, you might
 convert that `ContentBlock` into an `unordered-list-item`.
 

--- a/src/component/base/DraftEditorProps.js
+++ b/src/component/base/DraftEditorProps.js
@@ -94,7 +94,7 @@ export type DraftEditorProps = {
   // to trigger some special behavior. E.g. immediately converting `:)` to an
   // emoji Unicode character, or replacing ASCII quote characters with smart
   // quotes.
-  handleBeforeInput?: (e: SyntheticInputEvent) => boolean,
+  handleBeforeInput?: (chars: string) => boolean,
 
   handlePastedFiles?: (files: Array<Blob>) => boolean,
 


### PR DESCRIPTION
Currently the docs state that a `beforeInput` event is passed as an argument to the `handleBeforeInput` prop. This is incorrect, only the characters to be inserted are passed.