### PR TITLE
Fix cursor behavior for soft new lines

### DIFF
--- a/src/model/modifier/RichTextEditorUtil.js
+++ b/src/model/modifier/RichTextEditorUtil.js
@@ -87,10 +87,15 @@ var RichTextEditorUtil = {
       null
     );
 
-    return EditorState.push(
+    var newEditorState = EditorState.push(
       editorState,
       contentState,
       'insert-characters'
+    );
+    
+    return EditorState.forceSelection(
+      newEditorState,
+      contentState.getSelectionAfter()
     );
   },
 


### PR DESCRIPTION
Forcing a selection will cause the browser to behave properly and show the cursor for multiple new lines.