### PR TITLE
Opt-Space no longer scrolls (Chrome OSX)

### DIFF
--- a/src/component/handlers/edit/editOnKeyDown.js
+++ b/src/component/handlers/edit/editOnKeyDown.js
@@ -14,7 +14,7 @@
 
 var DraftModifier = require('DraftModifier');
 var EditorState = require('EditorState');
-var KeyBindingUtil = require('KeyBindingUtil')
+var KeyBindingUtil = require('KeyBindingUtil');
 var Keys = require('Keys');
 var SecondaryClipboard = require('SecondaryClipboard');
 

--- a/src/component/handlers/edit/editOnKeyDown.js
+++ b/src/component/handlers/edit/editOnKeyDown.js
@@ -17,6 +17,7 @@ var EditorState = require('EditorState');
 var KeyBindingUtil = require('KeyBindingUtil');
 var Keys = require('Keys');
 var SecondaryClipboard = require('SecondaryClipboard');
+var UserAgent = require('UserAgent');
 
 var keyCommandBackspaceToStartOfLine = require('keyCommandBackspaceToStartOfLine');
 var keyCommandBackspaceWord = require('keyCommandBackspaceWord');
@@ -32,6 +33,7 @@ var keyCommandUndo = require('keyCommandUndo');
 import type {DraftEditorCommand} from 'DraftEditorCommand';
 
 var { isOptionKeyCommand } = KeyBindingUtil;
+var isChrome = UserAgent.isBrowser('Chrome');
 
 /**
  * Map a `DraftEditorCommand` command value to a corresponding function.
@@ -107,7 +109,7 @@ function editOnKeyDown(e: SyntheticKeyboardEvent): void {
       return;
     case Keys.SPACE:
       // handling for OSX where option + space scrolls
-      if (isOptionKeyCommand(e)) {
+      if (isChrome && isOptionKeyCommand(e)) {
         e.preventDefault();
         // insert a space into the editor
         const contentState = DraftModifier.replaceText(

--- a/src/component/handlers/edit/editOnKeyDown.js
+++ b/src/component/handlers/edit/editOnKeyDown.js
@@ -106,6 +106,7 @@ function editOnKeyDown(e: SyntheticKeyboardEvent): void {
       this.props.onDownArrow && this.props.onDownArrow(e);
       return;
     case Keys.SPACE:
+      // handling for OSX where option + space scrolls
       if (isOptionKeyCommand(e)) {
         e.preventDefault();
         // insert a space into the editor

--- a/src/component/handlers/edit/editOnKeyDown.js
+++ b/src/component/handlers/edit/editOnKeyDown.js
@@ -12,7 +12,9 @@
 
 'use strict';
 
+var DraftModifier = require('DraftModifier');
 var EditorState = require('EditorState');
+var KeyBindingUtil = require('KeyBindingUtil')
 var Keys = require('Keys');
 var SecondaryClipboard = require('SecondaryClipboard');
 
@@ -28,6 +30,8 @@ var keyCommandTransposeCharacters = require('keyCommandTransposeCharacters');
 var keyCommandUndo = require('keyCommandUndo');
 
 import type {DraftEditorCommand} from 'DraftEditorCommand';
+
+var { isOptionKeyCommand } = KeyBindingUtil;
 
 /**
  * Map a `DraftEditorCommand` command value to a corresponding function.
@@ -101,6 +105,18 @@ function editOnKeyDown(e: SyntheticKeyboardEvent): void {
     case Keys.DOWN:
       this.props.onDownArrow && this.props.onDownArrow(e);
       return;
+    case Keys.SPACE:
+      if (isOptionKeyCommand(e)) {
+        e.preventDefault();
+        // insert a space into the editor
+        const contentState = DraftModifier.replaceText(
+            editorState.getCurrentContent(),
+            editorState.getSelection(),
+            ' '
+        );
+        this.update(EditorState.push(editorState, contentState, 'space'));
+        return;
+      }
   }
 
   var command = this.props.keyBindingFn(e);

--- a/src/component/handlers/edit/editOnKeyDown.js
+++ b/src/component/handlers/edit/editOnKeyDown.js
@@ -115,7 +115,7 @@ function editOnKeyDown(e: SyntheticKeyboardEvent): void {
         const contentState = DraftModifier.replaceText(
           editorState.getCurrentContent(),
           editorState.getSelection(),
-          ' '
+          '\u00a0'
         );
         this.update(EditorState.push(editorState, contentState, 'insert-characters'));
         return;

--- a/src/component/handlers/edit/editOnKeyDown.js
+++ b/src/component/handlers/edit/editOnKeyDown.js
@@ -113,11 +113,11 @@ function editOnKeyDown(e: SyntheticKeyboardEvent): void {
         e.preventDefault();
         // insert a space into the editor
         const contentState = DraftModifier.replaceText(
-            editorState.getCurrentContent(),
-            editorState.getSelection(),
-            ' '
+          editorState.getCurrentContent(),
+          editorState.getSelection(),
+          ' '
         );
-        this.update(EditorState.push(editorState, contentState, 'space'));
+        this.update(EditorState.push(editorState, contentState, 'insert-characters'));
         return;
       }
   }

--- a/src/component/utils/KeyBindingUtil.js
+++ b/src/component/utils/KeyBindingUtil.js
@@ -27,6 +27,10 @@ var KeyBindingUtil = {
     return !!e.ctrlKey && !e.altKey;
   },
 
+  isOptionKeyCommand: function(e: SyntheticKeyboardEvent): boolean {
+    return isOSX && e.altKey;
+  },
+
   hasCommandModifier: function(e: SyntheticKeyboardEvent): boolean {
     return isOSX ?
       (!!e.metaKey && !e.altKey) :


### PR DESCRIPTION
`Option + Space` no longer causes scrolling. This was only happening in Chrome/OSX. This was happening in the keyDown handler not the keyPress handler. 

I'm not sure if I like adding the ' ' to the editor in editOnKeyDown. Maybe I should implement this as a command?

Fixes #19 