### PR TITLE
Update entity example to provide contentState instead of blockArray

### DIFF
--- a/examples/entity/entity.html
+++ b/examples/entity/entity.html
@@ -112,10 +112,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             },
           ]);
 
-          const blocks = convertFromRaw(rawContent);
+          const contentState = ContentState.createFromBlockArray(convertFromRaw(rawContent));
 
           this.state = {
-            editorState: EditorState.createWithContent(blocks, decorator),
+            editorState: EditorState.createWithContent(contentState, decorator),
           };
 
           this.focus = () => this.refs.editor.focus();


### PR DESCRIPTION
As mentioned (and subsequently fixed in the documentation) by issues #28, #30, and #43 `createFromRaw` returns an `Array` of `ContentBlock` objects. This updates the [entity example](https://github.com/facebook/draft-js/blob/master/examples/entity/entity.html#L115-L118) to reflect those changes.