### PR TITLE
Export getDefaultKeyBinding and KeyBindingUtil

### DIFF
--- a/docs/Advanced-Topics-Key-Bindings.md
+++ b/docs/Advanced-Topics-Key-Bindings.md
@@ -45,7 +45,7 @@ write your contents to the server as a draft copy.
 First, let's define our key binding function:
 
 ```js
-import {KeyBindingUtil} from 'draft-js';
+import {getDefaultKeyBinding, KeyBindingUtil} from 'draft-js';
 const {hasCommandModifier} = KeyBindingUtil;
 
 function myKeyBindingFn(e: SyntheticKeyboardEvent): string {

--- a/src/Draft.js
+++ b/src/Draft.js
@@ -21,12 +21,14 @@ const DraftModifier = require('DraftModifier');
 const DraftEntity = require('DraftEntity');
 const DraftEntityInstance = require('DraftEntityInstance');
 const EditorState = require('EditorState');
+const KeyBindingUtil = require('KeyBindingUtil');
 const RichTextEditorUtil = require('RichTextEditorUtil');
 const SelectionState = require('SelectionState');
 
 const convertFromDraftStateToRaw = require('convertFromDraftStateToRaw');
 const convertFromRawToDraftState = require('convertFromRawToDraftState');
 const generateBlockKey = require('generateBlockKey');
+const getDefaultKeyBinding = require('getDefaultKeyBinding');
 
 const DraftPublic = {
   Editor: DraftEditor,
@@ -42,12 +44,14 @@ const DraftPublic = {
   ContentState,
   SelectionState,
 
+  KeyBindingUtil: KeyBindingUtil,
   Modifier: DraftModifier,
   RichUtils: RichTextEditorUtil,
 
   convertFromRaw: convertFromRawToDraftState,
   convertToRaw: convertFromDraftStateToRaw,
   genKey: generateBlockKey,
+  getDefaultKeyBinding: getDefaultKeyBinding,
 };
 
 module.exports = DraftPublic;


### PR DESCRIPTION
In [Advanced Topics: Key Bindings](https://facebook.github.io/draft-js/docs/advanced-topics-key-bindings.html) there is an [example](https://facebook.github.io/draft-js/docs/advanced-topics-key-bindings.html#example) where both `getDefaultKeyBinding()` and `KeyBindingUtil` are used, but neither are exported by `draft-js`. This PR exports both `getDefaultKeyBinding()` and `KeyBindingUtil` from `draft-js`.

Also in the above example, `getDefaultKeyBinding()` was not imported. This PR adds `getDefaultKeyBinding()` to the imports for the example.

Fixes #87 and #88.