### PR TITLE
Upgrade flow to 0.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "eslint": "^1.5.1",
     "eslint-plugin-react": "^3.2.2",
     "fbjs-scripts": "^0.6.0-alpha.1",
-    "flow-bin": "^0.22.1",
+    "flow-bin": "^0.23.0",
     "gulp": "^3.9.0",
     "gulp-babel": "^5.1.0",
     "gulp-browserify-thin": "^0.1.5",

--- a/src/.flowconfig
+++ b/src/.flowconfig
@@ -17,3 +17,6 @@ module.system=haste
 esproposal.class_static_fields=enable
 suppress_type=$FlowIssue
 suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe
+
+[version]
+0.23.0


### PR DESCRIPTION
Simplified version of #313. We don't actually need the Promise definition here (anymore?), though I did ship it in fbjs@0.8.1.

I also added the flow version we expect to the flowconfig so we'll hard fail there if we ever mismatch.