### PR TITLE
Android support

### DIFF
--- a/src/component/handlers/edit/editOnCompositionStart.js
+++ b/src/component/handlers/edit/editOnCompositionStart.js
@@ -21,6 +21,7 @@ var EditorState = require('EditorState');
 function editOnCompositionStart(e): void {
   this.setRenderGuard();
   this.setMode('composite');
+  this._onCompositionStart(e);
   this.update(
     EditorState.set(this.props.editorState, {inCompositionMode: true})
   );

--- a/src/component/handlers/edit/editOnCompositionStart.js
+++ b/src/component/handlers/edit/editOnCompositionStart.js
@@ -18,7 +18,7 @@ var EditorState = require('EditorState');
  * The user has begun using an IME input system. Switching to `composite` mode
  * allows handling composition input and disables other edit behavior.
  */
-function editOnCompositionStart(): void {
+function editOnCompositionStart(e): void {
   this.setRenderGuard();
   this.setMode('composite');
   this.update(

--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -21,7 +21,7 @@ var findAncestorOffsetKey = require('findAncestorOffsetKey');
 var nullthrows = require('nullthrows');
 
 var isGecko = UserAgent.isEngine('Gecko');
-
+var isAndroid = UserAgent.isPlatform('Android');
 var DOUBLE_NEWLINE = '\n\n';
 
 /**
@@ -40,7 +40,7 @@ function editOnInput(): void {
   var domSelection = global.getSelection();
 
   var {anchorNode, isCollapsed} = domSelection;
-  if (anchorNode.nodeType !== Node.TEXT_NODE) {
+  if (anchorNode.nodeType !== Node.TEXT_NODE && anchorNode.nodeType !== Node.ELEMENT_NODE) {
     return;
   }
 
@@ -88,7 +88,7 @@ function editOnInput(): void {
 
   var anchorOffset, focusOffset, startOffset, endOffset;
 
-  if (isGecko) {
+  if (isAndroid || isGecko) {
     // Firefox selection does not change while the context menu is open, so
     // we preserve the anchor and focus values of the DOM selection.
     anchorOffset = domSelection.anchorOffset;


### PR DESCRIPTION
This fixes some issues for chrome support on Android. (including crosswalk)
- [X] use the provided selection in editOnInput
- [X] remove former text provided in compositionstart

remaining issues:
- [ ] moving the selection while composition is active discard the composition
- [ ] calling restoreEditorDOM() close the keyboard

I believe this can be merged after review without waiting for the other fixes. The experience is already much improved.
