### PR TITLE
Switch to the more conservative Immutable.js ~3.7.4 version to avoid upstream flow definition errors.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "fbjs": "^0.8.1",
-    "immutable": "^3.7.4"
+    "immutable": "~3.7.4"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0-rc",


### PR DESCRIPTION
The `3.8.x` versions of Immutable.js have changed `#toOrderedMap(): OrderedMap` to `#toOrderedMap(): Map` which breaks Draft.js — so I propose we use `~3.7.4` instead of `^3.7.4`.

Draft.js's definition of `BlockMap` is `OrderedMap<string, ContentBlock>` which is not compatible with `Map`.

In the interim (until Immutable.js makes a decision as to whether `#toOrderedMap(): Map` is correct) using the `3.7.x` range allows Draft.js `master` to pass flow checks.