### PR TITLE
Add decoratedText prop to DecoratorComponent

### DIFF
--- a/src/component/contents/DraftEditorBlock.react.js
+++ b/src/component/contents/DraftEditorBlock.react.js
@@ -182,6 +182,7 @@ class DraftEditorBlock extends React.Component {
       return (
         <DecoratorComponent
           {...decoratorProps}
+          decoratedText={decoratedText}
           dir={dir}
           key={decoratorOffsetKey}
           entityKey={block.getEntityAt(leafSet.get('start'))}


### PR DESCRIPTION
Resolves #140 and #68.

Tested with `console.log(this.props.decoratedText)` in render method of TokenSpan in entity.html.