### PR TITLE
Implemented insertAtomicBlockBefore and insertAtomicBlockAfter

### DIFF
--- a/docs/APIReference-AtomicBlockUtils.md
+++ b/docs/APIReference-AtomicBlockUtils.md
@@ -24,3 +24,23 @@ insertAtomicBlock: function(
   character: string
 ): EditorState
 ```
+
+### insertAtomicBlockBefore
+
+```
+insertAtomicBlockBefore: function(
+  editorState: EditorState,
+  entityKey: string,
+  character: string
+): EditorState
+```
+
+### insertAtomicBlockAfter
+
+```
+insertAtomicBlockAfter: function(
+  editorState: EditorState,
+  entityKey: string,
+  character: string
+): EditorState
+```

--- a/src/model/modifier/AtomicBlockUtils.js
+++ b/src/model/modifier/AtomicBlockUtils.js
@@ -84,6 +84,54 @@ const AtomicBlockUtils = {
 
     return EditorState.push(editorState, newContent, 'insert-fragment');
   },
+
+  insertAtomicBlockBefore: function(
+    editorState: EditorState,
+    entityKey: string,
+    character: string
+  ): EditorState {
+    const contentState = editorState.getCurrentContent();
+    const selectionState = editorState.getSelection();
+    const charData = CharacterMetadata.create({entity: entityKey});
+
+    const withAtomicBlock = DraftModifier.insertBlockBefore(contentState, selectionState, new ContentBlock({
+      key: generateRandomKey(),
+      type: 'atomic',
+      text: character,
+      characterList: List(Repeat(charData, character.length)),
+    }));
+
+    const newContent = withAtomicBlock.merge({
+      selectionBefore: selectionState,
+      selectionAfter: withAtomicBlock.getSelectionAfter().set('hasFocus', true),
+    });
+
+    return EditorState.push(editorState, newContent, 'insert-fragment');
+  },
+  
+  insertAtomicBlockAfter: function(
+    editorState: EditorState,
+    entityKey: string,
+    character: string
+  ): EditorState {
+    const contentState = editorState.getCurrentContent();
+    const selectionState = editorState.getSelection();
+    const charData = CharacterMetadata.create({entity: entityKey});
+
+    const withAtomicBlock = DraftModifier.insertBlockAfter(contentState, selectionState, new ContentBlock({
+      key: generateRandomKey(),
+      type: 'atomic',
+      text: character,
+      characterList: List(Repeat(charData, character.length)),
+    }));
+
+    const newContent = withAtomicBlock.merge({
+      selectionBefore: selectionState,
+      selectionAfter: withAtomicBlock.getSelectionAfter().set('hasFocus', true),
+    });
+
+    return EditorState.push(editorState, newContent, 'insert-fragment');
+  },
 };
 
 module.exports = AtomicBlockUtils;

--- a/src/model/modifier/AtomicBlockUtils.js
+++ b/src/model/modifier/AtomicBlockUtils.js
@@ -52,7 +52,7 @@ const AtomicBlockUtils = {
       'atomic'
     );
 
-    const charData = CharacterMetadata.create({entity: entityKey});
+    const charData = CharacterMetadata.create(entityKey ? {entity: entityKey} : undefined);
 
     const fragmentArray = [
       new ContentBlock({
@@ -92,7 +92,7 @@ const AtomicBlockUtils = {
   ): EditorState {
     const contentState = editorState.getCurrentContent();
     const selectionState = editorState.getSelection();
-    const charData = CharacterMetadata.create({entity: entityKey});
+    const charData = CharacterMetadata.create(entityKey ? {entity: entityKey} : undefined);
 
     const withAtomicBlock = DraftModifier.insertBlockBefore(contentState, selectionState, new ContentBlock({
       key: generateRandomKey(),
@@ -116,7 +116,7 @@ const AtomicBlockUtils = {
   ): EditorState {
     const contentState = editorState.getCurrentContent();
     const selectionState = editorState.getSelection();
-    const charData = CharacterMetadata.create({entity: entityKey});
+    const charData = CharacterMetadata.create(entityKey ? {entity: entityKey} : undefined);
 
     const withAtomicBlock = DraftModifier.insertBlockAfter(contentState, selectionState, new ContentBlock({
       key: generateRandomKey(),

--- a/src/model/modifier/DraftModifier.js
+++ b/src/model/modifier/DraftModifier.js
@@ -27,8 +27,11 @@ var removeEntitiesAtEdges = require('removeEntitiesAtEdges');
 var removeRangeFromContentState = require('removeRangeFromContentState');
 var setBlockTypeForContentState = require('setBlockTypeForContentState');
 var splitBlockInContentState = require('splitBlockInContentState');
+var insertBlockBeforeInContentState = require('insertBlockBeforeInContentState');
+var insertBlockAfterInContentState = require('insertBlockAfterInContentState');
 
 import type {BlockMap} from 'BlockMap';
+import type ContentBlock from 'ContentBlock';
 import type ContentState from 'ContentState';
 import type {DraftBlockType} from 'DraftBlockType';
 import type {DraftInlineStyle} from 'DraftInlineStyle';
@@ -172,6 +175,30 @@ var DraftModifier = {
     return splitBlockInContentState(
       withoutText,
       withoutText.getSelectionAfter()
+    );
+  },
+
+  insertBlockBefore: function(
+    contentState: ContentState,
+    selectionState: SelectionState,
+    contentBlock: ContentBlock
+  ): ContentState {
+    return insertBlockBeforeInContentState(
+      contentState,
+      selectionState,
+      contentBlock
+    );
+  },
+
+  insertBlockAfter: function(
+    contentState: ContentState,
+    selectionState: SelectionState,
+    contentBlock: ContentBlock
+  ): ContentState {
+    return insertBlockAfterInContentState(
+      contentState,
+      selectionState,
+      contentBlock
     );
   },
 

--- a/src/model/transaction/insertBlockAfterInContentState.js
+++ b/src/model/transaction/insertBlockAfterInContentState.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule insertBlockAfterInContentState
+ * @typechecks
+ * @flow
+ */
+
+'use strict';
+
+var generateRandomKey = require('generateRandomKey');
+var invariant = require('invariant');
+
+import type ContentBlock from 'ContentBlock';
+import type ContentState from 'ContentState';
+import type SelectionState from 'SelectionState';
+
+function insertBlockAfterInContentState(
+  contentState: ContentState,
+  selectionState: SelectionState,
+  contentBlock: ContentBlock
+): ContentState {
+  invariant(
+    selectionState.isCollapsed(),
+    'Selection range must be collapsed.'
+  );
+
+  var key = selectionState.getAnchorKey();
+  var offset = selectionState.getAnchorOffset();
+  var blockMap = contentState.getBlockMap();
+  var lastBlockBeforeNewBlock = blockMap.get(key);
+  var blocksBefore = blockMap.toSeq().takeUntil(v => v === lastBlockBeforeNewBlock);
+  var blocksAfter = blockMap.toSeq().skipUntil(v => v === lastBlockBeforeNewBlock).rest();
+  var newBlocks = blocksBefore.concat(
+      [[lastBlockBeforeNewBlock.getKey(), lastBlockBeforeNewBlock], [contentBlock.getKey(), contentBlock]],
+      blocksAfter
+    ).toOrderedMap();
+
+  return contentState.merge({
+    blockMap: newBlocks,
+    selectionBefore: selectionState,
+    selectionAfter: selectionState.merge({
+      anchorKey: contentBlock.getKey(),
+      anchorOffset: 0,
+      focusKey: contentBlock.getKey(),
+      focusOffset: 0,
+      isBackward: false,
+    }),
+  });
+}
+
+module.exports = insertBlockAfterInContentState;

--- a/src/model/transaction/insertBlockAfterInContentState.js
+++ b/src/model/transaction/insertBlockAfterInContentState.js
@@ -13,7 +13,6 @@
 
 'use strict';
 
-var generateRandomKey = require('generateRandomKey');
 var invariant = require('invariant');
 
 import type ContentBlock from 'ContentBlock';
@@ -31,7 +30,6 @@ function insertBlockAfterInContentState(
   );
 
   var key = selectionState.getAnchorKey();
-  var offset = selectionState.getAnchorOffset();
   var blockMap = contentState.getBlockMap();
   var lastBlockBeforeNewBlock = blockMap.get(key);
   var blocksBefore = blockMap.toSeq().takeUntil(v => v === lastBlockBeforeNewBlock);

--- a/src/model/transaction/insertBlockBeforeInContentState.js
+++ b/src/model/transaction/insertBlockBeforeInContentState.js
@@ -13,7 +13,6 @@
 
 'use strict';
 
-var generateRandomKey = require('generateRandomKey');
 var invariant = require('invariant');
 
 import type ContentBlock from 'ContentBlock';
@@ -31,7 +30,6 @@ function insertBlockBeforeInContentState(
   );
 
   var key = selectionState.getAnchorKey();
-  var offset = selectionState.getAnchorOffset();
   var blockMap = contentState.getBlockMap();
   var firstBlockAfterNewBlock = blockMap.get(key);
   var blocksBefore = blockMap.toSeq().takeUntil(v => v === firstBlockAfterNewBlock);

--- a/src/model/transaction/insertBlockBeforeInContentState.js
+++ b/src/model/transaction/insertBlockBeforeInContentState.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule insertBlockBeforeInContentState
+ * @typechecks
+ * @flow
+ */
+
+'use strict';
+
+var generateRandomKey = require('generateRandomKey');
+var invariant = require('invariant');
+
+import type ContentBlock from 'ContentBlock';
+import type ContentState from 'ContentState';
+import type SelectionState from 'SelectionState';
+
+function insertBlockBeforeInContentState(
+  contentState: ContentState,
+  selectionState: SelectionState,
+  contentBlock: ContentBlock
+): ContentState {
+  invariant(
+    selectionState.isCollapsed(),
+    'Selection range must be collapsed.'
+  );
+
+  var key = selectionState.getAnchorKey();
+  var offset = selectionState.getAnchorOffset();
+  var blockMap = contentState.getBlockMap();
+  var firstBlockAfterNewBlock = blockMap.get(key);
+  var blocksBefore = blockMap.toSeq().takeUntil(v => v === firstBlockAfterNewBlock);
+  var blocksAfter = blockMap.toSeq().skipUntil(v => v === firstBlockAfterNewBlock).rest();
+  var newBlocks = blocksBefore.concat(
+      [[contentBlock.getKey(), contentBlock], [firstBlockAfterNewBlock.getKey(), firstBlockAfterNewBlock]],
+      blocksAfter
+    ).toOrderedMap();
+
+  return contentState.merge({
+    blockMap: newBlocks,
+    selectionBefore: selectionState,
+    selectionAfter: selectionState.merge({
+      anchorKey: contentBlock.getKey(),
+      anchorOffset: 0,
+      focusKey: contentBlock.getKey(),
+      focusOffset: 0,
+      isBackward: false,
+    }),
+  });
+}
+
+module.exports = insertBlockBeforeInContentState;

--- a/src/model/transaction/insertBlockBeforeInContentState.js
+++ b/src/model/transaction/insertBlockBeforeInContentState.js
@@ -35,9 +35,9 @@ function insertBlockBeforeInContentState(
   var blockMap = contentState.getBlockMap();
   var firstBlockAfterNewBlock = blockMap.get(key);
   var blocksBefore = blockMap.toSeq().takeUntil(v => v === firstBlockAfterNewBlock);
-  var blocksAfter = blockMap.toSeq().skipUntil(v => v === firstBlockAfterNewBlock).rest();
+  var blocksAfter = blockMap.toSeq().skipUntil(v => v === firstBlockAfterNewBlock);
   var newBlocks = blocksBefore.concat(
-      [[contentBlock.getKey(), contentBlock], [firstBlockAfterNewBlock.getKey(), firstBlockAfterNewBlock]],
+      [[contentBlock.getKey(), contentBlock]],
       blocksAfter
     ).toOrderedMap();
 


### PR DESCRIPTION
The function "insertAtomicBlock" within the module "AtomicBlockUtils" does not really make sense to me. To insert an atomic block, it splits an existing block and deletes text of the preceding block etc.

This is not what i want.

What i want is simply to insert a new atomic block, without affecting other blocks, but the order of the blockMap.
In this case you have to decide always if you want to insert the new atomic block before or after an other block. This is why there are to new functions: "insertAtomicBlockBefore" and "insertAtomicBlockAfter"

Issues i am not sure about:
- Do you agree with me that this is a useful feature?
- I am not sure if i have to do some entity handling since the functions move a new block inbetween two already existing blocks (which might have entities already)
- Please check my code since this is the first time i am contributing to the draft-js project
- Do i have to implement some tests?