### PR TITLE
missing-headers-on-convertFromHTMLToContentBlocks - Including missing…

### DIFF
--- a/examples/rich/rich.html
+++ b/examples/rich/rich.html
@@ -159,6 +159,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       const BLOCK_TYPES = [
         {label: 'H1', style: 'header-one'},
         {label: 'H2', style: 'header-two'},
+        {label: 'H3', style: 'header-three'},
+        {label: 'H4', style: 'header-four'},
+        {label: 'H5', style: 'header-five'},
+        {label: 'H6', style: 'header-six'},
         {label: 'Blockquote', style: 'blockquote'},
         {label: 'UL', style: 'unordered-list-item'},
         {label: 'OL', style: 'ordered-list-item'},

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -122,6 +122,14 @@ function getBlockTypeForTag(tag: string, lastList: ?string): DraftBlockType {
       return 'header-one';
     case 'h2':
       return 'header-two';
+    case 'h3':
+      return 'header-three';
+    case 'h4':
+      return 'header-four';
+    case 'h5':
+      return 'header-five';
+    case 'h6':
+      return 'header-six';
     case 'li':
       if (lastList === 'ol') {
         return 'ordered-list-item';


### PR DESCRIPTION
This fixes issue https://github.com/facebook/draft-js/issues/206

- Adding missing headers for convertFromHTMLToContentBlocks