### PR TITLE
Enhancement: Adding handlePastedText handler to handle pasted text in…

### DIFF
--- a/docs/APIReference-Editor.md
+++ b/docs/APIReference-Editor.md
@@ -165,7 +165,7 @@ and to convert typed emoticons into images.
 
 #### handlePastedText
 ```
-handlePastedText?: (text: string, html: string) => boolean
+handlePastedText?: (text: string, html?: string) => boolean
 ```
 Handle text and html(for rich text) that has been pasted directly into the editor.
 

--- a/docs/APIReference-Editor.md
+++ b/docs/APIReference-Editor.md
@@ -165,9 +165,9 @@ and to convert typed emoticons into images.
 
 #### handlePastedText
 ```
-handlePastedText?: (text: string) => boolean
+handlePastedText?: (text: string, html: string) => boolean
 ```
-Handle text that has been pasted directly into the editor.
+Handle text and html(for rich text) that has been pasted directly into the editor.
 
 #### handlePastedFiles
 ```

--- a/docs/APIReference-Editor.md
+++ b/docs/APIReference-Editor.md
@@ -163,6 +163,12 @@ convert that `ContentBlock` into an `unordered-list-item`.
 At Facebook, we also use this to convert typed ASCII quotes into "smart" quotes,
 and to convert typed emoticons into images.
 
+#### handlePastedText
+```
+handlePastedText?: (text: string) => boolean
+```
+Handle text that has been pasted directly into the editor.
+
 #### handlePastedFiles
 ```
 handlePastedFiles?: (files: Array<Blob>) => boolean

--- a/src/component/base/DraftEditorProps.js
+++ b/src/component/base/DraftEditorProps.js
@@ -98,7 +98,7 @@ export type DraftEditorProps = {
   // quotes.
   handleBeforeInput?: (chars: string) => boolean,
 
-  handlePastedText?: (text: string) => boolean,
+  handlePastedText?: (text: string, html: string) => boolean,
 
   handlePastedFiles?: (files: Array<Blob>) => boolean,
 

--- a/src/component/base/DraftEditorProps.js
+++ b/src/component/base/DraftEditorProps.js
@@ -98,7 +98,7 @@ export type DraftEditorProps = {
   // quotes.
   handleBeforeInput?: (chars: string) => boolean,
 
-  handlePastedText?: (text: string, html: string) => boolean,
+  handlePastedText?: (text: string, html?: string) => boolean,
 
   handlePastedFiles?: (files: Array<Blob>) => boolean,
 

--- a/src/component/base/DraftEditorProps.js
+++ b/src/component/base/DraftEditorProps.js
@@ -98,6 +98,8 @@ export type DraftEditorProps = {
   // quotes.
   handleBeforeInput?: (chars: string) => boolean,
 
+  handlePastedText?: (text: string) => boolean,
+
   handlePastedFiles?: (files: Array<Blob>) => boolean,
 
   // Handle dropped files
@@ -120,7 +122,6 @@ export type DraftEditorProps = {
   onTab?: (e: SyntheticKeyboardEvent) => void,
   onUpArrow?: (e: SyntheticKeyboardEvent) => void,
   onDownArrow?: (e: SyntheticKeyboardEvent) => void,
-  onPasteRawText?: (text: string) => void,
 
   onBlur?: (e: SyntheticEvent) => void,
   onFocus?: (e: SyntheticEvent) => void,

--- a/src/component/handlers/edit/editOnPaste.js
+++ b/src/component/handlers/edit/editOnPaste.js
@@ -85,8 +85,8 @@ function editOnPaste(e: SyntheticClipboardEvent): void {
   }
 
   let textBlocks: Array<string> = [];
-  const text = data.getText(),
-    html = data.getHTML();
+  const text = data.getText();
+  const html = data.getHTML();
 
   if (this.props.handlePastedText && this.props.handlePastedText(text, html)) {
     return;

--- a/src/component/handlers/edit/editOnPaste.js
+++ b/src/component/handlers/edit/editOnPaste.js
@@ -85,9 +85,10 @@ function editOnPaste(e: SyntheticClipboardEvent): void {
   }
 
   let textBlocks: Array<string> = [];
-  var text = data.getText();
+  const text = data.getText(),
+    html = data.getHTML();
 
-  if (this.props.handlePastedText && this.props.handlePastedText(text)) {
+  if (this.props.handlePastedText && this.props.handlePastedText(text, html)) {
     return;
   }
 
@@ -103,7 +104,6 @@ function editOnPaste(e: SyntheticClipboardEvent): void {
     // stripped during comparison -- this is because copy/paste within the
     // editor in Firefox and IE will not include empty lines. The resulting
     // paste will preserve the newlines correctly.
-    const html = data.getHTML();
     const internalClipboard = this.getClipboard();
     if (data.isRichText() && internalClipboard) {
       if (

--- a/src/component/handlers/edit/editOnPaste.js
+++ b/src/component/handlers/edit/editOnPaste.js
@@ -21,7 +21,6 @@ var EditorState = require('EditorState');
 
 var getEntityKeyForSelection = require('getEntityKeyForSelection');
 var getTextContentFromFiles = require('getTextContentFromFiles');
-var nullthrows = require('nullthrows');
 var splitTextIntoTextBlocks = require('splitTextIntoTextBlocks');
 
 import type {BlockMap} from 'BlockMap';
@@ -87,7 +86,11 @@ function editOnPaste(e: SyntheticClipboardEvent): void {
 
   let textBlocks: Array<string> = [];
   var text = data.getText();
-  this.props.onPasteRawText && this.props.onPasteRawText(text);
+
+  if (this.props.handlePastedText && this.props.handlePastedText(text)) {
+    return;
+  }
+
   if (text) {
     textBlocks = splitTextIntoTextBlocks(text);
   }


### PR DESCRIPTION
As discussed in the issue #195, adding handlePastedText handler to handle pasted text in Editor and removing nullThrows import (unused) to fix lint warning.