### PR TITLE
Improved documentation for EditorState. 

### DIFF
--- a/docs/APIReference-EditorState.md
+++ b/docs/APIReference-EditorState.md
@@ -95,6 +95,16 @@ The list below includes the most commonly used instance methods for `EditorState
       <pre>static forceSelection(editorState, selectionState): EditorState</pre>
     </a>
   </li>
+  <li>
+    <a href="#moveSelectionToEnd">
+      <pre>static moveSelectionToEnd(editorState): EditorState</pre>
+    </a>
+  </li>
+  <li>
+    <a href="#moveFocusToEnd">
+      <pre>static moveFocusToEnd(editorState): EditorState</pre>
+    </a>
+  </li>
 </ul>
 
 *Properties*
@@ -306,6 +316,25 @@ forcing the selection to be rendered.
 
 This is useful when the selection should be manually rendered in the correct
 location to maintain control of the rendered output.
+
+### moveSelectionToEnd
+
+```
+static moveSelectionToEnd(editorState: EditorState): EditorState
+```
+Returns a new `EditorState` object with the selection at the end.
+
+Move selection to the end of the editor without forcing focus.
+
+### moveFocusToEnd
+
+```
+static moveFocusToEnd(editorState: EditorState): EditorState
+```
+Returns a new `EditorState` object with selection at the end and forces focus.
+
+This is useful in scenarios where we want to programmatically focus the input
+and it makes sense to allow the user to continue working seamlessly.
 
 ## Properties and Getters
 

--- a/docs/APIReference-EditorState.md
+++ b/docs/APIReference-EditorState.md
@@ -324,7 +324,7 @@ static moveSelectionToEnd(editorState: EditorState): EditorState
 ```
 Returns a new `EditorState` object with the selection at the end.
 
-Move selection to the end of the editor without forcing focus.
+Moves selection to the end of the editor without forcing focus.
 
 ### moveFocusToEnd
 

--- a/src/model/immutable/EditorState.js
+++ b/src/model/immutable/EditorState.js
@@ -312,7 +312,7 @@ class EditorState {
 
   /**
    * Force focus to the end of the editor. This is useful in scenarios
-   * where we want to programatically focus the input and it makes sense
+   * where we want to programmatically focus the input and it makes sense
    * to allow the user to continue working seamlessly.
    */
   static moveFocusToEnd(editorState: EditorState): EditorState {


### PR DESCRIPTION
Added documentation for `moveSelectionToEnd` and `moveFocusToEnd`. These were missing from the documentation. 

#224 