### PR TITLE
Add index to block callbacks

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -56,8 +56,8 @@ const handlerMap = {
 };
 
 type DefaultProps = {
-  blockRendererFn?: (block: ContentBlock) => ?Object;
-  blockStyleFn?: (type: number) => string,
+  blockRendererFn?: (block: ContentBlock, index: number) => ?Object;
+  blockStyleFn?: (type: number, index: number) => string,
   keyBindingFn?: (e: SyntheticKeyboardEvent) => ?string,
   readOnly?: boolean,
   spellCheck?: boolean,

--- a/src/component/base/DraftEditorProps.js
+++ b/src/component/base/DraftEditorProps.js
@@ -42,10 +42,10 @@ export type DraftEditorProps = {
   // For a given `ContentBlock` object, return an object that specifies
   // a custom block component and/or props. If no object is returned,
   // the default `TextEditorBlock` is used.
-  blockRendererFn?: (block: ContentBlock) => ?Object,
+  blockRendererFn?: (block: ContentBlock, index: number) => ?Object,
 
   // Function that returns a cx map corresponding to block-level styles.
-  blockStyleFn?: (type: number) => string,
+  blockStyleFn?: (type: number, index: number) => string,
 
   // A function that accepts a synthetic key event and returns
   // the matching DraftEditorCommand constant, or null if no command should

--- a/src/component/contents/DraftEditorContents.react.js
+++ b/src/component/contents/DraftEditorContents.react.js
@@ -113,7 +113,7 @@ class DraftEditorContents extends React.Component {
       key = block.getKey();
       blockType = block.getType();
 
-      const customRenderer = blockRendererFn(block);
+      const customRenderer = blockRendererFn(block, ii);
       let CustomComponent, customProps, customEditable;
       if (customRenderer) {
         CustomComponent = customRenderer.component;
@@ -141,7 +141,7 @@ class DraftEditorContents extends React.Component {
 
       const Element = getElementForBlockType(blockType);
       const depth = block.getDepth();
-      let className = this.props.blockStyleFn(block);
+      let className = this.props.blockStyleFn(block, ii);
 
       // List items are special snowflakes, since we handle nesting and
       // counters manually.


### PR DESCRIPTION
Could be pretty handy to get the block index on the callbacks that run on every block.