### PR TITLE
accept customStyleMap in convertToRaw()

### DIFF
--- a/src/model/encoding/convertFromDraftStateToRaw.js
+++ b/src/model/encoding/convertFromDraftStateToRaw.js
@@ -14,6 +14,7 @@
 
 var DraftEntity = require('DraftEntity');
 var DraftStringKey = require('DraftStringKey');
+var DefaultDraftInlineStyle = require('DefaultDraftInlineStyle');
 
 var encodeEntityRanges = require('encodeEntityRanges');
 var encodeInlineStyleRanges = require('encodeInlineStyleRanges');
@@ -23,11 +24,18 @@ import type ContentState from 'ContentState';
 import type {RawDraftContentState} from 'RawDraftContentState';
 
 function convertFromDraftStateToRaw(
-  contentState: ContentState
+  contentState: ContentState,
+  customStyleMap: Object
 ): RawDraftContentState {
   var entityStorageKey = 0;
   var entityStorageMap = {};
   var rawBlocks = [];
+  var styleMap = {};
+  var styleKeys = [];
+
+  customStyleMap = customStyleMap || {};
+  styleMap = Object.assign({}, DefaultDraftInlineStyle, customStyleMap);
+  styleKeys = Object.keys(styleMap);
 
   contentState.getBlockMap().forEach((block, blockKey) => {
     block.findEntityRanges(
@@ -48,7 +56,7 @@ function convertFromDraftStateToRaw(
       text: block.getText(),
       type: block.getType(),
       depth: canHaveDepth(block) ? block.getDepth() : 0,
-      inlineStyleRanges: encodeInlineStyleRanges(block),
+      inlineStyleRanges: encodeInlineStyleRanges(block, styleKeys),
       entityRanges: encodeEntityRanges(block, entityStorageMap),
     });
   });

--- a/src/model/encoding/encodeInlineStyleRanges.js
+++ b/src/model/encoding/encodeInlineStyleRanges.js
@@ -12,7 +12,6 @@
 
 'use strict';
 
-var DefaultDraftInlineStyle = require('DefaultDraftInlineStyle');
 var UnicodeUtils = require('UnicodeUtils');
 
 var findRangesImmutable = require('findRangesImmutable');
@@ -65,11 +64,11 @@ function getEncodedInlinesForType(
  * treated separately.
  */
 function encodeInlineStyleRanges(
-  block: ContentBlock
+  block: ContentBlock,
+  styleKeys: Array
 ): Array<InlineStyleRange> {
   var styleList = block.getCharacterList().map(c => c.getStyle()).toList();
-  var styles = Object.keys(DefaultDraftInlineStyle);
-  var ranges: Array<Array<InlineStyleRange>> = styles
+  var ranges: Array<Array<InlineStyleRange>> = styleKeys
     .map(style => getEncodedInlinesForType(block, styleList, style));
 
   return Array.prototype.concat.apply(EMPTY_ARRAY, ranges);


### PR DESCRIPTION
Bug: only the default styles are saved when the content is 'exported'.