### PR TITLE
Adding more attributes to convertFromHTMLToContentBlocks entity whitelist

### DIFF
--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -57,7 +57,7 @@ var inlineTags = {
   s: 'STRIKETHROUGH',
   strike: 'STRIKETHROUGH',
   strong: 'BOLD',
-  u: 'UNDERLINE'
+  u: 'UNDERLINE',
 };
 
 var anchorAttr = [
@@ -65,7 +65,7 @@ var anchorAttr = [
   'href',
   'rel',
   'target',
-  'title'
+  'title',
 ];
 
 var lastBlock;
@@ -377,15 +377,14 @@ function genFragment(
   var entityId: ?string = null;
 
   while (child) {
-    if (nodeName === 'a' && child.href && hasValidLinkText(child)) {
-      // had to cast to Object due to https://github.com/facebook/flow/issues/1730
-      const anchor: Object = child;
-
-      let entityConfig = {};
+    if (child instanceof HTMLAnchorElement && child.href && hasValidLinkText(child)) {
+      const anchor: HTMLAnchorElement = child;
+      const entityConfig = {};
 
       anchorAttr.forEach((attr) => {
-        if (anchor[attr]) {
-          entityConfig[attr] = anchor[attr];
+        const anchorAttribute = anchor.getAttribute(attr);
+        if (anchorAttribute) {
+          entityConfig[attr] = anchorAttribute;
         }
       });
 

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -57,12 +57,7 @@ var inlineTags = {
   s: 'STRIKETHROUGH',
   strike: 'STRIKETHROUGH',
   strong: 'BOLD',
-  u: 'UNDERLINE',
-/**
- *
- *
- * @returns {6 +60,14 @@ var inlineTags = {}
- */
+  u: 'UNDERLINE'
 };
 
 var anchorAttr = [
@@ -383,11 +378,11 @@ function genFragment(
   while (child) {
     if (nodeName === 'a' && child.href && hasValidLinkText(child)) {
       // had to cast to Object due to https://github.com/facebook/flow/issues/1730
-      const anchor:Object = child;
+      const anchor: Object = child;
 
-      var entityConfig = {};
+      let entityConfig = {};
 
-      anchorAttr.forEach(attr => {
+      anchorAttr.forEach((attr) => {
         if (anchor[attr]) {
           entityConfig[attr] = anchor[attr];
         }

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -388,7 +388,7 @@ function genFragment(
         }
       });
 
-      entityConfig.url = new URI(entityConfig.href).toString();
+      entityConfig.url = new URI(anchor.href).toString();
 
       entityId = DraftEntity.create('LINK', 'MUTABLE', entityConfig);
     } else {

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -58,7 +58,20 @@ var inlineTags = {
   strike: 'STRIKETHROUGH',
   strong: 'BOLD',
   u: 'UNDERLINE',
+/**
+ *
+ *
+ * @returns {6 +60,14 @@ var inlineTags = {}
+ */
 };
+
+var anchorAttr = [
+  'className',
+  'href',
+  'rel',
+  'target',
+  'title'
+];
 
 var lastBlock;
 
@@ -366,12 +379,23 @@ function genFragment(
   }
 
   var entityId: ?string = null;
-  var href: ?string = null;
 
   while (child) {
     if (nodeName === 'a' && child.href && hasValidLinkText(child)) {
-      href = new URI(child.href).toString();
-      entityId = DraftEntity.create('LINK', 'MUTABLE', {url: href});
+      // had to cast to Object due to https://github.com/facebook/flow/issues/1730
+      const anchor:Object = child;
+
+      var entityConfig = {};
+
+      anchorAttr.forEach(attr => {
+        if (anchor[attr]) {
+          entityConfig[attr] = anchor[attr];
+        }
+      });
+
+      entityConfig.url = new URI(entityConfig.href).toString();
+
+      entityId = DraftEntity.create('LINK', 'MUTABLE', entityConfig);
     } else {
       entityId = undefined;
     }


### PR DESCRIPTION
Making sure that entities also support other common attributes for importing from html and pasting content. This is very important for compatibility with already existing applications
