### PR TITLE
Fix insertAtomicBlock function

### DIFF
--- a/src/model/modifier/AtomicBlockUtils.js
+++ b/src/model/modifier/AtomicBlockUtils.js
@@ -52,7 +52,7 @@ const AtomicBlockUtils = {
       'atomic'
     );
 
-    const charData = CharacterMetadata.create({entity: entityKey});
+    const charData = CharacterMetadata.create(entityKey ? {entity: entityKey} : undefined);
 
     const fragmentArray = [
       new ContentBlock({

--- a/src/model/modifier/AtomicBlockUtils.js
+++ b/src/model/modifier/AtomicBlockUtils.js
@@ -61,12 +61,6 @@ const AtomicBlockUtils = {
         text: character,
         characterList: List(Repeat(charData, character.length)),
       }),
-      new ContentBlock({
-        key: generateRandomKey(),
-        type: 'unstyled',
-        text: '',
-        characterList: List(),
-      }),
     ];
 
     const fragment = BlockMapBuilder.createFromArray(fragmentArray);

--- a/src/model/modifier/AtomicBlockUtils.js
+++ b/src/model/modifier/AtomicBlockUtils.js
@@ -29,6 +29,22 @@ const {
   Repeat,
 } = Immutable;
 
+function createAtomicBlock(
+  entityKey: string,
+  character: string
+): ContentBlock {
+  const charData = CharacterMetadata.create(
+    entityKey ? {entity: entityKey} : undefined
+  );
+
+  return new ContentBlock({
+    key: generateRandomKey(),
+    type: 'atomic',
+    text: character,
+    characterList: List(Repeat(charData, character.length)),
+  });
+}
+
 const AtomicBlockUtils = {
   insertAtomicBlock: function(
     editorState: EditorState,
@@ -49,16 +65,7 @@ const AtomicBlockUtils = {
       targetSelection.getFocusKey()
     );
 
-    const charData = CharacterMetadata.create(
-      entityKey ? {entity: entityKey} : undefined
-    );
-
-    const atomicBlock = new ContentBlock({
-      key: generateRandomKey(),
-      type: 'atomic',
-      text: character,
-      characterList: List(Repeat(charData, character.length)),
-    });
+    const atomicBlock = createAtomicBlock(entityKey, character);
 
     var withAtomicBlock;
 
@@ -93,6 +100,50 @@ const AtomicBlockUtils = {
         atomicBlock
       );
     }
+
+    const newContent = withAtomicBlock.merge({
+      selectionBefore: selectionState,
+      selectionAfter: withAtomicBlock.getSelectionAfter().set('hasFocus', true),
+    });
+
+    return EditorState.push(editorState, newContent, 'insert-fragment');
+  },
+
+  insertAtomicBlockBefore: function(
+    editorState: EditorState,
+    entityKey: string,
+    character: string
+  ): EditorState {
+    const contentState = editorState.getCurrentContent();
+    const selectionState = editorState.getSelection();
+    const atomicBlock = createAtomicBlock(entityKey, character);
+    const withAtomicBlock = insertBlockBeforeInContentState(
+      contentState,
+      selectionState,
+      atomicBlock
+    );
+
+    const newContent = withAtomicBlock.merge({
+      selectionBefore: selectionState,
+      selectionAfter: withAtomicBlock.getSelectionAfter().set('hasFocus', true),
+    });
+
+    return EditorState.push(editorState, newContent, 'insert-fragment');
+  },
+
+  insertAtomicBlockAfter: function(
+    editorState: EditorState,
+    entityKey: string,
+    character: string
+  ): EditorState {
+    const contentState = editorState.getCurrentContent();
+    const selectionState = editorState.getSelection();
+    const atomicBlock = createAtomicBlock(entityKey, character);
+    const withAtomicBlock = insertBlockAfterInContentState(
+      contentState,
+      selectionState,
+      atomicBlock
+    );
 
     const newContent = withAtomicBlock.merge({
       selectionBefore: selectionState,

--- a/src/model/modifier/__tests__/AtomicBlockUtils-test.js
+++ b/src/model/modifier/__tests__/AtomicBlockUtils-test.js
@@ -43,16 +43,11 @@ describe('AtomicBlockUtils', () => {
       );
       const resultContent = resultEditor.getCurrentContent();
 
-      // Empty block inserted above content.
       const firstBlock = resultContent.getBlockMap().first();
-      expect(firstBlock.getType()).toBe('unstyled');
-      expect(firstBlock.getText()).toBe('');
+      assertAtomicBlock(firstBlock);
 
       const secondBlock = resultContent.getBlockMap().skip(1).first();
-      assertAtomicBlock(secondBlock);
-
-      const thirdBlock = resultContent.getBlockMap().skip(2).first();
-      expect(thirdBlock.getText()).toBe(originalFirstBlock.getText());
+      expect(secondBlock.getText()).toBe(originalFirstBlock.getText());
     });
 
     it('must insert atomic within a block, via split', () => {
@@ -88,7 +83,7 @@ describe('AtomicBlockUtils', () => {
       expect(thirdBlock.getText()).toBe(originalFirstBlock.getText().slice(2));
     });
 
-    it('must insert atomic after a block', () => {
+    it('must insert atomic at end of block', () => {
       const targetSelection = selectionState.merge({
         anchorOffset: originalFirstBlock.getLength(),
         focusOffset: originalFirstBlock.getLength(),
@@ -111,10 +106,6 @@ describe('AtomicBlockUtils', () => {
 
       const secondBlock = resultContent.getBlockMap().skip(1).first();
       assertAtomicBlock(secondBlock);
-
-      const thirdBlock = resultContent.getBlockMap().skip(2).first();
-      expect(thirdBlock.getType()).toBe(originalFirstBlock.getType());
-      expect(thirdBlock.getText()).toBe('');
     });
   });
 
@@ -137,15 +128,11 @@ describe('AtomicBlockUtils', () => {
       const resultContent = resultEditor.getCurrentContent();
 
       const firstBlock = resultContent.getBlockMap().first();
-      expect(firstBlock.getType()).toBe(originalFirstBlock.getType());
-      expect(firstBlock.getText()).toBe('');
+      assertAtomicBlock(firstBlock);
 
       const secondBlock = resultContent.getBlockMap().skip(1).first();
-      assertAtomicBlock(secondBlock);
-
-      const thirdBlock = resultContent.getBlockMap().skip(2).first();
-      expect(thirdBlock.getType()).toBe(originalFirstBlock.getType());
-      expect(thirdBlock.getText()).toBe(originalFirstBlock.getText().slice(2));
+      expect(secondBlock.getType()).toBe(originalFirstBlock.getType());
+      expect(secondBlock.getText()).toBe(originalFirstBlock.getText().slice(2));
     });
 
     it('must insert atomic within a block', () => {
@@ -209,10 +196,6 @@ describe('AtomicBlockUtils', () => {
 
       const secondBlock = resultContent.getBlockMap().skip(1).first();
       assertAtomicBlock(secondBlock);
-
-      const thirdBlock = resultContent.getBlockMap().skip(2).first();
-      expect(thirdBlock.getType()).toBe(originalFirstBlock.getType());
-      expect(thirdBlock.getText()).toBe('');
     });
 
     it('must insert atomic for cross-block selection', () => {

--- a/src/model/modifier/__tests__/AtomicBlockUtils-test.js
+++ b/src/model/modifier/__tests__/AtomicBlockUtils-test.js
@@ -13,7 +13,7 @@
 
 jest.disableAutomock();
 
-const {insertAtomicBlock} = require('AtomicBlockUtils');
+const {insertAtomicBlock, insertAtomicBlockBefore, insertAtomicBlockAfter} = require('AtomicBlockUtils');
 const EditorState = require('EditorState');
 
 const getSampleStateForTesting = require('getSampleStateForTesting');
@@ -235,5 +235,36 @@ describe('AtomicBlockUtils', () => {
       expect(thirdBlock.getType()).toBe(originalFirstBlock.getType());
       expect(thirdBlock.getText()).toBe(originalThirdBlock.getText().slice(2));
     });
+  });
+
+  it('must insert atomic before a block', () => {
+    const resultEditor = insertAtomicBlockBefore(
+      editorState,
+      entityKey,
+      character
+    );
+    const resultContent = resultEditor.getCurrentContent();
+
+    const firstBlock = resultContent.getBlockMap().first();
+    assertAtomicBlock(firstBlock);
+
+    const secondBlock = resultContent.getBlockMap().skip(1).first();
+    expect(secondBlock.getText()).toBe(originalFirstBlock.getText());
+  });
+
+  it('must insert atomic after a block', () => {
+    const resultEditor = insertAtomicBlockAfter(
+      editorState,
+      entityKey,
+      character
+    );
+    const resultContent = resultEditor.getCurrentContent();
+
+    const firstBlock = resultContent.getBlockMap().first();
+    expect(firstBlock.getType()).toBe(originalFirstBlock.getType());
+    expect(firstBlock.getText()).toBe(originalFirstBlock.getText());
+
+    const secondBlock = resultContent.getBlockMap().skip(1).first();
+    assertAtomicBlock(secondBlock);
   });
 });

--- a/src/model/modifier/__tests__/RichTextEditorUtil-test.js
+++ b/src/model/modifier/__tests__/RichTextEditorUtil-test.js
@@ -16,6 +16,9 @@ const DraftModifier = require('DraftModifier');
 const EditorState = require('EditorState');
 const RichTextEditorUtil = require('RichTextEditorUtil');
 const SelectionState = require('SelectionState');
+const ContentBlock = require('ContentBlock');
+
+const insertBlockAfterInContentState = require('insertBlockAfterInContentState');
 
 const getSampleStateForTesting = require('getSampleStateForTesting');
 
@@ -30,6 +33,21 @@ describe('RichTextEditorUtil', () => {
       movedSelection,
       entityKey,
       character,
+    );
+  }
+
+  function insertEmptyBlockAfter(targetEditorState) {
+    const afterInsertBlock = insertBlockAfterInContentState(
+      targetEditorState.getCurrentContent(),
+      targetEditorState.getSelection().merge({
+        anchorOffset: targetEditorState.getSelection().getFocusOffset()
+      }),
+      new ContentBlock()
+    );
+    return EditorState.push(
+      targetEditorState,
+      afterInsertBlock,
+      'insert-fragment'
     );
   }
 
@@ -84,7 +102,8 @@ describe('RichTextEditorUtil', () => {
 
     it('removes a preceding atomic block', () => {
       const withAtomicBlock = insertAtomicBlock(editorState);
-      const afterBackspace = onBackspace(withAtomicBlock);
+      const withEmptyBlock = insertEmptyBlockAfter(withAtomicBlock);
+      const afterBackspace = onBackspace(withEmptyBlock);
       const contentState = afterBackspace.getCurrentContent();
       const blockMap = contentState.getBlockMap();
       expect(blockMap.size).toBe(4);
@@ -146,7 +165,7 @@ describe('RichTextEditorUtil', () => {
         false
       );
 
-      expect(blockMapAfterDelete.size).toBe(4);
+      expect(blockMapAfterDelete.size).toBe(3);
     });
   });
 });

--- a/src/model/transaction/insertBlockAfterInContentState.js
+++ b/src/model/transaction/insertBlockAfterInContentState.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule insertBlockAfterInContentState
+ * @typechecks
+ * @flow
+ */
+
+'use strict';
+
+var invariant = require('invariant');
+
+import type ContentBlock from 'ContentBlock';
+import type ContentState from 'ContentState';
+import type SelectionState from 'SelectionState';
+
+function insertBlockAfterInContentState(
+  contentState: ContentState,
+  selectionState: SelectionState,
+  contentBlock: ContentBlock
+): ContentState {
+  invariant(
+    selectionState.isCollapsed(),
+    'Selection range must be collapsed.'
+  );
+
+  var key = selectionState.getAnchorKey();
+  var blockMap = contentState.getBlockMap();
+  var blockAbove = blockMap.get(key);
+  var blocksBefore = blockMap.toSeq().takeUntil(v => v === blockAbove);
+  var blocksAfter = blockMap.toSeq().skipUntil(v => v === blockAbove).rest();
+  var newBlocks = blocksBefore.concat(
+      [[blockAbove.getKey(), blockAbove], [contentBlock.getKey(), contentBlock]],
+      blocksAfter
+    ).toOrderedMap();
+
+  return contentState.merge({
+    blockMap: newBlocks,
+    selectionBefore: selectionState,
+    selectionAfter: selectionState.merge({
+      anchorKey: contentBlock.getKey(),
+      anchorOffset: 0,
+      focusKey: contentBlock.getKey(),
+      focusOffset: contentBlock.getLength(),
+      isBackward: false,
+    }),
+  });
+}
+
+module.exports = insertBlockAfterInContentState;

--- a/src/model/transaction/insertBlockBeforeInContentState.js
+++ b/src/model/transaction/insertBlockBeforeInContentState.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule insertBlockBeforeInContentState
+ * @typechecks
+ * @flow
+ */
+
+'use strict';
+
+var invariant = require('invariant');
+
+import type ContentBlock from 'ContentBlock';
+import type ContentState from 'ContentState';
+import type SelectionState from 'SelectionState';
+
+function insertBlockBeforeInContentState(
+  contentState: ContentState,
+  selectionState: SelectionState,
+  contentBlock: ContentBlock
+): ContentState {
+  invariant(
+    selectionState.isCollapsed(),
+    'Selection range must be collapsed.'
+  );
+
+  var key = selectionState.getAnchorKey();
+  var blockMap = contentState.getBlockMap();
+  var blockBelow = blockMap.get(key);
+  var blocksBefore = blockMap.toSeq().takeUntil(v => v === blockBelow);
+  var blocksAfter = blockMap.toSeq().skipUntil(v => v === blockBelow);
+  var newBlocks = blocksBefore.concat(
+      [[contentBlock.getKey(), contentBlock], [blockBelow.getKey(), blockBelow]],
+      blocksAfter
+    ).toOrderedMap();
+
+  return contentState.merge({
+    blockMap: newBlocks,
+    selectionBefore: selectionState,
+    selectionAfter: selectionState.merge({
+      anchorKey: contentBlock.getKey(),
+      anchorOffset: 0,
+      focusKey: contentBlock.getKey(),
+      focusOffset: contentBlock.getLength(),
+      isBackward: false,
+    }),
+  });
+}
+
+module.exports = insertBlockBeforeInContentState;


### PR DESCRIPTION
Hey!

I'd like to enhance the insertAtomicBlock function. Before i start with my explanations, i try to define what is an atomic block in my eyes. Maybe i have a wrong understanding of atomic blocks, so this pull request starts on the wrong edge? Maybe not? We'll see.

In my eyes an atomic block does not only contain text, it can contain images, videos etc. Maybe there is no editable text in it, maybe there is. But from the view of the editor, this is just a block. The editor does not know what is inside. I would consider an atomic block, what for example for CKEditor is a widget. Actually this is where i am coming from, i'd like to implement "widgets" in a draft-js editor.

How i think the insertAtomicBlock function should work:
- After calling insertAtomicBlock, an atomic block should be inserted at the current selection
- If the current selection is at the beginning of a block, the new atomic block should be inserted before that block
- If the current selection is inbetween a text in a block, the block should be splitted and the new atomic block should be inserted inbetween the splitted blocks
- If the current selection is at the end of a block, the new atomic block should be inserted after that block
- There is no need for inserting an extra empty block before or after an atomic block
- The insertAtomicBlock function mustn't affect the styling of the blocks before and/or after
- An atomic block can have an entity or not. It mustn't be mandatory to define/create an entity for an atomic block
- I you want to insert an atomic block after/before an empty block, you need a function insertAtomicBlockAfter/insertAtomicBlockBefore, since you cannot determine the insertion direction by the selection

According to this i've created the this pull request.

Why? Problems with the current insertAtomicBlock implementation:
- It creates an extra empty block before or after the inserted block
- It affects the styling of blocks before and/or after the inserted atomic block
- It is mandatory to create an entity for an atomic block
- You cannot insert an atomic block before or after an empty block

In my eyes an atomic block should also be able to have a focus. Same principle than widgets in CKEditor for example. But i'll leave this to another pull request...

Please let me know what you think. Would be great to see this feature in the master.

Cheers, delijah
