### PR TITLE
Fix rich example

### DIFF
--- a/examples/rich/rich.html
+++ b/examples/rich/rich.html
@@ -46,7 +46,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         constructor(props) {
           super(props);
 
-          const customBlockRendering = Map({
+          const customBlockRenderMap = Map({
             'paragraph': {
               element: 'p',
             },

--- a/examples/rich/rich.html
+++ b/examples/rich/rich.html
@@ -40,7 +40,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         DefaultDraftBlockRenderMap,
       } = Draft;
 
-      const {Map} = immutable;
+      const {Map} = Immutable;
 
       class RichEditorExample extends React.Component {
         constructor(props) {


### PR DESCRIPTION
`rich` example is currently not working since `immutable` library and  `customBlockRenderMap` are not properly used. Updated after signing CLA.