### PR TITLE
Move critical editor style into JS

### DIFF
--- a/docs/Advanced-Topics-Issues-and-Pitfalls.md
+++ b/docs/Advanced-Topics-Issues-and-Pitfalls.md
@@ -32,6 +32,18 @@ you must always allow your `EditorState` to propagate to your `Editor`
 component without delay, and independently perform batched updates that do
 not affect the state of your `Editor` component.
 
+### Missing Draft.css
+
+The Draft framework includes a handful of CSS resources intended for use with
+the editor, available in a single file via the build, Draft.css.
+
+This CSS should be included when rendering the editor, as these styles set defaults
+for text alignment, spacing, and other important features. Without it, you may
+encounter issues with block positioning, alignment, and cursor behavior.
+
+If you choose to write your own CSS independent of Draft.css, you will most
+likely need to replicate much of the default styling.
+
 ## Known Issues
 
 ### React ContentEditable Warning

--- a/src/component/base/DraftEditor.css
+++ b/src/component/base/DraftEditor.css
@@ -29,11 +29,6 @@
   z-index: 1;
 }
 
-.public/DraftEditor/content {
-  outline: none;
-  white-space: pre-wrap;
-}
-
 .public/DraftEditor/block {
   position: relative;
 }

--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -219,6 +219,11 @@ class DraftEditor
     });
     const hasContent = this.props.editorState.getCurrentContent().hasText();
 
+    const contentStyle = {
+      outline: 'none',
+      whiteSpace: 'pre',
+    };
+
     return (
       <div className={rootClass}>
         {this._renderPlaceholder()}
@@ -262,6 +267,7 @@ class DraftEditor
             ref="editor"
             role={readOnly ? null : (this.props.role || 'textbox')}
             spellCheck={allowSpellCheck && this.props.spellCheck}
+            style={contentStyle}
             tabIndex={this.props.tabIndex}
             title={hasContent ? null : this.props.placeholder}>
             <DraftEditorContents


### PR DESCRIPTION
There have been a number of bug reports caused by Draft.css not being included. The main one is that the editor can start flipping out if `white-space: pre-wrap` is not applied.

Users should generally be including Draft.css, and should be aware of behavior gaps if they choose not to. Documenting this accordingly.