### PR TITLE
Fix a typo in the comment for blockRenderMap

### DIFF
--- a/src/component/base/DraftEditorProps.js
+++ b/src/component/base/DraftEditorProps.js
@@ -132,7 +132,7 @@ export type DraftEditorProps = {
   customStyleMap?: Object,
 
   // Provide a map of block rendering configurations. Each block type maps to
-  // an element tag and am optional react element wrapper. This configuration
+  // an element tag and an optional react element wrapper. This configuration
   // is used for both rendering and paste processing.
   blockRenderMap: DraftBlockRenderMap,
 };


### PR DESCRIPTION
FWIW, this doesn't appear to be used in any generated documentation.