### PR TITLE
block level metadata

### DIFF
--- a/docs/APIReference-ContentBlock.md
+++ b/docs/APIReference-ContentBlock.md
@@ -84,6 +84,11 @@ methods on a single `List` object.
     </a>
   </li>
   <li>
+    <a href="#getdata">
+      <pre>getData(): Map</pre>
+    </a>
+  </li>
+  <li>
     <a href="#findstyleranges">
       <pre>findStyleRanges(filterFn: Function, callback: Function): void</pre>
     </a>
@@ -126,6 +131,11 @@ methods on a single `List` object.
   <li>
     <a href="#depth">
       <pre>depth: number</pre>
+    </a>
+  </li>
+  <li>
+    <a href="#data">
+      <pre>data: Map</pre>
     </a>
   </li>
 </ul>
@@ -201,6 +211,13 @@ getEntityAt(offset: number): ?string
 Returns the entity key value (or `null` if none) at a given offset within this
 `ContentBlock`.
 
+### getData()
+
+```
+getData(): Map
+```
+Returns Block level metadata.
+
 ### findStyleRanges()
 
 ```
@@ -244,3 +261,6 @@ See `getCharacterList()`.
 
 ### depth
 See `getDepth()`.
+
+### data
+See `getData()`.

--- a/docs/APIReference-Modifier.md
+++ b/docs/APIReference-Modifier.md
@@ -68,6 +68,16 @@ will be the same as the input object if no edit was actually performed.
     </a>
   </li>
   <li>
+    <a href="#setblockdata">
+      <pre>setBlockData(...): ContentState</pre>
+    </a>
+  </li>
+  <li>
+    <a href="#mergeblockdata">
+      <pre>mergeBlockData(...): ContentState</pre>
+    </a>
+  </li>
+  <li>
     <a href="#applyentity">
       <pre>applyEntity(...): ContentState</pre>
     </a>
@@ -193,6 +203,28 @@ setBlockType(
 ): ContentState
 ```
 Set the block type for all selected blocks.
+
+### setBlockData
+
+```
+setBlockData(
+  contentState: ContentState,
+  selectionState: SelectionState,
+  blockData: Map
+): ContentState
+```
+Set the block data for all selected blocks.
+
+### mergeBlockData
+
+```
+mergeBlockData(
+  contentState: ContentState,
+  selectionState: SelectionState,
+  blockData: Map
+): ContentState
+```
+Update block data for all selected blocks.
 
 ### applyEntity
 

--- a/src/model/encoding/RawDraftContentBlock.js
+++ b/src/model/encoding/RawDraftContentBlock.js
@@ -27,4 +27,5 @@ export type RawDraftContentBlock = {
   depth: ?number;
   inlineStyleRanges: ?Array<InlineStyleRange>;
   entityRanges: ?Array<EntityRange>;
+  data: ?Object;
 };

--- a/src/model/encoding/convertFromDraftStateToRaw.js
+++ b/src/model/encoding/convertFromDraftStateToRaw.js
@@ -50,6 +50,7 @@ function convertFromDraftStateToRaw(
       depth: canHaveDepth(block) ? block.getDepth() : 0,
       inlineStyleRanges: encodeInlineStyleRanges(block),
       entityRanges: encodeEntityRanges(block, entityStorageMap),
+      data: block.getData().toJS(),
     });
   });
 

--- a/src/model/encoding/convertFromRawToDraftState.js
+++ b/src/model/encoding/convertFromRawToDraftState.js
@@ -14,6 +14,7 @@
 
 var ContentBlock = require('ContentBlock');
 var DraftEntity = require('DraftEntity');
+var Immutable = require('immutable');
 
 var createCharacterList = require('createCharacterList');
 var decodeEntityRanges = require('decodeEntityRanges');
@@ -21,6 +22,8 @@ var decodeInlineStyleRanges = require('decodeInlineStyleRanges');
 var generateRandomKey = require('generateRandomKey');
 
 import type {RawDraftContentState} from 'RawDraftContentState';
+
+var {Map} = Immutable;
 
 function convertFromRawToDraftState(
   rawState: RawDraftContentState
@@ -39,11 +42,12 @@ function convertFromRawToDraftState(
 
   return blocks.map(
     block => {
-      var {key, type, text, depth, inlineStyleRanges, entityRanges} = block;
+      var {key, type, text, depth, inlineStyleRanges, entityRanges, data} = block;
       key = key || generateRandomKey();
       depth = depth || 0;
       inlineStyleRanges = inlineStyleRanges || [];
       entityRanges = entityRanges || [];
+      data = Map(data);
 
       var inlineStyles = decodeInlineStyleRanges(text, inlineStyleRanges);
 
@@ -57,7 +61,7 @@ function convertFromRawToDraftState(
       var entities = decodeEntityRanges(text, filteredEntityRanges);
       var characterList = createCharacterList(inlineStyles, entities);
 
-      return new ContentBlock({key, type, text, depth, characterList});
+      return new ContentBlock({key, type, text, depth, characterList, data});
     }
   );
 }

--- a/src/model/immutable/ContentBlock.js
+++ b/src/model/immutable/ContentBlock.js
@@ -24,6 +24,7 @@ import type {DraftInlineStyle} from 'DraftInlineStyle';
 var {
   List,
   OrderedSet,
+  Map,
   Record,
 } = Immutable;
 
@@ -35,12 +36,14 @@ var defaultRecord: {
   text: string;
   characterList: List<CharacterMetadata>;
   depth: number;
+  data: Map;
 } = {
   key: '',
   type: 'unstyled',
   text: '',
   characterList: List(),
   depth: 0,
+  data: Map(),
 };
 
 var ContentBlockRecord = Record(defaultRecord);
@@ -68,6 +71,10 @@ class ContentBlock extends ContentBlockRecord {
 
   getDepth(): number {
     return this.get('depth');
+  }
+
+  getData(): Map {
+    return this.get('data');
   }
 
   getInlineStyleAt(offset: number): DraftInlineStyle {

--- a/src/model/modifier/DraftModifier.js
+++ b/src/model/modifier/DraftModifier.js
@@ -15,7 +15,7 @@
 
 var CharacterMetadata = require('CharacterMetadata');
 var ContentStateInlineStyle = require('ContentStateInlineStyle');
-var {OrderedSet} = require('immutable');
+var {OrderedSet, Map} = require('immutable');
 
 var applyEntityToContentState = require('applyEntityToContentState');
 var getCharacterRemovalRange = require('getCharacterRemovalRange');
@@ -211,6 +211,33 @@ var DraftModifier = {
       operation
     );
   },
+
+  setBlockData: function(
+    contentState: ContentState,
+    selectionState: SelectionState,
+    blockData: Map,
+  ): ContentState {
+    const operation = (block) => block.merge({data: blockData});
+    return modifyBlockForContentState(
+      contentState,
+      selectionState,
+      operation
+    );
+  },
+
+  mergeBlockData: function(
+    contentState: ContentState,
+    selectionState: SelectionState,
+    blockData: Map,
+  ): ContentState {
+    const operation = (block) => block.merge({data: block.getData().merge(blockData)});
+    return modifyBlockForContentState(
+      contentState,
+      selectionState,
+      operation
+    );
+  },
+
 
   applyEntity: function(
     contentState: ContentState,

--- a/src/model/modifier/DraftModifier.js
+++ b/src/model/modifier/DraftModifier.js
@@ -25,7 +25,7 @@ var insertTextIntoContentState = require('insertTextIntoContentState');
 var invariant = require('invariant');
 var removeEntitiesAtEdges = require('removeEntitiesAtEdges');
 var removeRangeFromContentState = require('removeRangeFromContentState');
-var setBlockTypeForContentState = require('setBlockTypeForContentState');
+var modifyBlockForContentState = require('modifyBlockForContentState');
 var splitBlockInContentState = require('splitBlockInContentState');
 
 import type {BlockMap} from 'BlockMap';
@@ -204,10 +204,11 @@ var DraftModifier = {
     selectionState: SelectionState,
     blockType: DraftBlockType
   ): ContentState {
-    return setBlockTypeForContentState(
+    const operation = (block) => block.merge({type: blockType, depth: 0});
+    return modifyBlockForContentState(
       contentState,
       selectionState,
-      blockType
+      operation
     );
   },
 

--- a/src/model/transaction/modifyBlockForContentState.js
+++ b/src/model/transaction/modifyBlockForContentState.js
@@ -6,23 +6,23 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @providesModule setBlockTypeForContentState
+ * @providesModule modifyBlockForContentState
  * @typechecks
  * @flow
  */
 
 'use strict';
 
-var Immutable = require('immutable');
+import Immutable from 'immutable';
 
+import type ContentBlock from 'ContentBlock';
 import type ContentState from 'ContentState';
-import type {DraftBlockType} from 'DraftBlockType';
 import type SelectionState from 'SelectionState';
 
-function setBlockTypeForContentState(
+function modifyBlockForContentState(
   contentState: ContentState,
   selectionState: SelectionState,
-  blockType: DraftBlockType,
+  operation: (block: ContentBlock) => ContentBlock,
 ): ContentState {
   var startKey = selectionState.getStartKey();
   var endKey = selectionState.getEndKey();
@@ -32,7 +32,7 @@ function setBlockTypeForContentState(
     .skipUntil((_, k) => k === startKey)
     .takeUntil((_, k) => k === endKey)
     .concat(Immutable.Map([[endKey, blockMap.get(endKey)]]))
-    .map(block => block.merge({type: blockType, depth: 0}));
+      .map(operation);
 
   return contentState.merge({
     blockMap: blockMap.merge(newBlocks),
@@ -41,4 +41,4 @@ function setBlockTypeForContentState(
   });
 }
 
-module.exports = setBlockTypeForContentState;
+module.exports = modifyBlockForContentState;

--- a/src/model/transaction/splitBlockInContentState.js
+++ b/src/model/transaction/splitBlockInContentState.js
@@ -18,6 +18,7 @@ var invariant = require('invariant');
 
 import type ContentState from 'ContentState';
 import type SelectionState from 'SelectionState';
+import {Map} from 'immutable';
 
 function splitBlockInContentState(
   contentState: ContentState,
@@ -46,6 +47,7 @@ function splitBlockInContentState(
     key: keyBelow,
     text: text.slice(offset),
     characterList: chars.slice(offset),
+    data: Map(),
   });
 
   var blocksBefore = blockMap.toSeq().takeUntil(v => v === blockToSplit);


### PR DESCRIPTION
This commit add support for block level metadata.

It is the same feature as https://github.com/facebook/draft-js/pull/157

This PR does not rely on entity, but just add a data field to ContentBlock.

hense block metadata are store in contentState and are supported by undo/redo.

Why not using entities?
- Entity are not made for block. what does type and mutability would map to?
- Entity are planned to be integrated into contentState anyway (see #185)
 