### PR TITLE
Fix Block.getLength() to be Unicode aware

### DIFF
--- a/docs/APIReference-ContentBlock.md
+++ b/docs/APIReference-ContentBlock.md
@@ -173,9 +173,8 @@ getLength(): number
 ```
 Returns the length of the plaintext for the `ContentBlock`.
 
-This value uses the standard JavaScript `length` property for the string, and
-is therefore not Unicode-aware -- surrogate pairs will be counted as two
-characters.
+This operation is Unicode-aware -- surrogate pairs will be counted as one
+character.
 
 ### getDepth()
 

--- a/src/model/immutable/ContentBlock.js
+++ b/src/model/immutable/ContentBlock.js
@@ -13,6 +13,7 @@
 
 'use strict';
 
+var UnicodeUtils = require('UnicodeUtils');
 var Immutable = require('immutable');
 
 var findRangesImmutable = require('findRangesImmutable');
@@ -63,7 +64,7 @@ class ContentBlock extends ContentBlockRecord {
   }
 
   getLength(): number {
-    return this.getText().length;
+    return UnicodeUtils.strlen(this.getText());
   }
 
   getDepth(): number {

--- a/src/model/immutable/__tests__/ContentBlock-test.js
+++ b/src/model/immutable/__tests__/ContentBlock-test.js
@@ -58,6 +58,16 @@ describe('ContentBlock', () => {
       expect(block.getLength()).toBe(5);
       expect(block.getCharacterList().count()).toBe(5);
     });
+
+    it('must retrieve properties when text includes surrogate pairs', () => {
+      var block = getSampleBlock();
+      var unicodeBlock = block.set('text', 'Alph\uD83D\uDCF7');
+      expect(unicodeBlock.getKey()).toBe('a');
+      expect(unicodeBlock.getText()).toBe('Alph\uD83D\uDCF7');
+      expect(unicodeBlock.getType()).toBe('unstyled');
+      expect(unicodeBlock.getLength()).toBe(5);
+      expect(unicodeBlock.getCharacterList().count()).toBe(5);
+    });
   });
 
   describe('style retrieval', () => {


### PR DESCRIPTION
As ```Block.getLength()``` is widely used, it should be Unicode aware.

It fixes not just ```Block.getLength()``` but also ```Modifier.applyEntity()``` which uses internally ```Block.getLength()``` to apply an ```Entity``` at a given range.

Let me know if you need more test coverage on this issue.