### PR TITLE
Improve variable use and names in joinChunks

### DIFF
--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -217,11 +217,12 @@ function processInlineTag(
 function joinChunks(A: Chunk, B: Chunk): Chunk {
   // Sometimes two blocks will touch in the DOM and we need to strip the
   // extra delimiter to preserve niceness.
-  var lastInB = B.text.slice(0, 1);
+  var lastInA = A.text.slice(-1);
+  var firstInB = B.text.slice(0, 1);
 
   if (
-    A.text.slice(-1) === '\r' &&
-    lastInB === '\r'
+    lastInA === '\r' &&
+    firstInB === '\r'
   ) {
     A.text = A.text.slice(0, -1);
     A.inlines.pop();
@@ -231,11 +232,11 @@ function joinChunks(A: Chunk, B: Chunk): Chunk {
 
   // Kill whitespace after blocks
   if (
-    A.text.slice(-1) === '\r'
+    lastInA === '\r'
   ) {
     if (B.text === SPACE || B.text === '\n') {
       return A;
-    } else if (lastInB === SPACE || lastInB === '\n') {
+    } else if (firstInB === SPACE || firstInB === '\n') {
       B.text = B.text.slice(1);
       B.inlines.shift();
       B.entities.shift();


### PR DESCRIPTION
When making my own modifications to this function this bugged me a bit. Renamed `lastInB` to `firstInB` to match what it actually is and add parity for chunk `A` by adding a `lastInA` instead of manually slicing every time.