### PR TITLE
Convert handler signature to return a `DraftHandleValue` value, instead of a boolean - #339

### DIFF
--- a/docs/APIReference-Editor.md
+++ b/docs/APIReference-Editor.md
@@ -140,20 +140,20 @@ These props allow you to set accessibility properties on your editor. See
 ### Cancelable Handlers (Optional)
 
 These prop functions are provided to allow custom event handling for a small
-set of useful events. By returning true from your handler, you indicate that
+set of useful events. By returning `'handled'` from your handler, you indicate that
 the event is handled and the Draft core should do nothing more with it. By returning
-false, you defer to Draft to handle the event.
+`'not-handled'`, you defer to Draft to handle the event.
 
 #### handleReturn
 ```
-handleReturn?: (e: SyntheticKeyboardEvent) => boolean
+handleReturn?: (e: SyntheticKeyboardEvent) => DraftHandleValue
 ```
 Handle a `RETURN` keydown event. Example usage: Choosing a mention tag from a
 rendered list of results to trigger applying the mention entity to your content.
 
 #### handleKeyCommand
 ```
-handleKeyCommand?: (command: string) => boolean
+handleKeyCommand?: (command: string) => DraftHandleValue
 ```
 Handle the named editor command. See
 [Advanced Topics: Key Bindings](/draft-js/docs/advanced-topics-key-bindings.html)
@@ -161,9 +161,9 @@ for details on usage.
 
 #### handleBeforeInput
 ```
-handleBeforeInput?: (chars: string) => boolean
+handleBeforeInput?: (chars: string) => DraftHandleValue
 ```
-Handle the characters to be inserted from a `beforeInput` event. Returning `true`
+Handle the characters to be inserted from a `beforeInput` event. Returning `'handled'`
 causes the default behavior of the `beforeInput` event to be prevented (i.e. it is
 the same as calling the `preventDefault` method on the event).
 Example usage: After a user has typed `- ` at the start of a new block, you might
@@ -174,25 +174,25 @@ and to convert typed emoticons into images.
 
 #### handlePastedText
 ```
-handlePastedText?: (text: string, html?: string) => boolean
+handlePastedText?: (text: string, html?: string) => DraftHandleValue
 ```
 Handle text and html(for rich text) that has been pasted directly into the editor. Returning true will prevent the default paste behavior. 
 
 #### handlePastedFiles
 ```
-handlePastedFiles?: (files: Array<Blob>) => boolean
+handlePastedFiles?: (files: Array<Blob>) => DraftHandleValue
 ```
 Handle files that have been pasted directly into the editor.
 
 #### handleDroppedFiles
 ```
-handleDroppedFiles?: (selection: SelectionState, files: Array<Blob>) => boolean
+handleDroppedFiles?: (selection: SelectionState, files: Array<Blob>) => DraftHandleValue
 ```
 Handle files that have been dropped into the editor.
 
 #### handleDrop
 ```
-handleDrop?: (selection: SelectionState, dataTransfer: Object, isInternal: DraftDragType) => boolean
+handleDrop?: (selection: SelectionState, dataTransfer: Object, isInternal: DraftDragType) => DraftHandleValue
 ```
 Handle other drop operations.
 

--- a/docs/Advanced-Topics-Key-Bindings.md
+++ b/docs/Advanced-Topics-Key-Bindings.md
@@ -34,8 +34,8 @@ fall-through case, so that your editor may benefit from default commands.
 
 With your custom command string, you may then implement the `handleKeyCommand`
 prop function, which allows you to map that command string to your desired
-behavior. If `handleKeyCommand` returns `true`, the command is considered
-handled. If it returns `false`, the command will fall through.
+behavior. If `handleKeyCommand` returns `'handled'`, the command is considered
+handled. If it returns `'not-handled'`, the command will fall through.
 
 ### Example
 
@@ -71,13 +71,13 @@ import {Editor} from 'draft-js';
 class MyEditor extends React.Component {
   // ...
 
-  handleKeyCommand(command: string): boolean {
+  handleKeyCommand(command: string): DraftHandleValue {
     if (command === 'myeditor-save') {
       // Perform a request to save your contents, set
       // a new `editorState`, etc.
-      return true;
+      return 'handled';
     }
-    return false;
+    return 'not-handled';
   }
 
   render() {
@@ -94,8 +94,8 @@ class MyEditor extends React.Component {
 ```
 
 The `'myeditor-save'` command can be used for our custom behavior, and returning
-true instructs the editor that the command has been handled and no more work
+`'handled'` instructs the editor that the command has been handled and no more work
 is required.
 
-By returning false in all other cases, default commands are able to fall
+By returning `'not-handled'` in all other cases, default commands are able to fall
 through to default handler behavior.

--- a/src/component/base/DraftEditorProps.js
+++ b/src/component/base/DraftEditorProps.js
@@ -18,6 +18,7 @@ import type {DraftDragType} from 'DraftDragType';
 import type {DraftEditorCommand} from 'DraftEditorCommand';
 import type {DraftTextAlignment} from 'DraftTextAlignment';
 import type {DraftInlineStyle} from 'DraftInlineStyle';
+import type {DraftHandleValue} from 'DraftHandleValue';
 import type EditorState from 'EditorState';
 import type SelectionState from 'SelectionState';
 
@@ -82,40 +83,40 @@ export type DraftEditorProps = {
 
   /**
    * Cancelable event handlers, handled from the top level down. A handler
-   * that returns true will be the last handler to execute for that event.
+   * that returns `handled` will be the last handler to execute for that event.
    */
 
   // Useful for managing special behavior for pressing the `Return` key. E.g.
   // removing the style from an empty list item.
-  handleReturn?: (e: SyntheticKeyboardEvent) => boolean,
+  handleReturn?: (e: SyntheticKeyboardEvent) => DraftHandleValue,
 
   // Map a key command string provided by your key binding function to a
   // specified behavior.
-  handleKeyCommand?: (command: DraftEditorCommand) => boolean,
+  handleKeyCommand?: (command: DraftEditorCommand) => DraftHandleValue,
 
   // Handle intended text insertion before the insertion occurs. This may be
   // useful in cases where the user has entered characters that you would like
   // to trigger some special behavior. E.g. immediately converting `:)` to an
   // emoji Unicode character, or replacing ASCII quote characters with smart
   // quotes.
-  handleBeforeInput?: (chars: string) => boolean,
+  handleBeforeInput?: (chars: string) => DraftHandleValue,
 
-  handlePastedText?: (text: string, html?: string) => boolean,
+  handlePastedText?: (text: string, html?: string) => DraftHandleValue,
 
-  handlePastedFiles?: (files: Array<Blob>) => boolean,
+  handlePastedFiles?: (files: Array<Blob>) => DraftHandleValue,
 
   // Handle dropped files
   handleDroppedFiles?: (
     selection: SelectionState,
     files: Array<Blob>
-  ) => boolean,
+  ) => DraftHandleValue,
 
   // Handle other drops to prevent default text movement/insertion behaviour
   handleDrop?: (
     selection: SelectionState,
     dataTransfer: Object,
     isInternal: DraftDragType
-  ) => boolean,
+  ) => DraftHandleValue,
 
   /**
    * Non-cancelable event triggers.

--- a/src/component/handlers/drag/DraftEditorDragHandler.js
+++ b/src/component/handlers/drag/DraftEditorDragHandler.js
@@ -88,7 +88,7 @@ var DraftEditorDragHandler = {
     const files = data.getFiles();
     if (files.length > 0) {
       if (this.props.handleDroppedFiles &&
-          this.props.handleDroppedFiles(dropSelection, files)) {
+          this.props.handleDroppedFiles(dropSelection, files) === 'handled') {
         return;
       }
 
@@ -107,7 +107,7 @@ var DraftEditorDragHandler = {
     const dragType = this._internalDrag ? 'internal' : 'external';
     if (
       this.props.handleDrop &&
-      this.props.handleDrop(dropSelection, data, dragType)
+      this.props.handleDrop(dropSelection, data, dragType) === 'handled'
     ) {
       return;
     }

--- a/src/component/handlers/drag/DraftEditorDragHandler.js
+++ b/src/component/handlers/drag/DraftEditorDragHandler.js
@@ -23,6 +23,7 @@ const getUpdatedSelectionState = require('getUpdatedSelectionState');
 const nullthrows = require('nullthrows');
 
 import type SelectionState from 'SelectionState';
+const isEventHandled = require('isEventHandled');
 
 /**
  * Get a SelectionState for the supplied mouse event.
@@ -87,8 +88,10 @@ var DraftEditorDragHandler = {
 
     const files = data.getFiles();
     if (files.length > 0) {
-      if (this.props.handleDroppedFiles &&
-          this.props.handleDroppedFiles(dropSelection, files) === 'handled') {
+      if (
+        this.props.handleDroppedFiles &&
+        isEventHandled(this.props.handleDroppedFiles(dropSelection, files))
+      ) {
         return;
       }
 
@@ -107,7 +110,7 @@ var DraftEditorDragHandler = {
     const dragType = this._internalDrag ? 'internal' : 'external';
     if (
       this.props.handleDrop &&
-      this.props.handleDrop(dropSelection, data, dragType) === 'handled'
+      isEventHandled(this.props.handleDrop(dropSelection, data, dragType))
     ) {
       return;
     }

--- a/src/component/handlers/edit/editOnBeforeInput.js
+++ b/src/component/handlers/edit/editOnBeforeInput.js
@@ -86,7 +86,7 @@ function editOnBeforeInput(e: SyntheticInputEvent): void {
   // Simple examples: replacing a raw text ':)' with a smile emoji or image
   // decorator, or setting a block to be a list item after typing '- ' at the
   // start of the block.
-  if (this.props.handleBeforeInput && this.props.handleBeforeInput(chars)) {
+  if (this.props.handleBeforeInput && this.props.handleBeforeInput(chars) === 'handled') {
     e.preventDefault();
     return;
   }

--- a/src/component/handlers/edit/editOnBeforeInput.js
+++ b/src/component/handlers/edit/editOnBeforeInput.js
@@ -22,6 +22,7 @@ var isSelectionAtLeafStart = require('isSelectionAtLeafStart');
 var nullthrows = require('nullthrows');
 
 import type {DraftInlineStyle} from 'DraftInlineStyle';
+const isEventHandled = require('isEventHandled');
 
 // When nothing is focused, Firefox regards two characters, `'` and `/`, as
 // commands that should open and focus the "quickfind" search bar. This should
@@ -86,7 +87,7 @@ function editOnBeforeInput(e: SyntheticInputEvent): void {
   // Simple examples: replacing a raw text ':)' with a smile emoji or image
   // decorator, or setting a block to be a list item after typing '- ' at the
   // start of the block.
-  if (this.props.handleBeforeInput && this.props.handleBeforeInput(chars) === 'handled') {
+  if (this.props.handleBeforeInput && isEventHandled(this.props.handleBeforeInput(chars))) {
     e.preventDefault();
     return;
   }

--- a/src/component/handlers/edit/editOnKeyDown.js
+++ b/src/component/handlers/edit/editOnKeyDown.js
@@ -90,7 +90,7 @@ function editOnKeyDown(e: SyntheticKeyboardEvent): void {
       e.preventDefault();
       // The top-level component may manually handle newline insertion. If
       // no special handling is performed, fall through to command handling.
-      if (this.props.handleReturn && this.props.handleReturn(e)) {
+      if (this.props.handleReturn && this.props.handleReturn(e) === 'handled') {
         return;
       }
       break;
@@ -147,7 +147,7 @@ function editOnKeyDown(e: SyntheticKeyboardEvent): void {
   e.preventDefault();
 
   // Allow components higher up the tree to handle the command first.
-  if (this.props.handleKeyCommand && this.props.handleKeyCommand(command)) {
+  if (this.props.handleKeyCommand && this.props.handleKeyCommand(command) === 'handled') {
     return;
   }
 

--- a/src/component/handlers/edit/editOnKeyDown.js
+++ b/src/component/handlers/edit/editOnKeyDown.js
@@ -31,6 +31,7 @@ var keyCommandTransposeCharacters = require('keyCommandTransposeCharacters');
 var keyCommandUndo = require('keyCommandUndo');
 
 import type {DraftEditorCommand} from 'DraftEditorCommand';
+const isEventHandled = require('isEventHandled');
 
 var {isOptionKeyCommand} = KeyBindingUtil;
 var isChrome = UserAgent.isBrowser('Chrome');
@@ -90,7 +91,7 @@ function editOnKeyDown(e: SyntheticKeyboardEvent): void {
       e.preventDefault();
       // The top-level component may manually handle newline insertion. If
       // no special handling is performed, fall through to command handling.
-      if (this.props.handleReturn && this.props.handleReturn(e) === 'handled') {
+      if (this.props.handleReturn && isEventHandled(this.props.handleReturn(e))) {
         return;
       }
       break;
@@ -147,7 +148,7 @@ function editOnKeyDown(e: SyntheticKeyboardEvent): void {
   e.preventDefault();
 
   // Allow components higher up the tree to handle the command first.
-  if (this.props.handleKeyCommand && this.props.handleKeyCommand(command) === 'handled') {
+  if (this.props.handleKeyCommand && isEventHandled(this.props.handleKeyCommand(command))) {
     return;
   }
 

--- a/src/component/handlers/edit/editOnPaste.js
+++ b/src/component/handlers/edit/editOnPaste.js
@@ -24,6 +24,7 @@ var getTextContentFromFiles = require('getTextContentFromFiles');
 var splitTextIntoTextBlocks = require('splitTextIntoTextBlocks');
 
 import type {BlockMap} from 'BlockMap';
+const isEventHandled = require('isEventHandled');
 
 /**
  * Paste content.
@@ -39,10 +40,7 @@ function editOnPaste(e: SyntheticClipboardEvent): void {
     if (files.length > 0) {
       // Allow customized paste handling for images, etc. Otherwise, fall
       // through to insert text contents into the editor.
-      if (
-        this.props.handlePastedFiles &&
-        this.props.handlePastedFiles(files) === 'handled'
-      ) {
+      if (this.props.handlePastedFiles && isEventHandled(this.props.handlePastedFiles(files))) {
         return;
       }
 
@@ -88,7 +86,7 @@ function editOnPaste(e: SyntheticClipboardEvent): void {
   const text = data.getText();
   const html = data.getHTML();
 
-  if (this.props.handlePastedText && this.props.handlePastedText(text, html) === 'handled') {
+  if (this.props.handlePastedText && isEventHandled(this.props.handlePastedText(text, html))) {
     return;
   }
 

--- a/src/component/handlers/edit/editOnPaste.js
+++ b/src/component/handlers/edit/editOnPaste.js
@@ -41,7 +41,7 @@ function editOnPaste(e: SyntheticClipboardEvent): void {
       // through to insert text contents into the editor.
       if (
         this.props.handlePastedFiles &&
-        this.props.handlePastedFiles(files)
+        this.props.handlePastedFiles(files) === 'handled'
       ) {
         return;
       }
@@ -88,7 +88,7 @@ function editOnPaste(e: SyntheticClipboardEvent): void {
   const text = data.getText();
   const html = data.getHTML();
 
-  if (this.props.handlePastedText && this.props.handlePastedText(text, html)) {
+  if (this.props.handlePastedText && this.props.handlePastedText(text, html) === 'handled') {
     return;
   }
 

--- a/src/component/utils/isEventHandled.js
+++ b/src/component/utils/isEventHandled.js
@@ -20,7 +20,7 @@ import type {DraftHandleValue} from 'DraftHandleValue';
  * from a handler indicates that it was handled.
  */
 function isEventHandled(value: DraftHandleValue): boolean {
-  return value === 'handled';
+  return value === 'handled' || value === true;
 }
 
 module.exports = isEventHandled;

--- a/src/component/utils/isEventHandled.js
+++ b/src/component/utils/isEventHandled.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule isEventHandled
+ * @typechecks
+ * @flow
+ */
+
+'use strict';
+
+import type {DraftHandleValue} from 'DraftHandleValue';
+
+/**
+ * Utility method for determining whether or not the value returned
+ * from a handler indicates that it was handled.
+ */
+function isEventHandled(value: DraftHandleValue): boolean {
+  return value === 'handled';
+}
+
+module.exports = isEventHandled;

--- a/src/model/constants/DraftHandleValue.js
+++ b/src/model/constants/DraftHandleValue.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule DraftHandleValue
+ * @flow
+ */
+
+/*eslint-disable no-bitwise*/
+
+'use strict';
+
+/**
+ * A type that allows us to avoid passing boolean arguments
+ * around to indicate whether an event was handled or not.
+ */
+export type DraftHandleValue = 'handled' | 'not-handled';

--- a/src/model/constants/DraftHandleValue.js
+++ b/src/model/constants/DraftHandleValue.js
@@ -15,7 +15,7 @@
 'use strict';
 
 /**
- * A type that allows us to avoid passing boolean arguments
- * around to indicate whether an event was handled or not.
+ * A type that allows us to avoid returning boolean values
+ * to indicate whether an event was handled or not.
  */
 export type DraftHandleValue = 'handled' | 'not-handled';


### PR DESCRIPTION
Changes for https://github.com/facebook/draft-js/issues/339

@hellendag I'm not personally happy with all the literal `'handled'` strings now. The same counts for every usage of string literals, like the values of `DraftRemovalDirection`, `DraftBlockType` or any other type value. What are your thoughts on extracting them into constant files and using those constants instead?

Something along these lines:
```js

import { HANDLED } from 'DraftHandleValueConstants';

/*...*/
handleReturn(e) {
  return HANDLED;
}
/*...*/
```
Since we already have those values to create the flow types, is that maybe a point where we can hook in to generate those constants, so we wouldn't have to duplicate them in two files?