### PR TITLE
Tree block structure

### DIFF
--- a/docs/APIReference-Modifier.md
+++ b/docs/APIReference-Modifier.md
@@ -4,6 +4,7 @@ title: Modifier
 layout: docs
 category: API Reference
 permalink: docs/api-reference-modifier.html
+next: experimental-nesting
 ---
 
 The `Modifier` module is a static set of utility functions that encapsulate common

--- a/docs/Experimental-Nesting.md
+++ b/docs/Experimental-Nesting.md
@@ -1,0 +1,88 @@
+---
+id: experimental-nesting
+title: Nesting
+layout: docs
+category: Experimental
+next: api-reference-data-conversion
+permalink: docs/experimental-nesting.html
+---
+
+## Overview
+
+By default Draft.js doesn't support nested blocks, but it can be enabled using some component props.
+
+### Usage
+
+```js
+import {Editor, EditorState, NestedUtils} from 'draft-js';
+
+class MyEditor extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {editorState: EditorState.createEmpty()};
+    this.onChange = (editorState) => this.setState({editorState});
+    this.handleKeyCommand = this.handleKeyCommand.bind(this);
+  }
+  handleKeyCommand(command) {
+    const newState = NestedUtils.handleKeyCommand(this.state.editorState, command);
+    if (newState) {
+      this.onChange(newState);
+      return true;
+    }
+    return false;
+  }
+  render() {
+    return (
+      <Editor
+        editorState={this.state.editorState}
+        blockRenderMap={NestedUtils.DefaultBlockRenderMap}
+        keyBindingFn={NestedUtils.keyBinding}
+        handleKeyCommand={this.handleKeyCommand}
+        onChange={this.onChange}
+      />
+    );
+  }
+}
+```
+
+### Commands
+
+`NestedUtils` provides two methods: `NestedUtils.keyBinding` and `NestedUtils.handleKeyCommand` to respond to user interractions with the right behavior for nested content.
+
+### Data Conversion
+
+`convertFromRaw` and `convertToRaw` supports nested blocks:
+
+```js
+import {convertFromRaw} from 'draft-js';
+
+var contentState = convertFronRaw({
+    blocks: [
+        {
+            type: 'heading-one',
+            text: 'My Awesome Article'
+        },
+        {
+            type: 'blockquote',
+            blocks: [
+                {
+                    type: 'heading-two',
+                    text: 'Another heading in a blockquote'
+                },
+                {
+                    type: 'unstyled',
+                    text: 'Followed by a paragraph.'
+                }
+            ]
+        }
+    ],
+    entityMap: {}
+});
+```
+
+### Usage
+
+```js
+
+```
+

--- a/docs/Experimental-Nesting.md
+++ b/docs/Experimental-Nesting.md
@@ -56,7 +56,7 @@ class MyEditor extends React.Component {
 ```js
 import {convertFromRaw} from 'draft-js';
 
-var contentState = convertFronRaw({
+var contentState = convertFromRaw({
     blocks: [
         {
             type: 'heading-one',

--- a/docs/Experimental-Nesting.md
+++ b/docs/Experimental-Nesting.md
@@ -47,7 +47,7 @@ class MyEditor extends React.Component {
 
 ### Commands
 
-`NestedUtils` provides two methods: `NestedUtils.keyBinding` and `NestedUtils.handleKeyCommand` to respond to user interractions with the right behavior for nested content.
+`NestedUtils` provides two methods: `NestedUtils.keyBinding` and `NestedUtils.handleKeyCommand` to respond to user interactions with the right behavior for nested content.
 
 ### Data Conversion
 
@@ -79,10 +79,3 @@ var contentState = convertFromRaw({
     entityMap: {}
 });
 ```
-
-### Usage
-
-```js
-
-```
-

--- a/examples/tree/tree.css
+++ b/examples/tree/tree.css
@@ -63,14 +63,23 @@
 }
 
 .RichEditor-editor table {
-    border: 1px solid #ccc;
-    display: block;
+  border: 1px solid #ccc;
+  display: block;
 }
 
 .RichEditor-editor tr {
-    padding: 0;
-    margin: 0;
+  padding: 0;
+  margin: 0;
 }
+
 .RichEditor-editor td {
-    border: 1px solid black;
+  border: 1px solid black;
+}
+
+#target {
+  width: 600px;
+}
+
+.public-DraftStyleDefault-block {
+  padding-left: 20px;
 }

--- a/examples/tree/tree.css
+++ b/examples/tree/tree.css
@@ -64,6 +64,7 @@
 
 .RichEditor-editor table {
     border: 1px solid #ccc;
+    display: block;
 }
 
 .RichEditor-editor tr {

--- a/examples/tree/tree.css
+++ b/examples/tree/tree.css
@@ -1,0 +1,75 @@
+.RichEditor-root {
+  background: #fff;
+  border: 1px solid #ddd;
+  font-family: 'Georgia', serif;
+  font-size: 14px;
+  padding: 15px;
+}
+
+.RichEditor-editor {
+  border-top: 1px solid #ddd;
+  cursor: text;
+  font-size: 16px;
+  margin-top: 10px;
+}
+
+.RichEditor-editor .public-DraftEditorPlaceholder-root,
+.RichEditor-editor .public-DraftEditor-content {
+  margin: 0 -15px -15px;
+  padding: 15px;
+}
+
+.RichEditor-editor .public-DraftEditor-content {
+  min-height: 100px;
+}
+
+.RichEditor-hidePlaceholder .public-DraftEditorPlaceholder-root {
+  display: none;
+}
+
+.RichEditor-editor .RichEditor-blockquote {
+  border-left: 5px solid #eee;
+  color: #666;
+  font-family: 'Hoefler Text', 'Georgia', serif;
+  font-style: italic;
+  margin: 16px 0;
+  padding: 10px 20px;
+}
+
+.RichEditor-editor .public-DraftStyleDefault-pre {
+  background-color: rgba(0, 0, 0, 0.05);
+  font-family: 'Inconsolata', 'Menlo', 'Consolas', monospace;
+  font-size: 16px;
+  padding: 20px;
+}
+
+.RichEditor-controls {
+  font-family: 'Helvetica', sans-serif;
+  font-size: 14px;
+  margin-bottom: 5px;
+  user-select: none;
+}
+
+.RichEditor-styleButton {
+  color: #999;
+  cursor: pointer;
+  margin-right: 16px;
+  padding: 2px 0;
+  display: inline-block;
+}
+
+.RichEditor-activeButton {
+  color: #5890ff;
+}
+
+.RichEditor-editor table {
+    border: 1px solid #ccc;
+}
+
+.RichEditor-editor tr {
+    padding: 0;
+    margin: 0;
+}
+.RichEditor-editor td {
+    border: 1px solid black;
+}

--- a/examples/tree/tree.html
+++ b/examples/tree/tree.html
@@ -38,7 +38,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
       const {
         ContentState,
-        DefaultDraftBlockRenderMap,
         Editor,
         EditorState,
         KeyBindingUtil,
@@ -51,36 +50,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       } = Draft;
       const {hasCommandModifier} = KeyBindingUtil;
 
-      const blockRenderMap = Immutable.Map(DefaultDraftBlockRenderMap.keySeq().toArray().reduce((o, v, i) => {
-        // we are manually enabling all default draft blocks to support nesting for this example
-        o[v] = Object.assign({}, DefaultDraftBlockRenderMap.get(v), {
-          nestingEnabled: true
-        });
-
-        return o;
-      }, {
-          'table': {
-            nestingEnabled: true,
-            element: 'table'
-          },
-          'tbody': {
-            nestingEnabled: true,
-            element: 'tbody'
-          },
-          'thead': {
-            nestingEnabled: true,
-            element: 'thead'
-          },
-          'cell': {
-            nestingEnabled: true,
-            element: 'td'
-          },
-          'row': {
-            nestingEnabled: true,
-            element: 'tr'
-          }
-      }));
-
       const baseContent = '<h1>Example with tree data structure<\/h1>\r\n\r\n<blockquote>\r\n   Hello World\r\n  <ul>\r\n     <li>\r\n        A first item of a list in a blockquote\r\n        <h1>A heading-one in the <strong>list<\/strong><\/h1>\r\n     <\/li>\r\n     <li>A second item of the list<\/li>\r\n  <\/ul>\r\n<\/blockquote>\r\n\r\n<table>\r\n  <tr>\r\n     <td>nested c<strong>ell<\/strong> 1<\/td>\r\n     <td>nested c<strong>ell<\/strong> 2<\/td>\r\n  <\/tr>\r\n  <tr>\r\n     <td>nested c<strong>ell<\/strong> 3<\/td>\r\n     <td>nested c<strong>ell<\/strong> 4<\/td>\r\n  <\/tr>\r\n<\/table>';
 
       class TreeEditorExample extends React.Component {
@@ -89,7 +58,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
           this.state = {
             editorState: EditorState.createEmpty(),
-            blockRenderMap: blockRenderMap
+            blockRenderMap: NestedUtils.DefaultBlockRenderMap
           };
 
           this.handleKeyCommand = (command) => this._handleKeyCommand(command);
@@ -126,8 +95,12 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         }
 
         _logState() {
+          console.log('===');
+          console.log('Raw editor state:');
           console.log(JSON.stringify(this.state.editorState.toJS(), null, 2));
-          console.log('raw=', convertToRaw(this.state.editorState.getCurrentContent()))
+          console.log('===');
+          console.log('Raw content state:');
+          console.log(JSON.stringify(convertToRaw(this.state.editorState.getCurrentContent()), null, 2))
         }
 
         _handleKeyCommand(command) {

--- a/examples/tree/tree.html
+++ b/examples/tree/tree.html
@@ -44,12 +44,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         RichUtils,
         NestedUtils,
         convertFromRaw,
+        convertToRaw,
         getDefaultKeyBinding,
         KeyBindingUtil
       } = Draft;
       const {hasCommandModifier} = KeyBindingUtil;
-
-      console.log('starting');
 
       const blockRenderMap = Immutable.Map(DefaultDraftBlockRenderMap.keySeq().toArray().reduce((o, v, i) => {
         // we are manually enabling all default draft blocks to support nesting for this example
@@ -214,7 +213,12 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
           this.focus = () => this.refs.editor.focus();
           this.onChange = (editorState) => this.setState({editorState});
-          this.logState = () => console.log(JSON.stringify(this.state.editorState.toJS(), null, 2));
+          this.logState = () => this._logState();
+        }
+
+        _logState() {
+          console.log(JSON.stringify(this.state.editorState.toJS(), null, 2));
+          console.log('raw=', convertToRaw(this.state.editorState.getCurrentContent()))
         }
 
         _handleKeyCommand(command) {

--- a/examples/tree/tree.html
+++ b/examples/tree/tree.html
@@ -50,7 +50,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       } = Draft;
       const {hasCommandModifier} = KeyBindingUtil;
 
-      const baseContent = '<h1>Example with tree data structure<\/h1>\r\n\r\n<blockquote>\r\n   Hello World\r\n  <ul>\r\n     <li>\r\n        A first item of a list in a blockquote\r\n        <h1>A heading-one in the <strong>list<\/strong><\/h1>\r\n     <\/li>\r\n     <li>A second item of the list<\/li>\r\n  <\/ul>\r\n<\/blockquote>\r\n\r\n<h2>root element</h2>\r\n\r\n<table>\r\n  <tr>\r\n     <td>nested c<strong>ell<\/strong> 1<\/td>\r\n     <td>nested c<strong>ell<\/strong> 2<\/td>\r\n  <\/tr>\r\n  <tr>\r\n     <td>nested c<strong>ell<\/strong> 3<\/td>\r\n     <td>nested c<strong>ell<\/strong> 4<\/td>\r\n  <\/tr>\r\n<\/table>';
+      const baseContent = '<h1>Example with tree data structure<\/h1>\r\n\r\n<blockquote>\r\n   Hello World\r\n  <ul>\r\n     <li>\r\n        A first item of a list in a blockquote\r\n        <h1>A heading-one in the <strong>list<\/strong><\/h1>\r\n     <\/li>\r\n     <li>A second item of the list<\/li>\r\n  <\/ul>\r\n<\/blockquote>\r\n\r\n<h2>root element</h2>';
 
       class TreeEditorExample extends React.Component {
         constructor(props) {

--- a/examples/tree/tree.html
+++ b/examples/tree/tree.html
@@ -50,7 +50,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       } = Draft;
       const {hasCommandModifier} = KeyBindingUtil;
 
-      const baseContent = '<h1>Example with tree data structure<\/h1>\r\n\r\n<blockquote>\r\n   Hello World\r\n  <ul>\r\n     <li>\r\n        A first item of a list in a blockquote\r\n        <h1>A heading-one in the <strong>list<\/strong><\/h1>\r\n     <\/li>\r\n     <li>A second item of the list<\/li>\r\n  <\/ul>\r\n<\/blockquote>\r\n\r\n<table>\r\n  <tr>\r\n     <td>nested c<strong>ell<\/strong> 1<\/td>\r\n     <td>nested c<strong>ell<\/strong> 2<\/td>\r\n  <\/tr>\r\n  <tr>\r\n     <td>nested c<strong>ell<\/strong> 3<\/td>\r\n     <td>nested c<strong>ell<\/strong> 4<\/td>\r\n  <\/tr>\r\n<\/table>';
+      const baseContent = '<h1>Example with tree data structure<\/h1>\r\n\r\n<blockquote>\r\n   Hello World\r\n  <ul>\r\n     <li>\r\n        A first item of a list in a blockquote\r\n        <h1>A heading-one in the <strong>list<\/strong><\/h1>\r\n     <\/li>\r\n     <li>A second item of the list<\/li>\r\n  <\/ul>\r\n<\/blockquote>\r\n\r\n<h2>root element</h2>\r\n\r\n<table>\r\n  <tr>\r\n     <td>nested c<strong>ell<\/strong> 1<\/td>\r\n     <td>nested c<strong>ell<\/strong> 2<\/td>\r\n  <\/tr>\r\n  <tr>\r\n     <td>nested c<strong>ell<\/strong> 3<\/td>\r\n     <td>nested c<strong>ell<\/strong> 4<\/td>\r\n  <\/tr>\r\n<\/table>';
 
       class TreeEditorExample extends React.Component {
         constructor(props) {
@@ -104,9 +104,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         }
 
         _handleKeyCommand(command) {
-          const {editorState} = this.state;
+          const {editorState, blockRenderMap} = this.state;
 
-          var newState = NestedUtils.handleKeyCommand(editorState, command);
+          var newState = NestedUtils.handleKeyCommand(editorState, command, blockRenderMap);
           if (newState) {
             this.onChange(newState);
             return true;
@@ -130,7 +130,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         _toggleBlockType(blockType) {
           this.onChange(
             RichUtils.toggleBlockType(
-              this.state.editorState,
+              NestedUtils.toggleBlockType(
+                this.state.editorState,
+                blockType
+              ),
               blockType
             )
           );

--- a/examples/tree/tree.html
+++ b/examples/tree/tree.html
@@ -41,12 +41,13 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         DefaultDraftBlockRenderMap,
         Editor,
         EditorState,
-        RichUtils,
+        KeyBindingUtil,
         NestedUtils,
+        RichUtils,
+        convertFromHTML,
         convertFromRaw,
         convertToRaw,
         getDefaultKeyBinding,
-        KeyBindingUtil
       } = Draft;
       const {hasCommandModifier} = KeyBindingUtil;
 
@@ -62,147 +63,32 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             nestingEnabled: true,
             element: 'table'
           },
+          'tbody': {
+            nestingEnabled: true,
+            element: 'tbody'
+          },
+          'thead': {
+            nestingEnabled: true,
+            element: 'thead'
+          },
           'cell': {
             nestingEnabled: true,
             element: 'td'
           },
           'row': {
             nestingEnabled: true,
-            element: 'tr',
-            wrapper: <tbody />,
+            element: 'tr'
           }
       }));
 
-      const baseContent = convertFromRaw({
-        blocks: [
-          {
-              type: 'header-one',
-              text: 'Example with tree data structure'
-          },
-          {
-            type: 'blockquote',
-            text: 'Hello World',
-            blocks: [
-              {
-                type: 'unordered-list-item',
-                text: 'A first item of a list in a blockquote',
-                blocks: [
-                  {
-                    type: 'unstyled',
-                    text: 'A paragraph in the list',
-                    inlineStyleRanges: [
-                      {
-                        offset: 19,
-                        length: 4,
-                        style: 'BOLD'
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                type: 'unordered-list-item',
-                text: 'A second item of the list'
-              }
-            ]
-          },
-          {
-            type: 'table',
-            text: ' ',
-            blocks: [
-              {
-                type: 'row',
-                text: ' ',
-                blocks: [
-                  {
-                    type: 'cell',
-                    text: ' ',
-                    blocks: [
-                      {
-                        type: 'unstyled',
-                        text: 'nested cell 1',
-                        inlineStyleRanges: [
-                          {
-                            offset: 8,
-                            length: 4,
-                            style: 'BOLD'
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    type: 'cell',
-                    text: ' ',
-                    blocks: [
-                      {
-                        type: 'unstyled',
-                        text: 'nested cell 2',
-                        inlineStyleRanges: [
-                          {
-                            offset: 8,
-                            length: 4,
-                            style: 'BOLD'
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                ]
-              },
-              {
-                type: 'row',
-                text: ' ',
-                blocks: [
-                  {
-                    type: 'cell',
-                    text: '',
-                    blocks: [
-                      {
-                        type: 'unstyled',
-                        text: 'nested cell 3',
-                        inlineStyleRanges: [
-                          {
-                            offset: 8,
-                            length: 4,
-                            style: 'BOLD'
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    type: 'cell',
-                    text: ' ',
-                    blocks: [
-                      {
-                        type: 'unstyled',
-                        text: 'nested cell 4',
-                        inlineStyleRanges: [
-                          {
-                            offset: 8,
-                            length: 4,
-                            style: 'BOLD'
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                ]
-              }
-            ]
-          }
-        ],
-        entityMap: {}
-      }, blockRenderMap);
-      console.log('baseContent is', baseContent.toJS());
+      const baseContent = '<h1>Example with tree data structure<\/h1>\r\n\r\n<blockquote>\r\n   Hello World\r\n  <ul>\r\n     <li>\r\n        A first item of a list in a blockquote\r\n        <h1>A heading-one in the <strong>list<\/strong><\/h1>\r\n     <\/li>\r\n     <li>A second item of the list<\/li>\r\n  <\/ul>\r\n<\/blockquote>\r\n\r\n<table>\r\n  <tr>\r\n     <td>nested c<strong>ell<\/strong> 1<\/td>\r\n     <td>nested c<strong>ell<\/strong> 2<\/td>\r\n  <\/tr>\r\n  <tr>\r\n     <td>nested c<strong>ell<\/strong> 3<\/td>\r\n     <td>nested c<strong>ell<\/strong> 4<\/td>\r\n  <\/tr>\r\n<\/table>';
 
       class TreeEditorExample extends React.Component {
         constructor(props) {
           super(props);
 
           this.state = {
-            editorState: EditorState.createWithContent(baseContent),
+            editorState: EditorState.createEmpty(),
             blockRenderMap: blockRenderMap
           };
 
@@ -214,6 +100,29 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           this.focus = () => this.refs.editor.focus();
           this.onChange = (editorState) => this.setState({editorState});
           this.logState = () => this._logState();
+          this.setContentFromMarkup = () => this._setContentFromMarkup();
+        }
+
+        componentDidMount() {
+          this._setContentFromMarkup();
+        }
+
+        _setHTMLContent(html) {
+            const {
+              blockRenderMap
+            } = this.state;
+
+            const contentBlocks = convertFromHTML(
+              html,
+              undefined,
+              blockRenderMap
+            );
+
+            const contentState = ContentState.createFromBlockArray(contentBlocks);
+
+            this.onChange(
+              EditorState.createWithContent(contentState)
+            );
         }
 
         _logState() {
@@ -263,6 +172,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           );
         }
 
+        _setContentFromMarkup() {
+          const htmlContent = this.refs.markupinput.value;
+          this._setHTMLContent(htmlContent);
+        }
+
         render() {
           const {editorState, blockRenderMap} = this.state;
 
@@ -306,6 +220,21 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 type="button"
                 value="Log State"
               />
+              <br />
+              <fieldset>
+              <textarea
+                style={styles.textarea}
+                placeholder="Enter html in here"
+                defaultValue={baseContent}
+                ref="markupinput"
+              />
+              <input
+                onClick={this.setContentFromMarkup}
+                style={styles.button}
+                type="button"
+                value="Set HTML content"
+              />
+              </fieldset>
             </div>
           );
         }
@@ -412,6 +341,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       };
 
       const styles = {
+        textarea: {
+          width: '100%',
+          minHeight: '200px'
+        },
         button: {
           marginTop: 10,
           textAlign: 'center',

--- a/examples/tree/tree.html
+++ b/examples/tree/tree.html
@@ -37,9 +37,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       'use strict';
 
       const {
+        AtomicBlockUtils,
         ContentState,
         Editor,
         EditorState,
+        Entity,
         KeyBindingUtil,
         NestedUtils,
         RichUtils,
@@ -48,9 +50,12 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         convertToRaw,
         getDefaultKeyBinding,
       } = Draft;
-      const {hasCommandModifier} = KeyBindingUtil;
 
-      const baseContent = '<h1>Example with tree data structure<\/h1>\r\n\r\n<blockquote>\r\n   Hello World\r\n  <ul>\r\n     <li>\r\n        A first item of a list in a blockquote\r\n        <h1>A heading-one in the <strong>list<\/strong><\/h1>\r\n     <\/li>\r\n     <li>A second item of the list<\/li>\r\n  <\/ul>\r\n<\/blockquote>\r\n\r\n<h2>root element</h2>';
+      const {
+        hasCommandModifier
+      } = KeyBindingUtil;
+
+      const baseContent = '<h1>Example with tree data structure<\/h1>\r\n\r\n<blockquote>\r\n   <p>Paragraph in top level blockquote</p>\r\n  <ul>\r\n     <li>\r\n        <h1>A heading-one in the <strong>list<\/strong><\/h1>\r\n     <\/li>\r\n     <li>A second item of the list<\/li>\r\n  <\/ul>\r\n<\/blockquote>\r\n\r\n<h2>root element</h2>';
 
       class TreeEditorExample extends React.Component {
         constructor(props) {
@@ -58,22 +63,71 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
           this.state = {
             editorState: EditorState.createEmpty(),
-            blockRenderMap: NestedUtils.DefaultBlockRenderMap
+            blockRenderMap: NestedUtils.DefaultBlockRenderMap.merge(new Immutable.OrderedMap(
+              {
+                'image': {
+                  element: 'img',
+                  nestingEnabled: false
+                }
+              }
+            ))
           };
 
+          this.focus = () => this.refs.editor.focus();
           this.handleKeyCommand = (command) => this._handleKeyCommand(command);
           this.keyBindingFn = (e) => this._keyBindingFn(e);
+          this.logState = () => this._logState();
+          this.onChange = (editorState) => this.setState({editorState});
+          this.setContentFromMarkup = () => this._setContentFromMarkup();
           this.toggleBlockType = (type) => this._toggleBlockType(type);
           this.toggleInlineStyle = (style) => this._toggleInlineStyle(style);
-
-          this.focus = () => this.refs.editor.focus();
-          this.onChange = (editorState) => this.setState({editorState});
-          this.logState = () => this._logState();
-          this.setContentFromMarkup = () => this._setContentFromMarkup();
+          this.blockRendererFn= (block) => this._blockRenderer(block);
+          this.addMedia = this._addMedia.bind(this);
+          this.addAudio = this._addAudio.bind(this);
+          this.addImage = this._addImage.bind(this);
+          this.addVideo = this._addVideo.bind(this);
         }
 
         componentDidMount() {
           this._setContentFromMarkup();
+        }
+
+        _blockRenderer(block) {
+          if (block.getType() === 'atomic') {
+            return {
+              component: Media,
+              editable: false,
+            };
+          }
+
+          return null;
+        }
+
+        _addMedia(type) {
+          const src = window.prompt('Enter a URL');
+          if (!src) {
+            return;
+          }
+
+          const entityKey = Entity.create(type, 'IMMUTABLE', {src});
+
+          return AtomicBlockUtils.insertAtomicBlock(
+            this.state.editorState,
+            entityKey,
+            ' '
+          );
+        }
+
+        _addAudio() {
+          this.onChange(this._addMedia('audio'));
+        }
+
+        _addImage() {
+          this.onChange(this._addMedia('image'));
+        }
+
+        _addVideo() {
+          this.onChange(this._addMedia('video'));
         }
 
         _setHTMLContent(html) {
@@ -101,6 +155,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           console.log('===');
           console.log('Raw content state:');
           console.log(JSON.stringify(convertToRaw(this.state.editorState.getCurrentContent()), null, 2))
+          console.log('===');
+          console.log('Blockmap:');
+          console.log(JSON.stringify(this.state.editorState.getCurrentContent().getBlockMap().toArray(), null, 2))
         }
 
         _handleKeyCommand(command) {
@@ -127,13 +184,21 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           );
         }
 
-        _toggleBlockType(blockType) {
+        _toggleBlockType(blockTypeAction) {
+          const {
+            editorState,
+            blockType
+          } = (
+            NestedUtils.toggleBlockType(
+              this.state.editorState,
+              blockTypeAction
+            )
+          );
+
+
           this.onChange(
             RichUtils.toggleBlockType(
-              NestedUtils.toggleBlockType(
-                this.state.editorState,
-                blockType
-              ),
+              editorState,
               blockType
             )
           );
@@ -176,9 +241,21 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 editorState={editorState}
                 onToggle={this.toggleInlineStyle}
               />
+              <div style={styles.buttons}>
+                <button onMouseDown={this.addAudio} style={{marginRight: 10}}>
+                  Add Audio
+                </button>
+                <button onMouseDown={this.addImage} style={{marginRight: 10}}>
+                  Add Image
+                </button>
+                <button onMouseDown={this.addVideo} style={{marginRight: 10}}>
+                  Add Video
+                </button>
+              </div>
               <div className={className} onClick={this.focus}>
                 <Editor
                   blockRenderMap={blockRenderMap}
+                  blockRendererFn={this.blockRendererFn}
                   blockStyleFn={getBlockStyle}
                   customStyleMap={styleMap}
                   editorState={editorState}
@@ -314,6 +391,35 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             )}
           </div>
         );
+      };
+
+      const Audio = (props) => {
+        return <audio controls src={props.src} style={styles.media} />;
+      };
+
+      const Image = (props) => {
+        return <img src={props.src} style={styles.media} />;
+      };
+
+      const Video = (props) => {
+        return <video controls src={props.src} style={styles.media} />;
+      };
+
+      const Media = (props) => {
+        const entity = Entity.get(props.block.getEntityAt(0));
+        const {src} = entity.getData();
+        const type = entity.getType();
+
+        let media;
+        if (type === 'audio') {
+          media = <Audio src={src} />;
+        } else if (type === 'image') {
+          media = <Image src={src} />;
+        } else if (type === 'video') {
+          media = <Video src={src} />;
+        }
+
+        return media;
       };
 
       const styles = {

--- a/examples/tree/tree.html
+++ b/examples/tree/tree.html
@@ -148,10 +148,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         }
 
         _keyBindingFn(e) {
-          if (e.keyCode === 13 /* `Enter` key */ && e.shiftKey) {
-            return 'split-nested-block';
-          }
-          return getDefaultKeyBinding(e);
+          return (
+              NestedUtils.keyBinding(e)
+              || getDefaultKeyBinding(e)
+          );
         }
 
         _toggleBlockType(blockType) {

--- a/examples/tree/tree.html
+++ b/examples/tree/tree.html
@@ -17,7 +17,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     <meta charset="utf-8" />
     <title>Draft • Tree Editor</title>
     <link rel="stylesheet" href="../../dist/Draft.css" />
+    <link rel="stylesheet" href="tree.css" />
     <style>
+      #target { width: 600px; }
       .public-DraftStyleDefault-block {
         padding-left: 20px;
       }
@@ -34,7 +36,14 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     <script type="text/babel">
       'use strict';
 
-      const {Editor, EditorState, ContentState, convertFromRaw} = Draft;
+      const {
+        ContentState,
+        DefaultDraftBlockRenderMap,
+        Editor,
+        EditorState,
+        RichUtils,
+        convertFromRaw
+      } = Draft;
 
       console.log('starting');
       var baseContent = convertFromRaw({
@@ -65,32 +74,190 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 text: 'Awesome'
               }
             ]
+          },
+          {
+            type: 'table',
+            text: ' ',
+            blocks: [
+              {
+                type: 'row',
+                text: ' ',
+                blocks: [
+                  {
+                    type: 'cell',
+                    text: ' ',
+                    blocks: [
+                      {
+                        type: 'unstyled',
+                        text: 'nested cell 1',
+                        inlineStyleRanges: [
+                          {
+                            offset: 8,
+                            length: 4,
+                            style: 'BOLD'
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    type: 'cell',
+                    text: ' ',
+                    blocks: [
+                      {
+                        type: 'unstyled',
+                        text: 'nested cell 2',
+                        inlineStyleRanges: [
+                          {
+                            offset: 8,
+                            length: 4,
+                            style: 'BOLD'
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                ]
+              },
+              {
+                type: 'row',
+                text: ' ',
+                blocks: [
+                  {
+                    type: 'cell',
+                    text: ' ',
+                    blocks: [
+                      {
+                        type: 'unstyled',
+                        text: 'nested cell 3',
+                        inlineStyleRanges: [
+                          {
+                            offset: 8,
+                            length: 4,
+                            style: 'BOLD'
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    type: 'cell',
+                    text: ' ',
+                    blocks: [
+                      {
+                        type: 'unstyled',
+                        text: 'nested cell 4',
+                        inlineStyleRanges: [
+                          {
+                            offset: 8,
+                            length: 4,
+                            style: 'BOLD'
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                ]
+              }
+            ]
           }
         ],
         entityMap: {}
       });
       console.log('baseContent is', baseContent.toJS());
 
-
       class TreeEditorExample extends React.Component {
         constructor(props) {
           super(props);
-          this.state = {editorState: EditorState.createWithContent(baseContent)};
+
+          this.state = {
+            editorState: EditorState.createWithContent(baseContent),
+						blockRenderMap: DefaultDraftBlockRenderMap.merge(Immutable.Map({
+                'table': {
+										element: 'table',
+                },
+                'cell': {
+                    element: 'td',
+                },
+                'row': {
+                    element: 'tr',
+                    wrapper: <tbody />
+                }
+            })),
+
+          };
+
+          this.handleKeyCommand = (command) => this._handleKeyCommand(command);
+          this.toggleBlockType = (type) => this._toggleBlockType(type);
+          this.toggleInlineStyle = (style) => this._toggleInlineStyle(style);
 
           this.focus = () => this.refs.editor.focus();
           this.onChange = (editorState) => this.setState({editorState});
-          this.logState = () => console.log(this.state.editorState.toJS());
+          this.logState = () => console.log(JSON.stringify(this.state.editorState.toJS(), null, 2));
+        }
+
+        _handleKeyCommand(command) {
+          const {editorState} = this.state;
+          const newState = RichUtils.handleKeyCommand(editorState, command);
+          if (newState) {
+            this.onChange(newState);
+            return true;
+          }
+          return false;
+        }
+
+        _toggleBlockType(blockType) {
+          this.onChange(
+            RichUtils.toggleBlockType(
+              this.state.editorState,
+              blockType
+            )
+          );
+        }
+
+        _toggleInlineStyle(inlineStyle) {
+          this.onChange(
+            RichUtils.toggleInlineStyle(
+              this.state.editorState,
+              inlineStyle
+            )
+          );
         }
 
         render() {
+          const {editorState, blockRenderMap} = this.state;
+
+          // If the user changes block type before entering any text, we can
+          // either style the placeholder or hide it. Let's just hide it now.
+          let className = 'RichEditor-editor';
+          var contentState = editorState.getCurrentContent();
+          if (!contentState.hasText()) {
+            if (contentState.getBlockMap().first().getType() !== 'unstyled') {
+              className += ' RichEditor-hidePlaceholder';
+            }
+          }
+
           return (
-            <div style={styles.root}>
-              <div style={styles.editor} onClick={this.focus}>
+            <div className="RichEditor-root">
+              <BlockStyleControls
+                editorState={editorState}
+                onToggle={this.toggleBlockType}
+              />
+              <InlineStyleControls
+                editorState={editorState}
+                onToggle={this.toggleInlineStyle}
+              />
+              <div className={className} onClick={this.focus}>
                 <Editor
-                  editorState={this.state.editorState}
+									blockRenderMap={blockRenderMap}
+                  blockStyleFn={getBlockStyle}
+                  customStyleMap={styleMap}
+                  editorState={editorState}
+                  handleKeyCommand={this.handleKeyCommand}
                   onChange={this.onChange}
-                  placeholder="Enter some text..."
+                  placeholder="Tell a story..."
                   ref="editor"
+                  spellCheck={true}
                 />
               </div>
               <input
@@ -104,22 +271,111 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         }
       }
 
+      // Custom overrides for "code" style.
+      const styleMap = {
+        CODE: {
+          backgroundColor: 'rgba(0, 0, 0, 0.05)',
+          fontFamily: '"Inconsolata", "Menlo", "Consolas", monospace',
+          fontSize: 16,
+          padding: 2,
+        },
+      };
+
+      function getBlockStyle(block) {
+        switch (block.getType()) {
+          case 'blockquote': return 'RichEditor-blockquote';
+          default: return null;
+        }
+      }
+
+      class StyleButton extends React.Component {
+        constructor() {
+          super();
+          this.onToggle = (e) => {
+            e.preventDefault();
+            this.props.onToggle(this.props.style);
+          };
+        }
+
+        render() {
+          let className = 'RichEditor-styleButton';
+          if (this.props.active) {
+            className += ' RichEditor-activeButton';
+          }
+
+          return (
+            <span className={className} onMouseDown={this.onToggle}>
+              {this.props.label}
+            </span>
+          );
+        }
+      }
+
+      const BLOCK_TYPES = [
+        {label: 'H1', style: 'header-one'},
+        {label: 'H2', style: 'header-two'},
+        {label: 'H3', style: 'header-three'},
+        {label: 'H4', style: 'header-four'},
+        {label: 'H5', style: 'header-five'},
+        {label: 'H6', style: 'header-six'},
+        {label: 'Blockquote', style: 'blockquote'},
+        {label: 'UL', style: 'unordered-list-item'},
+        {label: 'OL', style: 'ordered-list-item'},
+        {label: 'Code Block', style: 'code-block'},
+      ];
+
+      const BlockStyleControls = (props) => {
+        const {editorState} = props;
+        const selection = editorState.getSelection();
+        const blockType = editorState
+          .getCurrentContent()
+          .getBlockForKey(selection.getStartKey())
+          .getType();
+
+        return (
+          <div className="RichEditor-controls">
+            {BLOCK_TYPES.map((type) =>
+              <StyleButton
+                key={type.label}
+                active={type.style === blockType}
+                label={type.label}
+                onToggle={props.onToggle}
+                style={type.style}
+              />
+            )}
+          </div>
+        );
+      };
+
+      var INLINE_STYLES = [
+        {label: 'Bold', style: 'BOLD'},
+        {label: 'Italic', style: 'ITALIC'},
+        {label: 'Underline', style: 'UNDERLINE'},
+        {label: 'Monospace', style: 'CODE'},
+      ];
+
+      const InlineStyleControls = (props) => {
+        var currentStyle = props.editorState.getCurrentInlineStyle();
+        return (
+          <div className="RichEditor-controls">
+            {INLINE_STYLES.map(type =>
+              <StyleButton
+                key={type.label}
+                active={currentStyle.has(type.style)}
+                label={type.label}
+                onToggle={props.onToggle}
+                style={type.style}
+              />
+            )}
+          </div>
+        );
+      };
+
       const styles = {
-        root: {
-          fontFamily: '\'Helvetica\', sans-serif',
-          padding: 20,
-          width: 600,
-        },
-        editor: {
-          border: '1px solid #ccc',
-          cursor: 'text',
-          minHeight: 80,
-          padding: 10,
-        },
         button: {
           marginTop: 10,
           textAlign: 'center',
-        },
+        }
       };
 
       ReactDOM.render(

--- a/examples/tree/tree.html
+++ b/examples/tree/tree.html
@@ -18,12 +18,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     <title>Draft • Tree Editor</title>
     <link rel="stylesheet" href="../../dist/Draft.css" />
     <link rel="stylesheet" href="tree.css" />
-    <style>
-      #target { width: 600px; }
-      .public-DraftStyleDefault-block {
-        padding-left: 20px;
-      }
-    </style>
   </head>
   <body>
     <div id="target"></div>

--- a/examples/tree/tree.html
+++ b/examples/tree/tree.html
@@ -50,7 +50,31 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       const {hasCommandModifier} = KeyBindingUtil;
 
       console.log('starting');
-      var baseContent = convertFromRaw({
+
+      const blockRenderMap = Immutable.Map(DefaultDraftBlockRenderMap.keySeq().toArray().reduce((o, v, i) => {
+        // we are manually enabling all default draft blocks to support nesting for this example
+        o[v] = Object.assign({}, DefaultDraftBlockRenderMap.get(v), {
+          nestingEnabled: true
+        });
+
+        return o;
+      }, {
+          'table': {
+            nestingEnabled: true,
+            element: 'table'
+          },
+          'cell': {
+            nestingEnabled: true,
+            element: 'td'
+          },
+          'row': {
+            nestingEnabled: true,
+            element: 'tr',
+            wrapper: <tbody />,
+          }
+      }));
+
+      const baseContent = convertFromRaw({
         blocks: [
           {
               type: 'header-one',
@@ -171,7 +195,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           }
         ],
         entityMap: {}
-      });
+      }, blockRenderMap);
       console.log('baseContent is', baseContent.toJS());
 
       class TreeEditorExample extends React.Component {
@@ -180,19 +204,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
           this.state = {
             editorState: EditorState.createWithContent(baseContent),
-            blockRenderMap: DefaultDraftBlockRenderMap.merge(Immutable.Map({
-                'table': {
-                  element: 'table',
-                },
-                'cell': {
-                    element: 'td',
-                },
-                'row': {
-                    element: 'tr',
-                    wrapper: <tbody />
-                }
-            })),
-
+            blockRenderMap: blockRenderMap
           };
 
           this.handleKeyCommand = (command) => this._handleKeyCommand(command);

--- a/examples/tree/tree.html
+++ b/examples/tree/tree.html
@@ -42,26 +42,34 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         Editor,
         EditorState,
         RichUtils,
-        convertFromRaw
+        NestedUtils,
+        convertFromRaw,
+        getDefaultKeyBinding,
+        KeyBindingUtil
       } = Draft;
+      const {hasCommandModifier} = KeyBindingUtil;
 
       console.log('starting');
       var baseContent = convertFromRaw({
         blocks: [
           {
-            type: 'unstyled',
+              type: 'header-one',
+              text: 'Example with tree data structure'
+          },
+          {
+            type: 'blockquote',
             text: 'Hello World',
             blocks: [
               {
-                type: 'unstyled',
-                text: 'Cool',
+                type: 'unordered-list-item',
+                text: 'A first item of a list in a blockquote',
                 blocks: [
                   {
                     type: 'unstyled',
-                    text: 'Another deep block',
+                    text: 'A paragraph in the list',
                     inlineStyleRanges: [
                       {
-                        offset: 8,
+                        offset: 19,
                         length: 4,
                         style: 'BOLD'
                       }
@@ -70,8 +78,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 ]
               },
               {
-                type: 'unstyled',
-                text: 'Awesome'
+                type: 'unordered-list-item',
+                text: 'A second item of the list'
               }
             ]
           },
@@ -125,7 +133,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 blocks: [
                   {
                     type: 'cell',
-                    text: ' ',
+                    text: '',
                     blocks: [
                       {
                         type: 'unstyled',
@@ -172,9 +180,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
           this.state = {
             editorState: EditorState.createWithContent(baseContent),
-						blockRenderMap: DefaultDraftBlockRenderMap.merge(Immutable.Map({
+            blockRenderMap: DefaultDraftBlockRenderMap.merge(Immutable.Map({
                 'table': {
-										element: 'table',
+                  element: 'table',
                 },
                 'cell': {
                     element: 'td',
@@ -188,6 +196,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           };
 
           this.handleKeyCommand = (command) => this._handleKeyCommand(command);
+          this.keyBindingFn = (e) => this._keyBindingFn(e);
           this.toggleBlockType = (type) => this._toggleBlockType(type);
           this.toggleInlineStyle = (style) => this._toggleInlineStyle(style);
 
@@ -198,12 +207,26 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
         _handleKeyCommand(command) {
           const {editorState} = this.state;
-          const newState = RichUtils.handleKeyCommand(editorState, command);
+
+          var newState = NestedUtils.handleKeyCommand(editorState, command);
+          if (newState) {
+            this.onChange(newState);
+            return true;
+          }
+
+          newState = RichUtils.handleKeyCommand(editorState, command);
           if (newState) {
             this.onChange(newState);
             return true;
           }
           return false;
+        }
+
+        _keyBindingFn(e) {
+          if (e.keyCode === 13 /* `Enter` key */ && e.shiftKey) {
+            return 'split-nested-block';
+          }
+          return getDefaultKeyBinding(e);
         }
 
         _toggleBlockType(blockType) {
@@ -249,11 +272,12 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
               />
               <div className={className} onClick={this.focus}>
                 <Editor
-									blockRenderMap={blockRenderMap}
+                  blockRenderMap={blockRenderMap}
                   blockStyleFn={getBlockStyle}
                   customStyleMap={styleMap}
                   editorState={editorState}
                   handleKeyCommand={this.handleKeyCommand}
+                  keyBindingFn={this.keyBindingFn}
                   onChange={this.onChange}
                   placeholder="Tell a story..."
                   ref="editor"

--- a/examples/tree/tree.html
+++ b/examples/tree/tree.html
@@ -1,0 +1,131 @@
+<!--
+Copyright (c) 2013-present, Facebook, Inc. All rights reserved.
+
+This file provided by Facebook is for non-commercial testing and evaluation
+purposes only. Facebook reserves all rights not expressly granted.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+-->
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Draft • Tree Editor</title>
+    <link rel="stylesheet" href="../../dist/Draft.css" />
+    <style>
+      .public-DraftStyleDefault-block {
+        padding-left: 20px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="target"></div>
+    <script src="../../node_modules/react/dist/react.js"></script>
+    <script src="../../node_modules/react-dom/dist/react-dom.js"></script>
+    <script src="../../node_modules/immutable/dist/immutable.js"></script>
+    <script src="../../node_modules/es6-shim/es6-shim.js"></script>
+    <script src="../../node_modules/babel-core/browser.js"></script>
+    <script src="../../dist/Draft.js"></script>
+    <script type="text/babel">
+      'use strict';
+
+      const {Editor, EditorState, ContentState, convertFromRaw} = Draft;
+
+      console.log('starting');
+      var baseContent = convertFromRaw({
+        blocks: [
+          {
+            type: 'unstyled',
+            text: 'Hello World',
+            blocks: [
+              {
+                type: 'unstyled',
+                text: 'Cool',
+                blocks: [
+                  {
+                    type: 'unstyled',
+                    text: 'Another deep block',
+                    inlineStyleRanges: [
+                      {
+                        offset: 8,
+                        length: 4,
+                        style: 'BOLD'
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                type: 'unstyled',
+                text: 'Awesome'
+              }
+            ]
+          }
+        ],
+        entityMap: {}
+      });
+      console.log('baseContent is', baseContent.toJS());
+
+
+      class TreeEditorExample extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {editorState: EditorState.createWithContent(baseContent)};
+
+          this.focus = () => this.refs.editor.focus();
+          this.onChange = (editorState) => this.setState({editorState});
+          this.logState = () => console.log(this.state.editorState.toJS());
+        }
+
+        render() {
+          return (
+            <div style={styles.root}>
+              <div style={styles.editor} onClick={this.focus}>
+                <Editor
+                  editorState={this.state.editorState}
+                  onChange={this.onChange}
+                  placeholder="Enter some text..."
+                  ref="editor"
+                />
+              </div>
+              <input
+                onClick={this.logState}
+                style={styles.button}
+                type="button"
+                value="Log State"
+              />
+            </div>
+          );
+        }
+      }
+
+      const styles = {
+        root: {
+          fontFamily: '\'Helvetica\', sans-serif',
+          padding: 20,
+          width: 600,
+        },
+        editor: {
+          border: '1px solid #ccc',
+          cursor: 'text',
+          minHeight: 80,
+          padding: 10,
+        },
+        button: {
+          marginTop: 10,
+          textAlign: 'center',
+        },
+      };
+
+      ReactDOM.render(
+        <TreeEditorExample />,
+        document.getElementById('target')
+      );
+    </script>
+  </body>
+</html>

--- a/src/Draft.js
+++ b/src/Draft.js
@@ -27,6 +27,7 @@ const DraftEntityInstance = require('DraftEntityInstance');
 const EditorState = require('EditorState');
 const KeyBindingUtil = require('KeyBindingUtil');
 const RichTextEditorUtil = require('RichTextEditorUtil');
+const NestedTextEditorUtil = require('NestedTextEditorUtil');
 const SelectionState = require('SelectionState');
 
 const convertFromDraftStateToRaw = require('convertFromDraftStateToRaw');
@@ -56,6 +57,7 @@ const DraftPublic = {
   KeyBindingUtil,
   Modifier: DraftModifier,
   RichUtils: RichTextEditorUtil,
+  NestedUtils: NestedTextEditorUtil,
 
   DefaultDraftBlockRenderMap,
   DefaultDraftInlineStyle,

--- a/src/Draft.js
+++ b/src/Draft.js
@@ -35,6 +35,7 @@ const convertFromHTMLToContentBlocks =
   require('convertFromHTMLToContentBlocks');
 const convertFromRawToDraftState = require('convertFromRawToDraftState');
 const generateRandomKey = require('generateRandomKey');
+const generateNestedKey = require('generateNestedKey');
 const getDefaultKeyBinding = require('getDefaultKeyBinding');
 const getVisibleSelectionRect = require('getVisibleSelectionRect');
 
@@ -66,6 +67,7 @@ const DraftPublic = {
   convertFromRaw: convertFromRawToDraftState,
   convertToRaw: convertFromDraftStateToRaw,
   genKey: generateRandomKey,
+  genNestedKey: generateNestedKey,
   getDefaultKeyBinding,
   getVisibleSelectionRect,
 };

--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -219,7 +219,6 @@ class DraftEditor extends React.Component {
       'DraftEditor/alignRight': textAlignment === 'right',
       'DraftEditor/alignCenter': textAlignment === 'center',
     });
-    const hasContent = this.props.editorState.getCurrentContent().hasText();
 
     const contentStyle = {
       outline: 'none',

--- a/src/component/contents/DraftEditorBlock.react.js
+++ b/src/component/contents/DraftEditorBlock.react.js
@@ -61,17 +61,14 @@ class DraftEditorBlock extends React.Component {
     const {
         block,
         direction,
-        getBlockChildren,
+        blockMap,
         tree
     } = this.props;
 
-    const nestedBlocks = (
-      getBlockChildren ?
-        getBlockChildren(block.getKey()) :
-        false
+    const hasNestedBlocks = (
+     blockMap && blockMap.size > 0 ||
+     nextProps.blockMap && nextProps.blockMap.size > 0
     );
-
-    const hasNestedBlocks = nestedBlocks && nestedBlocks.size;
 
     return (
       hasNestedBlocks ||
@@ -218,20 +215,18 @@ class DraftEditorBlock extends React.Component {
   }
 
   render(): React.Element<any> {
-    const {direction, offsetKey, getBlockChildren, block} = this.props;
+    const {direction, offsetKey, blockMap} = this.props;
     const className = cx({
       'public/DraftStyleDefault/block': true,
       'public/DraftStyleDefault/ltr': direction === 'LTR',
       'public/DraftStyleDefault/rtl': direction === 'RTL',
     });
 
-    const nestedBlocks = getBlockChildren(block.getKey());
-
     // Render nested blocks or text but never both at the same time.
     return (
       <div data-offset-key={offsetKey} className={className}>
-        {nestedBlocks && nestedBlocks.size && nestedBlocks.size > 0 ?
-          this._renderBlockMap(nestedBlocks) :
+        {blockMap && blockMap.size && blockMap.size > 0 ?
+          this._renderBlockMap(blockMap) :
           this._renderChildren()
         }
       </div>

--- a/src/component/contents/DraftEditorBlock.react.js
+++ b/src/component/contents/DraftEditorBlock.react.js
@@ -214,7 +214,7 @@ class DraftEditorBlock extends React.Component {
     blocks: BlockMap
   ): React.Element {
     var DraftEditorBlocks = this.props.DraftEditorBlocks;
-    return <DraftEditorBlocks {...this.props} blocksAsArray={blocks.valueSeq().toArray()} />;
+    return <DraftEditorBlocks {...this.props} blockMap={blocks} />;
   }
 
   render(): React.Element<any> {
@@ -225,7 +225,7 @@ class DraftEditorBlock extends React.Component {
       'public/DraftStyleDefault/rtl': direction === 'RTL',
     });
 
-    const nestedBlocks = getBlockChildren ? getBlockChildren(block.getKey()) : [];
+    const nestedBlocks = getBlockChildren(block.getKey());
 
     // Render nested blocks or text but never both at the same time.
     return (

--- a/src/component/contents/DraftEditorBlock.react.js
+++ b/src/component/contents/DraftEditorBlock.react.js
@@ -32,6 +32,7 @@ const nullthrows = require('nullthrows');
 
 import type {BidiDirection} from 'UnicodeBidiDirection';
 import type {DraftDecoratorType} from 'DraftDecoratorType';
+import type {BlockMap} from 'BlockMap';
 import type {List} from 'immutable';
 
 const SCROLL_BUFFER = 10;
@@ -197,27 +198,26 @@ class DraftEditorBlock extends React.Component {
     }).toArray();
   }
 
-  _renderBlockMap(): React.Element {
-    var {getBlockChildren, block} = this.props;
+  _renderBlockMap(
+    blocks: BlockMap
+  ): React.Element {
     var DraftEditorBlocks = this.props.DraftEditorBlocks;
-
-    var blocks = getBlockChildren(block.getKey());
-
     return <DraftEditorBlocks {...this.props} blocksAsArray={blocks.valueSeq().toArray()} />;
   }
 
   render(): React.Element<any> {
-    const {direction, offsetKey} = this.props;
+    const {direction, offsetKey, getBlockChildren, block} = this.props;
     const className = cx({
       'public/DraftStyleDefault/block': true,
       'public/DraftStyleDefault/ltr': direction === 'LTR',
       'public/DraftStyleDefault/rtl': direction === 'RTL',
     });
 
+    const nestedBlocks = getBlockChildren(block.getKey());
+
     return (
       <div data-offset-key={offsetKey} className={className}>
-        {this._renderChildren()}
-        {this._renderBlockMap()}
+        {nestedBlocks.size > 0? this._renderBlockMap(nestedBlocks) : this._renderChildren()}
       </div>
     );
   }

--- a/src/component/contents/DraftEditorBlock.react.js
+++ b/src/component/contents/DraftEditorBlock.react.js
@@ -193,6 +193,15 @@ class DraftEditorBlock extends React.Component {
     }).toArray();
   }
 
+  _renderBlockMap(): React.Element {
+    var {getBlockChildren, block} = this.props;
+    var DraftEditorBlocks = this.props.DraftEditorBlocks;
+
+    var blocks = getBlockChildren(block.getKey());
+
+    return <DraftEditorBlocks {...this.props} blocksAsArray={blocks.valueSeq().toArray()} />;
+  }
+
   render(): React.Element<any> {
     const {direction, offsetKey} = this.props;
     const className = cx({
@@ -204,6 +213,7 @@ class DraftEditorBlock extends React.Component {
     return (
       <div data-offset-key={offsetKey} className={className}>
         {this._renderChildren()}
+        {this._renderBlockMap()}
       </div>
     );
   }

--- a/src/component/contents/DraftEditorBlock.react.js
+++ b/src/component/contents/DraftEditorBlock.react.js
@@ -57,7 +57,11 @@ type Props = {
  */
 class DraftEditorBlock extends React.Component {
   shouldComponentUpdate(nextProps: Props): boolean {
+    const nestedBlocks = this.props.getBlockChildren(this.props.block.getKey());
+    const hasNestedBlocks = nestedBlocks && nestedBlocks.size;
+
     return (
+      hasNestedBlocks ||
       this.props.block !== nextProps.block ||
       this.props.tree !== nextProps.tree ||
       this.props.direction !== nextProps.direction ||

--- a/src/component/contents/DraftEditorBlock.react.js
+++ b/src/component/contents/DraftEditorBlock.react.js
@@ -58,14 +58,26 @@ type Props = {
  */
 class DraftEditorBlock extends React.Component {
   shouldComponentUpdate(nextProps: Props): boolean {
-    const nestedBlocks = this.props.getBlockChildren(this.props.block.getKey());
+    const {
+        block,
+        direction,
+        getBlockChildren,
+        tree
+    } = this.props;
+
+    const nestedBlocks = (
+      getBlockChildren ?
+        getBlockChildren(block.getKey()) :
+        false
+    );
+
     const hasNestedBlocks = nestedBlocks && nestedBlocks.size;
 
     return (
       hasNestedBlocks ||
-      this.props.block !== nextProps.block ||
-      this.props.tree !== nextProps.tree ||
-      this.props.direction !== nextProps.direction ||
+      block !== nextProps.block ||
+      tree !== nextProps.tree ||
+      direction !== nextProps.direction ||
       (
         isBlockOnSelectionEdge(
           nextProps.selection,
@@ -213,11 +225,14 @@ class DraftEditorBlock extends React.Component {
       'public/DraftStyleDefault/rtl': direction === 'RTL',
     });
 
-    const nestedBlocks = getBlockChildren(block.getKey());
+    const nestedBlocks = getBlockChildren ? getBlockChildren(block.getKey()) : [];
 
     return (
       <div data-offset-key={offsetKey} className={className}>
-        {nestedBlocks.size > 0? this._renderBlockMap(nestedBlocks) : this._renderChildren()}
+        {nestedBlocks && nestedBlocks.size && nestedBlocks.size > 0 ?
+          this._renderBlockMap(nestedBlocks) :
+          this._renderChildren()
+        }
       </div>
     );
   }

--- a/src/component/contents/DraftEditorBlock.react.js
+++ b/src/component/contents/DraftEditorBlock.react.js
@@ -39,6 +39,7 @@ const SCROLL_BUFFER = 10;
 
 type Props = {
   block: ContentBlock,
+  blockMapTree: Object,
   customStyleMap: Object,
   tree: List<any>,
   selection: SelectionState,
@@ -61,17 +62,14 @@ class DraftEditorBlock extends React.Component {
     const {
         block,
         direction,
-        blockMap,
-        tree
+        blockMapTree,
+        tree,
     } = this.props;
 
-    const hasNestedBlocks = (
-     blockMap && blockMap.size > 0 ||
-     nextProps.blockMap && nextProps.blockMap.size > 0
-    );
+    const key = block.getKey();
 
     return (
-      hasNestedBlocks ||
+      blockMapTree.getIn([key, 'childrenBlocks']) !== nextProps.blockMapTree.getIn([key, 'childrenBlocks']) ||
       block !== nextProps.block ||
       tree !== nextProps.tree ||
       direction !== nextProps.direction ||

--- a/src/component/contents/DraftEditorBlock.react.js
+++ b/src/component/contents/DraftEditorBlock.react.js
@@ -227,6 +227,7 @@ class DraftEditorBlock extends React.Component {
 
     const nestedBlocks = getBlockChildren ? getBlockChildren(block.getKey()) : [];
 
+    // Render nested blocks or text but never both at the same time.
     return (
       <div data-offset-key={offsetKey} className={className}>
         {nestedBlocks && nestedBlocks.size && nestedBlocks.size > 0 ?

--- a/src/component/contents/DraftEditorBlocks.react.js
+++ b/src/component/contents/DraftEditorBlocks.react.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @providesModule DraftEditorContents.react
+ * @providesModule DraftEditorBlocks.react
  * @typechecks
  * @flow
  */

--- a/src/component/contents/DraftEditorBlocks.react.js
+++ b/src/component/contents/DraftEditorBlocks.react.js
@@ -72,7 +72,7 @@ class DraftEditorBlocks extends React.Component {
 
       const direction = directionMap.get(key);
       const offsetKey = DraftOffsetKey.encode(key, 0, 0);
-      const blockChildren = blockMapTree.get(key);
+      const blockChildren = blockMapTree.getIn([key, 'firstLevelBlocks']);
 
       const componentProps = {
         block,

--- a/src/component/contents/DraftEditorBlocks.react.js
+++ b/src/component/contents/DraftEditorBlocks.react.js
@@ -22,13 +22,6 @@ const joinClasses = require('joinClasses');
 const nullthrows = require('nullthrows');
 
 import type {BidiDirection} from 'UnicodeBidiDirection';
-import type ContentBlock from 'ContentBlock';
-
-type Props = {
-  blockRendererFn: Function,
-  blockStyleFn: (block: ContentBlock) => string,
-  blocksAsArray: Array<ContentBlock>,
-};
 
 /**
  * `DraftEditorContents` is the container component for all block components

--- a/src/component/contents/DraftEditorBlocks.react.js
+++ b/src/component/contents/DraftEditorBlocks.react.js
@@ -35,6 +35,7 @@ import type {BidiDirection} from 'UnicodeBidiDirection';
 class DraftEditorBlocks extends React.Component {
   render(): React.Element {
     const {
+      type,
       blockRenderMap,
       blockRendererFn,
       blockStyleFn,
@@ -168,7 +169,12 @@ class DraftEditorBlocks extends React.Component {
       }
     }
 
-    return <div data-blocks="true">{blocks}</div>;
+    const dataContents = type === 'contents' ? true : null;
+    const dataBlocks = dataContents ? null : true;
+
+    return (
+      <div data-contents={dataContents} data-blocks={dataBlocks} >{blocks}</div>
+    );
   }
 }
 

--- a/src/component/contents/DraftEditorBlocks.react.js
+++ b/src/component/contents/DraftEditorBlocks.react.js
@@ -24,7 +24,7 @@ const nullthrows = require('nullthrows');
 import type {BidiDirection} from 'UnicodeBidiDirection';
 
 /**
- * `DraftEditorContents` is the container component for all block components
+ * `DraftEditorBlocks` is the container component for all block components
  * rendered for a `DraftEditor`. It is optimized to aggressively avoid
  * re-rendering blocks whenever possible.
  *
@@ -173,6 +173,8 @@ class DraftEditorBlocks extends React.Component {
     const dataBlocks = dataContents ? null : true;
 
     return (
+      // data-contents will be true for the root level block otherwise
+      // it will just be a block container
       <div data-contents={dataContents} data-blocks={dataBlocks} >{blocks}</div>
     );
   }

--- a/src/component/contents/DraftEditorBlocks.react.js
+++ b/src/component/contents/DraftEditorBlocks.react.js
@@ -1,0 +1,210 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule DraftEditorContents.react
+ * @typechecks
+ * @flow
+ */
+
+'use strict';
+
+const DraftEditorBlock = require('DraftEditorBlock.react');
+const DraftOffsetKey = require('DraftOffsetKey');
+const React = require('React');
+
+const cx = require('cx');
+const joinClasses = require('joinClasses');
+const nullthrows = require('nullthrows');
+
+import type {BidiDirection} from 'UnicodeBidiDirection';
+import type ContentBlock from 'ContentBlock';
+
+type Props = {
+  blockRendererFn: Function,
+  blockStyleFn: (block: ContentBlock) => string,
+  blocksAsArray: Array<ContentBlock>,
+};
+
+/**
+ * `DraftEditorContents` is the container component for all block components
+ * rendered for a `DraftEditor`. It is optimized to aggressively avoid
+ * re-rendering blocks whenever possible.
+ *
+ * This component is separate from `DraftEditor` because certain props
+ * (for instance, ARIA props) must be allowed to update without affecting
+ * the contents of the editor.
+ */
+class DraftEditorBlocks extends React.Component {
+  render(): React.Element {
+    const {
+      blockRenderMap,
+      blockRendererFn,
+      blockStyleFn,
+      customStyleMap,
+      blocksAsArray,
+      selection,
+      forceSelection,
+      decorator,
+      directionMap,
+      getBlockTree,
+      getBlockChildren
+    } = this.props;
+
+    const blocks = [];
+    let currentWrapperElement = null;
+    let currentWrapperTemplate = null;
+    let currentDepth = null;
+    let currentWrappedBlocks;
+    let block, key, blockType, child, childProps, wrapperTemplate;
+
+    for (let ii = 0; ii < blocksAsArray.length; ii++) {
+      block = blocksAsArray[ii];
+      key = block.getKey();
+      blockType = block.getType();
+
+      const customRenderer = blockRendererFn(block);
+      let CustomComponent, customProps, customEditable;
+      if (customRenderer) {
+        CustomComponent = customRenderer.component;
+        customProps = customRenderer.props;
+        customEditable = customRenderer.editable;
+      }
+
+      const direction = directionMap.get(key);
+      const offsetKey = DraftOffsetKey.encode(key, 0, 0);
+      const componentProps = {
+        block,
+        blockProps: customProps,
+        customStyleMap,
+        decorator,
+        direction,
+        directionMap,
+        forceSelection,
+        key,
+        offsetKey,
+        selection,
+        blockRenderMap,
+        blockRendererFn,
+        blockStyleFn,
+        blocksAsArray,
+        getBlockTree,
+        getBlockChildren,
+        DraftEditorBlocks: DraftEditorBlocks,
+        tree: getBlockTree(key)
+      };
+
+      // Block render map must have a configuration specified for this
+      // block type.
+      const configForType = nullthrows(blockRenderMap.get(blockType));
+
+      wrapperTemplate = configForType.wrapper;
+
+      const useNewWrapper = wrapperTemplate !== currentWrapperTemplate;
+
+      const Element = (
+        blockRenderMap.get(blockType).element ||
+        blockRenderMap.get('unstyled').element
+      );
+
+      const depth = block.getDepth();
+      let className = blockStyleFn(block);
+
+      // List items are special snowflakes, since we handle nesting and
+      // counters manually.
+      if (Element === 'li') {
+        const shouldResetCount = (
+          useNewWrapper ||
+          currentDepth === null ||
+          depth > currentDepth
+        );
+        className = joinClasses(
+          className,
+          getListItemClasses(blockType, depth, shouldResetCount, direction)
+        );
+      }
+
+      const Component = CustomComponent || DraftEditorBlock;
+      childProps = {
+        className,
+        'data-block': true,
+        'data-editor': this.props.editorKey,
+        'data-offset-key': offsetKey,
+        key,
+      };
+      if (customEditable !== undefined) {
+        childProps = {
+          ...childProps,
+          contentEditable: customEditable,
+          suppressContentEditableWarning: true,
+        };
+      }
+
+      child = React.createElement(
+        Element,
+        childProps,
+        <Component {...componentProps} />,
+      );
+
+      if (wrapperTemplate) {
+        if (useNewWrapper) {
+          currentWrappedBlocks = [];
+          currentWrapperElement = React.cloneElement(
+            wrapperTemplate,
+            {
+              key: key + '-wrap',
+              'data-offset-key': offsetKey,
+            },
+            currentWrappedBlocks
+          );
+          currentWrapperTemplate = wrapperTemplate;
+          blocks.push(currentWrapperElement);
+        }
+        currentDepth = block.getDepth();
+        nullthrows(currentWrappedBlocks).push(child);
+      } else {
+        currentWrappedBlocks = null;
+        currentWrapperElement = null;
+        currentWrapperTemplate = null;
+        currentDepth = null;
+        blocks.push(child);
+      }
+    }
+
+    return <div data-blocks="true">{blocks}</div>;
+  }
+}
+
+/**
+ * Provide default styling for list items. This way, lists will be styled with
+ * proper counters and indentation even if the caller does not specify
+ * their own styling at all. If more than five levels of nesting are needed,
+ * the necessary CSS classes can be provided via `blockStyleFn` configuration.
+ */
+function getListItemClasses(
+  type: string,
+  depth: number,
+  shouldResetCount: boolean,
+  direction: BidiDirection
+): string {
+  return cx({
+    'public/DraftStyleDefault/unorderedListItem':
+      type === 'unordered-list-item',
+    'public/DraftStyleDefault/orderedListItem':
+      type === 'ordered-list-item',
+    'public/DraftStyleDefault/reset': shouldResetCount,
+    'public/DraftStyleDefault/depth0': depth === 0,
+    'public/DraftStyleDefault/depth1': depth === 1,
+    'public/DraftStyleDefault/depth2': depth === 2,
+    'public/DraftStyleDefault/depth3': depth === 3,
+    'public/DraftStyleDefault/depth4': depth === 4,
+    'public/DraftStyleDefault/listLTR': direction === 'LTR',
+    'public/DraftStyleDefault/listRTL': direction === 'RTL',
+  });
+}
+
+module.exports = DraftEditorBlocks;

--- a/src/component/contents/DraftEditorBlocks.react.js
+++ b/src/component/contents/DraftEditorBlocks.react.js
@@ -40,7 +40,7 @@ class DraftEditorBlocks extends React.Component {
       blockRendererFn,
       blockStyleFn,
       customStyleMap,
-      blocksAsArray,
+      blockMap,
       selection,
       forceSelection,
       decorator,
@@ -56,8 +56,7 @@ class DraftEditorBlocks extends React.Component {
     let currentWrappedBlocks;
     let block, key, blockType, child, childProps, wrapperTemplate;
 
-    for (let ii = 0; ii < blocksAsArray.length; ii++) {
-      block = blocksAsArray[ii];
+    blockMap.forEach((block) => {
       key = block.getKey();
       blockType = block.getType();
 
@@ -85,7 +84,7 @@ class DraftEditorBlocks extends React.Component {
         blockRenderMap,
         blockRendererFn,
         blockStyleFn,
-        blocksAsArray,
+        blockMap,
         getBlockTree,
         getBlockChildren,
         DraftEditorBlocks: DraftEditorBlocks,
@@ -167,7 +166,7 @@ class DraftEditorBlocks extends React.Component {
         currentDepth = null;
         blocks.push(child);
       }
-    }
+    });
 
     const dataContents = type === 'contents' ? true : null;
     const dataBlocks = dataContents ? null : true;

--- a/src/component/contents/DraftEditorBlocks.react.js
+++ b/src/component/contents/DraftEditorBlocks.react.js
@@ -41,12 +41,14 @@ class DraftEditorBlocks extends React.Component {
       blockStyleFn,
       customStyleMap,
       blockMap,
+      blockMapTree,
       selection,
       forceSelection,
       decorator,
       directionMap,
       getBlockTree,
-      getBlockChildren
+      getBlockChildren,
+      getBlockDescendants
     } = this.props;
 
     const blocks = [];
@@ -54,7 +56,7 @@ class DraftEditorBlocks extends React.Component {
     let currentWrapperTemplate = null;
     let currentDepth = null;
     let currentWrappedBlocks;
-    let block, key, blockType, child, childProps, wrapperTemplate;
+    let key, blockType, child, childProps, wrapperTemplate;
 
     blockMap.forEach((block) => {
       key = block.getKey();
@@ -70,6 +72,8 @@ class DraftEditorBlocks extends React.Component {
 
       const direction = directionMap.get(key);
       const offsetKey = DraftOffsetKey.encode(key, 0, 0);
+      const blockChildren = blockMapTree.get(key);
+
       const componentProps = {
         block,
         blockProps: customProps,
@@ -84,9 +88,11 @@ class DraftEditorBlocks extends React.Component {
         blockRenderMap,
         blockRendererFn,
         blockStyleFn,
-        blockMap,
+        blockMapTree,
+        blockMap: blockChildren,
         getBlockTree,
         getBlockChildren,
+        getBlockDescendants,
         DraftEditorBlocks: DraftEditorBlocks,
         tree: getBlockTree(key)
       };

--- a/src/component/contents/DraftEditorContents.react.js
+++ b/src/component/contents/DraftEditorContents.react.js
@@ -99,8 +99,8 @@ class DraftEditorContents extends React.Component {
     const forceSelection = editorState.mustForceSelection();
     const decorator = editorState.getDecorator();
     const directionMap = nullthrows(editorState.getDirectionMap());
-    const blockMap = content.getFirstLevelBlocks();
     const blockMapTree = content.getBlockDescendants();
+    const blockMap = blockMapTree.getIn(['__ROOT__', 'firstLevelBlocks']);
 
     return <DraftEditorBlocks
         type="contents"

--- a/src/component/contents/DraftEditorContents.react.js
+++ b/src/component/contents/DraftEditorContents.react.js
@@ -99,7 +99,7 @@ class DraftEditorContents extends React.Component {
     const forceSelection = editorState.mustForceSelection();
     const decorator = editorState.getDecorator();
     const directionMap = nullthrows(editorState.getDirectionMap());
-    const blocksAsArray = content.getFirstLevelBlocks().toArray();
+    const blockMap = content.getFirstLevelBlocks();
 
     return <DraftEditorBlocks
         type="contents"
@@ -107,7 +107,7 @@ class DraftEditorContents extends React.Component {
         forceSelection={forceSelection}
         decorator={decorator}
         directionMap={directionMap}
-        blocksAsArray={blocksAsArray}
+        blockMap={blockMap}
         blockStyleFn={blockStyleFn}
         blockRendererFn={blockRendererFn}
         blockRenderMap={blockRenderMap}

--- a/src/component/contents/DraftEditorContents.react.js
+++ b/src/component/contents/DraftEditorContents.react.js
@@ -13,16 +13,11 @@
 
 'use strict';
 
-const DraftEditorBlock = require('DraftEditorBlock.react');
-const DraftOffsetKey = require('DraftOffsetKey');
+const DraftEditorBlocks = require('DraftEditorBlocks.react');
 const EditorState = require('EditorState');
 const React = require('React');
-
-const cx = require('cx');
-const joinClasses = require('joinClasses');
 const nullthrows = require('nullthrows');
 
-import type {BidiDirection} from 'UnicodeBidiDirection';
 import type ContentBlock from 'ContentBlock';
 
 type Props = {
@@ -94,6 +89,7 @@ class DraftEditorContents extends React.Component {
     const {
       blockRenderMap,
       blockRendererFn,
+      blockStyleFn,
       customStyleMap,
       editorState,
     } = this.props;
@@ -103,150 +99,24 @@ class DraftEditorContents extends React.Component {
     const forceSelection = editorState.mustForceSelection();
     const decorator = editorState.getDecorator();
     const directionMap = nullthrows(editorState.getDirectionMap());
+    const blocksAsArray = content.getFirstLevelBlocks().toArray();
 
-    const blocksAsArray = content.getBlocksAsArray();
-    const blocks = [];
-    let currentWrapperElement = null;
-    let currentWrapperTemplate = null;
-    let currentDepth = null;
-    let currentWrappedBlocks;
-    let block, key, blockType, child, childProps, wrapperTemplate;
-
-    for (let ii = 0; ii < blocksAsArray.length; ii++) {
-      block = blocksAsArray[ii];
-      key = block.getKey();
-      blockType = block.getType();
-
-      const customRenderer = blockRendererFn(block);
-      let CustomComponent, customProps, customEditable;
-      if (customRenderer) {
-        CustomComponent = customRenderer.component;
-        customProps = customRenderer.props;
-        customEditable = customRenderer.editable;
-      }
-
-      const direction = directionMap.get(key);
-      const offsetKey = DraftOffsetKey.encode(key, 0, 0);
-      const componentProps = {
-        block,
-        blockProps: customProps,
-        customStyleMap,
-        decorator,
-        direction,
-        forceSelection,
-        key,
-        offsetKey,
-        selection,
-        tree: editorState.getBlockTree(key),
-      };
-
-      // Block render map must have a configuration specified for this
-      // block type.
-      const configForType = nullthrows(blockRenderMap.get(blockType));
-
-      wrapperTemplate = configForType.wrapper;
-
-      const useNewWrapper = wrapperTemplate !== currentWrapperTemplate;
-
-      const Element = (
-        blockRenderMap.get(blockType).element ||
-        blockRenderMap.get('unstyled').element
-      );
-
-      const depth = block.getDepth();
-      let className = this.props.blockStyleFn(block);
-
-      // List items are special snowflakes, since we handle nesting and
-      // counters manually.
-      if (Element === 'li') {
-        const shouldResetCount = (
-          useNewWrapper ||
-          currentDepth === null ||
-          depth > currentDepth
-        );
-        className = joinClasses(
-          className,
-          getListItemClasses(blockType, depth, shouldResetCount, direction)
-        );
-      }
-
-      const Component = CustomComponent || DraftEditorBlock;
-      childProps = {
-        className,
-        'data-block': true,
-        'data-editor': this.props.editorKey,
-        'data-offset-key': offsetKey,
-        key,
-      };
-      if (customEditable !== undefined) {
-        childProps = {
-          ...childProps,
-          contentEditable: customEditable,
-          suppressContentEditableWarning: true,
-        };
-      }
-
-      child = React.createElement(
-        Element,
-        childProps,
-        <Component {...componentProps} />,
-      );
-
-      if (wrapperTemplate) {
-        if (useNewWrapper) {
-          currentWrappedBlocks = [];
-          currentWrapperElement = React.cloneElement(
-            wrapperTemplate,
-            {
-              key: key + '-wrap',
-              'data-offset-key': offsetKey,
-            },
-            currentWrappedBlocks
-          );
-          currentWrapperTemplate = wrapperTemplate;
-          blocks.push(currentWrapperElement);
-        }
-        currentDepth = block.getDepth();
-        nullthrows(currentWrappedBlocks).push(child);
-      } else {
-        currentWrappedBlocks = null;
-        currentWrapperElement = null;
-        currentWrapperTemplate = null;
-        currentDepth = null;
-        blocks.push(child);
-      }
-    }
-
-    return <div data-contents="true">{blocks}</div>;
+    return <div data-contents="true">
+      <DraftEditorBlocks
+        selection={selection}
+        forceSelection={forceSelection}
+        decorator={decorator}
+        directionMap={directionMap}
+        blocksAsArray={blocksAsArray}
+        blockStyleFn={blockStyleFn}
+        blockRendererFn={blockRendererFn}
+        blockRenderMap={blockRenderMap}
+        customStyleMap={customStyleMap}
+        getBlockTree={editorState.getBlockTree.bind(editorState)}
+        getBlockChildren={content.getBlockChildren.bind(content)}
+      />
+    </div>;
   }
-}
-
-/**
- * Provide default styling for list items. This way, lists will be styled with
- * proper counters and indentation even if the caller does not specify
- * their own styling at all. If more than five levels of nesting are needed,
- * the necessary CSS classes can be provided via `blockStyleFn` configuration.
- */
-function getListItemClasses(
-  type: string,
-  depth: number,
-  shouldResetCount: boolean,
-  direction: BidiDirection
-): string {
-  return cx({
-    'public/DraftStyleDefault/unorderedListItem':
-      type === 'unordered-list-item',
-    'public/DraftStyleDefault/orderedListItem':
-      type === 'ordered-list-item',
-    'public/DraftStyleDefault/reset': shouldResetCount,
-    'public/DraftStyleDefault/depth0': depth === 0,
-    'public/DraftStyleDefault/depth1': depth === 1,
-    'public/DraftStyleDefault/depth2': depth === 2,
-    'public/DraftStyleDefault/depth3': depth === 3,
-    'public/DraftStyleDefault/depth4': depth === 4,
-    'public/DraftStyleDefault/listLTR': direction === 'LTR',
-    'public/DraftStyleDefault/listRTL': direction === 'RTL',
-  });
 }
 
 module.exports = DraftEditorContents;

--- a/src/component/contents/DraftEditorContents.react.js
+++ b/src/component/contents/DraftEditorContents.react.js
@@ -101,8 +101,8 @@ class DraftEditorContents extends React.Component {
     const directionMap = nullthrows(editorState.getDirectionMap());
     const blocksAsArray = content.getFirstLevelBlocks().toArray();
 
-    return <div data-contents="true">
-      <DraftEditorBlocks
+    return <DraftEditorBlocks
+        type="contents"
         selection={selection}
         forceSelection={forceSelection}
         decorator={decorator}
@@ -114,8 +114,7 @@ class DraftEditorContents extends React.Component {
         customStyleMap={customStyleMap}
         getBlockTree={editorState.getBlockTree.bind(editorState)}
         getBlockChildren={content.getBlockChildren.bind(content)}
-      />
-    </div>;
+      />;
   }
 }
 

--- a/src/component/contents/DraftEditorContents.react.js
+++ b/src/component/contents/DraftEditorContents.react.js
@@ -100,6 +100,7 @@ class DraftEditorContents extends React.Component {
     const decorator = editorState.getDecorator();
     const directionMap = nullthrows(editorState.getDirectionMap());
     const blockMap = content.getFirstLevelBlocks();
+    const blockMapTree = content.getBlockDescendants();
 
     return <DraftEditorBlocks
         type="contents"
@@ -108,12 +109,14 @@ class DraftEditorContents extends React.Component {
         decorator={decorator}
         directionMap={directionMap}
         blockMap={blockMap}
+        blockMapTree={blockMapTree}
         blockStyleFn={blockStyleFn}
         blockRendererFn={blockRendererFn}
         blockRenderMap={blockRenderMap}
         customStyleMap={customStyleMap}
         getBlockTree={editorState.getBlockTree.bind(editorState)}
         getBlockChildren={content.getBlockChildren.bind(content)}
+        getBlockDescendants={content.getBlockDescendants.bind(content)}
       />;
   }
 }

--- a/src/component/contents/__tests__/DraftEditorBlock.react-test.js
+++ b/src/component/contents/__tests__/DraftEditorBlock.react-test.js
@@ -99,6 +99,7 @@ function getSelection() {
 
 function getProps(block, decorator) {
   return {
+    blockMapTree: new Immutable.Map(),
     block,
     tree: BlockTree.generate(block, decorator),
     selection: getSelection(),

--- a/src/component/selection/DraftOffsetKey.js
+++ b/src/component/selection/DraftOffsetKey.js
@@ -27,10 +27,11 @@ var DraftOffsetKey = {
 
   decode: function(offsetKey: string): DraftOffsetKeyPath {
     var [blockKey, decoratorKey, leafKey] = offsetKey.split(KEY_DELIMITER);
+
     return {
       blockKey,
       decoratorKey: parseInt(decoratorKey, 10),
-      leafKey: parseInt(leafKey, 10),
+      leafKey: parseInt(leafKey, 10)
     };
   },
 };

--- a/src/component/selection/getDraftEditorSelectionWithNodes.js
+++ b/src/component/selection/getDraftEditorSelectionWithNodes.js
@@ -39,6 +39,21 @@ function getDraftEditorSelectionWithNodes(
   focusNode: Node,
   focusOffset: number
 ): DOMDerivedSelection {
+  // if we end-up having the data-blocks component in our selection we need to make
+  // sure we pass the focus to the last child within it
+  if (focusNode && focusNode.getAttribute && focusNode.getAttribute('data-blocks'))  {
+    focusNode = focusNode.lastChild;
+    var child = focusNode;
+
+    // navigate throught the html elements until we get into the last textNode
+    while (child) {
+      focusNode = child;
+      child = child.lastChild;
+    }
+
+    focusOffset = typeof focusNode === 'string' ? focusNode.length : focusOffset;
+  }
+
   var anchorIsTextNode = anchorNode.nodeType === Node.TEXT_NODE;
   var focusIsTextNode = focusNode.nodeType === Node.TEXT_NODE;
 

--- a/src/component/selection/getDraftEditorSelectionWithNodes.js
+++ b/src/component/selection/getDraftEditorSelectionWithNodes.js
@@ -39,21 +39,6 @@ function getDraftEditorSelectionWithNodes(
   focusNode: Node,
   focusOffset: number
 ): DOMDerivedSelection {
-  // if we end-up having the data-blocks component in our selection we need to make
-  // sure we pass the focus to the last child within it
-  if (focusNode && focusNode.getAttribute && focusNode.getAttribute('data-blocks'))  {
-    focusNode = focusNode.lastChild;
-    var child = focusNode;
-
-    // navigate throught the html elements until we get into the last textNode
-    while (child) {
-      focusNode = child;
-      child = child.lastChild;
-    }
-
-    focusOffset = typeof focusNode === 'string' ? focusNode.length : focusOffset;
-  }
-
   var anchorIsTextNode = anchorNode.nodeType === Node.TEXT_NODE;
   var focusIsTextNode = focusNode.nodeType === Node.TEXT_NODE;
 
@@ -136,7 +121,17 @@ function getDraftEditorSelectionWithNodes(
  * Identify the first leaf descendant for the given node.
  */
 function getFirstLeaf(node: Node): Node {
-  while (node.firstChild && getSelectionOffsetKeyForNode(node.firstChild)) {
+  while (
+    node.firstChild &&
+    (
+      // data-blocks has no offset
+      (
+        node.firstChild instanceof Element &&
+        node.firstChild.getAttribute('data-blocks') === 'true'
+      ) ||
+      getSelectionOffsetKeyForNode(node.firstChild)
+    )
+  ) {
     node = node.firstChild;
   }
   return node;
@@ -146,7 +141,17 @@ function getFirstLeaf(node: Node): Node {
  * Identify the last leaf descendant for the given node.
  */
 function getLastLeaf(node: Node): Node {
-  while (node.lastChild && getSelectionOffsetKeyForNode(node.lastChild)) {
+  while (
+    node.lastChild &&
+    (
+      // data-blocks has no offset
+      (
+        node.lastChild instanceof Element &&
+        node.lastChild.getAttribute('data-blocks') === 'true'
+      ) ||
+      getSelectionOffsetKeyForNode(node.lastChild)
+    )
+  ) {
     node = node.lastChild;
   }
   return node;

--- a/src/component/selection/getSampleSelectionMocksForTesting.js
+++ b/src/component/selection/getSampleSelectionMocksForTesting.js
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule getSampleSelectionMocksForTesting
+ * @typechecks
+ * @flow
+ */
+
+
+'use strict';
+
+var CharacterMetadata = require('CharacterMetadata');
+var ContentBlock = require('ContentBlock');
+var ContentState = require('ContentState');
+var EditorState = require('EditorState');
+var Immutable = require('immutable');
+
+var {BOLD} = require('SampleDraftInlineStyle');
+var {EMPTY} = CharacterMetadata;
+
+function getSampleSelectionMocksForTesting() {
+  var editorState;
+  var root;
+  var contents;
+  var blocks;
+  var decorators;
+  var leafs;
+  var leafChildren;
+  var textNodes;
+
+  root = document.createElement('div');
+  contents = document.createElement('div');
+  contents.setAttribute('data-contents', 'true');
+  root.appendChild(contents);
+
+  var text = [
+    'Washington',
+    'Jefferson',
+    'Lincoln',
+    'Roosevelt',
+    'Kennedy',
+    'Obama',
+  ];
+
+  var textA = text[0] + text[1];
+  var textB = text[2] + text[3];
+  var textC = text[4] + text[5];
+
+  var boldChar = CharacterMetadata.create({
+    style: BOLD
+  });
+  var aChars = Immutable.List(
+    Immutable.Repeat(EMPTY, text[0].length).concat(
+      Immutable.Repeat(boldChar, text[1].length)
+    )
+  );
+  var bChars = Immutable.List(
+    Immutable.Repeat(EMPTY, text[2].length).concat(
+      Immutable.Repeat(boldChar, text[3].length)
+    )
+  );
+  var cChars = Immutable.List(
+    Immutable.Repeat(EMPTY, text[4].length).concat(
+      Immutable.Repeat(boldChar, text[5].length)
+    )
+  );
+
+  var contentBlocks = [
+    new ContentBlock({
+      key: 'a',
+      type: 'unstyled',
+      text: textA,
+      characterList: aChars,
+    }),
+    new ContentBlock({
+      key: 'b',
+      type: 'unstyled',
+      text: textB,
+      characterList: bChars,
+    }),
+    new ContentBlock({
+      key: 'c',
+      type: 'unstyled',
+      text: textC,
+      characterList: cChars,
+    }),
+  ];
+
+  var contentState = ContentState.createFromBlockArray(contentBlocks);
+  editorState = EditorState.createWithContent(contentState);
+
+  textNodes = text
+    .map(
+      function(text) {
+        return document.createTextNode(text);
+      }
+    );
+  leafChildren = textNodes
+    .map(
+      function(textNode) {
+        var span = document.createElement('span');
+        span.appendChild(textNode);
+        return span;
+      }
+    );
+  leafs = ['a-0-0', 'a-0-1', 'b-0-0', 'b-0-1', 'c-0-0', 'c-0-1']
+    .map(
+      function(blockKey, ii) {
+        var span = document.createElement('span');
+        span.setAttribute('data-offset-key', '' + blockKey);
+        span.appendChild(leafChildren[ii]);
+        return span;
+      }
+    );
+  decorators = ['a-0-0', 'b-0-0', 'c-0-0']
+    .map(
+      function(decoratorKey, ii) {
+        var span = document.createElement('span');
+        span.setAttribute('data-offset-key', '' + decoratorKey);
+        span.appendChild(leafs[(ii * 2)]);
+        span.appendChild(leafs[(ii * 2) + 1]);
+        return span;
+      }
+    );
+  blocks = ['a-0-0', 'b-0-0', 'c-0-0']
+    .map(
+      function(blockKey, ii) {
+        var blockElement = document.createElement('div');
+        blockElement.setAttribute('data-offset-key', '' + blockKey);
+        blockElement.appendChild(decorators[ii]);
+        return blockElement;
+      }
+    );
+  blocks.forEach(
+    function(blockElem) {
+      contents.appendChild(blockElem);
+    }
+  );
+
+  return {
+    editorState,
+    root,
+    contents,
+    blocks,
+    decorators,
+    leafs,
+    leafChildren,
+    textNodes
+  };
+}
+
+module.exports = getSampleSelectionMocksForTesting;

--- a/src/component/selection/getSampleSelectionMocksForTestingNestedBlocks.js
+++ b/src/component/selection/getSampleSelectionMocksForTestingNestedBlocks.js
@@ -1,0 +1,186 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule getSampleSelectionMocksForTestingNestedBlocks
+ * @typechecks
+ * @flow
+ */
+
+'use strict';
+
+var CharacterMetadata = require('CharacterMetadata');
+var ContentBlock = require('ContentBlock');
+var ContentState = require('ContentState');
+var EditorState = require('EditorState');
+var Immutable = require('immutable');
+
+var {BOLD} = require('SampleDraftInlineStyle');
+var {EMPTY} = CharacterMetadata;
+
+function getSampleSelectionMocksForTestingNestedBlocks() {
+  var editorState;
+  var root;
+  var contents;
+  var blocks;
+  var decorators;
+  var leafs;
+  var leafChildren;
+  var textNodes;
+
+  root = document.createElement('div');
+  contents = document.createElement('div');
+  contents.setAttribute('data-contents', 'true');
+  root.appendChild(contents);
+
+  var text = [
+    'Washington',
+    '',
+    'Lincoln',
+    'Kennedy'
+  ];
+
+  var textA = text[0];
+  var textB = text[1];
+  var textC = text[2];
+  var textD = text[3];
+
+  var boldChar = CharacterMetadata.create({
+    style: BOLD
+  });
+  var aChars = Immutable.List(
+    Immutable.Repeat(boldChar, text[0].length)
+  );
+  var bChars = Immutable.List(
+    Immutable.Repeat(EMPTY, text[1].length)
+  );
+  var cChars = Immutable.List(
+    Immutable.Repeat(boldChar, text[2].length)
+  );
+  var dChars = Immutable.List(
+    Immutable.Repeat(EMPTY, text[3].length)
+  );
+
+  var contentBlocks = [
+    new ContentBlock({
+      key: 'a',
+      type: 'unstyled',
+      text: textA,
+      characterList: aChars,
+    }),
+    new ContentBlock({
+      key: 'b',
+      type: 'unstyled',
+      text: textB,
+      characterList: bChars,
+    }),
+    new ContentBlock({
+      key: 'b/c',
+      type: 'unstyled',
+      text: textC,
+      characterList: cChars,
+    }),
+    new ContentBlock({
+      key: 'b/d',
+      type: 'unstyled',
+      text: textD,
+      characterList: dChars,
+    }),
+  ];
+
+  var contentState = ContentState.createFromBlockArray(contentBlocks);
+  var blockKeys = contentState.getBlockMap().keySeq();
+
+  editorState = EditorState.createWithContent(contentState);
+
+  textNodes = text
+    .map(
+      function(text) {
+        return document.createTextNode(text);
+      }
+    );
+  leafChildren = textNodes
+    .map(
+      function(textNode) {
+        var span = document.createElement('span');
+        span.appendChild(textNode);
+        return span;
+      }
+    );
+  leafs = ['a-0-0', 'b-0-0', 'b/c-0-0', 'b/d-0-0']
+    .map(
+      function(blockKey, ii) {
+        var span = document.createElement('span');
+        span.setAttribute('data-offset-key', '' + blockKey);
+        span.appendChild(leafChildren[ii]);
+        return span;
+      }
+    );
+  decorators = ['a-0-0', 'b-0-0', 'b/c-0-0', 'b/d-0-0']
+    .map(
+      function(decoratorKey, ii) {
+        var span = document.createElement('span');
+        span.setAttribute('data-offset-key', '' + decoratorKey);
+        span.appendChild(leafs[ii]);
+        return span;
+      }
+    );
+  blocks = ['a-0-0', 'b-0-0', 'b/c-0-0', 'b/d-0-0']
+    .map(
+      function(blockKey, ii) {
+        var blockElement = document.createElement('div');
+        var dataBlock = document.createElement('div');
+        blockElement.setAttribute('data-offset-key', '' + blockKey);
+        blockElement.appendChild(decorators[ii]);
+
+        dataBlock.setAttribute('data-offset-key', '' + blockKey);
+        dataBlock.setAttribute('data-block', 'true');
+        dataBlock.appendChild(blockElement);
+
+        return dataBlock;
+      }
+    );
+
+  blocks.forEach(
+    function(blockElem, index, arr) {
+      const currentBlock = contentBlocks[index];
+      const parentKey = currentBlock.getParentKey();
+      const hasChildren = contentState.getBlockChildren(currentBlock.getKey()).size > 0;
+
+      if (hasChildren) { // if a block has children it should not have leafs just a data-blocks container
+        const dataBlocks = document.createElement('div');
+        dataBlocks.setAttribute('data-blocks', 'true');
+        blockElem.firstChild.replaceChild(dataBlocks, blockElem.querySelector('span'));
+      }
+
+      if (parentKey) {
+        const parentIndex = blockKeys.indexOf(parentKey);
+        const parentBlockElement = arr[parentIndex];
+        const blockContainer = parentBlockElement.querySelector('div[data-blocks]');
+
+        if (blockContainer) {
+          blockContainer.appendChild(blockElem);
+        }
+      } else {
+        contents.appendChild(blockElem);
+      }
+    }
+  );
+
+  return {
+    editorState,
+    root,
+    contents,
+    blocks,
+    decorators,
+    leafs,
+    leafChildren,
+    textNodes
+  };
+}
+
+module.exports = getSampleSelectionMocksForTestingNestedBlocks;

--- a/src/model/constants/DraftEditorCommand.js
+++ b/src/model/constants/DraftEditorCommand.js
@@ -67,6 +67,11 @@ export type DraftEditorCommand = (
   'split-block' |
 
   /**
+   * Split a block in two and create a nested one
+   */
+  'split-nested-block' |
+
+  /**
    * Self-explanatory.
    */
   'transpose-characters' |

--- a/src/model/constants/DraftEditorCommand.js
+++ b/src/model/constants/DraftEditorCommand.js
@@ -67,9 +67,14 @@ export type DraftEditorCommand = (
   'split-block' |
 
   /**
-   * Split a block in two and create a nested one
+   * Split a block in two by creating two nested blocks
    */
   'split-nested-block' |
+
+  /**
+   * Split the parent block in two
+   */
+  'split-parent-block' |
 
   /**
    * Self-explanatory.

--- a/src/model/encoding/RawDraftContentBlock.js
+++ b/src/model/encoding/RawDraftContentBlock.js
@@ -27,4 +27,5 @@ export type RawDraftContentBlock = {
   depth: ?number;
   inlineStyleRanges: ?Array<InlineStyleRange>;
   entityRanges: ?Array<EntityRange>;
+  blocks: ?Array<RawDraftContentBlock>;
 };

--- a/src/model/encoding/__tests__/convertFromRawToDraftState.js
+++ b/src/model/encoding/__tests__/convertFromRawToDraftState.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+ui_infra
+ */
+
+jest.disableAutomock();
+
+var ContentState = require('ContentState');
+var NestedTextEditorUtil = require('NestedTextEditorUtil');
+
+describe('convertFromRawToDraftState', () => {
+  var convertFromRawToDraftState = require('convertFromRawToDraftState');
+
+  it('should generate a ContentState', function() {
+    var result = convertFromRawToDraftState({
+      blocks: [
+        {
+          type: 'unstyled',
+          text: 'Hello World'
+        }
+      ],
+      entityMap: {}
+    });
+
+    expect(result).toEqual(jasmine.any(ContentState));
+    expect(result.getBlockMap().size).toEqual(1);
+  });
+
+  it('should generate a nested ContentState', function() {
+    var contentState = convertFromRawToDraftState({
+      blocks: [
+        {
+          type: 'blockquote',
+          text: '',
+          blocks: [
+            {
+              type: 'unstyled',
+              text: 'Hello'
+            },
+            {
+              type: 'unstyled',
+              text: 'World'
+            }
+          ]
+        }
+      ],
+      entityMap: {}
+    }, NestedTextEditorUtil.DefaultBlockRenderMap);
+
+    expect(contentState.getBlockMap().size).toEqual(3);
+
+    var mainBlocks = contentState.getFirstLevelBlocks();
+    var mainBlock = mainBlocks.first();
+
+    expect(mainBlocks.size).toBe(1);
+    expect(mainBlock.getType()).toBe('blockquote');
+
+    var mainKey = mainBlock.getKey();
+
+    // Verify nesting
+    var children = contentState.getBlockChildren(mainKey);
+    expect(children.size).toBe(2);
+
+    // Check order in blockMap
+    expect(contentState.getKeyBefore(mainKey)).toBeFalsy();
+    expect(contentState.getKeyAfter(mainKey)).toBe(children.first().getKey());
+  });
+
+});

--- a/src/model/encoding/__tests__/convertFromRawToDraftState.js
+++ b/src/model/encoding/__tests__/convertFromRawToDraftState.js
@@ -11,14 +11,14 @@
 
 jest.disableAutomock();
 
-var ContentState = require('ContentState');
-var NestedTextEditorUtil = require('NestedTextEditorUtil');
+const ContentState = require('ContentState');
+const NestedTextEditorUtil = require('NestedTextEditorUtil');
 
 describe('convertFromRawToDraftState', () => {
-  var convertFromRawToDraftState = require('convertFromRawToDraftState');
+  const convertFromRawToDraftState = require('convertFromRawToDraftState');
 
-  it('should generate a ContentState', function() {
-    var result = convertFromRawToDraftState({
+  it('should generate a ContentState', () => {
+    const result = convertFromRawToDraftState({
       blocks: [
         {
           type: 'unstyled',
@@ -32,8 +32,8 @@ describe('convertFromRawToDraftState', () => {
     expect(result.getBlockMap().size).toEqual(1);
   });
 
-  it('should generate a nested ContentState', function() {
-    var contentState = convertFromRawToDraftState({
+  it('should generate a nested ContentState', () => {
+    const contentState = convertFromRawToDraftState({
       blocks: [
         {
           type: 'blockquote',
@@ -55,16 +55,16 @@ describe('convertFromRawToDraftState', () => {
 
     expect(contentState.getBlockMap().size).toEqual(3);
 
-    var mainBlocks = contentState.getFirstLevelBlocks();
-    var mainBlock = mainBlocks.first();
+    const mainBlocks = contentState.getFirstLevelBlocks();
+    const mainBlock = mainBlocks.first();
 
     expect(mainBlocks.size).toBe(1);
     expect(mainBlock.getType()).toBe('blockquote');
 
-    var mainKey = mainBlock.getKey();
+    const mainKey = mainBlock.getKey();
 
     // Verify nesting
-    var children = contentState.getBlockChildren(mainKey);
+    const children = contentState.getBlockChildren(mainKey);
     expect(children.size).toBe(2);
 
     // Check order in blockMap

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -409,6 +409,7 @@ function genFragment(
     isValidBlock = blockTags.indexOf(nodeName) !== -1;
 
     var insideANestableBlock = (
+      blockKey &&
       chunk.keys.indexOf(blockKey) !== -1 &&
       lastBlock && blockRenderMap.get(lastBlock) &&
       blockRenderMap.get(lastBlock).nestingEnabled

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -594,7 +594,7 @@ function convertFromHTMLtoContentBlocks(
       var hasChildren = key && nextChunkKey && nextChunkKey.indexOf(key + '/') !== -1;
 
       if (blockConfig && blockConfig.nestingEnabled && hasChildren) {
-        var character = ' ';
+        var character = '';
         var blockKey = key || generateRandomKey();
 
         if ((hasChildren && textBlock) || !hasChildren) {

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -408,8 +408,14 @@ function genFragment(
     // if we are on an invalid block we can re-use the key since it wont generate a block
     isValidBlock = blockTags.indexOf(nodeName) !== -1;
 
+    var insideANestableBlock = (
+      chunk.keys.indexOf(blockKey) !== -1 &&
+      lastBlock && blockRenderMap.get(lastBlock) &&
+      blockRenderMap.get(lastBlock).nestingEnabled
+    );
+
     var chunkKey = (
-      blockKey ?
+      blockKey  && (hasNestingEnabled || insideANestableBlock) ?
         (
           isValidBlock ?
             generateNestedKey(blockKey) :

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -109,7 +109,7 @@ function getSoftNewlineChunk(): Chunk {
   };
 }
 
-function getBlockDividerChunk(block: DraftBlockType, depth: number, key=generateRandomKey(): string): Chunk {
+function getBlockDividerChunk(block: DraftBlockType, depth: number, key: string = generateRandomKey()): Chunk {
   return {
     text: '\r',
     inlines: [OrderedSet()],
@@ -550,26 +550,16 @@ function convertFromHTMLtoContentBlocks(
         nullthrows(chunk).keys[ii] :
         null;
 
-      var blockConfig = {
+      return new ContentBlock({
         key: key || generateRandomKey(),
         type: blockType,
         depth: nullthrows(chunk).blocks[ii].depth,
         text: textBlock,
         characterList,
-      };
-
-      //console.log("=========");
-      //console.log(JSON.stringify(blockConfig, null, 2));
-      //console.log("Key used on the block is :", chunk.keys[ii]);
-      //console.log("Key used on the block is :", chunk.blocks[ii].type);
-      //console.log("=========");
-
-      return new ContentBlock(blockConfig);
+      });
     }
   );
 
-  console.log(JSON.stringify(contentBlocks, null, 2));
-  //
   return contentBlocks;
 }
 

--- a/src/model/encoding/convertFromRawToDraftState.js
+++ b/src/model/encoding/convertFromRawToDraftState.js
@@ -72,6 +72,10 @@ function convertBlocksFromRaw(
       var entities = decodeEntityRanges(text, filteredEntityRanges);
       var characterList = createCharacterList(inlineStyles, entities);
 
+      // Push parent block first
+      result.push(new ContentBlock({key, type, text, depth, characterList}));
+
+      // Then push child blocks
       result = result.concat(
         convertBlocksFromRaw(
           blocks,
@@ -81,8 +85,6 @@ function convertBlocksFromRaw(
           block
         )
       );
-
-      result.push(new ContentBlock({key, type, text, depth, characterList}));
 
       return result;
     }, []
@@ -106,9 +108,6 @@ function convertFromRawToDraftState(
   );
 
   var contentBlocks = convertBlocksFromRaw(blocks, fromStorageToLocal, blockRenderMap);
-
-  console.log(JSON.stringify(contentBlocks, null, 2));
-
   return ContentState.createFromBlockArray(contentBlocks);
 }
 

--- a/src/model/encoding/convertFromRawToDraftState.js
+++ b/src/model/encoding/convertFromRawToDraftState.js
@@ -76,6 +76,8 @@ function convertFromRawToDraftState(
 
   var contentBlocks = convertBlocksFromRaw(blocks, fromStorageToLocal);
 
+  console.log(JSON.stringify(contentBlocks, null, 2));
+
   return ContentState.createFromBlockArray(contentBlocks);
 }
 

--- a/src/model/encoding/convertFromRawToDraftState.js
+++ b/src/model/encoding/convertFromRawToDraftState.js
@@ -24,7 +24,7 @@ var generateRandomKey = require('generateRandomKey');
 import type {RawDraftContentState} from 'RawDraftContentState';
 
 function convertBlocksFromRaw(
-  inputBlocks: Array,
+  inputBlocks: Array<ContentBlock>,
   fromStorageToLocal: Object,
   parentKey: ?string
 ) : Array<ContentBlock> {

--- a/src/model/encoding/convertFromRawToDraftState.js
+++ b/src/model/encoding/convertFromRawToDraftState.js
@@ -24,9 +24,10 @@ var generateRandomKey = require('generateRandomKey');
 
 import type {RawDraftContentState} from 'RawDraftContentState';
 import type {DraftBlockRenderMap} from 'DraftBlockRenderMap';
+import type {RawDraftContentBlock} from 'RawDraftContentBlock';
 
 function convertBlocksFromRaw(
-  inputBlocks: Array<ContentBlock>,
+  inputBlocks: Array<RawDraftContentBlock>,
   fromStorageToLocal: Object,
   blockRenderMap: DraftBlockRenderMap,
   parentKey: ?string,
@@ -90,7 +91,7 @@ function convertBlocksFromRaw(
 
 function convertFromRawToDraftState(
   rawState: RawDraftContentState,
-  blockRenderMap=DefaultDraftBlockRenderMap: DraftBlockRenderMap
+  blockRenderMap:DraftBlockRenderMap=DefaultDraftBlockRenderMap
 ): ContentState {
   var {blocks, entityMap} = rawState;
 

--- a/src/model/encoding/convertFromRawToDraftState.js
+++ b/src/model/encoding/convertFromRawToDraftState.js
@@ -58,7 +58,7 @@ function convertBlocksFromRaw(
 
       key = parentKey && parentBlockRenderingConfig &&
         parentBlockRenderingConfig.nestingEnabled ?
-          generateNestedKey(parentKey) :
+          generateNestedKey(parentKey, key) :
           key;
 
       var inlineStyles = decodeInlineStyleRanges(text, inlineStyleRanges);

--- a/src/model/encoding/convertFromRawToDraftState.js
+++ b/src/model/encoding/convertFromRawToDraftState.js
@@ -21,6 +21,7 @@ var createCharacterList = require('createCharacterList');
 var decodeEntityRanges = require('decodeEntityRanges');
 var decodeInlineStyleRanges = require('decodeInlineStyleRanges');
 var generateRandomKey = require('generateRandomKey');
+const generateNestedKey = require('generateNestedKey');
 
 import type {RawDraftContentState} from 'RawDraftContentState';
 import type {DraftBlockRenderMap} from 'DraftBlockRenderMap';
@@ -57,7 +58,7 @@ function convertBlocksFromRaw(
 
       key = parentKey && parentBlockRenderingConfig &&
         parentBlockRenderingConfig.nestingEnabled ?
-          parentKey + key :
+          generateNestedKey(parentKey) :
           key;
 
       var inlineStyles = decodeInlineStyleRanges(text, inlineStyleRanges);
@@ -81,7 +82,7 @@ function convertBlocksFromRaw(
           blocks,
           fromStorageToLocal,
           blockRenderMap,
-          key + '/',
+          key,
           block
         )
       );

--- a/src/model/immutable/BlockMapBuilder.js
+++ b/src/model/immutable/BlockMapBuilder.js
@@ -22,7 +22,7 @@ var {OrderedMap} = Immutable;
 var BlockMapBuilder = {
   createFromArray: function(
     blocks: Array<ContentBlock>
-  ): BlockMap {
+  ): BlockMap | OrderedMap {
     return OrderedMap(
       blocks.map(
         block => [block.getKey(), block]

--- a/src/model/immutable/BlockMapBuilder.js
+++ b/src/model/immutable/BlockMapBuilder.js
@@ -22,7 +22,7 @@ var {OrderedMap} = Immutable;
 var BlockMapBuilder = {
   createFromArray: function(
     blocks: Array<ContentBlock>
-  ): BlockMap | OrderedMap {
+  ): BlockMap {
     return OrderedMap(
       blocks.map(
         block => [block.getKey(), block]

--- a/src/model/immutable/ContentBlock.js
+++ b/src/model/immutable/ContentBlock.js
@@ -77,6 +77,10 @@ class ContentBlock extends ContentBlockRecord {
     return parts.slice(0, -1).join('/');
   }
 
+  hasParent(): boolean {
+    return (this.getParentKey() !== '');
+  }
+
   getInnerKey(): string {
     var key = this.getKey();
     var parts = key.split('/');

--- a/src/model/immutable/ContentBlock.js
+++ b/src/model/immutable/ContentBlock.js
@@ -77,6 +77,13 @@ class ContentBlock extends ContentBlockRecord {
     return parts.slice(0, -1).join('/');
   }
 
+  getInnerKey(): string {
+    var key = this.getKey();
+    var parts = key.split('/');
+
+    return parts[parts.length - 1];
+  }
+
   getInlineStyleAt(offset: number): DraftInlineStyle {
     var character = this.getCharacterList().get(offset);
     return character ? character.getStyle() : EMPTY_SET;

--- a/src/model/immutable/ContentBlock.js
+++ b/src/model/immutable/ContentBlock.js
@@ -20,10 +20,12 @@ var findRangesImmutable = require('findRangesImmutable');
 import type CharacterMetadata from 'CharacterMetadata';
 import type {DraftBlockType} from 'DraftBlockType';
 import type {DraftInlineStyle} from 'DraftInlineStyle';
+import type {BlockMap} from 'BlockMap';
 
 var {
   List,
   OrderedSet,
+  OrderedMap,
   Record,
 } = Immutable;
 
@@ -68,6 +70,13 @@ class ContentBlock extends ContentBlockRecord {
 
   getDepth(): number {
     return this.get('depth');
+  }
+
+  getParentKey(): string {
+    var key = this.getKey();
+    var parts = key.split('/');
+
+    return parts.slice(0, -1).join('/');
   }
 
   getInlineStyleAt(offset: number): DraftInlineStyle {

--- a/src/model/immutable/ContentBlock.js
+++ b/src/model/immutable/ContentBlock.js
@@ -20,12 +20,10 @@ var findRangesImmutable = require('findRangesImmutable');
 import type CharacterMetadata from 'CharacterMetadata';
 import type {DraftBlockType} from 'DraftBlockType';
 import type {DraftInlineStyle} from 'DraftInlineStyle';
-import type {BlockMap} from 'BlockMap';
 
 var {
   List,
   OrderedSet,
-  OrderedMap,
   Record,
 } = Immutable;
 

--- a/src/model/immutable/ContentState.js
+++ b/src/model/immutable/ContentState.js
@@ -8,9 +8,7 @@
  *
  * @providesModule ContentState
  * @typechecks
- * @flow
- */
-
+ * @flow */
 'use strict';
 
 const BlockMapBuilder = require('BlockMapBuilder');
@@ -56,6 +54,7 @@ class ContentState extends ContentStateRecord {
     return block;
   }
 
+  // return all blocks
   getFirstLevelBlocks(): BlockMap {
     return this.getBlockChildren('');
   }

--- a/src/model/immutable/ContentState.js
+++ b/src/model/immutable/ContentState.js
@@ -59,30 +59,61 @@ class ContentState extends ContentStateRecord {
     return this.getBlockChildren('');
   }
 
-  getBlockDescendants(): Object {
+  /*
+   * This algorithm is used to create the blockMap nesting as well as to
+   * enhance performance checks for nested blocks allowing each block to
+   * know when any of it's children has changed.
+   */
+  getBlockDescendants() {
     return this.getBlockMap()
       .reverse()
       .reduce((treeMap, block) => {
         const key = block.getKey();
         const parentKey = block.getParentKey();
-        const blockList = treeMap.set(key, treeMap.get(key) || new Immutable.OrderedMap());
+
+        // create one if does not exist
+        const blockList = (
+          treeMap.get(key) ?
+            treeMap :
+            treeMap.set(key, new Immutable.Map({
+              firstLevelBlocks: new Immutable.OrderedMap(),
+              childrenBlocks: new Immutable.Set()
+            }))
+        );
 
         if (parentKey) {
-          const parentList = blockList.set(parentKey, blockList.get(parentKey) || new Immutable.OrderedMap());
-          const addBlockToParentList = parentList.setIn([parentKey, key], block);
-
-          const mergedParent = (
-            addBlockToParentList.get(key).size ?
-              addBlockToParentList.mergeIn(parentKey, addBlockToParentList.get(key)) :
-              addBlockToParentList
+          // create one if does not exist
+          const parentList = (
+            blockList.get(parentKey) ?
+              blockList :
+              blockList.set(parentKey, new Immutable.Map({
+                firstLevelBlocks: new Immutable.OrderedMap(),
+                childrenBlocks: new Immutable.Set()
+              }))
           );
 
-          return mergedParent;
-        }
+          // add current block to parent children list
+          const addBlockToParentList = parentList.setIn([parentKey, 'firstLevelBlocks', key], block);
+          const addGrandChildren = addBlockToParentList.setIn(
+            [parentKey, 'childrenBlocks'],
+            addBlockToParentList.getIn([parentKey, 'childrenBlocks'])
+              .add(
+                // we include all the current block children and itself
+                addBlockToParentList.getIn([key, 'firstLevelBlocks']).set(key, block)
+              )
+          );
 
-        return blockList;
-      }, new Immutable.OrderedMap())
-      .map(blockMap => blockMap.reverse());
+          return addGrandChildren;
+        } else {
+          // Since the iteration is done backwards, we either have no children or
+          // we already have all children's defined, we should now revert back the order
+          // since we are doing a reversed loop
+          const currentBlock = blockList.getIn([key, 'firstLevelBlocks']);
+
+          // we reverse it back since we will use this to create our blocks
+          return blockList.setIn([key, 'firstLevelBlocks'], currentBlock.reverse());
+        }
+      }, new Immutable.Map());
   }
 
   getBlockChildren(key: string): BlockMap {

--- a/src/model/immutable/ContentState.js
+++ b/src/model/immutable/ContentState.js
@@ -8,7 +8,8 @@
  *
  * @providesModule ContentState
  * @typechecks
- * @flow */
+ * @flow
+ */
 'use strict';
 
 const BlockMapBuilder = require('BlockMapBuilder');
@@ -54,7 +55,6 @@ class ContentState extends ContentStateRecord {
     return block;
   }
 
-  // return all blocks
   getFirstLevelBlocks(): BlockMap {
     return this.getBlockChildren('');
   }

--- a/src/model/immutable/ContentState.js
+++ b/src/model/immutable/ContentState.js
@@ -59,6 +59,32 @@ class ContentState extends ContentStateRecord {
     return this.getBlockChildren('');
   }
 
+  getBlockDescendants(): Object {
+    return this.getBlockMap()
+      .reverse()
+      .reduce((treeMap, block) => {
+        const key = block.getKey();
+        const parentKey = block.getParentKey();
+        const blockList = treeMap.set(key, treeMap.get(key) || new Immutable.OrderedMap());
+
+        if (parentKey) {
+          const parentList = blockList.set(parentKey, blockList.get(parentKey) || new Immutable.OrderedMap());
+          const addBlockToParentList = parentList.setIn([parentKey, key], block);
+
+          const mergedParent = (
+            addBlockToParentList.get(key).size ?
+              addBlockToParentList.mergeIn(parentKey, addBlockToParentList.get(key)) :
+              addBlockToParentList
+          );
+
+          return mergedParent;
+        }
+
+        return blockList;
+      }, new Immutable.OrderedMap())
+      .map(blockMap => blockMap.reverse());
+  }
+
   getBlockChildren(key: string): BlockMap {
     return this.getBlockMap()
     .filter(function(block) {

--- a/src/model/immutable/ContentState.js
+++ b/src/model/immutable/ContentState.js
@@ -56,6 +56,17 @@ class ContentState extends ContentStateRecord {
     return block;
   }
 
+  getFirstLevelBlocks(): BlockMap {
+    return this.getBlockChildren('');
+  }
+
+  getBlockChildren(key: string): BlockMap {
+    return this.getBlockMap()
+    .filter(function(block) {
+      return block.getParentKey() === key;
+    });
+  }
+
   getKeyBefore(key: string): ?string {
     return this.getBlockMap()
       .reverse()

--- a/src/model/immutable/DefaultDraftBlockRenderMap.js
+++ b/src/model/immutable/DefaultDraftBlockRenderMap.js
@@ -24,41 +24,53 @@ const PRE_WRAP = <pre className={cx('public/DraftStyleDefault/pre')} />;
 module.exports = Map({
   'header-one': {
     element: 'h1',
+    nestingEnabled: false
   },
   'header-two': {
     element: 'h2',
+    nestingEnabled: false
   },
   'header-three': {
     element: 'h3',
+    nestingEnabled: false
   },
   'header-four': {
     element: 'h4',
+    nestingEnabled: false
   },
   'header-five': {
     element: 'h5',
+    nestingEnabled: false
   },
   'header-six': {
     element: 'h6',
+    nestingEnabled: false
   },
   'unordered-list-item': {
     element: 'li',
     wrapper: UL_WRAP,
+    nestingEnabled: false
   },
   'ordered-list-item': {
     element: 'li',
     wrapper: OL_WRAP,
+    nestingEnabled: false
   },
   'blockquote': {
     element: 'blockquote',
+    nestingEnabled: false
   },
   'atomic': {
     element: 'figure',
+    nestingEnabled: false
   },
   'code-block': {
     element: 'pre',
     wrapper: PRE_WRAP,
+    nestingEnabled: false
   },
   'unstyled': {
     element: 'div',
+    nestingEnabled: false
   },
 });

--- a/src/model/immutable/EditorChangeType.js
+++ b/src/model/immutable/EditorChangeType.js
@@ -27,5 +27,6 @@ export type EditorChangeType = (
   'remove-range' |
   'spellcheck-change' |
   'split-block' |
+  'split-nested-block' |
   'undo'
 );

--- a/src/model/immutable/EditorState.js
+++ b/src/model/immutable/EditorState.js
@@ -14,6 +14,7 @@
 
 var BlockTree = require('BlockTree');
 var ContentState = require('ContentState');
+var ContentBlock = require('ContentBlock');
 var EditorBidiService = require('EditorBidiService');
 var Immutable = require('immutable');
 var SelectionState = require('SelectionState');
@@ -21,11 +22,12 @@ var SelectionState = require('SelectionState');
 import type {BlockMap} from 'BlockMap';
 import type {DraftDecoratorType} from 'DraftDecoratorType';
 import type {DraftInlineStyle} from 'DraftInlineStyle';
-import type {List, OrderedMap} from 'immutable';
+import type {List} from 'immutable';
 import type {EditorChangeType} from 'EditorChangeType';
 
 var {
   OrderedSet,
+  OrderedMap,
   Record,
   Stack,
 } = Immutable;

--- a/src/model/immutable/EditorState.js
+++ b/src/model/immutable/EditorState.js
@@ -14,7 +14,6 @@
 
 var BlockTree = require('BlockTree');
 var ContentState = require('ContentState');
-var ContentBlock = require('ContentBlock');
 var EditorBidiService = require('EditorBidiService');
 var Immutable = require('immutable');
 var SelectionState = require('SelectionState');

--- a/src/model/immutable/__tests__/ContentBlock-test.js
+++ b/src/model/immutable/__tests__/ContentBlock-test.js
@@ -106,4 +106,29 @@ describe('ContentBlock', () => {
       expect(calls[2]).toEqual([4, 5]);
     });
   });
+
+  describe('parent key retrieval', () => {
+    it('must properly retrieve key of parent if first level', () => {
+      var block = getSampleBlock();
+      expect(block.getParentKey()).toBe('');
+    });
+
+    it('must properly retrieve key of parent if nested', () => {
+      var block = new ContentBlock({
+        key: 'a/b',
+        type: 'unstyled',
+        text: ''
+      });
+      expect(block.getParentKey()).toBe('a');
+    });
+
+    it('must properly retrieve key of parent if deep nested', () => {
+      var block = new ContentBlock({
+        key: 'a/b/b',
+        type: 'unstyled',
+        text: ''
+      });
+      expect(block.getParentKey()).toBe('a/b');
+    });
+  });
 });

--- a/src/model/immutable/__tests__/ContentState-test.js
+++ b/src/model/immutable/__tests__/ContentState-test.js
@@ -26,6 +26,13 @@ var MULTI_BLOCK = [
   {text: 'Four score', key: 'b'},
   {text: 'and seven', key: 'c'},
 ];
+var NESTED_BLOCK = [
+  {text: 'Four score', key: 'd'},
+  {text: 'and seven', key: 'e'},
+  {text: 'Nested in e', key: 'e/f'},
+  {text: 'Nested in e', key: 'e/g'},
+  {text: 'Nested in e/g', key: 'e/g/h'},
+];
 
 var SelectionState = require('SelectionState');
 
@@ -86,6 +93,43 @@ describe('ContentState', () => {
       expect(block instanceof ContentBlock).toBe(true);
       expect(block.getText()).toBe(SINGLE_BLOCK[0].text);
       expect(state.getBlockForKey('x')).toBe(undefined);
+    });
+  });
+
+  describe('nested block fetching', () => {
+    it('must retrieve nested block for key', () => {
+      var state = getSample(NESTED_BLOCK);
+      var blocks = state.getBlockChildren('e');
+
+      expect(blocks.size).toBe(2);
+      expect(blocks.has('e/f')).toBe(true);
+      expect(blocks.has('e/g')).toBe(true);
+    });
+
+    it('must retrieve nested block for a deeper key', () => {
+      var state = getSample(NESTED_BLOCK);
+      var blocks = state.getBlockChildren('e/g');
+
+      expect(blocks.size).toBe(1);
+      expect(blocks.has('e/g/h')).toBe(true);
+    });
+
+    it('must return an empty map if none', () => {
+      var state = getSample(NESTED_BLOCK);
+      var blocks = state.getBlockChildren('d');
+
+      expect(blocks.size).toBe(0);
+    });
+  });
+
+  describe('first level block fetching', () => {
+    it('must retrieve first level block', () => {
+      var state = getSample(NESTED_BLOCK);
+      var blocks = state.getFirstLevelBlocks();
+
+      expect(blocks.size).toBe(2);
+      expect(blocks.has('d')).toBe(true);
+      expect(blocks.has('e')).toBe(true);
     });
   });
 });

--- a/src/model/keys/__tests__/generateNestedKey-test.js
+++ b/src/model/keys/__tests__/generateNestedKey-test.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+ui_infra
+ */
+
+'use strict';
+
+jest.disableAutomock();
+
+const generateNestedKey = require('generateNestedKey');
+
+describe('generateNestedKey', () => {
+  const parentKey = 'foo';
+
+  it('must generate a new nested key for a parentKey', () => {
+    const newNestedKey = generateNestedKey(parentKey);
+    const newNestedKeyArr = newNestedKey.split('/');
+
+    expect(newNestedKey).not.toBe(parentKey);
+    expect(newNestedKeyArr.length).toBe(2);
+    expect(newNestedKeyArr[0]).toBe(parentKey);
+  });
+
+  it('must allow child key to be used to generate a a new nested key for a parentKey', () => {
+    const childKey = 'bar';
+    const newNestedKey = generateNestedKey(parentKey, childKey);
+    const newNestedKeyArr = newNestedKey.split('/');
+
+    expect(newNestedKey).not.toBe(parentKey);
+    expect(newNestedKeyArr.length).toBe(2);
+    expect(newNestedKeyArr[1]).toBe(childKey);
+  });
+});

--- a/src/model/keys/__tests__/randomizeBlockMapKeys-test.js
+++ b/src/model/keys/__tests__/randomizeBlockMapKeys-test.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+ui_infra
+ */
+
+'use strict';
+
+jest.disableAutomock();
+
+const getSampleStateForTesting = require('getSampleStateForTesting');
+const getSampleStateForTestingNestedBlocks = require('getSampleStateForTestingNestedBlocks');
+
+const randomizeBlockMapKeys = require('randomizeBlockMapKeys');
+
+describe('randomizeBlockMapKeys', () => {
+  it('must randomize blockMap keys', () => {
+    const {
+      contentState
+    } = getSampleStateForTesting();
+
+    const blockMap = contentState.getBlockMap();
+    const blockKeys = blockMap.keySeq().toArray();
+
+    const newBlockMap = randomizeBlockMapKeys(blockMap);
+    const newKeys = newBlockMap.keySeq().toArray();
+
+    expect(blockKeys).not.toBe(newKeys);
+    expect(blockMap.first().getText()).toBe(newBlockMap.first().getText());
+    expect(blockMap.first().getKey()).not.toBe(newBlockMap.first().getKey());
+    expect(blockKeys.length).toBe(newKeys.length);
+  });
+
+  it('must randomize blockMap keys with nesting enabled', () => {
+    const {
+      contentState
+    } = getSampleStateForTestingNestedBlocks();
+
+    const blockMap = contentState.getBlockMap();
+    const blockKeys = blockMap.keySeq().toArray();
+
+    const blockWithParent = blockMap.skip(2).first();
+    const blockWithParentKeyArr = blockWithParent.getKey().split('/');
+
+    const newBlockMap = randomizeBlockMapKeys(blockMap);
+    const newKeys = newBlockMap.keySeq().toArray();
+
+    const newBlockWithParent = newBlockMap.skip(2).first();
+    const newBlockWithParentKeyArr = newBlockWithParent.getKey().split('/');
+
+    expect(blockKeys).not.toBe(newKeys);
+    expect(blockMap.first().getText()).toBe(newBlockMap.first().getText());
+    expect(blockMap.first().getKey()).not.toBe(newBlockMap.first().getKey());
+    expect(blockWithParent.getKey()).not.toBe(newBlockWithParent.getKey());
+    expect(blockWithParentKeyArr.length).toBe(newBlockWithParentKeyArr.length);
+    expect(blockKeys.length).toBe(newKeys.length);
+  });
+
+  it('must retain parent key from fragment that has not supplied a parent block', () => {
+    const {
+      contentState
+    } = getSampleStateForTestingNestedBlocks();
+
+    const blockMap = contentState.getBlockMap().skip(2); // not including 'a' and root block 'b'
+    const blockKeys = blockMap.keySeq().toArray();
+
+    const blockWithParent = blockMap.first();
+    const blockWithParentKeyArr = blockWithParent.getKey().split('/');
+
+    const newBlockMap = randomizeBlockMapKeys(blockMap);
+    const newKeys = newBlockMap.keySeq().toArray();
+
+    const newBlockWithParent = newBlockMap.first();
+    const newBlockWithParentKeyArr = newBlockWithParent.getKey().split('/');
+
+    expect(blockKeys).not.toBe(newKeys);
+    expect(blockMap.first().getText()).toBe(newBlockMap.first().getText());
+    expect(blockMap.first().getKey()).not.toBe(newBlockMap.first().getKey());
+    expect(blockWithParent.getKey()).not.toBe(newBlockWithParent.getKey());
+    expect(blockWithParentKeyArr.length).toBe(newBlockWithParentKeyArr.length);
+    expect(blockKeys.length).toBe(newKeys.length);
+  });
+});

--- a/src/model/keys/generateNestedKey.js
+++ b/src/model/keys/generateNestedKey.js
@@ -13,14 +13,19 @@
 
 'use strict';
 
-var generateRandomKey = require('generateRandomKey');
+const generateRandomKey = require('generateRandomKey');
 
+/*
+ * Returns a nested key based on a parent key. If a child key is
+ * supplied it will be used, otherwise a new random key will be
+ * created.
+ */
 function generateNestedKey(
   parentKey: string,
   childKey: ?string
 ): string {
-  childKey = childKey || generateRandomKey();
-  return parentKey + '/' + childKey;
+  const key = childKey || generateRandomKey();
+  return parentKey + '/' + key;
 }
 
 module.exports = generateNestedKey;

--- a/src/model/keys/generateNestedKey.js
+++ b/src/model/keys/generateNestedKey.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule generateNestedKey
+ * @typechecks
+ * @flow
+ */
+
+'use strict';
+
+var generateRandomKey = require('generateRandomKey');
+
+function generateNestedKey(
+  parentKey: string,
+  childKey: ?string
+): string {
+  childKey = childKey || generateRandomKey();
+  return parentKey + '/' + childKey;
+}
+
+module.exports = generateNestedKey;

--- a/src/model/keys/randomizeBlockMapKeys.js
+++ b/src/model/keys/randomizeBlockMapKeys.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule randomizeBlockMapKeys
+ * @typechecks
+ * @flow
+ */
+
+'use strict';
+
+const BlockMapBuilder = require('BlockMapBuilder');
+const ContentBlock = require('ContentBlock');
+const generateNestedKey = require('generateNestedKey');
+const generateRandomKey = require('generateRandomKey');
+
+import type {BlockMap} from 'BlockMap';
+
+/*
+ * Returns a new randomized keys blockmap that will
+ * also respect nesting keys rules
+ */
+function randomizeBlockMapKeys(
+  blockMap: BlockMap
+): BlockMap {
+  let newKeyHashMap = {};
+  const contentBlocks = (
+    blockMap
+    .map((block, blockKey) => {
+      const parentKey = block.getParentKey();
+
+      const newKey = newKeyHashMap[blockKey] = (
+        parentKey ?
+          newKeyHashMap[parentKey] ? // we could be inserting just a fragment
+            generateNestedKey(newKeyHashMap[parentKey]) :
+            generateNestedKey(parentKey) :
+          generateRandomKey()
+      );
+
+      return new ContentBlock({
+        key: newKey,
+        type: block.getType(),
+        depth: block.getDepth(),
+        text: block.getText(),
+        characterList: block.getCharacterList()
+      });
+    })
+    .toArray()
+  );
+
+  return BlockMapBuilder.createFromArray(contentBlocks);
+}
+
+module.exports = randomizeBlockMapKeys;

--- a/src/model/modifier/AtomicBlockUtils.js
+++ b/src/model/modifier/AtomicBlockUtils.js
@@ -21,6 +21,7 @@ const EditorState = require('EditorState');
 const Immutable = require('immutable');
 
 const generateRandomKey = require('generateRandomKey');
+const generateNestedKey = require('generateNestedKey');
 
 const {
   List,
@@ -35,6 +36,9 @@ const AtomicBlockUtils = {
   ): EditorState {
     const contentState = editorState.getCurrentContent();
     const selectionState = editorState.getSelection();
+    const targetKey = selectionState.getStartKey();
+    const targetBlock = contentState.getBlockForKey(targetKey);
+    const targetBlockParentKey = targetBlock.getParentKey();
 
     const afterRemoval = DraftModifier.removeRange(
       contentState,
@@ -56,13 +60,13 @@ const AtomicBlockUtils = {
 
     const fragmentArray = [
       new ContentBlock({
-        key: generateRandomKey(),
+        key: targetBlockParentKey ? generateNestedKey(targetBlockParentKey) : generateRandomKey(),
         type: 'atomic',
         text: character,
         characterList: List(Repeat(charData, character.length)),
       }),
       new ContentBlock({
-        key: generateRandomKey(),
+        key: targetBlockParentKey ? generateNestedKey(targetBlockParentKey) : generateRandomKey(),
         type: 'unstyled',
         text: '',
         characterList: List(),

--- a/src/model/modifier/NestedTextEditorUtil.js
+++ b/src/model/modifier/NestedTextEditorUtil.js
@@ -18,7 +18,6 @@ const EditorState = require('EditorState');
 const Immutable = require('immutable');
 const generateNestedKey = require('generateNestedKey');
 const generateRandomKey = require('generateRandomKey');
-const splitBlockInContentState = require('splitBlockInContentState');
 const splitBlockWithNestingInContentState = require('splitBlockWithNestingInContentState');
 
 import type {

--- a/src/model/modifier/NestedTextEditorUtil.js
+++ b/src/model/modifier/NestedTextEditorUtil.js
@@ -22,17 +22,29 @@ const NestedTextEditorUtil = {
     editorState: EditorState,
     command: DraftEditorCommand
   ): ?EditorState {
+    var selectionState = editorState.getSelection();
+    var contentState = editorState.getCurrentContent();
+    var key = selectionState.getAnchorKey();
+    var nestedBlocks = contentState.getBlockChildren(key);
+
+    if (command === 'split-block' && nestedBlocks.size > 0) {
+      command = 'split-nested-block';
+    }
+
     switch (command) {
       case 'split-nested-block':
-        var contentState = splitNestedBlockInContentState(
-          editorState.getCurrentContent(),
-          editorState.getSelection()
-        );
+        contentState = splitNestedBlockInContentState(contentState, selectionState);
         return EditorState.push(editorState, contentState, 'split-nested-block');
       default:
         return null;
     }
   },
+
+  keyBinding: function(e) {
+    if (e.keyCode === 13 /* `Enter` key */ && e.shiftKey) {
+      return 'split-nested-block';
+    }
+  }
 
 };
 

--- a/src/model/modifier/NestedTextEditorUtil.js
+++ b/src/model/modifier/NestedTextEditorUtil.js
@@ -20,50 +20,58 @@ const DefaultDraftBlockRenderMap = require('DefaultDraftBlockRenderMap');
 import type {DraftEditorCommand} from 'DraftEditorCommand';
 import type {DraftBlockRenderMap} from 'DraftBlockRenderMap';
 
-var DefaultBlockRenderMap = DefaultDraftBlockRenderMap
-    .mergeWith(function(prev, next) {
-      return Immutable.fromJS(prev).merge(next).toJS();
-    }, {
-      'unordered-list-item': {
-        nestingEnabled: true
-      },
-      'ordered-list-item': {
-        nestingEnabled: true
-      },
-      'blockquote': {
-        nestingEnabled: true
-      },
 
-      // Table blocks
-      'table': {
-        element: 'table',
-        nestingEnabled: true
-      },
-      'table-header': {
-        element: 'thead',
-        nestingEnabled: true
-      },
-      'table-body': {
-        element: 'tbody',
-        nestingEnabled: true
-      },
-      'table-row': {
-        element: 'tr',
-        nestingEnabled: true
-      },
-      'table-cell': {
-        element: 'td',
-        nestingEnabled: true
-      }
-    });
+const enabledNestingConfiguration = {
+  nestingEnabled: true
+};
 
+const defaultEnabledBlocks = [
+  'unordered-list-item',
+  'ordered-list-item',
+  'blockquote',
+];
+
+const DefaultBlockRenderMap = Immutable.Map(
+  DefaultDraftBlockRenderMap.keySeq().toArray().reduce((o, v, i) => {
+    // we are manually enabling all default draft blocks to support nesting for this example
+    const blockExtendConfiguration = (
+      defaultEnabledBlocks.indexOf(v) !== -1 ?
+        enabledNestingConfiguration :
+        {}
+    );
+
+    o[v] = Object.assign({}, DefaultDraftBlockRenderMap.get(v), blockExtendConfiguration);
+    return o;
+  }, {
+    'table': {
+      element: 'table',
+      nestingEnabled: true
+    },
+    'table-body': {
+      element: 'tbody',
+      nestingEnabled: true
+    },
+    'table-header': {
+      element: 'thead',
+      nestingEnabled: true
+    },
+    'table-cell': {
+      element: 'td',
+      nestingEnabled: true
+    },
+    'table-row': {
+      element: 'tr',
+      nestingEnabled: true
+    }
+  })
+);
 
 const NestedTextEditorUtil = {
   DefaultBlockRenderMap: DefaultBlockRenderMap,
 
   handleKeyCommand: function(
     editorState: EditorState,
-    //blockRenderMap: DraftBlockRenderMap,
+    blockRenderMap: DraftBlockRenderMap,
     command: DraftEditorCommand
   ): ?EditorState {
     var selectionState = editorState.getSelection();

--- a/src/model/modifier/NestedTextEditorUtil.js
+++ b/src/model/modifier/NestedTextEditorUtil.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2013-present, Facebook, Inc.
  * All rights reserved.
  *
@@ -36,10 +36,6 @@ const {
   Repeat,
 } = Immutable;
 
-const flatten = list => list.reduce(
-  (a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), []
-);
-
 const EMPTY_CHAR = '';
 const EMPTY_CHAR_LIST = List(Repeat(CharacterMetadata.create(), EMPTY_CHAR.length));
 
@@ -47,19 +43,17 @@ const DefaultBlockRenderMap = new Immutable.Map(
   new Immutable.fromJS(
     DefaultDraftBlockRenderMap.toJS()
   ).mergeDeep(
-    new Immutable.fromJS(
-      {
-        'blockquote': {
-          nestingEnabled: true
-        },
-        'unordered-list-item':{
-          nestingEnabled: true
-        },
-        'ordered-list-item': {
-          nestingEnabled: true
-        }
+    new Immutable.fromJS({
+      'blockquote': {
+        nestingEnabled: true
+      },
+      'unordered-list-item': {
+        nestingEnabled: true
+      },
+      'ordered-list-item': {
+        nestingEnabled: true
       }
-    )
+    })
   ).toJS()
 );
 
@@ -70,67 +64,151 @@ const NestedTextEditorUtil = {
     editorState: EditorState,
     blockType: DraftBlockType,
     blockRenderMap: DefaultDraftBlockRenderMap = NestedTextEditorUtil.DefaultBlockRenderMap
-  ): EditorState {
+  ): Object {
     const contentState = editorState.getCurrentContent();
     const selectionState = editorState.getSelection();
     const currentBlock = contentState.getBlockForKey(selectionState.getStartKey());
+    const key = currentBlock.getKey();
     const renderOpt = blockRenderMap.get(currentBlock.getType());
     const hasNestingEnabled = renderOpt && renderOpt.nestingEnabled;
+    const targetTypeRenderOpt = blockRenderMap.get(blockType);
+    const parentKey = currentBlock.getParentKey();
+    const parentBlock = contentState.getBlockForKey(parentKey);
+    const parentRenderOpt = parentBlock && blockRenderMap.get(parentBlock.getType());
+    const isCousinType = (
+      renderOpt &&
+      targetTypeRenderOpt &&
+      renderOpt.element === targetTypeRenderOpt.element
+    );
+    const isParentCousinType = (
+      parentRenderOpt &&
+      targetTypeRenderOpt &&
+      parentRenderOpt.element === targetTypeRenderOpt.element
+    );
+
+    const canHandleCommand = (
+      (
+        hasNestingEnabled ||
+        targetTypeRenderOpt.nestingEnabled
+      ) &&
+      blockType !== currentBlock.getType()
+    );
+
+    if (!canHandleCommand) {
+      return {
+        editorState,
+        blockType
+      };
+    }
+
     const blockMap = contentState.getBlockMap();
 
-    // we want to move the current text to inside this block
-    if (hasNestingEnabled && blockType !== currentBlock.getType()) {
-      const targetKey = generateNestedKey(currentBlock.getKey());
-      const newContentState = ContentState.createFromBlockArray(
-        flatten(
-          blockMap
-          .filter(block => block !== null)
-          .map((block, index) => {
-            if (block === currentBlock) {
-              return [
-                new ContentBlock({
-                  key: currentBlock.getKey(),
-                  type: currentBlock.getType(),
-                  depth: currentBlock.getDepth(),
-                  text: EMPTY_CHAR,
-                  characterList: EMPTY_CHAR_LIST
-                }),
-                new ContentBlock({
-                  key: targetKey,
-                  type: 'unstyled',
-                  depth: 0,
-                  text: currentBlock.getText(),
-                  characterList: currentBlock.getCharacterList()
-                })
-              ];
-            }
-            return block;
-          })
-          .toArray()
-        )
+    if (isParentCousinType) {
+      const toggleCousinBlockContentState = ContentState.createFromBlockArray(
+        blockMap
+        .map((block, index) => {
+          if (block === parentBlock) {
+            return new ContentBlock({
+              key: block.getKey(),
+              type: blockType,
+              depth: block.getDepth(),
+              text: block.getText(),
+              characterList: block.getCharacterList()
+            });
+          }
+          if (block === currentBlock) {
+            return new ContentBlock({
+              key: block.getKey(),
+              // since we use the toggleUtils together with RichUtils we
+              // need to update this type to something else so that it does not get
+              // toggled and instead just get restored
+              // this is a temporary hack while nesting tree is not a first customer
+              type: 'unstyled',
+              depth: block.getDepth(),
+              text: block.getText(),
+              characterList: block.getCharacterList()
+            });
+          }
+          return block;
+        })
+        .toArray()
       );
 
-      return EditorState.push(
+      return {
+        editorState: EditorState.push(
+          editorState,
+          toggleCousinBlockContentState.merge({
+            selectionBefore: selectionState,
+            selectionAfter: selectionState.merge({
+              anchorKey: key,
+              anchorOffset: selectionState.getAnchorOffset(),
+              focusKey: key,
+              focusOffset: selectionState.getFocusOffset(),
+              isBackward: false,
+            })
+          }),
+          'change-block-type'
+        ),
+        blockType: currentBlock.getType() // we then send the original type to be restored
+      };
+    }
+
+    // we want to move the current text to inside this block
+    const targetKey = generateNestedKey(key);
+
+    const newContentState = ContentState.createFromBlockArray(
+      blockMap
+      .map((block, index) => {
+        if (block === currentBlock) {
+          if (isCousinType) {
+            return new ContentBlock({
+              key: key,
+              type: 'unstyled',
+              depth: currentBlock.getDepth(),
+              text: currentBlock.getText(),
+              characterList: currentBlock.getCharacterList()
+            });
+          } else {
+            return [
+              new ContentBlock({
+                key: key,
+                type: currentBlock.getType(),
+                depth: currentBlock.getDepth(),
+                text: EMPTY_CHAR,
+                characterList: EMPTY_CHAR_LIST
+              }),
+              new ContentBlock({
+                key: targetKey,
+                type: 'unstyled',
+                depth: 0,
+                text: currentBlock.getText(),
+                characterList: currentBlock.getCharacterList()
+              })
+            ];
+          }
+        }
+        return block;
+      })
+      .reduce((a, b) => a.concat(b), [])
+    );
+
+    return {
+      editorState: EditorState.push(
         editorState,
         newContentState.merge({
           selectionBefore: selectionState,
           selectionAfter: selectionState.merge({
-            anchorKey: targetKey,
+            anchorKey: isCousinType ? key : targetKey,
             anchorOffset: selectionState.getAnchorOffset(),
-            focusKey: targetKey,
+            focusKey: isCousinType ? key : targetKey,
             focusOffset: selectionState.getFocusOffset(),
             isBackward: false,
           })
         }),
         'change-block-type'
-      );
-    }
-
-    // check if the current block has nesting prop enabled
-    // create a new unstyled block and transfer the text to it
-    // restore selection to this block
-
-    return editorState;
+      ),
+      blockType
+    };
   },
 
   handleKeyCommand: function(
@@ -138,18 +216,16 @@ const NestedTextEditorUtil = {
     command: DraftEditorCommand,
     blockRenderMap: DraftBlockRenderMap = DefaultBlockRenderMap
   ): ? EditorState {
-    var selectionState = editorState.getSelection();
-    var contentState = editorState.getCurrentContent();
-    var key = selectionState.getAnchorKey();
+    const selectionState = editorState.getSelection();
+    const contentState = editorState.getCurrentContent();
+    const key = selectionState.getAnchorKey();
 
-    var currentBlock = contentState.getBlockForKey(key);
-    var nestedBlocks = contentState.getBlockChildren(key);
+    const currentBlock = contentState.getBlockForKey(key);
+    const nestedBlocks = contentState.getBlockChildren(key);
 
-    var parentKey = currentBlock.getParentKey();
-    var parentBlock = parentKey ? contentState.getBlockForKey(parentKey) : null;
-    var previousBlock = contentState.getBlockBefore(key);
-    var nextBlock = contentState.getBlockAfter(key);
-    var isCollapsed = selectionState.isCollapsed();
+    const parentKey = currentBlock.getParentKey();
+    const parentBlock = contentState.getBlockForKey(parentKey);
+    const nextBlock = contentState.getBlockAfter(key);
 
     // Option of rendering for the current block
     const renderOpt = blockRenderMap.get(currentBlock.getType());
@@ -164,12 +240,10 @@ const NestedTextEditorUtil = {
     if (command === 'split-block') {
       if (
         currentBlock.hasParent() &&
-        (
-          !hasNestingEnabled ||
+        (!hasNestingEnabled ||
           currentBlock.getLength() === 0
         ) &&
-        (
-          !nextBlock ||
+        (!nextBlock ||
           (
             hasWrapper &&
             nextBlock.getType() !== currentBlock.getType()
@@ -190,222 +264,21 @@ const NestedTextEditorUtil = {
     }
 
     // Prevent creation of nested blocks
-    if (!hasNestingEnabled && command == 'split-nested-block') {
+    if (!hasNestingEnabled && command === 'split-nested-block') {
       command = 'split-block';
     }
 
     switch (command) {
       case 'backspace':
-        if (
-          isCollapsed &&
-          selectionState.getEndOffset() === 0 &&
-          previousBlock &&
-          previousBlock.getKey() === currentBlock.getParentKey()
-        ) {
-          const targetBlock = getFirstAvailableLeafBeforeBlock(
-            currentBlock,
-            contentState
-          );
-
-          if (targetBlock === currentBlock) {
-            return null;
-          }
-
-          const blockMap = contentState.getBlockMap();
-
-          const targetKey = targetBlock.getKey();
-
-          const newContentState = ContentState.createFromBlockArray(
-            flatten(
-              blockMap
-              .filter(block => block !== null)
-              .map((block, index) => {
-                if (!targetBlock && previousBlock === block) {
-                  return [
-                    new ContentBlock({
-                      key: targetKey,
-                      type: currentBlock.getType(),
-                      depth: currentBlock.getDepth(),
-                      text: currentBlock.getText(),
-                      characterList: currentBlock.getCharacterList()
-                    }),
-                    block
-                  ];
-                } else if (targetBlock && block === targetBlock) {
-                  return new ContentBlock({
-                    key: targetKey,
-                    type: targetBlock.getType(),
-                    depth: targetBlock.getDepth(),
-                    text: targetBlock.getText() + currentBlock.getText(),
-                    characterList: targetBlock.getCharacterList().concat(currentBlock.getCharacterList())
-                  });
-                }
-                return block;
-              })
-              .filter(block => block !== currentBlock)
-              .toArray()
-            )
-          );
-
-          const selectionOffset = newContentState.getBlockForKey(targetKey).getLength();
-
-          return EditorState.push(
-            editorState,
-            newContentState.merge({
-              selectionBefore: selectionState,
-              selectionAfter: selectionState.merge({
-                anchorKey: targetKey,
-                anchorOffset: selectionOffset,
-                focusKey: targetKey,
-                focusOffset: selectionOffset,
-                isBackward: false,
-              })
-            }),
-            'backspace-character'
-          );
-        }
-        break;
+        return NestedTextEditorUtil.onBackspace(editorState, blockRenderMap);
       case 'delete':
-        // are pressing delete while being just befefore a block that has children
-        // we want instead to move the block and all its children up to this block if it supports nesting
-        // otherwise split the children right after in case it doesnt
-        if (
-          nextBlock &&
-          isCollapsed &&
-          selectionState.getEndOffset() === currentBlock.getLength() &&
-          contentState.getBlockChildren(
-            nextBlock.getKey()
-          ).size
-        ) {
-          // find the first descendand from the nextElement
-          const blockMap = contentState.getBlockMap();
-
-          // the previous block is invalid so we need a new target
-          const targetBlock = getFirstAvailableLeafAfterBlock(currentBlock, contentState);
-
-          const newContentState = ContentState.createFromBlockArray(
-            flatten(
-              blockMap
-              .filter(block => block !== null)
-              .map((block, index) => {
-                if (block === currentBlock) {
-                  return new ContentBlock({
-                    key: key,
-                    type: currentBlock.getType(),
-                    depth: currentBlock.getDepth(),
-                    text: currentBlock.getText() + targetBlock.getText(),
-                    characterList: currentBlock.getCharacterList().concat(targetBlock.getCharacterList())
-                  });
-                }
-                return block;
-              })
-              .filter(block => block !== targetBlock)
-              .toArray()
-            )
-          );
-
-          const selectionOffset = currentBlock.getLength();
-
-          return EditorState.push(
-            editorState,
-            newContentState.merge({
-              selectionBefore: selectionState,
-              selectionAfter: selectionState.merge({
-                anchorKey: key,
-                anchorOffset: selectionOffset,
-                focusKey: key,
-                focusOffset: selectionOffset,
-                isBackward: false,
-              })
-            }),
-            'delete-character'
-          );
-        }
-        break;
+        return NestedTextEditorUtil.onDelete(editorState, blockRenderMap);
       case 'split-block':
-        if (selectionState.isCollapsed()) {
-          contentState = splitBlockInContentState(contentState, selectionState);
-          return EditorState.push(editorState, contentState, 'split-block');
-        }
-        break;
-
+        return NestedTextEditorUtil.onSplitBlock(editorState, blockRenderMap);
       case 'split-nested-block':
-        contentState = splitBlockWithNestingInContentState(contentState, selectionState);
-        return EditorState.push(editorState, contentState, 'split-block');
-
+        return NestedTextEditorUtil.onSplitNestedBlock(editorState, blockRenderMap);
       case 'split-parent-block':
-        const blockMap = contentState.getBlockMap();
-        const parentBlock = contentState.getBlockForKey(parentKey);
-
-        const targetKey = (
-          hasWrapper ?
-            generateNestedKey(parentKey) :
-            parentBlock.getParentKey() ?
-              generateNestedKey(parentBlock.getParentKey()) :
-              generateRandomKey()
-        );
-
-        const newContentState = ContentState.createFromBlockArray(
-          flatten(
-            blockMap
-            .filter(block => block !== null)
-            .map((block, index) => {
-              if (block === currentBlock) {
-                const splittedBlockType = (
-                  !parentHasWrapper && (hasWrapper || !parentBlock.getParentKey()) ?
-                  'unstyled' :
-                  parentBlock.getType()
-                );
-                const splittedBlock = new ContentBlock({
-                  key: targetKey,
-                  type: splittedBlockType,
-                  depth: parentBlock ? parentBlock.getDepth() : 0,
-                  text: currentBlock.getText().slice(selectionState.getEndOffset()),
-                  characterList: currentBlock.getCharacterList().slice(selectionState.getEndOffset())
-                });
-
-                // if we are on an empty block when we split we should remove it
-                // therefore we only return the splitted block
-                if (
-                  currentBlock.getLength() === 0 &&
-                  contentState.getBlockChildren(key).size === 0
-                ) {
-                  return splittedBlock;
-                }
-
-                return [
-                  new ContentBlock({
-                    key: block.getKey(),
-                    type: block.getType(),
-                    depth: block.getDepth(),
-                    text: currentBlock.getText().slice(0, selectionState.getStartOffset()),
-                    characterList: currentBlock.getCharacterList().slice(0, selectionState.getStartOffset())
-                  }),
-                  splittedBlock
-                ];
-              }
-              return block;
-            })
-            .filter(block => block !== null)
-            .toArray()
-          )
-        );
-
-        return EditorState.push(
-          editorState,
-          newContentState.merge({
-            selectionBefore: selectionState,
-            selectionAfter: selectionState.merge({
-              anchorKey: targetKey,
-              anchorOffset: 0,
-              focusKey: targetKey,
-              focusOffset: 0,
-              isBackward: false,
-            })
-          }),
-          'split-block'
-        );
-
+        return NestedTextEditorUtil.onSplitParent(editorState, blockRenderMap);
       default:
         return null;
     }
@@ -415,6 +288,288 @@ const NestedTextEditorUtil = {
     if (e.keyCode === 13 /* `Enter` key */ && e.shiftKey) {
       return 'split-nested-block';
     }
+  },
+
+  onBackspace: function(
+    editorState: EditorState,
+    blockRenderMap: DraftBlockRenderMap = DefaultBlockRenderMap
+  ): ? EditorState {
+    const selectionState = editorState.getSelection();
+    const isCollapsed = selectionState.isCollapsed();
+    const contentState = editorState.getCurrentContent();
+    const key = selectionState.getAnchorKey();
+
+    const currentBlock = contentState.getBlockForKey(key);
+    const previousBlock = contentState.getBlockBefore(key);
+
+    const canHandleCommand = (
+      isCollapsed &&
+      selectionState.getEndOffset() === 0 &&
+      previousBlock &&
+      previousBlock.getKey() === currentBlock.getParentKey()
+    );
+
+    if (!canHandleCommand) {
+      return null;
+    }
+
+    const targetBlock = getFirstAvailableLeafBeforeBlock(
+      currentBlock,
+      contentState
+    );
+
+    if (targetBlock === currentBlock) {
+      return null;
+    }
+
+    const blockMap = contentState.getBlockMap();
+
+    const targetKey = targetBlock.getKey();
+
+    const newContentState = ContentState.createFromBlockArray(
+      blockMap
+      .filter(block => block !== null)
+      .map((block, index) => {
+        if (!targetBlock && previousBlock === block) {
+          return [
+            new ContentBlock({
+              key: targetKey,
+              type: currentBlock.getType(),
+              depth: currentBlock.getDepth(),
+              text: currentBlock.getText(),
+              characterList: currentBlock.getCharacterList()
+            }),
+            block
+          ];
+        } else if (targetBlock && block === targetBlock) {
+          return new ContentBlock({
+            key: targetKey,
+            type: targetBlock.getType(),
+            depth: targetBlock.getDepth(),
+            text: targetBlock.getText() + currentBlock.getText(),
+            characterList: targetBlock.getCharacterList().concat(currentBlock.getCharacterList())
+          });
+        }
+        return block;
+      })
+      .filter(block => block !== currentBlock)
+      .reduce((a, b) => a.concat(b), [])
+    );
+
+    const selectionOffset = newContentState.getBlockForKey(targetKey).getLength();
+
+    return EditorState.push(
+      editorState,
+      newContentState.merge({
+        selectionBefore: selectionState,
+        selectionAfter: selectionState.merge({
+          anchorKey: targetKey,
+          anchorOffset: selectionOffset,
+          focusKey: targetKey,
+          focusOffset: selectionOffset,
+          isBackward: false,
+        })
+      }),
+      'backspace-character'
+    );
+  },
+
+  onDelete: function(
+    editorState: EditorState,
+    blockRenderMap: DraftBlockRenderMap = DefaultBlockRenderMap
+  ): ? EditorState {
+    const selectionState = editorState.getSelection();
+    const contentState = editorState.getCurrentContent();
+    const key = selectionState.getAnchorKey();
+
+    const currentBlock = contentState.getBlockForKey(key);
+
+    const nextBlock = contentState.getBlockAfter(key);
+    const isCollapsed = selectionState.isCollapsed();
+
+    const canHandleCommand = (
+      nextBlock &&
+      isCollapsed &&
+      selectionState.getEndOffset() === currentBlock.getLength() &&
+      contentState.getBlockChildren(
+        nextBlock.getKey()
+      ).size
+    );
+
+    if (!canHandleCommand) {
+      return null;
+    }
+
+    // are pressing delete while being just befefore a block that has children
+    // we want instead to move the block and all its children up to this block if it supports nesting
+    // otherwise split the children right after in case it doesnt
+    // find the first descendand from the nextElement
+    const blockMap = contentState.getBlockMap();
+
+    // the previous block is invalid so we need a new target
+    const targetBlock = getFirstAvailableLeafAfterBlock(currentBlock, contentState);
+
+    const newContentState = ContentState.createFromBlockArray(
+      blockMap
+      .filter(block => block !== null)
+      .map((block, index) => {
+        if (block === currentBlock) {
+          return new ContentBlock({
+            key: key,
+            type: currentBlock.getType(),
+            depth: currentBlock.getDepth(),
+            text: currentBlock.getText() + targetBlock.getText(),
+            characterList: currentBlock.getCharacterList().concat(targetBlock.getCharacterList())
+          });
+        }
+        return block;
+      })
+      .filter(block => block !== targetBlock)
+      .reduce((a, b) => a.concat(b), [])
+    );
+
+    const selectionOffset = currentBlock.getLength();
+
+    return EditorState.push(
+      editorState,
+      newContentState.merge({
+        selectionBefore: selectionState,
+        selectionAfter: selectionState.merge({
+          anchorKey: key,
+          anchorOffset: selectionOffset,
+          focusKey: key,
+          focusOffset: selectionOffset,
+          isBackward: false,
+        })
+      }),
+      'delete-character'
+    );
+
+  },
+
+  onSplitBlock: function(
+    editorState: EditorState,
+    blockRenderMap: DraftBlockRenderMap = DefaultBlockRenderMap
+  ): ? EditorState {
+    const contentState = editorState.getCurrentContent();
+    const selectionState = editorState.getSelection();
+
+    const canHandleCommand = selectionState.isCollapsed();
+
+    if (!canHandleCommand) {
+      return null;
+    }
+
+    return EditorState.push(
+      editorState,
+      splitBlockInContentState(contentState, selectionState),
+      'split-block'
+    );
+  },
+
+  onSplitNestedBlock: function(
+    editorState: EditorState,
+    blockRenderMap: DraftBlockRenderMap = DefaultBlockRenderMap
+  ): ? EditorState {
+    const selectionState = editorState.getSelection();
+    const contentState = editorState.getCurrentContent();
+
+    return EditorState.push(
+      editorState,
+      splitBlockWithNestingInContentState(contentState, selectionState),
+      'split-block'
+    );
+  },
+
+  onSplitParent: function(
+    editorState: EditorState,
+    blockRenderMap: DraftBlockRenderMap = DefaultBlockRenderMap
+  ): ? EditorState {
+    const selectionState = editorState.getSelection();
+    const contentState = editorState.getCurrentContent();
+    const key = selectionState.getAnchorKey();
+
+    const currentBlock = contentState.getBlockForKey(key);
+
+    const parentKey = currentBlock.getParentKey();
+    const parentBlock = contentState.getBlockForKey(parentKey);
+
+    // Option of rendering for the current block
+    const renderOpt = blockRenderMap.get(currentBlock.getType());
+    const parentRenderOpt = parentBlock && blockRenderMap.get(parentBlock.getType());
+
+    const hasWrapper = renderOpt && renderOpt.wrapper;
+
+    const parentHasWrapper = parentRenderOpt && parentRenderOpt.wrapper;
+
+    const blockMap = contentState.getBlockMap();
+
+    const targetKey = (
+      hasWrapper ?
+      generateNestedKey(parentKey) :
+      parentBlock && parentBlock.getParentKey() ?
+      generateNestedKey(parentBlock.getParentKey()) :
+      generateRandomKey()
+    );
+
+    const newContentState = ContentState.createFromBlockArray(
+      blockMap
+      .filter(block => block !== null)
+      .map((block, index) => {
+        if (block === currentBlock) {
+          const splittedBlockType = (!parentHasWrapper && (hasWrapper || !parentBlock.getParentKey()) ?
+            'unstyled' :
+            parentBlock.getType()
+          );
+          const splittedBlock = new ContentBlock({
+            key: targetKey,
+            type: splittedBlockType,
+            depth: parentBlock ? parentBlock.getDepth() : 0,
+            text: currentBlock.getText().slice(selectionState.getEndOffset()),
+            characterList: currentBlock.getCharacterList().slice(selectionState.getEndOffset())
+          });
+
+          // if we are on an empty block when we split we should remove it
+          // therefore we only return the splitted block
+          if (
+            currentBlock.getLength() === 0 &&
+            contentState.getBlockChildren(key).size === 0
+          ) {
+            return splittedBlock;
+          }
+
+          return [
+            new ContentBlock({
+              key: block.getKey(),
+              type: block.getType(),
+              depth: block.getDepth(),
+              text: currentBlock.getText().slice(0, selectionState.getStartOffset()),
+              characterList: currentBlock.getCharacterList().slice(0, selectionState.getStartOffset())
+            }),
+            splittedBlock
+          ];
+        }
+        return block;
+      })
+      .filter(block => block !== null)
+      .reduce((a, b) => a.concat(b), [])
+    );
+
+    return EditorState.push(
+      editorState,
+      newContentState.merge({
+        selectionBefore: selectionState,
+        selectionAfter: selectionState.merge({
+          anchorKey: targetKey,
+          anchorOffset: 0,
+          focusKey: targetKey,
+          focusOffset: 0,
+          isBackward: false,
+        })
+      }),
+      'split-block'
+    );
+
   }
 };
 
@@ -425,8 +580,7 @@ function getFirstAvailableLeafBeforeBlock(
 ): ContentBlock {
   let previousLeafBlock = contentState.getBlockBefore(block.getKey());
 
-  while (
-    !!previousLeafBlock &&
+  while (!!previousLeafBlock &&
     contentState.getBlockChildren(previousLeafBlock.getKey()).size !== 0 &&
     !condition(previousLeafBlock)
   ) {
@@ -443,8 +597,7 @@ function getFirstAvailableLeafAfterBlock(
 ): ContentBlock {
   let nextLeafBlock = contentState.getBlockAfter(block.getKey());
 
-  while (
-    !!nextLeafBlock &&
+  while (!!nextLeafBlock &&
     contentState.getBlockChildren(nextLeafBlock.getKey()).size !== 0 &&
     contentState.getBlockAfter(nextLeafBlock.getKey()) &&
     !condition(nextLeafBlock)

--- a/src/model/modifier/NestedTextEditorUtil.js
+++ b/src/model/modifier/NestedTextEditorUtil.js
@@ -273,8 +273,6 @@ const NestedTextEditorUtil = {
         return NestedTextEditorUtil.onBackspace(editorState, blockRenderMap);
       case 'delete':
         return NestedTextEditorUtil.onDelete(editorState, blockRenderMap);
-      case 'split-block':
-        return NestedTextEditorUtil.onSplitBlock(editorState, blockRenderMap);
       case 'split-nested-block':
         return NestedTextEditorUtil.onSplitNestedBlock(editorState, blockRenderMap);
       case 'split-parent-block':
@@ -445,26 +443,6 @@ const NestedTextEditorUtil = {
       'delete-character'
     );
 
-  },
-
-  onSplitBlock: function(
-    editorState: EditorState,
-    blockRenderMap: DraftBlockRenderMap = DefaultBlockRenderMap
-  ): ? EditorState {
-    const contentState = editorState.getCurrentContent();
-    const selectionState = editorState.getSelection();
-
-    const canHandleCommand = selectionState.isCollapsed();
-
-    if (!canHandleCommand) {
-      return null;
-    }
-
-    return EditorState.push(
-      editorState,
-      splitBlockInContentState(contentState, selectionState),
-      'split-block'
-    );
   },
 
   onSplitNestedBlock: function(

--- a/src/model/modifier/NestedTextEditorUtil.js
+++ b/src/model/modifier/NestedTextEditorUtil.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule NestedTextEditorUtil
+ * @typechecks
+ * @flow
+ */
+
+const EditorState = require('EditorState');
+const splitNestedBlockInContentState = require('splitNestedBlockInContentState');
+
+import type {DraftEditorCommand} from 'DraftEditorCommand';
+
+const NestedTextEditorUtil = {
+
+  handleKeyCommand: function(
+    editorState: EditorState,
+    command: DraftEditorCommand
+  ): ?EditorState {
+    switch (command) {
+      case 'split-nested-block':
+        var contentState = splitNestedBlockInContentState(
+          editorState.getCurrentContent(),
+          editorState.getSelection()
+        );
+        return EditorState.push(editorState, contentState, 'split-nested-block');
+      default:
+        return null;
+    }
+  },
+
+};
+
+module.exports = NestedTextEditorUtil;

--- a/src/model/modifier/NestedTextEditorUtil.js
+++ b/src/model/modifier/NestedTextEditorUtil.js
@@ -10,16 +10,35 @@
  * @typechecks
  * @flow
  */
-
-const Immutable = require('immutable');
+const CharacterMetadata = require('CharacterMetadata');
+const ContentBlock = require('ContentBlock');
+const ContentState = require('ContentState');
+const DefaultDraftBlockRenderMap = require('DefaultDraftBlockRenderMap');
 const EditorState = require('EditorState');
+const Immutable = require('immutable');
+const generateNestedKey = require('generateNestedKey');
+const generateRandomKey = require('generateRandomKey');
 const splitBlockInContentState = require('splitBlockInContentState');
 const splitBlockWithNestingInContentState = require('splitBlockWithNestingInContentState');
-const DefaultDraftBlockRenderMap = require('DefaultDraftBlockRenderMap');
 
-import type {DraftEditorCommand} from 'DraftEditorCommand';
-import type {DraftBlockRenderMap} from 'DraftBlockRenderMap';
+import type {
+  DraftBlockType
+} from 'DraftBlockType';
+import type {
+  DraftEditorCommand
+} from 'DraftEditorCommand';
+import type {
+  DraftBlockRenderMap
+} from 'DraftBlockRenderMap';
 
+const {
+  List,
+  Repeat,
+} = Immutable;
+
+const flatten = list => list.reduce(
+  (a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), []
+);
 
 const enabledNestingConfiguration = {
   nestingEnabled: true
@@ -31,13 +50,15 @@ const defaultEnabledBlocks = [
   'blockquote',
 ];
 
+const EMPTY_CHAR = '';
+const EMPTY_CHAR_LIST = List(Repeat(CharacterMetadata.create(), EMPTY_CHAR.length));
+
 const DefaultBlockRenderMap = Immutable.Map(
   DefaultDraftBlockRenderMap.keySeq().toArray().reduce((o, v, i) => {
     // we are manually enabling all default draft blocks to support nesting for this example
     const blockExtendConfiguration = (
       defaultEnabledBlocks.indexOf(v) !== -1 ?
-        enabledNestingConfiguration :
-        {}
+      enabledNestingConfiguration : {}
     );
 
     o[v] = Object.assign({}, DefaultDraftBlockRenderMap.get(v), blockExtendConfiguration);
@@ -69,11 +90,78 @@ const DefaultBlockRenderMap = Immutable.Map(
 const NestedTextEditorUtil = {
   DefaultBlockRenderMap: DefaultBlockRenderMap,
 
+  toggleBlockType: function(
+    editorState: EditorState,
+    blockType: DraftBlockType,
+    blockRenderMap: DefaultDraftBlockRenderMap = NestedTextEditorUtil.DefaultBlockRenderMap
+  ): EditorState {
+    const contentState = editorState.getCurrentContent();
+    const selectionState = editorState.getSelection();
+    const currentBlock = contentState.getBlockForKey(selectionState.getStartKey());
+    const renderOpt = blockRenderMap.get(currentBlock.getType());
+    const hasNestingEnabled = renderOpt && renderOpt.nestingEnabled;
+    const blockMap = contentState.getBlockMap();
+
+    // we want to move the current text to inside this block
+    if (hasNestingEnabled && blockType !== currentBlock.getType()) {
+      const targetKey = generateNestedKey(currentBlock.getKey());
+      const newContentState = ContentState.createFromBlockArray(
+        flatten(
+          blockMap
+          .filter(block => block !== null)
+          .map((block, index) => {
+            if (block === currentBlock) {
+              return [
+                new ContentBlock({
+                  key: currentBlock.getKey(),
+                  type: currentBlock.getType(),
+                  depth: currentBlock.getDepth(),
+                  text: EMPTY_CHAR,
+                  characterList: EMPTY_CHAR_LIST
+                }),
+                new ContentBlock({
+                  key: targetKey,
+                  type: 'unstyled',
+                  depth: 0,
+                  text: currentBlock.getText(),
+                  characterList: currentBlock.getCharacterList()
+                })
+              ];
+            }
+            return block;
+          })
+          .toArray()
+        )
+      );
+
+      return EditorState.push(
+        editorState,
+        newContentState.merge({
+          selectionBefore: selectionState,
+          selectionAfter: selectionState.merge({
+            anchorKey: targetKey,
+            anchorOffset: selectionState.getAnchorOffset(),
+            focusKey: targetKey,
+            focusOffset: selectionState.getFocusOffset(),
+            isBackward: false,
+          })
+        }),
+        'change-block-type'
+      );
+    }
+
+    // check if the current block has nesting prop enabled
+    // create a new unstyled block and transfer the text to it
+    // restore selection to this block
+
+    return editorState;
+  },
+
   handleKeyCommand: function(
     editorState: EditorState,
-    blockRenderMap: DraftBlockRenderMap,
-    command: DraftEditorCommand
-  ): ?EditorState {
+    command: DraftEditorCommand,
+    blockRenderMap: DraftBlockRenderMap = DefaultBlockRenderMap
+  ): ? EditorState {
     var selectionState = editorState.getSelection();
     var contentState = editorState.getCurrentContent();
     var key = selectionState.getAnchorKey();
@@ -81,18 +169,41 @@ const NestedTextEditorUtil = {
     var currentBlock = contentState.getBlockForKey(key);
     var nestedBlocks = contentState.getBlockChildren(key);
 
+    var parentKey = currentBlock.getParentKey();
+    var parentBlock = parentKey ? contentState.getBlockForKey(parentKey) : null;
+    var previousBlock = contentState.getBlockBefore(key);
+    var nextBlock = contentState.getBlockAfter(key);
+    var isCollapsed = selectionState.isCollapsed();
+
     // Option of rendering for the current block
-    var renderOpt = blockRenderMap.get(currentBlock.getType());
-    var hasNestingEnabled = renderOpt && renderOpt.nestingEnabled;
+    const renderOpt = blockRenderMap.get(currentBlock.getType());
+    const parentRenderOpt = parentBlock && blockRenderMap.get(parentBlock.getType());
+
+    const hasNestingEnabled = renderOpt && renderOpt.nestingEnabled;
+    const hasWrapper = renderOpt && renderOpt.wrapper;
+
+    const parentHasWrapper = parentRenderOpt && parentRenderOpt.wrapper;
 
     // Press enter
     if (command === 'split-block') {
-      var nextBlock = contentState.getBlockAfter(key);
-
-      // In an empty last nested block
-      if (currentBlock.hasParent()
-      && currentBlock.getLength() === 0
-      && (!nextBlock || nextBlock.getParentKey() !== currentBlock.getParentKey())) {
+      if (
+        currentBlock.hasParent() &&
+        (
+          !hasNestingEnabled ||
+          currentBlock.getLength() === 0
+        ) &&
+        (
+          !nextBlock ||
+          (
+            hasWrapper &&
+            nextBlock.getType() !== currentBlock.getType()
+          ) ||
+          (
+            nextBlock.getParentKey() !== currentBlock.getParentKey() &&
+            (currentBlock.getLength() === 0 || parentHasWrapper)
+          )
+        )
+      ) {
         command = 'split-parent-block';
       }
 
@@ -104,10 +215,135 @@ const NestedTextEditorUtil = {
 
     // Prevent creation of nested blocks
     if (!hasNestingEnabled && command == 'split-nested-block') {
-      command = 'split-block'
+      command = 'split-block';
     }
 
     switch (command) {
+      case 'backspace':
+        if (
+          isCollapsed &&
+          selectionState.getEndOffset() === 0 &&
+          previousBlock &&
+          previousBlock.getKey() === currentBlock.getParentKey()
+        ) {
+          const blockMap = contentState.getBlockMap();
+
+          // the previous block is invalid so we need a new target
+          const targetBlock = contentState.getBlockBefore(
+            getAncestorBlock(currentBlock, contentState).getKey()
+          );
+
+          // if we dont have any targetBlock its because the invalid block
+          // is the first block on the array so we need to create a new block before it
+          const targetKey = targetBlock ? targetBlock.getKey() : generateRandomKey();
+
+          const newContentState = ContentState.createFromBlockArray(
+            flatten(
+              blockMap
+              .filter(block => block !== null)
+              .map((block, index) => {
+                if (!targetBlock && previousBlock === block) {
+                  return [
+                    new ContentBlock({
+                      key: targetKey,
+                      type: currentBlock.getType(),
+                      depth: currentBlock.getDepth(),
+                      text: currentBlock.getText(),
+                      characterList: currentBlock.getCharacterList()
+                    }),
+                    block
+                  ];
+                } else if (targetBlock && block === targetBlock) {
+                  return new ContentBlock({
+                    key: targetKey,
+                    type: targetBlock.getType(),
+                    depth: targetBlock.getDepth(),
+                    text: targetBlock.getText() + currentBlock.getText(),
+                    characterList: targetBlock.getCharacterList().concat(currentBlock.getCharacterList())
+                  });
+                }
+                return block;
+              })
+              .filter(block => block !== currentBlock)
+              .toArray()
+            )
+          );
+
+          const selectionOffset = newContentState.getBlockForKey(targetKey).getLength();
+
+          return EditorState.push(
+            editorState,
+            newContentState.merge({
+              selectionBefore: selectionState,
+              selectionAfter: selectionState.merge({
+                anchorKey: targetKey,
+                anchorOffset: selectionOffset,
+                focusKey: targetKey,
+                focusOffset: selectionOffset,
+                isBackward: false,
+              })
+            }),
+            'backspace-character'
+          );
+        }
+        break;
+      case 'delete':
+        // are pressing delete while being just befefore a block that has children
+        // we want instead to move the block and all its children up to this block if it supports nesting
+        // otherwise split the children right after in case it doesnt
+        if (
+          nextBlock &&
+          isCollapsed &&
+          selectionState.getEndOffset() === currentBlock.getLength() &&
+          contentState.getBlockChildren(
+            nextBlock.getKey()
+          ).size
+        ) {
+          // find the first descendand from the nextElement
+          const blockMap = contentState.getBlockMap();
+
+          // the previous block is invalid so we need a new target
+          const targetBlock = getFirstLeafBlock(nextBlock, contentState);
+
+          const newContentState = ContentState.createFromBlockArray(
+            flatten(
+              blockMap
+              .filter(block => block !== null)
+              .map((block, index) => {
+                if (block === currentBlock) {
+                  return new ContentBlock({
+                    key: key,
+                    type: currentBlock.getType(),
+                    depth: currentBlock.getDepth(),
+                    text: currentBlock.getText() + targetBlock.getText(),
+                    characterList: currentBlock.getCharacterList().concat(targetBlock.getCharacterList())
+                  });
+                }
+                return block;
+              })
+              .filter(block => block !== targetBlock)
+              .toArray()
+            )
+          );
+
+          const selectionOffset = currentBlock.getLength();
+
+          return EditorState.push(
+            editorState,
+            newContentState.merge({
+              selectionBefore: selectionState,
+              selectionAfter: selectionState.merge({
+                anchorKey: key,
+                anchorOffset: selectionOffset,
+                focusKey: key,
+                focusOffset: selectionOffset,
+                isBackward: false,
+              })
+            }),
+            'delete-character'
+          );
+        }
+        break;
       case 'split-block':
         contentState = splitBlockInContentState(contentState, selectionState);
         return EditorState.push(editorState, contentState, 'split-block');
@@ -117,25 +353,72 @@ const NestedTextEditorUtil = {
         return EditorState.push(editorState, contentState, 'split-block');
 
       case 'split-parent-block':
-        var parentKey = currentBlock.getParentKey();
+        const blockMap = contentState.getBlockMap();
+        const parentBlock = contentState.getBlockForKey(parentKey);
 
-        // Split parent block
-        var parentSelection = selectionState.merge({
-          anchorKey: parentKey,
-          anchorOffset: 0,
-          focusKey: parentKey,
-          focusOffset: 0,
-          isBackward: false,
-        });
-        contentState = splitBlockInContentState(contentState, parentSelection);
-
-        // Remove current block (the empty one)
-        contentState = contentState.set('blockMap',
-          contentState.getBlockMap()
-          .filter(block => block !== currentBlock)
+        const targetKey = (
+          hasWrapper ?
+            generateNestedKey(parentKey) :
+            parentBlock.getParentKey() ?
+              generateNestedKey(parentBlock.getParentKey()) :
+              generateRandomKey()
         );
 
-        return EditorState.push(editorState, contentState, 'split-block');
+        const newContentState = ContentState.createFromBlockArray(
+          flatten(
+            blockMap
+            .filter(block => block !== null)
+            .map((block, index) => {
+              if (block === currentBlock) {
+                const splittedBlock = new ContentBlock({
+                  key: targetKey,
+                  type: hasWrapper || !parentBlock.getParentKey() ? 'unstyled' : parentBlock.getType(),
+                  depth: parentBlock ? parentBlock.getDepth() : 0,
+                  text: currentBlock.getText().slice(selectionState.getEndOffset()),
+                  characterList: currentBlock.getCharacterList().slice(selectionState.getEndOffset())
+                });
+
+                // if we are on an empty block when we split we should remove it
+                // therefore we only return the splitted block
+                if (
+                  currentBlock.getLength() === 0 &&
+                  contentState.getBlockChildren(key).size === 0
+                ) {
+                  return splittedBlock;
+                }
+
+                return [
+                  new ContentBlock({
+                    key: block.getKey(),
+                    type: block.getType(),
+                    depth: block.getDepth(),
+                    text: currentBlock.getText().slice(0, selectionState.getEndOffset()),
+                    characterList: currentBlock.getCharacterList().slice(0, selectionState.getEndOffset())
+                  }),
+                  splittedBlock
+                ];
+              }
+              return block;
+            })
+            .filter(block => block !== null)
+            .toArray()
+          )
+        );
+
+        return EditorState.push(
+          editorState,
+          newContentState.merge({
+            selectionBefore: selectionState,
+            selectionAfter: selectionState.merge({
+              anchorKey: targetKey,
+              anchorOffset: 0,
+              focusKey: targetKey,
+              focusOffset: 0,
+              isBackward: false,
+            })
+          }),
+          'split-block'
+        );
 
       default:
         return null;
@@ -147,7 +430,38 @@ const NestedTextEditorUtil = {
       return 'split-nested-block';
     }
   }
-
 };
+
+function getAncestorBlock(
+  block: ContentBlock,
+  contentState: ContentState,
+  condition: Function = function() {
+    return true;
+  }
+): ContentBlock {
+  while (!!block &&
+    block.getParentKey() !== '' &&
+    condition(block)
+  ) {
+    block = contentState.getBlockForKey(block.getParentKey());
+  }
+  return block;
+}
+
+function getFirstLeafBlock(
+  block: ContentBlock,
+  contentState: ContentState,
+  condition: Function = function() {
+    return true;
+  }
+): ContentBlock {
+  while (!!block &&
+    contentState.getBlockChildren(block.getKey()).size > 0 &&
+    condition(block)
+  ) {
+    block = contentState.getBlockChildren(block.getKey()).first();
+  }
+  return block;
+}
 
 module.exports = NestedTextEditorUtil;

--- a/src/model/modifier/NestedTextEditorUtil.js
+++ b/src/model/modifier/NestedTextEditorUtil.js
@@ -40,7 +40,7 @@ const NestedTextEditorUtil = {
     }
   },
 
-  keyBinding: function(e) {
+  keyBinding: function(e: SyntheticKeyboardEvent) {
     if (e.keyCode === 13 /* `Enter` key */ && e.shiftKey) {
       return 'split-nested-block';
     }

--- a/src/model/modifier/NestedTextEditorUtil.js
+++ b/src/model/modifier/NestedTextEditorUtil.js
@@ -80,8 +80,10 @@ const NestedTextEditorUtil = {
 
     var currentBlock = contentState.getBlockForKey(key);
     var nestedBlocks = contentState.getBlockChildren(key);
-    /*var renderOpt = blockRenderMap.get(currentBlock.getType());
-    var hasNestingEnabled = renderOpt && renderOpt.nestingEnabled;*/
+
+    // Option of rendering for the current block
+    var renderOpt = blockRenderMap.get(currentBlock.getType());
+    var hasNestingEnabled = renderOpt && renderOpt.nestingEnabled;
 
     // Press enter
     if (command === 'split-block') {
@@ -100,7 +102,16 @@ const NestedTextEditorUtil = {
       }
     }
 
+    // Prevent creation of nested blocks
+    if (!hasNestingEnabled && command == 'split-nested-block') {
+      command = 'split-block'
+    }
+
     switch (command) {
+      case 'split-block':
+        contentState = splitBlockInContentState(contentState, selectionState);
+        return EditorState.push(editorState, contentState, 'split-block');
+
       case 'split-nested-block':
         contentState = splitBlockWithNestingInContentState(contentState, selectionState);
         return EditorState.push(editorState, contentState, 'split-block');

--- a/src/model/modifier/__tests__/NestedTextEditorUtil-test.js
+++ b/src/model/modifier/__tests__/NestedTextEditorUtil-test.js
@@ -1,0 +1,366 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails isaac, oncall+ui_infra
+ */
+
+jest.disableAutomock();
+
+const EditorState = require('EditorState');
+
+const NestedTextEditorUtil = require('NestedTextEditorUtil');
+const getSampleStateForTestingNestedBlocks = require('getSampleStateForTestingNestedBlocks');
+
+describe('NestedTextEditorUtil', () => {
+  const {
+    editorState,
+    selectionState
+  } = getSampleStateForTestingNestedBlocks();
+
+  describe('onBackspace', () => {
+    const {
+      onBackspace
+    } = NestedTextEditorUtil;
+
+    it('does not handle non-zero-offset or non-collapsed selections', () => {
+      const nonZero = selectionState.merge({
+        anchorKey: 'b/c',
+        focusKey: 'b/c',
+        anchorOffset: 7,
+        focusOffset: 7
+      });
+      expect(
+        onBackspace(EditorState.forceSelection(editorState, nonZero))
+      ).toBe(
+        null
+      );
+
+      const nonCollapsed = nonZero.merge({
+        anchorOffset: 0
+      });
+      expect(
+        onBackspace(EditorState.forceSelection(editorState, nonCollapsed))
+      ).toBe(
+        null
+      );
+    });
+
+    it('does not handle if the previous block is not its parent', () => {
+      const nonFirstChild = selectionState.merge({
+        anchorKey: 'b/d',
+        focusKey: 'b/d',
+        anchorOffset: 0,
+        focusOffset: 0
+      });
+
+      expect(
+        onBackspace(EditorState.forceSelection(editorState, nonFirstChild))
+      ).toBe(
+        null
+      );
+    });
+
+    it('backspace on the start of a leaf block should remove block and merge text to previous leaf', () => {
+      const contentState = editorState.getCurrentContent();
+      const targetBlock = contentState.getBlockForKey('a');
+      const oldBlock = contentState.getBlockForKey('b/c');
+
+      const firstChildLeaf = selectionState.merge({
+        anchorKey: 'b/c',
+        focusKey: 'b/c',
+        anchorOffset: 0,
+        focusOffset: 0
+      });
+
+      const deletedState = onBackspace(
+        EditorState.forceSelection(editorState, firstChildLeaf)
+      );
+      const newContentState = deletedState.getCurrentContent();
+      const transformedTargetBlock = newContentState.getBlockForKey('a');
+
+      const expectedText = targetBlock.getText() + oldBlock.getText();
+
+      expect(
+        transformedTargetBlock.getText()
+      ).toBe(
+        expectedText
+      );
+
+      expect(
+        newContentState.getBlockForKey('b/c')
+      ).toBe(
+        undefined
+      );
+    });
+  });
+
+  describe('onDelete', () => {
+    const {
+      onDelete
+    } = NestedTextEditorUtil;
+
+    it('does not handle non-block-end or non-collapsed selections', () => {
+      const nonBlockEnd = selectionState.merge({
+        anchorKey: 'a',
+        focusKey: 'a',
+        anchorOffset: 0,
+        focusOffset: 0
+      });
+      expect(
+        onDelete(EditorState.forceSelection(editorState, nonBlockEnd))
+      ).toBe(
+        null
+      );
+
+      const nonCollapsed = nonBlockEnd.merge({
+        anchorOffset: 5,
+      });
+      expect(
+        onDelete(EditorState.forceSelection(editorState, nonCollapsed))
+      ).toBe(
+        null
+      );
+    });
+
+    it('does not handle if it is the last block on the blockMap', () => {
+      const lastBlock = selectionState.merge({
+        anchorKey: 'f',
+        focusKey: 'f',
+        anchorOffset: 7,
+        focusOffset: 7
+      });
+      expect(
+        onDelete(EditorState.forceSelection(editorState, lastBlock))
+      ).toBe(
+        null
+      );
+    });
+
+    it('does not handle if the next block has no children', () => {
+      const noChildrenSelection = selectionState.merge({
+        anchorKey: 'b/d/e',
+        focusKey: 'b/d/e',
+        anchorOffset: 4,
+        focusOffset: 4
+      });
+      expect(
+        onDelete(EditorState.forceSelection(editorState, noChildrenSelection))
+      ).toBe(
+        null
+      );
+    });
+
+    it('delete on the end of a leaf block should remove block and merge text to previous leaf', () => {
+      const contentState = editorState.getCurrentContent();
+      const targetBlock = contentState.getBlockForKey('a');
+      const oldBlock = contentState.getBlockForKey('b/c');
+
+      const firstChildLeaf = selectionState.merge({
+        anchorKey: 'a',
+        focusKey: 'a',
+        anchorOffset: targetBlock.getLength(),
+        focusOffset: targetBlock.getLength()
+      });
+
+      const deletedState = onDelete(
+        EditorState.forceSelection(editorState, firstChildLeaf)
+      );
+      const newContentState = deletedState.getCurrentContent();
+      const transformedTargetBlock = newContentState.getBlockForKey('a');
+
+      const expectedText = targetBlock.getText() + oldBlock.getText();
+
+      expect(
+        transformedTargetBlock.getText()
+      ).toBe(
+        expectedText
+      );
+
+      expect(
+        newContentState.getBlockForKey('b/c')
+      ).toBe(
+        undefined
+      );
+    });
+  });
+
+  describe('onSplitBlock', () => {
+    const {
+      onSplitBlock
+    } = NestedTextEditorUtil;
+
+    it('does not handle non-collapsed selections', () => {
+      const nonZero = selectionState.merge({
+        anchorKey: 'b/c',
+        focusKey: 'b/c',
+        anchorOffset: 1,
+        focusOffset: 0
+      });
+      expect(
+        onSplitBlock(EditorState.forceSelection(editorState, nonZero))
+      ).toBe(
+        null
+      );
+    });
+  });
+
+  describe('toggleBlockType', () => {
+    const {
+      toggleBlockType,
+      DefaultBlockRenderMap
+    } = NestedTextEditorUtil;
+
+    it('does not handle non nesting enabled blocks', () => {
+      const nestingDisabledBlock = selectionState.merge({
+        anchorKey: 'a',
+        focusKey: 'a'
+      });
+      const selectedBlockState = EditorState.forceSelection(
+        editorState,
+        nestingDisabledBlock
+      );
+      expect(
+        toggleBlockType(
+          selectedBlockState,
+          'header-two',
+          DefaultBlockRenderMap
+        ).editorState
+      ).toBe(
+        selectedBlockState
+      );
+    });
+
+    it('does not handle nesting enabled blocks with same blockType', () => {
+      const nestingDisabledBlock = selectionState.merge({
+        anchorKey: 'b',
+        focusKey: 'b'
+      });
+      const selectedBlockState = EditorState.forceSelection(
+        editorState,
+        nestingDisabledBlock
+      );
+      expect(
+        toggleBlockType(
+          selectedBlockState,
+          'blockquote',
+          DefaultBlockRenderMap
+        ).editorState
+      ).toBe(
+        selectedBlockState
+      );
+    });
+
+    // Example:
+    //
+    // Having the cursor on the H1 and trying to change blocktype to unordered-list
+    // it should not update h1 instead it should udate its parent block type
+    //
+    // ordered-list > h1
+    // should become
+    // unordered-list > h1
+    it('should change parent block type when changing type for same tag element', () => {
+      const selectedBlock = selectionState.merge({
+        anchorKey: 'b/d/e',
+        focusKey: 'b/d/e'
+      });
+      const selectedBlockState = EditorState.forceSelection(
+        editorState,
+        selectedBlock
+      );
+      const toggledState = toggleBlockType(
+          selectedBlockState,
+          'ordered-list-item',
+          DefaultBlockRenderMap
+      ).editorState;
+
+      const parentBlockType = editorState.getCurrentContent().getBlockForKey('b/d');
+      const updatedParentBlockType = toggledState.getCurrentContent().getBlockForKey('b/d');
+
+      expect(parentBlockType.getType()).toBe('unordered-list-item');
+      expect(updatedParentBlockType.getType()).toBe('ordered-list-item');
+    });
+
+    // Example:
+    //
+    // Changing the block type inside a nested enable block that has text should
+    // transfer it's text to a nested unstyled block example
+    //
+    // blockquote > ordered-list-item
+    // should become
+    // blockquote > ordered-list-item > unstyled
+    //
+    it('should retain parent type and create a new nested block with text from parent', () => {
+      const targetBlockKey = 'b/d';
+      const selectedBlock = selectionState.merge({
+        anchorKey: targetBlockKey,
+        focusKey: targetBlockKey,
+        focusOffset: 0,
+        anchorOffset: 0
+      });
+      const selectedBlockState = EditorState.forceSelection(
+        editorState,
+        selectedBlock
+      );
+      const toggledState = toggleBlockType(
+          selectedBlockState,
+          'unstyled',
+          DefaultBlockRenderMap
+      ).editorState;
+
+      const oldContentState = editorState.getCurrentContent();
+      const newContentState = toggledState.getCurrentContent();
+
+      const initialBlock = oldContentState.getBlockForKey(targetBlockKey);
+      const updatedBlock = newContentState.getBlockForKey(targetBlockKey);
+      const newBlock = newContentState.getBlockAfter(targetBlockKey);
+
+      expect(oldContentState.getBlockChildren(targetBlockKey).size).toBe(1);
+      expect(newContentState.getBlockChildren(targetBlockKey).size).toBe(2);
+      expect(initialBlock.getType()).toBe(updatedBlock.getType());
+      expect(updatedBlock.getText()).toBe('');
+      expect(newBlock.getText()).toBe(initialBlock.getText());
+      expect(newBlock.getType()).toBe('unstyled');
+    });
+  });
+
+  describe('onSplitParent', () => {
+    const {
+      onSplitParent,
+      DefaultBlockRenderMap
+    } = NestedTextEditorUtil;
+
+    const contentState = editorState.getCurrentContent();
+
+    it('must split a nested block retaining parent', () => {
+      const selectedBlock = selectionState.merge({
+        anchorKey: 'b/d',
+        focusKey: 'b/d',
+        focusOffset: 0,
+        anchorOffset: 0
+      });
+      const selectedBlockState = EditorState.forceSelection(
+        editorState,
+        selectedBlock
+      );
+      const afterSplit = onSplitParent(selectedBlockState, DefaultBlockRenderMap).getCurrentContent();
+      const afterBlockMap = afterSplit.getBlockMap();
+      const initialBlock = contentState.getBlockForKey('b/d');
+      const splittedBlock = afterSplit.getBlockForKey('b/d');
+      const newBlock = afterSplit.getBlockAfter('b/d');
+
+      expect(editorState.getCurrentContent().getBlockMap().size).toBe(6);
+      expect(afterBlockMap.size).toBe(7);
+
+      expect(splittedBlock.getText()).toBe('');
+      expect(splittedBlock.getType()).toBe(initialBlock.getType());
+      expect(newBlock.getText()).toBe(initialBlock.getText());
+      expect(newBlock.getType()).toBe('unstyled');
+      expect(newBlock.getParentKey()).toBe(initialBlock.getParentKey());
+    });
+  });
+});

--- a/src/model/modifier/__tests__/NestedTextEditorUtil-test.js
+++ b/src/model/modifier/__tests__/NestedTextEditorUtil-test.js
@@ -189,26 +189,6 @@ describe('NestedTextEditorUtil', () => {
     });
   });
 
-  describe('onSplitBlock', () => {
-    const {
-      onSplitBlock
-    } = NestedTextEditorUtil;
-
-    it('does not handle non-collapsed selections', () => {
-      const nonZero = selectionState.merge({
-        anchorKey: 'b/c',
-        focusKey: 'b/c',
-        anchorOffset: 1,
-        focusOffset: 0
-      });
-      expect(
-        onSplitBlock(EditorState.forceSelection(editorState, nonZero))
-      ).toBe(
-        null
-      );
-    });
-  });
-
   describe('toggleBlockType', () => {
     const {
       toggleBlockType,

--- a/src/model/paste/__tests__/DraftPasteProcessor-test.js
+++ b/src/model/paste/__tests__/DraftPasteProcessor-test.js
@@ -424,19 +424,17 @@ describe('DraftPasteProcessor when nesting support is enabled', function() {
     );
 
     assertBlockIsChildrenOf(output[1], output[0]);
-    assertBlockIsChildrenOf(output[2], output[1]);
 
     assertBlockTypes(output, [
       'blockquote',
-      'header-one',
-      'unstyled',
+      'header-one'
     ]);
   });
 
-  it('leaft block should wrap text on unstyled block', function() {
+  it('leaft with text and blocks should wrap text on unstyled', function() {
     var nestingText = 'nesting enabled block';
     var html = `
-      <li>${nestingText}</li>
+      <li>${nestingText}<h1>foo</h1></li>
     `;
 
     var output = DraftPasteProcessor.processHTML(
@@ -449,7 +447,8 @@ describe('DraftPasteProcessor when nesting support is enabled', function() {
 
     assertBlockTypes(output, [
       'unordered-list-item',
-      'unstyled'
+      'unstyled',
+      'header-one'
     ]);
 
     assertBlockIsChildrenOf(unstyledBlock, listBlock);

--- a/src/model/transaction/__tests__/getContentStateFragment-test.js
+++ b/src/model/transaction/__tests__/getContentStateFragment-test.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+ui_infra
+ */
+
+'use strict';
+
+jest.disableAutomock();
+
+const getContentStateFragment = require('getContentStateFragment');
+const getSampleStateForTesting = require('getSampleStateForTesting');
+const getSampleStateForTestingNestedBlocks = require('getSampleStateForTestingNestedBlocks');
+
+describe('getContentStateFragment', () => {
+  it('must return a new blockMap with randomized block keys', () => {
+    const {
+      contentState,
+      selectionState,
+    } = getSampleStateForTesting();
+
+    const selection = selectionState.merge({
+      focusKey: 'c'
+    });
+
+    const blockMap = contentState.getBlockMap();
+    const blockKeys = blockMap.keySeq().toArray();
+
+    const newBlockMap = getContentStateFragment(contentState, selection);
+    const newKeys = newBlockMap.keySeq().toArray();
+
+    expect(blockKeys).not.toBe(newKeys);
+    expect(blockMap.first().getText()).toBe(newBlockMap.first().getText());
+    expect(blockMap.skip(1).first().getText()).toBe(newBlockMap.skip(1).first().getText());
+    expect(blockMap.last().getText()).toBe(newBlockMap.last().getText());
+    expect(blockKeys.length).toBe(newKeys.length);
+  });
+
+  it('must return a new blockMap with randomized block keys with nesting enabled', () => {
+    const {
+      contentState,
+      selectionState,
+    } = getSampleStateForTestingNestedBlocks();
+
+    const selection = selectionState.merge({
+      focusKey: 'f'
+    });
+
+    const blockMap = contentState.getBlockMap();
+    const blockKeys = blockMap.keySeq().toArray();
+
+    const newBlockMap = getContentStateFragment(contentState, selection);
+    const newKeys = newBlockMap.keySeq().toArray();
+
+    expect(blockKeys).not.toBe(newKeys);
+    expect(blockMap.first().getText()).toBe(newBlockMap.first().getText());
+    expect(blockMap.skip(1).first().getText()).toBe(newBlockMap.skip(1).first().getText());
+    expect(blockMap.last().getText()).toBe(newBlockMap.last().getText());
+    expect(blockKeys.length).toBe(newKeys.length);
+  });
+});

--- a/src/model/transaction/__tests__/insertFragmentIntoContentState-test.js
+++ b/src/model/transaction/__tests__/insertFragmentIntoContentState-test.js
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+ui_infra
+ */
+
+'use strict';
+
+jest.disableAutomock();
+
+const insertFragmentIntoContentState = require('insertFragmentIntoContentState');
+
+const getSampleStateForTesting = require('getSampleStateForTesting');
+const getSampleStateForTestingNestedBlocks = require('getSampleStateForTestingNestedBlocks');
+
+describe('insertFragmentIntoContentState+', () => {
+  it('must randomize fragment keys and insert blocks at the end of last block text', () => {
+    const {
+      contentState,
+      selectionState,
+    } = getSampleStateForTesting();
+
+    const blockMap = contentState.getBlockMap();
+    const blockKeys = blockMap.keySeq().toArray();
+
+    const fisrtBlock = blockMap.first();
+    const lastBlock = blockMap.last();
+
+    const selection = selectionState.merge({
+      focusKey: lastBlock.getKey(),
+      anchorKey: lastBlock.getKey(),
+      focusOffset: lastBlock.getLength(),
+      anchorOffset:  lastBlock.getLength()
+    });
+
+    // we are trying to use the current blockMap to insert and replace the existing one
+    const fragmentBlockMap = contentState.getBlockMap();
+    const newKeys = fragmentBlockMap.keySeq().toArray();
+
+    const newContentState = insertFragmentIntoContentState(
+      contentState,
+      selection,
+      fragmentBlockMap
+    );
+
+    const newBlockMap = newContentState.getBlockMap();
+
+    expect(blockKeys).not.toBe(newKeys);
+    expect(lastBlock.getText() + fisrtBlock.getText()).toBe(newBlockMap.skip(2).first().getText());
+    expect(blockMap.last().getText()).toBe(newBlockMap.last().getText());
+  });
+
+  it('must randomize fragment keys and insert blocks at the end of last block text with nesting enabled', () => {
+    const {
+      contentState,
+      selectionState,
+    } = getSampleStateForTestingNestedBlocks();
+
+    const blockMap = contentState.getBlockMap();
+    const blockKeys = blockMap.keySeq().toArray();
+
+    const fisrtBlock = blockMap.first();
+    const lastBlock = blockMap.last();
+
+    const selection = selectionState.merge({
+      focusKey: lastBlock.getKey(),
+      anchorKey: lastBlock.getKey(),
+      focusOffset: lastBlock.getLength(),
+      anchorOffset:  lastBlock.getLength()
+    });
+
+    // we are trying to use the current blockMap to insert and replace the existing one
+    const fragmentBlockMap = contentState.getBlockMap();
+    const newKeys = fragmentBlockMap.keySeq().toArray();
+
+    const newContentState = insertFragmentIntoContentState(
+      contentState,
+      selection,
+      fragmentBlockMap
+    );
+
+    const newBlockMap = newContentState.getBlockMap();
+
+    expect(blockKeys).not.toBe(newKeys);
+    expect(lastBlock.getText() + fisrtBlock.getText()).toBe(newBlockMap.skip(5).first().getText());
+    expect(blockMap.last().getText()).toBe(newBlockMap.last().getText());
+  });
+});

--- a/src/model/transaction/__tests__/splitBlockWithNestingInContentState-test.js
+++ b/src/model/transaction/__tests__/splitBlockWithNestingInContentState-test.js
@@ -1,0 +1,195 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+ui_infra
+ */
+
+'use strict';
+
+jest.disableAutomock();
+
+var Immutable = require('immutable');
+var getSampleStateForTesting = require('getSampleStateForTesting');
+var splitBlockWithNestingInContentState = require('splitBlockWithNestingInContentState');
+
+describe('splitBlockWithNestingInContentState', () => {
+  var {
+    contentState,
+    selectionState,
+  } = getSampleStateForTesting();
+
+  function checkForCharacterList(block) {
+    expect(Immutable.List.isList(block.getCharacterList())).toBe(true);
+  }
+
+  function getInlineStyles(block) {
+    return block.getCharacterList().map(c => c.getStyle()).toJS();
+  }
+
+  function getEntities(block) {
+    return block.getCharacterList().map(c => c.getEntity()).toJS();
+  }
+
+  it('must be restricted to collapsed selections', () => {
+    expect(() => {
+      var nonCollapsed = selectionState.set('focusOffset', 1);
+      return splitBlockWithNestingInContentState(contentState, nonCollapsed);
+    }).toThrow();
+
+    expect(() => {
+      return splitBlockWithNestingInContentState(contentState, selectionState);
+    }).not.toThrow();
+  });
+
+  it('must split at the beginning of a block', () => {
+    var initialBlock = contentState.getBlockMap().first();
+    var afterSplit = splitBlockWithNestingInContentState(contentState, selectionState);
+    var afterBlockMap = afterSplit.getBlockMap();
+    expect(afterBlockMap.size).toBe(5);
+
+    var preSplitBlock = afterBlockMap.first();
+    expect(preSplitBlock.getKey()).toBe(initialBlock.getKey());
+    expect(preSplitBlock.getText()).toBe('');
+    expect(getInlineStyles(preSplitBlock)).toEqual([]);
+    expect(getEntities(preSplitBlock)).toEqual([]);
+
+    var nestedBlocks = afterSplit.getBlockChildren(initialBlock.getKey());
+    expect(nestedBlocks.size).toBe(2);
+
+    var firstNestedBlock = nestedBlocks.first();
+    var lastNestedBlock = nestedBlocks.last();
+
+    // First block should contain nothing
+    expect(firstNestedBlock.getKey()).not.toBe(lastNestedBlock.getKey());
+    expect(firstNestedBlock.getType()).toBe(lastNestedBlock.getType());
+    expect(firstNestedBlock.getType()).toBe('unstyled');
+    expect(firstNestedBlock.getText()).toBe('');
+    expect(getInlineStyles(firstNestedBlock)).toEqual([]);
+    expect(getEntities(firstNestedBlock)).toEqual([]);
+
+    // Last block should contain everything
+    expect(lastNestedBlock.getKey()).not.toBe(firstNestedBlock.getKey());
+    expect(lastNestedBlock.getText()).toBe(initialBlock.getText());
+
+    expect(
+      getInlineStyles(initialBlock)
+    ).toEqual(
+      getInlineStyles(lastNestedBlock)
+    );
+    expect(
+      getEntities(lastNestedBlock)
+    ).toEqual(
+      getEntities(initialBlock)
+    );
+
+    checkForCharacterList(firstNestedBlock);
+    checkForCharacterList(lastNestedBlock);
+  });
+
+  it('must split within a block', () => {
+    var initialBlock = contentState.getBlockMap().first();
+    var SPLIT_OFFSET = 3;
+    var selection = selectionState.merge({
+      anchorOffset: SPLIT_OFFSET,
+      focusOffset: SPLIT_OFFSET,
+    });
+
+    var afterSplit = splitBlockWithNestingInContentState(contentState, selection);
+    var afterBlockMap = afterSplit.getBlockMap();
+    expect(afterBlockMap.size).toBe(5);
+
+    var preSplitBlock = afterBlockMap.first();
+    expect(preSplitBlock.getKey()).toBe(initialBlock.getKey());
+    expect(preSplitBlock.getText()).toBe('');
+    expect(getInlineStyles(preSplitBlock)).toEqual([]);
+    expect(getEntities(preSplitBlock)).toEqual([]);
+
+    var nestedBlocks = afterSplit.getBlockChildren(initialBlock.getKey());
+    expect(nestedBlocks.size).toBe(2);
+
+    var firstNestedBlock = nestedBlocks.first();
+    var lastNestedBlock = nestedBlocks.last();
+
+    // First block should contain everything until offset
+    expect(firstNestedBlock.getText()).toBe(initialBlock.getText().slice(0, SPLIT_OFFSET));
+    expect(
+      getInlineStyles(firstNestedBlock)
+    ).toEqual(
+      getInlineStyles(initialBlock).slice(0, SPLIT_OFFSET)
+    );
+    expect(
+      getEntities(firstNestedBlock)
+    ).toEqual(
+      getEntities(initialBlock).slice(0, SPLIT_OFFSET)
+    );
+
+    // First block should contain everything after offset
+    expect(lastNestedBlock.getText()).toBe(initialBlock.getText().slice(SPLIT_OFFSET));
+    expect(
+      getInlineStyles(lastNestedBlock)
+    ).toEqual(
+      getInlineStyles(initialBlock).slice(SPLIT_OFFSET)
+    );
+    expect(
+      getEntities(lastNestedBlock)
+    ).toEqual(
+      getEntities(initialBlock).slice(SPLIT_OFFSET)
+    );
+  });
+
+  it('must split at the end of a block', () => {
+    var initialBlock = contentState.getBlockMap().first();
+    var end = initialBlock.getLength();
+    var selection = selectionState.merge({
+      anchorOffset: end,
+      focusOffset: end,
+    });
+
+    var afterSplit = splitBlockWithNestingInContentState(contentState, selection);
+    var afterBlockMap = afterSplit.getBlockMap();
+    expect(afterBlockMap.size).toBe(5);
+
+    var preSplitBlock = afterBlockMap.first();
+    expect(preSplitBlock.getKey()).toBe(initialBlock.getKey());
+    expect(preSplitBlock.getText()).toBe('');
+    expect(getInlineStyles(preSplitBlock)).toEqual([]);
+    expect(getEntities(preSplitBlock)).toEqual([]);
+
+    var nestedBlocks = afterSplit.getBlockChildren(initialBlock.getKey());
+    expect(nestedBlocks.size).toBe(2);
+
+    var firstNestedBlock = nestedBlocks.first();
+    var lastNestedBlock = nestedBlocks.last();
+
+    expect(firstNestedBlock.getKey()).not.toBe(lastNestedBlock.getKey());
+    expect(firstNestedBlock.getType()).toBe(lastNestedBlock.getType());
+    expect(firstNestedBlock.getType()).toBe('unstyled');
+    expect(lastNestedBlock.getKey()).not.toBe(firstNestedBlock.getKey());
+
+    // First block should contain everything
+    expect(firstNestedBlock.getText()).toBe(initialBlock.getText());
+    expect(
+      getInlineStyles(firstNestedBlock)
+    ).toEqual(
+      getInlineStyles(initialBlock)
+    );
+    expect(
+      getEntities(firstNestedBlock)
+    ).toEqual(
+      getEntities(initialBlock)
+    );
+
+    // Second block should be empty
+    expect(lastNestedBlock.getText()).toBe('');
+    expect(getInlineStyles(lastNestedBlock)).toEqual([]);
+    expect(getEntities(lastNestedBlock)).toEqual([]);
+
+    checkForCharacterList(firstNestedBlock);
+    checkForCharacterList(lastNestedBlock);
+  });
+});

--- a/src/model/transaction/__tests__/splitBlockWithNestingInContentState-test.js
+++ b/src/model/transaction/__tests__/splitBlockWithNestingInContentState-test.js
@@ -18,7 +18,7 @@ var getSampleStateForTesting = require('getSampleStateForTesting');
 var splitBlockWithNestingInContentState = require('splitBlockWithNestingInContentState');
 
 describe('splitBlockWithNestingInContentState', () => {
-  var {
+  const {
     contentState,
     selectionState,
   } = getSampleStateForTesting();
@@ -37,7 +37,7 @@ describe('splitBlockWithNestingInContentState', () => {
 
   it('must be restricted to collapsed selections', () => {
     expect(() => {
-      var nonCollapsed = selectionState.set('focusOffset', 1);
+      const nonCollapsed = selectionState.set('focusOffset', 1);
       return splitBlockWithNestingInContentState(contentState, nonCollapsed);
     }).toThrow();
 
@@ -47,22 +47,22 @@ describe('splitBlockWithNestingInContentState', () => {
   });
 
   it('must split at the beginning of a block', () => {
-    var initialBlock = contentState.getBlockMap().first();
-    var afterSplit = splitBlockWithNestingInContentState(contentState, selectionState);
-    var afterBlockMap = afterSplit.getBlockMap();
+    const initialBlock = contentState.getBlockMap().first();
+    const afterSplit = splitBlockWithNestingInContentState(contentState, selectionState);
+    const afterBlockMap = afterSplit.getBlockMap();
     expect(afterBlockMap.size).toBe(5);
 
-    var preSplitBlock = afterBlockMap.first();
+    const preSplitBlock = afterBlockMap.first();
     expect(preSplitBlock.getKey()).toBe(initialBlock.getKey());
     expect(preSplitBlock.getText()).toBe('');
     expect(getInlineStyles(preSplitBlock)).toEqual([]);
     expect(getEntities(preSplitBlock)).toEqual([]);
 
-    var nestedBlocks = afterSplit.getBlockChildren(initialBlock.getKey());
+    const nestedBlocks = afterSplit.getBlockChildren(initialBlock.getKey());
     expect(nestedBlocks.size).toBe(2);
 
-    var firstNestedBlock = nestedBlocks.first();
-    var lastNestedBlock = nestedBlocks.last();
+    const firstNestedBlock = nestedBlocks.first();
+    const lastNestedBlock = nestedBlocks.last();
 
     // First block should contain nothing
     expect(firstNestedBlock.getKey()).not.toBe(lastNestedBlock.getKey());
@@ -92,28 +92,28 @@ describe('splitBlockWithNestingInContentState', () => {
   });
 
   it('must split within a block', () => {
-    var initialBlock = contentState.getBlockMap().first();
-    var SPLIT_OFFSET = 3;
-    var selection = selectionState.merge({
+    const initialBlock = contentState.getBlockMap().first();
+    const SPLIT_OFFSET = 3;
+    const selection = selectionState.merge({
       anchorOffset: SPLIT_OFFSET,
       focusOffset: SPLIT_OFFSET,
     });
 
-    var afterSplit = splitBlockWithNestingInContentState(contentState, selection);
-    var afterBlockMap = afterSplit.getBlockMap();
+    const afterSplit = splitBlockWithNestingInContentState(contentState, selection);
+    const afterBlockMap = afterSplit.getBlockMap();
     expect(afterBlockMap.size).toBe(5);
 
-    var preSplitBlock = afterBlockMap.first();
+    const preSplitBlock = afterBlockMap.first();
     expect(preSplitBlock.getKey()).toBe(initialBlock.getKey());
     expect(preSplitBlock.getText()).toBe('');
     expect(getInlineStyles(preSplitBlock)).toEqual([]);
     expect(getEntities(preSplitBlock)).toEqual([]);
 
-    var nestedBlocks = afterSplit.getBlockChildren(initialBlock.getKey());
+    const nestedBlocks = afterSplit.getBlockChildren(initialBlock.getKey());
     expect(nestedBlocks.size).toBe(2);
 
-    var firstNestedBlock = nestedBlocks.first();
-    var lastNestedBlock = nestedBlocks.last();
+    const firstNestedBlock = nestedBlocks.first();
+    const lastNestedBlock = nestedBlocks.last();
 
     // First block should contain everything until offset
     expect(firstNestedBlock.getText()).toBe(initialBlock.getText().slice(0, SPLIT_OFFSET));
@@ -143,28 +143,28 @@ describe('splitBlockWithNestingInContentState', () => {
   });
 
   it('must split at the end of a block', () => {
-    var initialBlock = contentState.getBlockMap().first();
-    var end = initialBlock.getLength();
-    var selection = selectionState.merge({
+    const initialBlock = contentState.getBlockMap().first();
+    const end = initialBlock.getLength();
+    const selection = selectionState.merge({
       anchorOffset: end,
       focusOffset: end,
     });
 
-    var afterSplit = splitBlockWithNestingInContentState(contentState, selection);
-    var afterBlockMap = afterSplit.getBlockMap();
+    const afterSplit = splitBlockWithNestingInContentState(contentState, selection);
+    const afterBlockMap = afterSplit.getBlockMap();
     expect(afterBlockMap.size).toBe(5);
 
-    var preSplitBlock = afterBlockMap.first();
+    const preSplitBlock = afterBlockMap.first();
     expect(preSplitBlock.getKey()).toBe(initialBlock.getKey());
     expect(preSplitBlock.getText()).toBe('');
     expect(getInlineStyles(preSplitBlock)).toEqual([]);
     expect(getEntities(preSplitBlock)).toEqual([]);
 
-    var nestedBlocks = afterSplit.getBlockChildren(initialBlock.getKey());
+    const nestedBlocks = afterSplit.getBlockChildren(initialBlock.getKey());
     expect(nestedBlocks.size).toBe(2);
 
-    var firstNestedBlock = nestedBlocks.first();
-    var lastNestedBlock = nestedBlocks.last();
+    const firstNestedBlock = nestedBlocks.first();
+    const lastNestedBlock = nestedBlocks.last();
 
     expect(firstNestedBlock.getKey()).not.toBe(lastNestedBlock.getKey());
     expect(firstNestedBlock.getType()).toBe(lastNestedBlock.getType());

--- a/src/model/transaction/getContentStateFragment.js
+++ b/src/model/transaction/getContentStateFragment.js
@@ -14,6 +14,7 @@
 'use strict';
 
 var generateRandomKey = require('generateRandomKey');
+var generateNestedKey = require('generateNestedKey');
 var removeEntitiesAtEdges = require('removeEntitiesAtEdges');
 
 import type {BlockMap} from 'BlockMap';
@@ -42,8 +43,17 @@ function getContentStateFragment(
   var startIndex = blockKeys.indexOf(startKey);
   var endIndex = blockKeys.indexOf(endKey) + 1;
 
+  // nesting uses keys to handle their blocks
+  // we need to generate new keys but preserving their nesting
+  var newKeyHashMap = {};
+
   var slice = blockMap.slice(startIndex, endIndex).map((block, blockKey) => {
-    var newKey = generateRandomKey();
+    var parentKey = block.getParentKey();
+    var newKey = newKeyHashMap[blockKey] = (
+      parentKey && newKeyHashMap[parentKey] ?
+        generateNestedKey(newKeyHashMap[parentKey]) :
+        generateRandomKey()
+    );
 
     var text = block.getText();
     var chars = block.getCharacterList();

--- a/src/model/transaction/getSampleStateForTestingNestedBlocks.js
+++ b/src/model/transaction/getSampleStateForTestingNestedBlocks.js
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule getSampleStateForTestingNestedBlocks
+ * @typechecks
+ * @flow
+ */
+
+'use strict';
+
+const BlockMapBuilder = require('BlockMapBuilder');
+const CharacterMetadata = require('CharacterMetadata');
+const ContentBlock = require('ContentBlock');
+const ContentState = require('ContentState');
+const EditorState = require('EditorState');
+const Immutable = require('immutable');
+const SampleDraftInlineStyle = require('SampleDraftInlineStyle');
+const SelectionState = require('SelectionState');
+
+const {
+  BOLD,
+  ITALIC
+} = SampleDraftInlineStyle;
+const ENTITY_KEY = '123';
+
+const BLOCKS = [
+  new ContentBlock({
+    key: 'a',
+    type: 'header-one',
+    text: 'Alpha',
+    characterList: Immutable.List(
+      Immutable.Repeat(CharacterMetadata.EMPTY, 5)
+    ),
+  }),
+  new ContentBlock({
+    key: 'b',
+    type: 'blockquote',
+    text: '',
+    characterList: Immutable.List(
+      Immutable.Repeat(
+        CharacterMetadata.create({
+          style: BOLD,
+          entity: ENTITY_KEY
+        }),
+        5
+      )
+    ),
+  }),
+  new ContentBlock({
+    key: 'b/c',
+    type: 'ordered-list-item',
+    text: 'Charlie',
+    characterList: Immutable.List(
+      Immutable.Repeat(
+        CharacterMetadata.create({
+          style: ITALIC,
+          entity: null
+        }),
+        7
+      )
+    ),
+  }),
+  new ContentBlock({
+    key: 'b/d',
+    type: 'unordered-list-item',
+    text: '',
+    characterList: Immutable.List(
+      Immutable.Repeat(
+        CharacterMetadata.create({
+          style: ITALIC,
+          entity: null
+        }),
+        7
+      )
+    ),
+  }),
+  new ContentBlock({
+    key: 'b/d/e',
+    type: 'header-one',
+    text: 'Echo',
+    characterList: Immutable.List(
+      Immutable.Repeat(
+        CharacterMetadata.create({
+          style: ITALIC,
+          entity: null
+        }),
+        7
+      )
+    ),
+  }),
+  new ContentBlock({
+    key: 'f',
+    type: 'blockquote',
+    text: 'Foxtrot',
+    characterList: Immutable.List(
+      Immutable.Repeat(
+        CharacterMetadata.create({
+          style: ITALIC,
+          entity: null
+        }),
+        7
+      )
+    ),
+  }),
+];
+
+const selectionState = new SelectionState({
+  anchorKey: 'a',
+  anchorOffset: 0,
+  focusKey: 'e',
+  focusOffset: 0,
+  isBackward: false,
+  hasFocus: true,
+});
+
+const blockMap = BlockMapBuilder.createFromArray(BLOCKS);
+const contentState = new ContentState({
+  blockMap,
+  selectionBefore: selectionState,
+  selectionAfter: selectionState,
+});
+
+const editorState = EditorState.forceSelection(
+  EditorState.createWithContent(contentState),
+  selectionState
+);
+
+function getSampleStateForTestingNestedBlocks(): Object {
+  return {
+    editorState,
+    contentState,
+    selectionState
+  };
+}
+
+module.exports = getSampleStateForTestingNestedBlocks;

--- a/src/model/transaction/insertFragmentIntoContentState.js
+++ b/src/model/transaction/insertFragmentIntoContentState.js
@@ -18,6 +18,8 @@ var BlockMapBuilder = require('BlockMapBuilder');
 var insertIntoList = require('insertIntoList');
 var invariant = require('invariant');
 
+var randomizeBlockMapKeys = require('randomizeBlockMapKeys');
+
 import type {BlockMap} from 'BlockMap';
 import type ContentState from 'ContentState';
 import type SelectionState from 'SelectionState';
@@ -25,7 +27,7 @@ import type SelectionState from 'SelectionState';
 function insertFragmentIntoContentState(
   contentState: ContentState,
   selectionState: SelectionState,
-  fragment: BlockMap
+  fragmentBlockMap: BlockMap
 ): ContentState {
   invariant(
     selectionState.isCollapsed(),
@@ -36,6 +38,11 @@ function insertFragmentIntoContentState(
   var targetOffset = selectionState.getStartOffset();
 
   var blockMap = contentState.getBlockMap();
+
+  // we need to make sure that the fragment have unique keys
+  // that would not clash with the blockMap, so we need to
+  // generate new set of keys for all nested elements
+  var fragment = randomizeBlockMapKeys(fragmentBlockMap);
 
   var fragmentSize = fragment.size;
   var finalKey;

--- a/src/model/transaction/insertFragmentIntoContentState.js
+++ b/src/model/transaction/insertFragmentIntoContentState.js
@@ -98,6 +98,7 @@ function insertFragmentIntoContentState(
       var appendToHead = fragment.first();
 
       var modifiedHead = block.merge({
+        key: appendToHead.getKey(),
         text: headText + appendToHead.getText(),
         characterList: headCharacters.concat(appendToHead.getCharacterList()),
         type: headText ? block.getType() : appendToHead.getType(),
@@ -108,7 +109,7 @@ function insertFragmentIntoContentState(
       // Insert fragment blocks after the head and before the tail.
       fragment.slice(1, fragmentSize - 1).forEach(
         fragmentBlock => {
-          newBlockArr.push(fragmentBlock.set('key', generateRandomKey()));
+          newBlockArr.push(fragmentBlock);
         }
       );
 

--- a/src/model/transaction/insertFragmentIntoContentState.js
+++ b/src/model/transaction/insertFragmentIntoContentState.js
@@ -15,7 +15,6 @@
 
 var BlockMapBuilder = require('BlockMapBuilder');
 
-var generateRandomKey = require('generateRandomKey');
 var insertIntoList = require('insertIntoList');
 var invariant = require('invariant');
 
@@ -98,7 +97,6 @@ function insertFragmentIntoContentState(
       var appendToHead = fragment.first();
 
       var modifiedHead = block.merge({
-        key: appendToHead.getKey(),
         text: headText + appendToHead.getText(),
         characterList: headCharacters.concat(appendToHead.getCharacterList()),
         type: headText ? block.getType() : appendToHead.getType(),
@@ -117,10 +115,9 @@ function insertFragmentIntoContentState(
       var tailText = text.slice(targetOffset, blockSize);
       var tailCharacters = chars.slice(targetOffset, blockSize);
       var prependToTail = fragment.last();
-      finalKey = generateRandomKey();
+      finalKey = prependToTail.getKey();
 
       var modifiedTail = prependToTail.merge({
-        key: finalKey,
         text: prependToTail.getText() + tailText,
         characterList: prependToTail
           .getCharacterList()

--- a/src/model/transaction/removeRangeFromContentState.js
+++ b/src/model/transaction/removeRangeFromContentState.js
@@ -38,6 +38,18 @@ function removeRangeFromContentState(
 
   var nextBlock = contentState.getBlockAfter(endKey);
   var nextBlockKey = nextBlock ? nextBlock.getKey() : '';
+
+  /*
+   * when dealing with selection ranges across nested blocks we need to be able to
+   * identify what is the most common shared parent beteween sibling blocks
+   *
+   * example
+   *
+   * li > bq > unstyled
+   * li > bq > header-one
+   *
+   * the topMosCommonParentKey would be the key for `li > bq`
+   */
   var topMostCommonParentKey = nextBlockKey.split('/').reduce((value, key, index) => {
     if (endKey.indexOf(key) !== -1) {
       value.push(key);

--- a/src/model/transaction/removeRangeFromContentState.js
+++ b/src/model/transaction/removeRangeFromContentState.js
@@ -35,6 +35,16 @@ function removeRangeFromContentState(
 
   var startBlock = blockMap.get(startKey);
   var endBlock = blockMap.get(endKey);
+
+  var nextBlock = contentState.getBlockAfter(endKey);
+  var nextBlockKey = nextBlock ? nextBlock.getKey() : '';
+  var topMostCommonParentKey = nextBlockKey.split('/').reduce((value, key, index) => {
+    if (endKey.indexOf(key) !== -1) {
+      value.push(key);
+    }
+    return value;
+  }, []).join('/');
+
   var characterList;
 
   if (startBlock === endBlock) {
@@ -62,6 +72,7 @@ function removeRangeFromContentState(
     .toSeq()
     .skipUntil((_, k) => k === startKey)
     .takeUntil((_, k) => k === endKey)
+    .filterNot((_, k) => topMostCommonParentKey.indexOf(k) !== -1)
     .concat(Immutable.Map([[endKey, null]]))
     .map((_, k) => { return k === startKey ? modifiedStart : null; });
 

--- a/src/model/transaction/splitBlockInContentState.js
+++ b/src/model/transaction/splitBlockInContentState.js
@@ -32,6 +32,7 @@ function splitBlockInContentState(
   var offset = selectionState.getAnchorOffset();
   var blockMap = contentState.getBlockMap();
   var blockToSplit = blockMap.get(key);
+  var parentKey = blockToSplit.getParentKey();
 
   var text = blockToSplit.getText();
   var chars = blockToSplit.getCharacterList();
@@ -42,6 +43,10 @@ function splitBlockInContentState(
   });
 
   var keyBelow = generateRandomKey();
+  if (parentKey) {
+    keyBelow = parentKey + '/' + keyBelow;
+  }
+
   var blockBelow = blockAbove.merge({
     key: keyBelow,
     text: text.slice(offset),

--- a/src/model/transaction/splitBlockInContentState.js
+++ b/src/model/transaction/splitBlockInContentState.js
@@ -13,6 +13,7 @@
 
 'use strict';
 
+var generateNestedKey = require('generateNestedKey');
 var generateRandomKey = require('generateRandomKey');
 var invariant = require('invariant');
 
@@ -42,10 +43,7 @@ function splitBlockInContentState(
     characterList: chars.slice(0, offset),
   });
 
-  var keyBelow = generateRandomKey();
-  if (parentKey) {
-    keyBelow = parentKey + '/' + keyBelow;
-  }
+  var keyBelow = parentKey ? generateNestedKey(parentKey) : generateRandomKey();
 
   var blockBelow = blockAbove.merge({
     key: keyBelow,

--- a/src/model/transaction/splitBlockWithNestingInContentState.js
+++ b/src/model/transaction/splitBlockWithNestingInContentState.js
@@ -13,15 +13,15 @@
 
 'use strict';
 
-var Immutable = require('immutable');
-var generateNestedKey = require('generateNestedKey');
-var invariant = require('invariant');
-var ContentBlock = require('ContentBlock');
+const Immutable = require('immutable');
+const generateNestedKey = require('generateNestedKey');
+const invariant = require('invariant');
+const ContentBlock = require('ContentBlock');
 
 import type ContentState from 'ContentState';
 import type SelectionState from 'SelectionState';
 
-var {
+const {
   List
 } = Immutable;
 
@@ -45,39 +45,39 @@ function splitBlockWithNestingInContentState(
     'Selection range must be collapsed.'
   );
 
-  var key = selectionState.getAnchorKey();
-  var offset = selectionState.getAnchorOffset();
-  var blockMap = contentState.getBlockMap();
-  var blockToSplit = blockMap.get(key);
+  const key = selectionState.getAnchorKey();
+  const offset = selectionState.getAnchorOffset();
+  const blockMap = contentState.getBlockMap();
+  const blockToSplit = blockMap.get(key);
 
-  var text = blockToSplit.getText();
-  var chars = blockToSplit.getCharacterList();
+  const text = blockToSplit.getText();
+  const chars = blockToSplit.getCharacterList();
 
-  var firstNestedKey = generateNestedKey(key);
-  var secondNestedKey = generateNestedKey(key);
+  const firstNestedKey = generateNestedKey(key);
+  const secondNestedKey = generateNestedKey(key);
 
-  var newParentBlock = blockToSplit.merge({
+  const newParentBlock = blockToSplit.merge({
     text: '',
     characterList: List()
   });
 
-  var firstNestedBlock = new ContentBlock({
+  const firstNestedBlock = new ContentBlock({
     key: firstNestedKey,
     type: blockType,
     text: text.slice(0, offset),
     characterList: chars.slice(0, offset)
   });
 
-  var secondNestedBlock = new ContentBlock({
+  const secondNestedBlock = new ContentBlock({
     key: secondNestedKey,
     type: blockType,
     text: text.slice(offset),
     characterList: chars.slice(offset)
   });
 
-  var blocksBefore = blockMap.toSeq().takeUntil(v => v === blockToSplit);
-  var blocksAfter = blockMap.toSeq().skipUntil(v => v === blockToSplit).rest();
-  var newBlocks = blocksBefore.concat(
+  const blocksBefore = blockMap.toSeq().takeUntil(v => v === blockToSplit);
+  const blocksAfter = blockMap.toSeq().skipUntil(v => v === blockToSplit).rest();
+  const newBlocks = blocksBefore.concat(
       [[newParentBlock.getKey(), newParentBlock],
         [firstNestedBlock.getKey(), firstNestedBlock],
         [secondNestedBlock.getKey(), secondNestedBlock]],

--- a/src/model/transaction/splitBlockWithNestingInContentState.js
+++ b/src/model/transaction/splitBlockWithNestingInContentState.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @providesModule splitNestedBlockInContentState
+ * @providesModule splitBlockWithNestingInContentState
  * @typechecks
  * @flow
  */
@@ -35,7 +35,7 @@ var {
                             UNSTYLED "Hello"
                             UNSTYLED " World"
 */
-function splitNestedBlockInContentState(
+function splitBlockWithNestingInContentState(
   contentState: ContentState,
   selectionState: SelectionState,
   blockType:string='unstyled'
@@ -97,4 +97,4 @@ function splitNestedBlockInContentState(
   });
 }
 
-module.exports = splitNestedBlockInContentState;
+module.exports = splitBlockWithNestingInContentState;

--- a/src/model/transaction/splitNestedBlockInContentState.js
+++ b/src/model/transaction/splitNestedBlockInContentState.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule splitNestedBlockInContentState
+ * @typechecks
+ * @flow
+ */
+
+'use strict';
+
+var generateRandomKey = require('generateRandomKey');
+var invariant = require('invariant');
+
+import type ContentState from 'ContentState';
+import type SelectionState from 'SelectionState';
+
+function splitNestedBlockInContentState(
+  contentState: ContentState,
+  selectionState: SelectionState
+): ContentState {
+  invariant(
+    selectionState.isCollapsed(),
+    'Selection range must be collapsed.'
+  );
+
+  var key = selectionState.getAnchorKey();
+  var offset = selectionState.getAnchorOffset();
+  var blockMap = contentState.getBlockMap();
+  var blockToSplit = blockMap.get(key);
+
+  var text = blockToSplit.getText();
+  var chars = blockToSplit.getCharacterList();
+
+  var blockAbove = blockToSplit.merge({
+    text: text.slice(0, offset),
+    characterList: chars.slice(0, offset),
+  });
+
+  var keyBelow = key + '/' + generateRandomKey();
+
+  var blockBelow = blockAbove.merge({
+    key: keyBelow,
+    text: text.slice(offset),
+    characterList: chars.slice(offset),
+  });
+
+  var blocksBefore = blockMap.toSeq().takeUntil(v => v === blockToSplit);
+  var blocksAfter = blockMap.toSeq().skipUntil(v => v === blockToSplit).rest();
+  var newBlocks = blocksBefore.concat(
+      [[blockAbove.getKey(), blockAbove], [blockBelow.getKey(), blockBelow]],
+      blocksAfter
+    ).toOrderedMap();
+
+  return contentState.merge({
+    blockMap: newBlocks,
+    selectionBefore: selectionState,
+    selectionAfter: selectionState.merge({
+      anchorKey: keyBelow,
+      anchorOffset: 0,
+      focusKey: keyBelow,
+      focusOffset: 0,
+      isBackward: false,
+    }),
+  });
+}
+
+module.exports = splitNestedBlockInContentState;

--- a/src/model/transaction/splitNestedBlockInContentState.js
+++ b/src/model/transaction/splitNestedBlockInContentState.js
@@ -38,14 +38,12 @@ var {
 function splitNestedBlockInContentState(
   contentState: ContentState,
   selectionState: SelectionState,
-  blockType: string
+  blockType:string='unstyled'
 ): ContentState {
   invariant(
     selectionState.isCollapsed(),
     'Selection range must be collapsed.'
   );
-
-  blockType = blockType || 'unstyled';
 
   var key = selectionState.getAnchorKey();
   var offset = selectionState.getAnchorOffset();

--- a/website/core/metadata.js
+++ b/website/core/metadata.js
@@ -177,7 +177,8 @@ module.exports = {
       "title": "Modifier",
       "layout": "docs",
       "category": "API Reference",
-      "permalink": "docs/api-reference-modifier.html"
+      "permalink": "docs/api-reference-modifier.html",
+      "next": "experimental-nesting"
     },
     {
       "id": "api-reference-rich-utils",
@@ -194,6 +195,14 @@ module.exports = {
       "category": "API Reference",
       "next": "api-reference-composite-decorator",
       "permalink": "docs/api-reference-selection-state.html"
+    },
+    {
+      "id": "experimental-nesting",
+      "title": "Nesting",
+      "layout": "docs",
+      "category": "Experimental",
+      "next": "api-reference-data-conversion",
+      "permalink": "docs/experimental-nesting.html"
     },
     {
       "id": "getting-started",


### PR DESCRIPTION
This PR implements support for a tree structure that can be used to render tables, blockquote, list, etc. For context on this topic, see discussion in #143.

The main goal is also to not break compatibility with people already using Draft, and keep “flatness” as the basic use case.
### Implementation

To represent a tree and keep compatibility with the flat model, we decide to not change the data structure, but instead to leverage keys in the `ContentState.blockMap`.

Basically, children of the block `a` will be blocks in the `blockMap` with keys `a/b`, `a/c`; and `a/b/d` is a child of `a/b`.
### Demo

A demo is available at [samypesse.github.io/test-draft-js/](http://samypesse.github.io/test-draft-js/) (similar to the [tree](https://github.com/SamyPesse/draft-js/blob/feature/tree/examples/tree/tree.html) example).
### Compatibility

Nesting is disabled by default to keep “flatness” as the basic use case. It should be enabled for the right block types in the `blockRenderMap`, and Draft will provides a `NestedUtils` module to help use nested blocks and provide the right editing UX.
