### PR TITLE
minor-fix-for-getting-supported-tags - Making sure the supported tags…

### DIFF
--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -135,7 +135,7 @@ function getBlockMapSupportedTags(
     .map((config) => config.element)
     .valueSeq()
     .toSet()
-    .filter((tag) => tag !== unstyledElement)
+    .filter((tag) => tag && tag !== unstyledElement)
     .toArray()
     .sort();
 }


### PR DESCRIPTION
Making sure that we always return a valid array of tags

- Before this fix we could sometimes have 'null' as part of the set depending on how the blockRenderMap has been defined, since they could have defined just a wrapper renderer and no element.