### PR TITLE
Make 'Return' key go through command flow

### DIFF
--- a/src/component/handlers/edit/editOnKeyDown.js
+++ b/src/component/handlers/edit/editOnKeyDown.js
@@ -83,11 +83,11 @@ function editOnKeyDown(e: SyntheticKeyboardEvent): void {
     case Keys.RETURN:
       e.preventDefault();
       // The top-level component may manually handle newline insertion. If
-      // no special handling is performed, insert a newline.
-      if (!this.props.handleReturn || !this.props.handleReturn(e)) {
-        this.update(keyCommandInsertNewline(editorState));
+      // no special handling is performed, fall through to command handling
+      if (this.props.handleReturn && this.props.handleReturn(e)) {
+        return;
       }
-      return;
+      break;
     case Keys.ESC:
       e.preventDefault();
       this.props.onEscape && this.props.onEscape(e);

--- a/src/component/utils/getDefaultKeyBinding.js
+++ b/src/component/utils/getDefaultKeyBinding.js
@@ -102,6 +102,8 @@ function getDefaultKeyBinding(
       return null;
     case 90: // Z
       return getZCommand(e) || null;
+    case Keys.RETURN:
+      return 'split-block';
     case Keys.DELETE:
       return getDeleteCommand(e);
     case Keys.BACKSPACE:


### PR DESCRIPTION
As suggested by @hellendag in https://github.com/facebook/draft-js/pull/216#issuecomment-197979832

This allows customization of custom block  split behavior when hitting 'Return'.