### PR TITLE
Rich example: Remove P

### DIFF
--- a/examples/rich/rich.html
+++ b/examples/rich/rich.html
@@ -46,19 +46,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         constructor(props) {
           super(props);
 
-          const customBlockRenderMap = Map({
-            'paragraph': {
-              element: 'p',
-            },
-            'unstyled': {
-              element: 'p',
-            },
-          });
-
           this.state = {
-            blockRenderMap: DefaultDraftBlockRenderMap.merge(
-              customBlockRenderMap,
-            ),
             editorState: EditorState.createEmpty(),
           };
 
@@ -123,7 +111,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
               />
               <div className={className} onClick={this.focus}>
                 <Editor
-                  blockRenderMap={this.state.blockRenderMap}
                   blockStyleFn={getBlockStyle}
                   customStyleMap={styleMap}
                   editorState={editorState}
@@ -180,7 +167,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       }
 
       const BLOCK_TYPES = [
-        {label: 'P', style:  'paragraph'},
         {label: 'H1', style: 'header-one'},
         {label: 'H2', style: 'header-two'},
         {label: 'H3', style: 'header-three'},


### PR DESCRIPTION
I think this adds confusion, and it breaks spacing. I'd be happy to have a different example for this, but I don't think this is the right way to exemplify the block render map.