### PR TITLE
Add support for h4, h5, h6 block tags

### DIFF
--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -46,7 +46,9 @@ var REGEX_NBSP = new RegExp(NBSP, 'g');
 
 // Block tag flow is different because LIs do not have
 // a deterministic style ;_;
-var blockTags = ['p', 'h1', 'h2', 'h3', 'li', 'blockquote', 'pre'];
+var blockTags = [
+  'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li', 'blockquote', 'pre'
+];
 var inlineTags = {
   b: 'BOLD',
   code: 'CODE',


### PR DESCRIPTION
This adds support for h4, h5, and h6 block tags in `convertFromHTMLToContentBlocks.js`.

I see that #205 would solve for this as well, so maybe this is unnecessary. Given this is a simple change, I thought I'd submit the PR regardless.