### PR TITLE
Added polyfills for IE9+

### DIFF
--- a/website/src/draft-js/index.js
+++ b/website/src/draft-js/index.js
@@ -251,7 +251,52 @@ var index = React.createClass({
             </div>
           </section>
         </section>
+        <script type="text/javascript" dangerouslySetInnerHTML={{__html: `
+          // Polyfills requires to get example working in IE9+
 
+          if (!String.prototype.startsWith) {
+              String.prototype.startsWith = function(searchString, position){
+                position = position || 0;
+                return this.substr(position, searchString.length) === searchString;
+            };
+          }
+
+          if (!String.prototype.endsWith) {
+            String.prototype.endsWith = function(searchString, position) {
+                var subjectString = this.toString();
+                if (typeof position !== 'number' || !isFinite(position) || Math.floor(position) !== position || position > subjectString.length) {
+                  position = subjectString.length;
+                }
+                position -= searchString.length;
+                var lastIndex = subjectString.indexOf(searchString, position);
+                return lastIndex !== -1 && lastIndex === position;
+            };
+          }
+
+          if (typeof Object.assign != 'function') {
+            (function () {
+              Object.assign = function (target) {
+                'use strict';
+                if (target === undefined || target === null) {
+                  throw new TypeError('Cannot convert undefined or null to object');
+                }
+
+                var output = Object(target);
+                for (var index = 1; index < arguments.length; index++) {
+                  var source = arguments[index];
+                  if (source !== undefined && source !== null) {
+                    for (var nextKey in source) {
+                      if (source.hasOwnProperty(nextKey)) {
+                        output[nextKey] = source[nextKey];
+                      }
+                    }
+                  }
+                }
+                return output;
+              };
+            })();
+          }
+        `}} />
         <script src="https://cdnjs.cloudflare.com/ajax/libs/react/0.14.7/react.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/react/0.14.7/react-dom.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/immutable/3.7.6/immutable.js"></script>


### PR DESCRIPTION
Draft.js website doesn't work in IE9+. This is because Draft.js relies on 3 methods that are not currently supported in IE; `String.startsWith`, `String.endsWith` and `Object.assign`. This pull request adds them.

I assumed the Babel Polyfill would have added all three, but that appears not to be the case.

Please see https://github.com/facebook/draft-js/issues/83 for more details.