### PR TITLE
Fix deletion behavior around atomic blocks

### DIFF
--- a/src/model/modifier/RichTextEditorUtil.js
+++ b/src/model/modifier/RichTextEditorUtil.js
@@ -16,6 +16,7 @@
 var DraftEntity = require('DraftEntity');
 var DraftModifier = require('DraftModifier');
 var EditorState = require('EditorState');
+var SelectionState = require('SelectionState');
 
 var adjustBlockDepthForContentState = require('adjustBlockDepthForContentState');
 var nullthrows = require('nullthrows');
@@ -23,7 +24,6 @@ var nullthrows = require('nullthrows');
 import type ContentState from 'ContentState';
 import type {DraftBlockType} from 'DraftBlockType';
 import type {DraftEditorCommand} from 'DraftEditorCommand';
-import type SelectionState from 'SelectionState';
 import type URI from 'URI';
 
 var RichTextEditorUtil = {
@@ -116,13 +116,6 @@ var RichTextEditorUtil = {
     // First, try to remove a preceding atomic block.
     var content = editorState.getCurrentContent();
     var startKey = selection.getStartKey();
-    var blockAfter = content.getBlockAfter(startKey);
-
-    // If the current block is empty, just delete it.
-    if (blockAfter && content.getBlockForKey(startKey).getLength() === 0) {
-      return null;
-    }
-
     var blockBefore = content.getBlockBefore(startKey);
 
     if (blockBefore && blockBefore.getType() === 'atomic') {
@@ -166,56 +159,33 @@ var RichTextEditorUtil = {
   },
 
   onDelete: function(editorState: EditorState): ?EditorState {
-    var selection = editorState.getSelection();
+    const selection = editorState.getSelection();
     if (!selection.isCollapsed()) {
       return null;
     }
 
-    var content = editorState.getCurrentContent();
-    var startKey = selection.getStartKey();
-    var block = content.getBlockForKey(startKey);
-    var length = block.getLength();
+    const content = editorState.getCurrentContent();
+    const startKey = selection.getStartKey();
+    const block = content.getBlockForKey(startKey);
+    const length = block.getLength();
 
     // The cursor is somewhere within the text. Behave normally.
     if (selection.getStartOffset() < length) {
       return null;
     }
 
-    var blockAfter = content.getBlockAfter(startKey);
+    const blockAfter = content.getBlockAfter(startKey);
 
     if (!blockAfter || blockAfter.getType() !== 'atomic') {
       return null;
     }
 
-    // If the current block is empty, delete it.
-    if (length === 0) {
-      var target = selection.merge({
-        focusKey: blockAfter.getKey(),
-        focusOffset: 0,
-      });
-
-      var withoutEmptyBlock = DraftModifier.removeRange(
-        content,
-        target,
-        'forward'
-      );
-
-      var preserveAtomicBlock = DraftModifier.setBlockType(
-        withoutEmptyBlock,
-        withoutEmptyBlock.getSelectionAfter(),
-        'atomic'
-      );
-
-      return EditorState.push(editorState, preserveAtomicBlock, 'remove-range');
-    }
-
-    // Otherwise, delete the atomic block.
-    var atomicBlockTarget = selection.merge({
+    const atomicBlockTarget = selection.merge({
       focusKey: blockAfter.getKey(),
       focusOffset: blockAfter.getLength(),
     });
 
-    var withoutAtomicBlock = DraftModifier.removeRange(
+    const withoutAtomicBlock = DraftModifier.removeRange(
       content,
       atomicBlockTarget,
       'forward'


### PR DESCRIPTION
There is currently a selection state bug for deletion behavior around atomic blocks. Namely, removing an atomic block from a neighboring block will remove the atomic block but leave the cursor in an invalid state.

Make it so that atomic blocks will be removed during:

- Forward deletion from the last offset of a preceding block
- Backward deletion from the zero offset of a following block

@tasti and I discussed whether there should be some special behavior for forward deletion from an empty preceding block, i.e. removing the current block and moving the cursor upward, but this seemed magical.

We can try this out and adjust the behavior as needed.

Test Plan:

View media.html. Add text and an image block. Put cursor in block above image, forward delete. Verify that atomic block is removed. Repeat with cursor in block below image and backspace, verify same.

Fixes #326.