### PR TITLE
add start & end to decorated component

### DIFF
--- a/src/component/contents/DraftEditorBlock.react.js
+++ b/src/component/contents/DraftEditorBlock.react.js
@@ -167,10 +167,9 @@ class DraftEditorBlock extends React.Component {
 
       var decoratorProps = decorator.getPropsForKey(decoratorKey);
       var decoratorOffsetKey = DraftOffsetKey.encode(blockKey, ii, 0);
-      var decoratedText = text.slice(
-        leavesForLeafSet.first().get('start'),
-        leavesForLeafSet.last().get('end')
-      );
+      var start = leavesForLeafSet.first().get('start');
+      var end = leavesForLeafSet.first().get('end');
+      var decoratedText = text.slice(start, end);
 
       // Resetting dir to the same value on a child node makes Chrome/Firefox
       // confused on cursor movement. See http://jsfiddle.net/d157kLck/3/
@@ -183,6 +182,8 @@ class DraftEditorBlock extends React.Component {
         <DecoratorComponent
           {...decoratorProps}
           decoratedText={decoratedText}
+          start={start}
+          end={end}
           dir={dir}
           key={decoratorOffsetKey}
           entityKey={block.getEntityAt(leafSet.get('start'))}


### PR DESCRIPTION
In order to know which part to replace in case of an @-mention it is nice to have these parameters. You can get them from the selection as well, but it's bit tricky as the same work already done in the `strategy` like we did here: https://github.com/nikgraf/draft-js-plugin-editor/blob/master/src/mentionPlugin/MentionSearch/index.js#L39