### PR TITLE
#191: Add `word-wrap, word-break` properties

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -228,7 +228,6 @@ class DraftEditor
       outline: 'none',
       whiteSpace: 'pre-wrap',
       wordWrap: 'break-word',
-      wordBreak: 'break-all',
     };
 
     return (

--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -227,6 +227,8 @@ class DraftEditor
     const contentStyle = {
       outline: 'none',
       whiteSpace: 'pre-wrap',
+      wordWrap: 'break-word',
+      wordBreak: 'break-all',
     };
 
     return (


### PR DESCRIPTION
This should fix word wrapping in Firefox.

![screen shot 2016-03-10 at 9 07 46 pm](https://cloud.githubusercontent.com/assets/102968/13691125/393e3922-e704-11e5-94e2-8ac803753e84.png)
