### PR TITLE
Consider passing in a style prop to the editor

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -220,7 +220,7 @@ class DraftEditor
     const hasContent = this.props.editorState.getCurrentContent().hasText();
 
     return (
-      <div className={rootClass}>
+      <div className={rootClass} style={this.props.style}>
         {this._renderPlaceholder()}
         <div
           className={cx('DraftEditor/editorContainer')}


### PR DESCRIPTION
In my code I'd like to be able to pass in a `style` object like this

```html
<div style={styles.editorContainer} onClick={this._focus}>
  <SideControl />
  <PopoverControl />
  <Editor
    style={{paddingTop: 1}} // Fix for collapsing margins
    editorState={this.state.editorState}
    onChange={this._onChange}
    ref="editor"
    ...
  />
</div>
```

Currently I achieve the same thing with a style sheet but I don't like having to have the extra file dependency. 
```css
.DraftEditor-root {
  /* Stop collapsing margins breaking our side control positioning */
  padding-top: 1px;
}
```
