### PR TITLE
Always delete empty block on delete

### DIFF
--- a/src/model/modifier/RichTextEditorUtil.js
+++ b/src/model/modifier/RichTextEditorUtil.js
@@ -176,7 +176,32 @@ const RichTextEditorUtil = {
 
     const blockAfter = content.getBlockAfter(startKey);
 
-    if (!blockAfter || blockAfter.getType() !== 'atomic') {
+    if (!blockAfter) {
+      return null;
+    }
+
+    // Always delete empty blocks followed by non-atomic blocks
+    if (blockAfter.getType() !== "atomic") {
+      if (length === 0) {
+        var target = selection.merge({
+          focusKey: blockAfter.getKey(),
+          focusOffset: 0,
+        });
+
+        var withoutEmptyBlock = DraftModifier.removeRange(
+          content,
+          target,
+          'forward'
+        );
+
+        var preserveType = DraftModifier.setBlockType(
+          withoutEmptyBlock,
+          withoutEmptyBlock.getSelectionAfter(),
+          blockAfter.getType()
+        );
+
+        return EditorState.push(editorState, preserveType, 'remove-range');
+      }
       return null;
     }
 

--- a/src/model/modifier/__tests__/RichTextEditorUtil-test.js
+++ b/src/model/modifier/__tests__/RichTextEditorUtil-test.js
@@ -148,5 +148,30 @@ describe('RichTextEditorUtil', () => {
 
       expect(blockMapAfterDelete.size).toBe(4);
     });
+
+    it('deletes an empty block', () => {
+      // Make first block empty
+      const contentState = editorState.getCurrentContent();
+      const originalFirstBlock = contentState.getFirstBlock();
+      const targetSelection = selectionState.merge({
+        anchorOffset: 0,
+        focusOffset: originalFirstBlock.getText().length,
+      });
+      const withEmptyBlock = DraftModifier.removeRange(
+        contentState, 
+        targetSelection, 
+        'back'
+      );
+      const editorWithEmptyBlock = EditorState.push(
+        editorState, 
+        withEmptyBlock, 
+        'remove-range'
+      );
+
+      const afterDelete = onDelete(editorWithEmptyBlock);
+
+      const firstBlock = afterDelete.getCurrentContent().getBlockMap().first();
+      expect(firstBlock.getType()).toBe('unordered-list-item');
+    });
   });
 });


### PR DESCRIPTION
When hitting 'Delete' on an empty block, deletes the current block (instead of merging in the following block). This behavior is consistent with most other word editors, and also consistent with the case where the empty block is followed by a media block (in which case it already deleted the block).

This resolves #190 
