### PR TITLE
Only calculate directions for changed blocks && followers

### DIFF
--- a/src/model/immutable/EditorBidiService.js
+++ b/src/model/immutable/EditorBidiService.js
@@ -27,25 +27,52 @@ var bidiService;
 var EditorBidiService = {
   getDirectionMap: function(
     content: ContentState,
-    prevBidiMap: ?OrderedMap
+    prevBidiMap: ?OrderedMap,
+    prevContent: ?ContentState,
   ): OrderedMap {
+    if (content === prevContent) {
+      return prevBidiMap;
+    }
+
     if (!bidiService) {
       bidiService = new UnicodeBidiService();
     } else {
       bidiService.reset();
     }
 
-    var blockMap = content.getBlockMap();
-    var nextBidi = blockMap
-      .valueSeq()
-      .map(block => nullthrows(bidiService).getDirection(block.getText()));
-    var bidiMap = OrderedMap(blockMap.keySeq().zip(nextBidi));
+    var newBlockMap = content.getBlockMap();
 
-    if (prevBidiMap != null && Immutable.is(prevBidiMap, bidiMap)) {
-      return prevBidiMap;
+    if (!prevBidiMap || !prevContent) {
+      var nextBidi = newBlockMap
+        .valueSeq()
+        .map(block => nullthrows(bidiService).getDirection(block.getText()));
+
+      return OrderedMap(newBlockMap.keySeq().zip(nextBidi));
+    } else {
+      // only update direction for blocks that have changed, then continue looking until we find an unchanged direction.
+
+      var prevLineChanged = false;
+      var prevBlockMap = prevContent.getBlockMap();
+
+      var hasChanged = false;
+
+      var newBidiMap = newBlockMap
+        .map((block, key) => {
+          if (prevLineChanged || block != prevBlockMap.get(key)) {
+            var newDirection = nullthrows(bidiService).getDirection(block.getText());
+            var oldDirection = prevBidiMap.get(key);
+            if (newDirection !== oldDirection) {
+              prevLineChanged = true;
+              hasChanged = true;
+            }
+            return newDirection;
+          } else {
+            return prevBidiMap.get(key);
+          }
+        });
+
+      return hasChanged ? newBidiMap : prevBidiMap; 
     }
-
-    return bidiMap;
   },
 };
 

--- a/src/model/immutable/EditorState.js
+++ b/src/model/immutable/EditorState.js
@@ -340,7 +340,8 @@ class EditorState {
     var forceSelection = changeType !== 'insert-characters';
     var directionMap = EditorBidiService.getDirectionMap(
       contentState,
-      editorState.getDirectionMap()
+      editorState.getDirectionMap(),
+      editorState.getCurrentContent(),
     );
 
     if (!editorState.getAllowUndo()) {

--- a/src/model/immutable/__tests__/EditorBidiService-test.js
+++ b/src/model/immutable/__tests__/EditorBidiService-test.js
@@ -70,9 +70,11 @@ describe('EditorBidiService', () => {
     var directions = EditorBidiService.getDirectionMap(state);
 
     var nextState = getContentState([ltr]);
+
     var nextDirections = EditorBidiService.getDirectionMap(
       nextState,
-      directions
+      directions,
+      state      
     );
 
     expect(state).not.toBe(nextState);
@@ -92,7 +94,8 @@ describe('EditorBidiService', () => {
     var nextState = getContentState([newLTR]);
     var nextDirections = EditorBidiService.getDirectionMap(
       nextState,
-      directions
+      directions,
+      state
     );
 
     expect(state).not.toBe(nextState);
@@ -112,7 +115,8 @@ describe('EditorBidiService', () => {
     var nextState = getContentState([newLTR]);
     var nextDirections = EditorBidiService.getDirectionMap(
       nextState,
-      directions
+      directions,
+      state
     );
 
     expect(state).not.toBe(nextState);
@@ -131,7 +135,8 @@ describe('EditorBidiService', () => {
     var nextState = getContentState([newLTR]);
     var nextDirections = EditorBidiService.getDirectionMap(
       nextState,
-      directions
+      directions,
+      state
     );
 
     expect(state).not.toBe(nextState);
@@ -162,7 +167,8 @@ describe('EditorBidiService', () => {
     var nextState = getContentState([ltr, rtl]);
     var nextDirections = EditorBidiService.getDirectionMap(
       nextState,
-      directions
+      directions,
+      state
     );
 
     expect(state).not.toBe(nextState);


### PR DESCRIPTION
Fixes https://github.com/facebook/draft-js/issues/146, a significant lag when editing large documents, caused by every keystroke triggering a full re-calculation of the direction of every block.

It now only calculates direction for blocks that have changed or are right after a block whose direction changed. 
