### PR TITLE
Add EditorState.setInlineStyleOverride

### DIFF
--- a/docs/APIReference-EditorState.md
+++ b/docs/APIReference-EditorState.md
@@ -105,6 +105,11 @@ The list below includes the most commonly used instance methods for `EditorState
       <pre>static moveFocusToEnd(editorState): EditorState</pre>
     </a>
   </li>
+  <li>
+    <a href="#setInlineStyleOverride">
+      <pre>static setInlineStyleOverride(inlineStyleOverride): EditorState</pre>
+    </a>
+  </li>
 </ul>
 
 *Properties*
@@ -335,6 +340,14 @@ Returns a new `EditorState` object with selection at the end and forces focus.
 
 This is useful in scenarios where we want to programmatically focus the input
 and it makes sense to allow the user to continue working seamlessly.
+
+### setInlineStyleOverride
+
+```
+static setInlineStyleOverride(inlineStyleOverride: DraftInlineStyle): EditorState
+```
+Returns a new `EditorState` object with the specified `DraftInlineStyle` applied
+as the set of inline styles to be applied to the next inserted characters.
 
 ## Properties and Getters
 

--- a/src/model/immutable/EditorState.js
+++ b/src/model/immutable/EditorState.js
@@ -210,6 +210,13 @@ class EditorState {
     return this.getImmutable().get('inlineStyleOverride');
   }
 
+  static setInlineStyleOverride(
+    editorState: EditorState,
+    inlineStyleOverride: DraftInlineStyle
+  ): EditorState {
+    return EditorState.set(editorState, { inlineStyleOverride });
+  }
+
   /**
    * Get the appropriate inline style for the editor state. If an
    * override is in place, use it. Otherwise, the current style is

--- a/src/model/modifier/RichTextEditorUtil.js
+++ b/src/model/modifier/RichTextEditorUtil.js
@@ -358,12 +358,12 @@ var RichTextEditorUtil = {
     // set the result as the new inline style override. This will then be
     // used as the inline style for the next character to be inserted.
     if (selection.isCollapsed()) {
-      return EditorState.set(editorState, {
-        inlineStyleOverride:
-          currentStyle.has(inlineStyle)
-            ? currentStyle.remove(inlineStyle)
-            : currentStyle.add(inlineStyle),
-      });
+      return EditorState.setInlineStyleOverride(
+        editorState,
+        currentStyle.has(inlineStyle)
+          ? currentStyle.remove(inlineStyle)
+          : currentStyle.add(inlineStyle),
+      );
     }
 
     // If characters are selected, immediately apply or remove the


### PR DESCRIPTION
As discussed on Slack, this change adds a convenience method to `EditorState` for setting the inline style override without resorting to the undocumented `EditorState.set` method.