### PR TITLE
introduce minHeight prop

### DIFF
--- a/examples/color/color.html
+++ b/examples/color/color.html
@@ -98,6 +98,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                   onChange={this.onChange}
                   placeholder="Write something colorful..."
                   ref="editor"
+                  minHeight={400}
                 />
               </div>
             </div>
@@ -194,7 +195,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           cursor: 'text',
           fontSize: 16,
           marginTop: 20,
-          minHeight: 400,
           paddingTop: 20,
         },
         controls: {

--- a/examples/entity/entity.html
+++ b/examples/entity/entity.html
@@ -138,6 +138,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                   onChange={this.onChange}
                   placeholder="Enter some text..."
                   ref="editor"
+                  minHeight={80}
                 />
               </div>
               <input
@@ -195,7 +196,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         editor: {
           border: '1px solid #ccc',
           cursor: 'text',
-          minHeight: 80,
           padding: 10,
         },
         button: {

--- a/examples/link/link.html
+++ b/examples/link/link.html
@@ -160,6 +160,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                   onChange={this.onChange}
                   placeholder="Enter some text..."
                   ref="editor"
+                  minHeight={80}
                 />
               </div>
               <input
@@ -215,7 +216,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         editor: {
           border: '1px solid #ccc',
           cursor: 'text',
-          minHeight: 80,
           padding: 10,
         },
         button: {

--- a/examples/plaintext/plaintext.html
+++ b/examples/plaintext/plaintext.html
@@ -50,6 +50,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                   onChange={this.onChange}
                   placeholder="Enter some text..."
                   ref="editor"
+                  minHeight={80}
                 />
               </div>
               <input
@@ -72,7 +73,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         editor: {
           border: '1px solid #ccc',
           cursor: 'text',
-          minHeight: 80,
           padding: 10,
         },
         button: {

--- a/examples/rich/RichEditor.css
+++ b/examples/rich/RichEditor.css
@@ -19,10 +19,6 @@
   padding: 15px;
 }
 
-.RichEditor-editor .public-DraftEditor-content {
-  min-height: 100px;
-}
-
 .RichEditor-hidePlaceholder .public-DraftEditorPlaceholder-root {
   display: none;
 }

--- a/examples/rich/rich.html
+++ b/examples/rich/rich.html
@@ -109,6 +109,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                   placeholder="Tell a story..."
                   ref="editor"
                   spellCheck={true}
+                  minHeight={100}
                 />
               </div>
             </div>

--- a/examples/tweet/tweet.html
+++ b/examples/tweet/tweet.html
@@ -64,6 +64,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                   placeholder="Write a tweet..."
                   ref="editor"
                   spellCheck={true}
+                  minHeight={40}
                 />
               </div>
               <input
@@ -119,7 +120,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           border: '1px solid #ddd',
           cursor: 'text',
           fontSize: 16,
-          minHeight: 40,
           padding: 10,
         },
         button: {

--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -222,6 +222,7 @@ class DraftEditor
     const contentStyle = {
       outline: 'none',
       whiteSpace: 'pre-wrap',
+      minHeight: this.props.minHeight,
     };
 
     return (

--- a/website/src/draft-js/index.js
+++ b/website/src/draft-js/index.js
@@ -97,6 +97,7 @@ class RichEditorExample extends React.Component {
             placeholder="Tell a story..."
             ref="editor"
             spellCheck={true}
+            minHeight={100}
           />
         </div>
       </div>


### PR DESCRIPTION
To avoid selection issues it is important the the div with the attribute contenteditable is expanded. Even in the examples minHeight was set to the container which led these issues:

https://draftjs.slack.com/files/nikgraf/F0RA7K0KW/focus_test_1.mov

In the RichText example it was working properly due setting min-height in CSS via deep selectors. I feel like this is not obvious and an easy trap to fall into. Exposing a prop and using it in all the examples it might help …