### PR TITLE
Fix examples

### DIFF
--- a/examples/entity/entity.html
+++ b/examples/entity/entity.html
@@ -15,7 +15,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>Draft • Plain Text Editor</title>
+    <title>Draft • Entity Editor</title>
     <link rel="stylesheet" href="../../dist/Draft.css" />
   </head>
   <body>
@@ -115,10 +115,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           const blocks = convertFromRaw(rawContent);
 
           this.state = {
-            editorState: EditorState.createWithContent(
-              ContentState.createFromBlockArray(blocks),
-              decorator
-            ),
+            editorState: EditorState.createWithContent(blocks, decorator),
           };
 
           this.focus = () => this.refs.editor.focus();

--- a/examples/tex/js/components/TeXEditorExample.js
+++ b/examples/tex/js/components/TeXEditorExample.js
@@ -23,14 +23,13 @@ import {content} from '../data/content';
 import {insertTeXBlock} from '../modifiers/insertTeXBlock';
 import {removeTeXBlock} from '../modifiers/removeTeXBlock';
 
-var {ContentState, Editor, EditorState, RichUtils} = Draft;
+var {Editor, EditorState, RichUtils} = Draft;
 
 export default class TeXEditorExample extends React.Component {
   constructor(props) {
     super(props);
-    const contentState = ContentState.createFromBlockArray(content);
     this.state = {
-      editorState: EditorState.createWithContent(contentState),
+      editorState: EditorState.createWithContent(content),
       liveTeXEdits: Map(),
     };
 

--- a/examples/tex/package.json
+++ b/examples/tex/package.json
@@ -15,8 +15,8 @@
     "express": "^4.13.1",
     "immutable": "^3.7.4",
     "katex": "^0.5.1",
-    "react": "^0.14.0",
-    "react-dom": "^0.14.7",
+    "react": "^15.0.0",
+    "react-dom": "^15.0.0",
     "webpack": "^1.10.5",
     "webpack-dev-server": "^1.10.1"
   }


### PR DESCRIPTION
The recent change to `convertFromRaw` left some examples broken.

Also update TeX example to React 15.

Fixes #307 and #308.