### PR TITLE
Remove h3-h6 from the lightweight editor demo

### DIFF
--- a/website/src/draft-js/index.js
+++ b/website/src/draft-js/index.js
@@ -147,10 +147,6 @@ class StyleButton extends React.Component {
 const BLOCK_TYPES = [
   {label: 'H1', style: 'header-one'},
   {label: 'H2', style: 'header-two'},
-  {label: 'H3', style: 'header-three'},
-  {label: 'H4', style: 'header-four'},
-  {label: 'H5', style: 'header-five'},
-  {label: 'H6', style: 'header-six'},
   {label: 'Blockquote', style: 'blockquote'},
   {label: 'UL', style: 'unordered-list-item'},
   {label: 'OL', style: 'ordered-list-item'},


### PR DESCRIPTION
Removed the H3-H6 from the demo as it is just a lightweight demo, and H1-H2 should be enough to get the point across. As suggested by @hellendag in [#222 (comment)](https://github.com/facebook/draft-js/issues/222#issuecomment-199341556).