### PR TITLE
gulp-development-task - Adding a dev gulp task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -187,6 +187,10 @@ gulp.task('watch', function() {
   gulp.watch(paths.src, ['modules']);
 });
 
+gulp.task('dev', function() {
+  gulp.watch(paths.src, ['modules', 'dist']);
+});
+
 gulp.task('default', function(cb) {
   runSequence('check-dependencies', 'clean', 'modules', ['dist', 'dist:min'], cb);
 });


### PR DESCRIPTION
- Having a development task for gulp allow us to do TDD a lot quicker and exploratory testing using the html files