### PR TITLE
Add support for block-level metadata

### DIFF
--- a/src/model/encoding/RawDraftContentBlock.js
+++ b/src/model/encoding/RawDraftContentBlock.js
@@ -27,4 +27,5 @@ export type RawDraftContentBlock = {
   depth: ?number;
   inlineStyleRanges: ?Array<InlineStyleRange>;
   entityRanges: ?Array<EntityRange>;
+  blockEntity: ?string,
 };

--- a/src/model/encoding/convertFromDraftStateToRaw.js
+++ b/src/model/encoding/convertFromDraftStateToRaw.js
@@ -48,6 +48,7 @@ function convertFromDraftStateToRaw(
       text: block.getText(),
       type: block.getType(),
       depth: canHaveDepth(block) ? block.getDepth() : 0,
+      blockEntity: block.getBlockEntity(),
       inlineStyleRanges: encodeInlineStyleRanges(block),
       entityRanges: encodeEntityRanges(block, entityStorageMap),
     });

--- a/src/model/encoding/convertFromRawToDraftState.js
+++ b/src/model/encoding/convertFromRawToDraftState.js
@@ -39,7 +39,7 @@ function convertFromRawToDraftState(
 
   return blocks.map(
     block => {
-      var {key, type, text, depth, inlineStyleRanges, entityRanges} = block;
+      var {key, type, text, depth, inlineStyleRanges, entityRanges, blockEntity} = block;
       key = key || generateRandomKey();
       depth = depth || 0;
       inlineStyleRanges = inlineStyleRanges || [];
@@ -57,7 +57,7 @@ function convertFromRawToDraftState(
       var entities = decodeEntityRanges(text, filteredEntityRanges);
       var characterList = createCharacterList(inlineStyles, entities);
 
-      return new ContentBlock({key, type, text, depth, characterList});
+      return new ContentBlock({key, type, text, depth, characterList, blockEntity});
     }
   );
 }

--- a/src/model/immutable/ContentBlock.js
+++ b/src/model/immutable/ContentBlock.js
@@ -34,13 +34,15 @@ var defaultRecord: {
   type: DraftBlockType;
   text: string;
   characterList: List<CharacterMetadata>;
-  depth: number;
+  depth: number,
+  blockEntity: ?string;
 } = {
   key: '',
   type: 'unstyled',
   text: '',
   characterList: List(),
   depth: 0,
+  blockEntity: null,
 };
 
 var ContentBlockRecord = Record(defaultRecord);
@@ -78,6 +80,10 @@ class ContentBlock extends ContentBlockRecord {
   getEntityAt(offset: number): ?string {
     var character = this.getCharacterList().get(offset);
     return character ? character.getEntity() : null;
+  }
+
+  getBlockEntity(): ?string {
+    return this.get('blockEntity');
   }
 
   /**

--- a/src/model/immutable/__tests__/ContentBlock-test.js
+++ b/src/model/immutable/__tests__/ContentBlock-test.js
@@ -84,7 +84,14 @@ describe('ContentBlock', () => {
     });
   });
 
-  describe('entity retrieval', () => {
+  describe('block entity retrieval', () => {
+    it('must retrieve block-level entities', () => {
+      var block = getSampleBlock().set('blockEntity', ENTITY_KEY);
+      expect(block.getBlockEntity()).toBe(ENTITY_KEY);
+    });
+  });
+
+  describe('caracter entity retrieval', () => {
     it('must properly retrieve entity at offset', () => {
       var block = getSampleBlock();
       expect(block.getEntityAt(0)).toBe(ENTITY_KEY);

--- a/src/model/transaction/__tests__/splitBlockInContentState-test.js
+++ b/src/model/transaction/__tests__/splitBlockInContentState-test.js
@@ -58,6 +58,7 @@ describe('removeRangeFromContentState', () => {
     expect(preSplitBlock.getText()).toBe('');
     expect(getInlineStyles(preSplitBlock)).toEqual([]);
     expect(getEntities(preSplitBlock)).toEqual([]);
+    expect(preSplitBlock.getBlockEntity()).toEqual('EntityA');
 
     var postSplitBlock = afterBlockMap.skip(1).first();
     expect(preSplitBlock.getKey()).not.toBe(postSplitBlock.getKey());
@@ -66,6 +67,8 @@ describe('removeRangeFromContentState', () => {
     expect(postSplitBlock.getKey()).not.toBe(initialBlock.getKey());
     expect(postSplitBlock.getType()).toBe(initialBlock.getType());
     expect(postSplitBlock.getText()).toBe(initialBlock.getText());
+    expect(postSplitBlock.getBlockEntity()).toEqual(null);
+
     expect(
       getInlineStyles(initialBlock)
     ).toEqual(

--- a/src/model/transaction/getSampleStateForTesting.js
+++ b/src/model/transaction/getSampleStateForTesting.js
@@ -32,6 +32,7 @@ var BLOCKS = [
     characterList: Immutable.List(
       Immutable.Repeat(CharacterMetadata.EMPTY, 5)
     ),
+    blockEntity: 'EntityA',
   }),
   new ContentBlock({
     key: 'b',

--- a/src/model/transaction/splitBlockInContentState.js
+++ b/src/model/transaction/splitBlockInContentState.js
@@ -46,6 +46,7 @@ function splitBlockInContentState(
     key: keyBelow,
     text: text.slice(offset),
     characterList: chars.slice(offset),
+    blockEntity: null,
   });
 
   var blocksBefore = blockMap.toSeq().takeUntil(v => v === blockToSplit);


### PR DESCRIPTION
It's now possible to associate entities to a whole block. These are
retrieved with block.getBlockEntity()

When spliting a block, the entity only remains linked to the first block
of the split