### PR TITLE
fix contentEditable warning

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -262,6 +262,7 @@ class DraftEditor
             ref="editor"
             role={readOnly ? null : (this.props.role || 'textbox')}
             spellCheck={allowSpellCheck && this.props.spellCheck}
+            suppressContentEditableWarning={true}
             tabIndex={this.props.tabIndex}
             title={hasContent ? null : this.props.placeholder}>
             <DraftEditorContents


### PR DESCRIPTION
See https://github.com/facebook/draft-js/issues/53. The issue has been fixed in the React repo: https://github.com/facebook/react/pull/6112 .