### PR TITLE
Decorator do not have `data-offset-key` attribute. Fix `getSelectionOffsetKeyForNode` function

### DIFF
--- a/src/component/selection/__tests__/getDraftEditorSelection-test.js
+++ b/src/component/selection/__tests__/getDraftEditorSelection-test.js
@@ -131,7 +131,8 @@ describe('getDraftEditorSelection', function() {
       .map(
         function(decoratorKey, ii) {
           var span = document.createElement('span');
-          span.setAttribute('data-offset-key', '' + decoratorKey);
+          // decorator do not have data-offset-key attribute
+          span.setAttribute('decorator-key', '' + decoratorKey);
           span.appendChild(leafs[(ii * 2)]);
           span.appendChild(leafs[(ii * 2) + 1]);
           return span;

--- a/src/component/selection/__tests__/getDraftEditorSelection-test.js
+++ b/src/component/selection/__tests__/getDraftEditorSelection-test.js
@@ -131,7 +131,7 @@ describe('getDraftEditorSelection', function() {
       .map(
         function(decoratorKey, ii) {
           var span = document.createElement('span');
-          // decorator do not have data-offset-key attribute
+          // Decorators may not have `data-offset-key` attribute
           span.setAttribute('decorator-key', '' + decoratorKey);
           span.appendChild(leafs[(ii * 2)]);
           span.appendChild(leafs[(ii * 2) + 1]);

--- a/src/component/selection/getSelectionOffsetKeyForNode.js
+++ b/src/component/selection/getSelectionOffsetKeyForNode.js
@@ -17,7 +17,15 @@
  * Get offset key from a node.
  */
 function getSelectionOffsetKeyForNode(node: Node): ?string {
-  return node instanceof Element ? node.getAttribute('data-offset-key') : null;
+  if (node instanceof Element) {
+    var offsetKey = node.getAttribute('data-offset-key');
+    if (offsetKey) return offsetKey;
+    for (var ii = 0; ii < node.children.length; ii++) {
+      var childOffsetKey = getSelectionOffsetKeyForNode(node.children[ii]);
+      if (childOffsetKey) return childOffsetKey;
+    }
+  }
+  return null;
 }
 
 module.exports = getSelectionOffsetKeyForNode;

--- a/src/component/selection/getSelectionOffsetKeyForNode.js
+++ b/src/component/selection/getSelectionOffsetKeyForNode.js
@@ -14,15 +14,20 @@
 'use strict';
 
 /**
- * Get offset key from a node.
+ * Get offset key from a node or it's child nodes. Return the first offset key
+ * found on the DOM tree of given node.
  */
 function getSelectionOffsetKeyForNode(node: Node): ?string {
   if (node instanceof Element) {
     var offsetKey = node.getAttribute('data-offset-key');
-    if (offsetKey) return offsetKey;
-    for (var ii = 0; ii < node.children.length; ii++) {
-      var childOffsetKey = getSelectionOffsetKeyForNode(node.children[ii]);
-      if (childOffsetKey) return childOffsetKey;
+    if (offsetKey) {
+      return offsetKey;
+    }
+    for (var ii = 0; ii < node.childNodes.length; ii++) {
+      var childOffsetKey = getSelectionOffsetKeyForNode(node.childNodes[ii]);
+      if (childOffsetKey) {
+        return childOffsetKey;
+      }
     }
   }
   return null;


### PR DESCRIPTION
Decorator do not have `data-offset-key` attribute. Fix the implementation of `getSelectionOffsetKeyForNode` function to resolve the `data-offset-key` from decorator's children and fix tests.

Related issue https://github.com/facebook/draft-js/issues/476