### PR TITLE
Make some dist build changes

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,6 +11,7 @@
 
 var babel = require('gulp-babel');
 var del = require('del');
+var cleanCSS = require('gulp-clean-css');
 var concatCSS = require('gulp-concat-css');
 var derequire = require('gulp-derequire');
 var flatten = require('gulp-flatten');
@@ -133,6 +134,8 @@ gulp.task('css', function() {
       callback(null, file);
     }))
     .pipe(concatCSS('Draft.css'))
+    // Avoid rewriting rules *just in case*, just compress
+    .pipe(cleanCSS({advanced: false}))
     .pipe(gulp.dest(paths.dist));
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -55,6 +55,11 @@ var buildDist = function(opts) {
       library: 'Draft',
     },
     plugins: [
+      new webpackStream.webpack.DefinePlugin({
+        'process.env.NODE_ENV': JSON.stringify(
+          opts.debug ? 'development' : 'production'
+        ),
+      }),
       new webpackStream.webpack.optimize.OccurenceOrderPlugin(),
       new webpackStream.webpack.optimize.DedupePlugin(),
     ],

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,6 +17,8 @@ var derequire = require('gulp-derequire');
 var flatten = require('gulp-flatten');
 var gulp = require('gulp');
 var gulpUtil = require('gulp-util');
+var header = require('gulp-header');
+var packageData = require('./package.json');
 var runSequence = require('run-sequence');
 var through = require('through2');
 var webpackStream = require('webpack-stream');
@@ -41,6 +43,18 @@ var paths = {
 // Ensure that we use another plugin that isn't specified in the default Babel
 // options, converting __DEV__.
 babelOpts.plugins.push(babelPluginDEV);
+
+var COPYRIGHT_HEADER = `/**
+ * Draft v<%= version %>
+ *
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+`;
 
 var buildDist = function(opts) {
   var webpackOpts = {
@@ -136,6 +150,7 @@ gulp.task('css', function() {
     .pipe(concatCSS('Draft.css'))
     // Avoid rewriting rules *just in case*, just compress
     .pipe(cleanCSS({advanced: false}))
+    .pipe(header(COPYRIGHT_HEADER, {version: packageData.version}))
     .pipe(gulp.dest(paths.dist));
 });
 
@@ -147,6 +162,7 @@ gulp.task('dist', ['modules', 'css'], function() {
   return gulp.src('./lib/Draft.js')
     .pipe(buildDist(opts))
     .pipe(derequire())
+    .pipe(header(COPYRIGHT_HEADER, {version: packageData.version}))
     .pipe(gulp.dest(paths.dist));
 });
 
@@ -157,6 +173,7 @@ gulp.task('dist:min', ['modules'], function() {
   };
   return gulp.src('./lib/Draft.js')
     .pipe(buildDist(opts))
+    .pipe(header(COPYRIGHT_HEADER, {version: packageData.version}))
     .pipe(gulp.dest(paths.dist));
 });
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "gulp": "^3.9.0",
     "gulp-babel": "^5.1.0",
     "gulp-browserify-thin": "^0.1.5",
+    "gulp-clean-css": "^2.0.3",
     "gulp-concat-css": "^2.2.0",
     "gulp-derequire": "^2.1.0",
     "gulp-flatten": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "gulp-concat-css": "^2.2.0",
     "gulp-derequire": "^2.1.0",
     "gulp-flatten": "^0.2.0",
+    "gulp-header": "^1.7.1",
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.6",
     "jest-cli": "^0.9.0-fb1",


### PR DESCRIPTION
- Inline `process.env.NODE_ENV === 'production'` checks
- Compress CSS
- Add copyright headers to dist files

It's not a *huge* difference on the size front but definitely better. And the copyright thing is something we should do regardless of the rest.
<img width="591" alt="screen shot 2016-03-09 at 4 26 17 pm" src="https://cloud.githubusercontent.com/assets/8445/13655376/bc78d212-e613-11e5-8f39-0268bf4d32f2.png">
