### PR TITLE
removes non-existant "undo/redo" from docs

### DIFF
--- a/docs/APIReference-EditorState.md
+++ b/docs/APIReference-EditorState.md
@@ -267,8 +267,7 @@ static push(
 ```
 Returns a new `EditorState` object with the specified `ContentState` applied
 as the new `currentContent`. Based on the `changeType`, this `ContentState`
-may be regarded as a boundary state for undo/redo behavior. See
-[Undo/Redo](/draft-js/docs/advanced-undo-redo.html) discussion for details.
+may be regarded as a boundary state for undo/redo behavior.
 
 All content changes must be applied to the EditorState with this method.
 


### PR DESCRIPTION
fixes #462

in the api reference for editor state under the "push" method there
was a link to a non-existant "advanced undo/redo" page. since this page
didn't exist we should just remove it, and add it back in if it ever
comes to fruition.