### PR TITLE
Use Slackin link for Slack invites

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,7 @@ comment inputs, [Notes](https://www.facebook.com/notes/), and
 
 ## Discussion and Support
 
-Join our [Slack team](https://draftjs.slack.com)! Signup is currently invite-only.
-Use your email address to
-[request an invite](http://goo.gl/forms/ru9B3HNcXJ) and we'll add you soon.
+Join our [Slack team](https://draftjs.herokuapp.com)!
 
 ## Contribute
 


### PR DESCRIPTION
Still not sure if we'll be moving over to Discord, but in the meantime this will streamline things.