### PR TITLE
upgrade gulp header to 1.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "gulp-concat-css": "^2.2.0",
     "gulp-derequire": "^2.1.0",
     "gulp-flatten": "^0.2.0",
-    "gulp-header": "^1.7.1",
+    "gulp-header": "^1.8.2",
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.6",
     "jest": "^12.1.1",


### PR DESCRIPTION
I clone project of draft.js and after run npm install, I ran command npm build and I got error:

fs.js:839
  return binding.lstat(pathModule._makeLong(path));
                 ^

Error: ENOENT: no such file or directory, lstat '/Draft.min.js'

Root cause: 
+ Because version of gulp-header 

Solution:
+ I upgrade version to gulp-header into 1.8.2

reference:
http://stackoverflow.com/questions/37885398/gulp-build-for-semantic-ui-is-giving-error-enoent-no-such-file-or-directory