### PR TITLE
Lock gulp-header at 1.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "gulp-concat-css": "^2.2.0",
     "gulp-derequire": "^2.1.0",
     "gulp-flatten": "^0.2.0",
-    "gulp-header": "^1.7.1",
+    "gulp-header": "1.8.2",
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.6",
     "jest": "^12.1.1",


### PR DESCRIPTION
This works around the regression that 1.8.3 introduced.

Fixes #475.