### PR TITLE
Now uses internalClipboard when present and in Safari. 

### DIFF
--- a/src/component/handlers/edit/editOnPaste.js
+++ b/src/component/handlers/edit/editOnPaste.js
@@ -190,10 +190,9 @@ function areTextBlocksAndClipboardEqual(
   textBlocks: Array<string>,
   blockMap: BlockMap
 ): boolean {
-  let i = 0;
   return (
     textBlocks.length === blockMap.size &&
-    blockMap.toSeq().every((block) => block.getText() === textBlocks[i++])
+    blockMap.valueSeq().every((block, i) => block.getText() === textBlocks[i])
   );
 }
 

--- a/src/component/handlers/edit/editOnPaste.js
+++ b/src/component/handlers/edit/editOnPaste.js
@@ -190,17 +190,11 @@ function areTextBlocksAndClipboardEqual(
   textBlocks: Array<string>,
   blockMap: BlockMap
 ): boolean {
-  if (textBlocks.length != blockMap.size) {
-    return false;
-  }
   let i = 0;
-  for (const block of blockMap) {
-    if (block[1].getText() !== textBlocks[i]) {
-      return false;
-    }
-    i++;
-  }
-  return true;
+  return (
+    textBlocks.length === blockMap.size &&
+    blockMap.toSeq().every((block) => block.getText() === textBlocks[i++])
+  );
 }
 
 module.exports = editOnPaste;

--- a/src/component/handlers/edit/editOnPaste.js
+++ b/src/component/handlers/edit/editOnPaste.js
@@ -127,8 +127,9 @@ function editOnPaste(e: SyntheticClipboardEvent): void {
         return;
       }
     // Safari does not properly store text/html. Use the internalClipboard
-    // if present.   
-    } else if (isSafari && internalClipboard) {
+    // if present and equal to what is on the clipboard.
+    } else if (isSafari && internalClipboard &&
+        areTextBlocksAndClipboardEqual(textBlocks, internalClipboard)) {
       this.update(
         insertFragment(this.props.editorState, internalClipboard)
       );
@@ -183,6 +184,23 @@ function insertFragment(
     newContent,
     'insert-fragment'
   );
+}
+
+function areTextBlocksAndClipboardEqual(
+  textBlocks: Array<string>,
+  blockMap: BlockMap
+): boolean {
+  if (textBlocks.length != blockMap.size) {
+    return false;
+  }
+  let i = 0;
+  for (const block of blockMap) {
+    if (block[1].getText() !== textBlocks[i]) {
+      return false;
+    }
+    i++;
+  }
+  return true;
 }
 
 module.exports = editOnPaste;

--- a/src/component/handlers/edit/editOnPaste.js
+++ b/src/component/handlers/edit/editOnPaste.js
@@ -18,12 +18,14 @@ var DataTransfer = require('DataTransfer');
 var DraftModifier = require('DraftModifier');
 var DraftPasteProcessor = require('DraftPasteProcessor');
 var EditorState = require('EditorState');
+var UserAgent = require('UserAgent');
 
 var getEntityKeyForSelection = require('getEntityKeyForSelection');
 var getTextContentFromFiles = require('getTextContentFromFiles');
 var splitTextIntoTextBlocks = require('splitTextIntoTextBlocks');
 
 import type {BlockMap} from 'BlockMap';
+var isSafari = UserAgent.isBrowser('Safari');
 
 /**
  * Paste content.
@@ -124,6 +126,13 @@ function editOnPaste(e: SyntheticClipboardEvent): void {
         );
         return;
       }
+    // Safari does not properly store text/html. Use the internalClipboard
+    // if present.   
+    } else if (isSafari && internalClipboard) {
+      this.update(
+        insertFragment(this.props.editorState, internalClipboard)
+      );
+      return;
     }
 
     // If there is html paste data, try to parse that.

--- a/src/component/handlers/edit/editOnPaste.js
+++ b/src/component/handlers/edit/editOnPaste.js
@@ -18,14 +18,12 @@ var DataTransfer = require('DataTransfer');
 var DraftModifier = require('DraftModifier');
 var DraftPasteProcessor = require('DraftPasteProcessor');
 var EditorState = require('EditorState');
-var UserAgent = require('UserAgent');
 
 var getEntityKeyForSelection = require('getEntityKeyForSelection');
 var getTextContentFromFiles = require('getTextContentFromFiles');
 var splitTextIntoTextBlocks = require('splitTextIntoTextBlocks');
 
 import type {BlockMap} from 'BlockMap';
-var isSafari = UserAgent.isBrowser('Safari');
 
 /**
  * Paste content.
@@ -126,9 +124,10 @@ function editOnPaste(e: SyntheticClipboardEvent): void {
         );
         return;
       }
-    // Safari does not properly store text/html. Use the internalClipboard
+    // Safari does not properly store text/html in some cases. Use the internalClipboard
     // if present and equal to what is on the clipboard.
-    } else if (isSafari && internalClipboard &&
+    } else if (data.types.includes('com.apple.webarchive') && !data.types.includes('text/html')
+        && internalClipboard &&
         areTextBlocksAndClipboardEqual(textBlocks, internalClipboard)) {
       this.update(
         insertFragment(this.props.editorState, internalClipboard)


### PR DESCRIPTION
After looking at how CKEditor I realized I was overthinking this. No extra clipboard library was need. The clipboard was already being stored. 

The only drawback to this solution is that formatting is only preserved when cut and pasted within one editor instance. 

Fixes #147 