### PR TITLE
handle xml carriage return, and zero width spaces

### DIFF
--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -45,6 +45,8 @@ var MAX_DEPTH = 4;
 var REGEX_CR = new RegExp('\r', 'g');
 var REGEX_LF = new RegExp('\n', 'g');
 var REGEX_NBSP = new RegExp(NBSP, 'g');
+var REGEX_CARRIAGE = new RegExp('(&#13;|&#13)', 'g');
+var REGEX_ZWS = new RegExp('(&#8203;|&#8203)', 'g');
 
 // Block tag flow is different because LIs do not have
 // a deterministic style ;_;
@@ -422,7 +424,9 @@ function getChunkForHTML(
   html = html
     .trim()
     .replace(REGEX_CR, '')
-    .replace(REGEX_NBSP, SPACE);
+    .replace(REGEX_NBSP, SPACE)
+    .replace(REGEX_CARRIAGE, '')
+    .replace(REGEX_ZWS, '');
 
   const supportedBlockTags = getBlockMapSupportedTags(blockRenderMap);
 

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -45,8 +45,8 @@ var MAX_DEPTH = 4;
 var REGEX_CR = new RegExp('\r', 'g');
 var REGEX_LF = new RegExp('\n', 'g');
 var REGEX_NBSP = new RegExp(NBSP, 'g');
-var REGEX_CARRIAGE = new RegExp('(&#13;|&#13)', 'g');
-var REGEX_ZWS = new RegExp('(&#8203;|&#8203)', 'g');
+var REGEX_CARRIAGE = new RegExp('&#13;?', 'g');
+var REGEX_ZWS = new RegExp('&#8203;?', 'g');
 
 // Block tag flow is different because LIs do not have
 // a deterministic style ;_;

--- a/src/model/paste/__tests__/DraftPasteProcessor-test.js
+++ b/src/model/paste/__tests__/DraftPasteProcessor-test.js
@@ -209,6 +209,12 @@ describe('DraftPasteProcessor', function() {
     expect(output[0].getText()).toBe('hi\nhello');
   });
 
+  it('must strip xml carriages and zero width spaces', function() {
+    var html = 'hi&#13;&#8203;hello';
+    var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    expect(output[0].getText()).toBe('hihello');
+  });
+
   it('must split unstyled blocks on two br tags', function() {
     var html = 'hi<br><br>hello';
     var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);


### PR DESCRIPTION
Fixes #274

ignores carriage returns from xml entities, and also their zero-width-spaced
bretheren.