### PR TITLE
Prevent loss of entity during spellchecking

### DIFF
--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -82,7 +82,23 @@ function editOnInput(): void {
 
   var entityKey = block.getEntityAt(start);
   var entity = entityKey && Entity.get(entityKey);
-  var applyEntity = entity && entity.getMutability() !== 'IMMUTABLE';
+  var applyEntity = true;
+  var entityType = entity && entity.getMutability();
+  var changeType = 'spellcheck-change';
+
+  if (entityType) {
+    var isImmutableEntity =  entityType === 'IMMUTABLE';
+    var isSegmentedEntity =  entityType === 'SEGMENTED';
+    changeType = (isImmutableEntity || isSegmentedEntity) ?
+      'apply-entity' :
+      changeType;
+
+    if (isImmutableEntity) {
+      applyEntity = false;
+    }
+
+  }
+
   var newContent = DraftModifier.replaceText(
     content,
     targetRange,
@@ -125,7 +141,7 @@ function editOnInput(): void {
     EditorState.push(
       editorState,
       contentWithAdjustedDOMSelection,
-      'spellcheck-change'
+      changeType
     )
   );
 }

--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -15,6 +15,7 @@
 var DraftModifier = require('DraftModifier');
 var DraftOffsetKey = require('DraftOffsetKey');
 var EditorState = require('EditorState');
+var Entity = require('DraftEntity');
 var UserAgent = require('UserAgent');
 
 var findAncestorOffsetKey = require('findAncestorOffsetKey');
@@ -79,12 +80,15 @@ function editOnInput(): void {
     isBackward: false,
   });
 
+  var entityKey = block.getEntityAt(start);
+  var entity = entityKey && Entity.get(entityKey);
+  var applyEntity = entity && entity.getMutability() !== 'IMMUTABLE';
   var newContent = DraftModifier.replaceText(
     content,
     targetRange,
     domText,
     block.getInlineStyleAt(start),
-    block.getEntityAt(start)
+    applyEntity ? block.getEntityAt(start) : null,
   );
 
   var anchorOffset, focusOffset, startOffset, endOffset;

--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -82,31 +82,21 @@ function editOnInput(): void {
 
   var entityKey = block.getEntityAt(start);
   var entity = entityKey && Entity.get(entityKey);
-  var applyEntity = true;
   var entityType = entity && entity.getMutability();
-  var changeType = 'spellcheck-change';
+  const preserveEntity = entityType === 'MUTABLE';
 
-  if (entityType) {
-    var isImmutableEntity = entityType === 'IMMUTABLE';
-    var isSegmentedEntity = entityType === 'SEGMENTED';
-
-    // Immutable or segmented entities cannot properly be handled by the
-    // default browser undo, so we have to use a different change type to
-    // force using our internal undo method instead of falling through to the
-    // native browser undo.
-    changeType = (isImmutableEntity || isSegmentedEntity) ?
-      'apply-entity' :
-      changeType;
-
-    applyEntity = !(isImmutableEntity || isSegmentedEntity);
-  }
+  // Immutable or segmented entities cannot properly be handled by the
+  // default browser undo, so we have to use a different change type to
+  // force using our internal undo method instead of falling through to the
+  // native browser undo.
+  const changeType = preserveEntity ? 'spellcheck-change' : 'apply-entity';
 
   var newContent = DraftModifier.replaceText(
     content,
     targetRange,
     domText,
     block.getInlineStyleAt(start),
-    applyEntity ? block.getEntityAt(start) : null,
+    preserveEntity ? block.getEntityAt(start) : null,
   );
 
   var anchorOffset, focusOffset, startOffset, endOffset;
@@ -139,7 +129,7 @@ function editOnInput(): void {
   // after the change, so we are not merging the selection.
   var contentWithAdjustedDOMSelection = newContent.merge({
     selectionBefore: content.getSelectionAfter(),
-    selectionAfter: selection.merge({anchorOffset, focusOffset})
+    selectionAfter: selection.merge({anchorOffset, focusOffset}),
   });
 
   this.update(

--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -83,7 +83,8 @@ function editOnInput(): void {
     content,
     targetRange,
     domText,
-    block.getInlineStyleAt(start)
+    block.getInlineStyleAt(start),
+    block.getEntityAt(start)
   );
 
   var anchorOffset, focusOffset, startOffset, endOffset;

--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -100,18 +100,19 @@ function editOnInput(): void {
       'apply-entity' :
       changeType;
 
-    if (isImmutableEntity) {
-      applyEntity = false;
-    } else if (isSegmentedEntity) {
+    if (isImmutableEntity || isSegmentedEntity) {
       var characterRemoved = domText.length < modelText.length;
+
       if (characterRemoved) {
-        mergeSelection = false;
         newContent = DraftModifier.removeRange(
           content,
           selection,
           'backward',
         );
-      } else {
+        mergeSelection = false;
+      }
+
+      if (!characterRemoved) {
         applyEntity = false;
       }
     }


### PR DESCRIPTION
Right now entities are lost when using the spellchecking feature of a browser. This change fixes that.

- [x] Fix `IMMUTABLE` entity undo bug
- [x] Completely remove `IMMUTABLE` entity and insert characters if spell change adds characters
- [x] Completely remove `IMMUTABLE` entity and insert characters if spell change changes characters
- [x] Completely remove `IMMUTABLE` entity and insert all characters if spell change removes characters
- [x] Completely remove `SEGMENTED` entity and insert characters if if spell change removes characters
- [x] Completely remove `SEGMENTED` entity and insert characters if character within entity is changed
- [x] Completely remove `SEGMENTED` entity and insert characters if character is added within entity
