### PR TITLE
Adds customStyleMap for more control over inline style ranges #342

### DIFF
--- a/docs/APIReference-Editor.md
+++ b/docs/APIReference-Editor.md
@@ -83,6 +83,15 @@ style. See
 [Advanced Topics: Inline Styles](/draft-js/docs/advanced-topics-inline-styles.html)
 for details on usage.
 
+#### customStyleFn
+```
+customStyleFn?: (style: DraftInlineStyle) => ?Object
+```
+Optionally define a function to transform inline styles to CSS objects that are applied
+to spans of text. See
+[Advanced Topics: Inline Styles](/draft-js/docs/advanced-topics-inline-styles.html)
+for details on usage.
+
 ### Behavior (Optional)
 
 #### readOnly

--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -282,6 +282,7 @@ class DraftEditor extends React.Component {
               customStyleMap={
                 {...DefaultDraftInlineStyle, ...this.props.customStyleMap}
               }
+              customStyleFn={this.props.customStyleFn}
               editorKey={this._editorKey}
               editorState={this.props.editorState}
             />

--- a/src/component/base/DraftEditorProps.js
+++ b/src/component/base/DraftEditorProps.js
@@ -17,6 +17,7 @@ import type {DraftBlockRenderMap} from 'DraftBlockRenderMap';
 import type {DraftDragType} from 'DraftDragType';
 import type {DraftEditorCommand} from 'DraftEditorCommand';
 import type {DraftTextAlignment} from 'DraftTextAlignment';
+import type {DraftInlineStyle} from 'DraftInlineStyle';
 import type EditorState from 'EditorState';
 import type SelectionState from 'SelectionState';
 
@@ -135,4 +136,8 @@ export type DraftEditorProps = {
   // an element tag and am optional react element wrapper. This configuration
   // is used for both rendering and paste processing.
   blockRenderMap: DraftBlockRenderMap,
+
+  // Provide a function that will construct CSS style objects given inline
+  // style names.
+  customStyleFn?: (style: DraftInlineStyle) => Object
 };

--- a/src/component/base/DraftEditorProps.js
+++ b/src/component/base/DraftEditorProps.js
@@ -139,5 +139,5 @@ export type DraftEditorProps = {
 
   // Provide a function that will construct CSS style objects given inline
   // style names.
-  customStyleFn?: (style: DraftInlineStyle) => Object
+  customStyleFn?: (style: DraftInlineStyle) => ?Object
 };

--- a/src/component/base/DraftEditorProps.js
+++ b/src/component/base/DraftEditorProps.js
@@ -132,12 +132,12 @@ export type DraftEditorProps = {
   // that will be rendered for matching ranges.
   customStyleMap?: Object,
 
+  // Provide a function that will construct CSS style objects given inline
+  // style names.
+  customStyleFn?: (style: DraftInlineStyle) => ?Object,
+
   // Provide a map of block rendering configurations. Each block type maps to
   // an element tag and am optional react element wrapper. This configuration
   // is used for both rendering and paste processing.
-  blockRenderMap: DraftBlockRenderMap,
-
-  // Provide a function that will construct CSS style objects given inline
-  // style names.
-  customStyleFn?: (style: DraftInlineStyle) => ?Object
+  blockRenderMap: DraftBlockRenderMap
 };

--- a/src/component/contents/DraftEditorBlock.react.js
+++ b/src/component/contents/DraftEditorBlock.react.js
@@ -39,6 +39,7 @@ const SCROLL_BUFFER = 10;
 type Props = {
   block: ContentBlock,
   customStyleMap: Object,
+  customStyleFn: Function,
   tree: List<any>,
   selection: SelectionState,
   decorator: DraftDecoratorType,
@@ -144,6 +145,7 @@ class DraftEditorBlock extends React.Component {
             text={text.slice(start, end)}
             styleSet={block.getInlineStyleAt(start)}
             customStyleMap={this.props.customStyleMap}
+            customStyleFn={this.props.customStyleFn}
             isLast={ii === lastLeafSet && jj === lastLeaf}
           />
         );

--- a/src/component/contents/DraftEditorContents.react.js
+++ b/src/component/contents/DraftEditorContents.react.js
@@ -95,6 +95,7 @@ class DraftEditorContents extends React.Component {
       blockRenderMap,
       blockRendererFn,
       customStyleMap,
+      customStyleFn,
       editorState,
     } = this.props;
 
@@ -131,6 +132,7 @@ class DraftEditorContents extends React.Component {
         block,
         blockProps: customProps,
         customStyleMap,
+        customStyleFn,
         decorator,
         direction,
         forceSelection,

--- a/src/component/contents/DraftEditorLeaf.react.js
+++ b/src/component/contents/DraftEditorLeaf.react.js
@@ -150,9 +150,7 @@ class DraftEditorLeaf extends React.Component {
 
     if (customStyleFn) {
       const newStyles = customStyleFn(styleSet);
-      if (newStyles !== undefined) {
-        styleObj = Object.assign(styleObj, newStyles);
-      }
+      styleObj = Object.assign(styleObj, newStyles);
     }
 
     return (

--- a/src/component/contents/DraftEditorLeaf.react.js
+++ b/src/component/contents/DraftEditorLeaf.react.js
@@ -30,6 +30,9 @@ type Props = {
   // Mapping of style names to CSS declarations.
   customStyleMap: Object,
 
+  // Function that maps style names to CSS style objects.
+  customStyleFn: Function,
+
   // Whether to force the DOM selection after render.
   forceSelection: boolean,
 
@@ -129,8 +132,8 @@ class DraftEditorLeaf extends React.Component {
       text += '\n';
     }
 
-    const {customStyleMap, offsetKey, styleSet} = this.props;
-    const styleObj = styleSet.reduce((map, styleName) => {
+    const {customStyleMap, customStyleFn, offsetKey, styleSet} = this.props;
+    let styleObj = styleSet.reduce((map, styleName) => {
       const mergedStyles = {};
       const style = customStyleMap[styleName];
 
@@ -144,6 +147,13 @@ class DraftEditorLeaf extends React.Component {
 
       return Object.assign(map, style, mergedStyles);
     }, {});
+
+    if (customStyleFn) {
+      const newStyles = customStyleFn(styleSet);
+      if (newStyles !== undefined) {
+        styleObj = Object.assign(styleObj, newStyles);
+      }
+    }
 
     return (
       <span


### PR DESCRIPTION
cc @hellendag

Note, I also considered making `customStyleMap` and `customStyleFn` mutually exclusive, where if the latter were specified, then the former would materialize a function with the current behavior and only pass down `customStyleMap` to the leaf component -- but, then you'd lose the default behavior, which seems a little aggressive.

I think as long as it's clear that `customStyleFn` will execute after any `customStyleMap` additions then this is fine.

The downside here, is that just specifying a `customStyleFn` means that the default draft styles will always apply and you'd have to overwrite them to stop it (which is the current situation anyway).