### PR TITLE
Improve `html` styles

### DIFF
--- a/website/src/draft-js/css/draft.css
+++ b/website/src/draft-js/css/draft.css
@@ -1,13 +1,10 @@
 html {
+  background-color: #fffcfc;
+  color: #484848;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-family: proxima-nova, "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-weight: 300;
-  color: #484848;
   line-height: 1.28;
-}
-
-body {
-  background-color: #FFFCFC;
 }
 
 .subHeader {
@@ -166,10 +163,6 @@ html * {
   border: none;
   margin: 0;
   padding: 0;
-}
-
-html {
-  background: #f9f9f9;
 }
 
 .left {


### PR DESCRIPTION
When the browser is narrower than `.container` or taller than the content, `<html>` `background-color` is visible:

<p align="center">
  <img src="https://cloud.githubusercontent.com/assets/220979/13725333/ff857572-e863-11e5-92bf-33f8626014cc.png" width="400">
</p>

_You can also see this issue if you decrease the browser’s zoom level._

**Changes:**
- De-dupe the `html` selector
- Move `body` `background-color` to `html`
- Remove `body` rule
- :abc: `html` properties