### PR TITLE
Fixing copy/paste behavior for custom blocks

### DIFF
--- a/src/component/contents/DraftEditorContents.react.js
+++ b/src/component/contents/DraftEditorContents.react.js
@@ -129,6 +129,7 @@ class DraftEditorContents extends React.Component {
         customStyleMap,
         decorator,
         direction,
+        editorKey: this.props.editorKey,
         forceSelection,
         key,
         offsetKey,


### PR DESCRIPTION
Currently custom blocks do not receive the `editorKey`, so they cannot be used when copy/pasting. This fixes that issue.
