### PR TITLE
Custom block component wrapper

### DIFF
--- a/docs/Advanced-Topics-Block-Components.md
+++ b/docs/Advanced-Topics-Block-Components.md
@@ -40,6 +40,7 @@ function myBlockRenderer(contentBlock) {
   if (type === 'media') {
     return {
       component: MediaComponent,
+      editable: false,
       props: {
         foo: 'bar',
       },
@@ -62,7 +63,8 @@ If no custom renderer object is returned by the `blockRendererFn` function,
 
 The `component` property defines the component to be used, while the optional
 `props` object includes props that will be passed through to the rendered
-custom component.
+custom component. In addition, the optional `editable` property determines
+whether the custom component is `contentEditable`.
 
 By defining this function within the context of a higher-level component,
 the props for this custom component may be bound to that component, allowing
@@ -80,7 +82,8 @@ code.
 import {Entity} from 'draft-js';
 class MediaComponent extends React.Component {
   render() {
-    const {block, foo} = this.props;
+    const {block} = this.props;
+    const {foo} = this.props.blockProps;
     const data = Entity.get(block.getEntityAt(0)).getData();
     // Return a <figure> or some other content using this data.
   }

--- a/examples/tex/js/components/TeXBlock.js
+++ b/examples/tex/js/components/TeXBlock.js
@@ -165,12 +165,10 @@ export default class TeXBlock extends React.Component {
     }
 
     return (
-      <figure
-        contentEditable={false}
-        className={className}>
+      <div className={className}>
         <KatexOutput content={texContent} onClick={this._onClick} />
         {editPanel}
-      </figure>
+      </div>
     );
   }
 }

--- a/examples/tex/js/components/TeXEditorExample.js
+++ b/examples/tex/js/components/TeXEditorExample.js
@@ -38,6 +38,7 @@ export default class TeXEditorExample extends React.Component {
       if (block.getType() === 'media') {
         return {
           component: TeXBlock,
+          editable: false,
           props: {
             onStartEdit: (blockKey) => {
               var {liveTeXEdits} = this.state;

--- a/src/component/contents/DraftEditorContents.react.js
+++ b/src/component/contents/DraftEditorContents.react.js
@@ -106,7 +106,7 @@ class DraftEditorContents extends React.Component {
     let currentWrapperTemplate = null;
     let currentDepth = null;
     let currentWrappedBlocks;
-    let block, key, blockType, child, wrapperTemplate;
+    let block, key, blockType, child, childProps, wrapperTemplate;
 
     for (let ii = 0; ii < blocksAsArray.length; ii++) {
       block = blocksAsArray[ii];
@@ -114,10 +114,11 @@ class DraftEditorContents extends React.Component {
       blockType = block.getType();
 
       const customRenderer = blockRendererFn(block);
-      let CustomComponent, customProps;
+      let CustomComponent, customProps, customEditable;
       if (customRenderer) {
         CustomComponent = customRenderer.component;
         customProps = customRenderer.props;
+        customEditable = customRenderer.editable;
       }
 
       const direction = directionMap.get(key);
@@ -138,40 +139,43 @@ class DraftEditorContents extends React.Component {
       wrapperTemplate = getWrapperTemplateForBlockType(blockType);
       const useNewWrapper = wrapperTemplate !== currentWrapperTemplate;
 
-      if (CustomComponent) {
-        child = <CustomComponent {...componentProps} />;
-      } else {
-        const Element = getElementForBlockType(blockType);
-        const depth = block.getDepth();
-        let className = this.props.blockStyleFn(block);
+      const Element = getElementForBlockType(blockType);
+      const depth = block.getDepth();
+      let className = this.props.blockStyleFn(block);
 
-        // List items are special snowflakes, since we handle nesting and
-        // counters manually.
-        if (Element === 'li') {
-          const shouldResetCount = (
-            useNewWrapper ||
-            currentDepth === null ||
-            depth > currentDepth
-          );
-          className = joinClasses(
-            className,
-            getListItemClasses(blockType, depth, shouldResetCount, direction)
-          );
-        }
-
-        /* $FlowFixMe - Support DOM elements in React.createElement */
-        child = React.createElement(
-          Element,
-          {
-            className,
-            'data-block': true,
-            'data-editor': this.props.editorKey,
-            'data-offset-key': offsetKey,
-            key,
-          },
-          <DraftEditorBlock {...componentProps} />,
+      // List items are special snowflakes, since we handle nesting and
+      // counters manually.
+      if (Element === 'li') {
+        const shouldResetCount = (
+          useNewWrapper ||
+          currentDepth === null ||
+          depth > currentDepth
+        );
+        className = joinClasses(
+          className,
+          getListItemClasses(blockType, depth, shouldResetCount, direction)
         );
       }
+
+      const Component = CustomComponent || DraftEditorBlock;
+      childProps = {
+        className,
+        'data-block': true,
+        'data-editor': this.props.editorKey,
+        'data-offset-key': offsetKey,
+        key,
+      };
+      if (customEditable !== undefined) {
+        childProps['contentEditable'] = customEditable;
+        childProps['suppressContentEditableWarning'] = true;
+      }
+
+      /* $FlowFixMe - Support DOM elements in React.createElement */
+      child = React.createElement(
+        Element,
+        childProps,
+        <Component {...componentProps} />,
+      );
 
       if (wrapperTemplate) {
         if (useNewWrapper) {


### PR DESCRIPTION
cc: #124 

This creates a wrapper around Custom Block Components. The wrapper provides the necessary props (`contentEditable`, `data-block`, `data-edtior`, `data-offset-key`) required to correctly render custom block components, without the need for a developer to manually set these props within their `blockRendererFn`.

Details:
- This is a breaking API change for those creating wrappers manually.
- The custom block component is wrapped by an element based on its `DraftBlockType` (selected in `getElementForBlockType`).
- The `editable` property is optional (used for setting `contentEditable` on the custom block component). If `editable` isn't set, a `contentEditable` prop will not be set on the custom component (i.e. it would just inherit from above)