### PR TITLE
Add style un-setting to paste handler

### DIFF
--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -48,6 +48,10 @@ var REGEX_NBSP = new RegExp(NBSP, 'g');
 var REGEX_CARRIAGE = new RegExp('&#13;?', 'g');
 var REGEX_ZWS = new RegExp('&#8203;?', 'g');
 
+// https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight
+const boldValues = ['bold', 'bolder', '500', '600', '700', '800', '900'];
+const notBoldValues = ['light', 'lighter', '100', '200', '300', '400'];
+
 // Block tag flow is different because LIs do not have
 // a deterministic style ;_;
 var inlineTags = {
@@ -196,20 +200,31 @@ function processInlineTag(
   } else if (node instanceof HTMLElement) {
     const htmlElement = node;
     currentStyle = currentStyle.withMutations(style => {
-      if (htmlElement.style.fontWeight === 'bold') {
+      const fontWeight = htmlElement.style.fontWeight;
+      const fontStyle = htmlElement.style.fontStyle;
+      const textDecoration = htmlElement.style.textDecoration;
+
+      if (boldValues.indexOf(fontWeight) >= 0) {
         style.add('BOLD');
+      } else if (notBoldValues.indexOf(fontWeight) >= 0) {
+        style.remove('BOLD');
       }
 
-      if (htmlElement.style.fontStyle === 'italic') {
+      if (fontStyle === 'italic') {
         style.add('ITALIC');
+      } else if (fontStyle === 'normal') {
+        style.remove('ITALIC');
       }
 
-      if (htmlElement.style.textDecoration === 'underline') {
+      if (textDecoration === 'underline') {
         style.add('UNDERLINE');
       }
-
-      if (htmlElement.style.textDecoration === 'line-through') {
+      if (textDecoration === 'line-through') {
         style.add('STRIKETHROUGH');
+      }
+      if (textDecoration === 'none') {
+        style.remove('UNDERLINE');
+        style.remove('STRIKETHROUGH');
       }
     }).toOrderedSet();
   }

--- a/src/model/paste/__tests__/DraftPasteProcessor-test.js
+++ b/src/model/paste/__tests__/DraftPasteProcessor-test.js
@@ -352,6 +352,54 @@ describe('DraftPasteProcessor', function() {
     expect(output[1].getText()).toBe('what');
   });
 
+  it('Should detect when somthing is un-styled in a child', function() {
+    let html = `<b>hello<span style="font-weight:400;">there</span></b>`;
+    let output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    assertInlineStyles(output[0], [
+      ['BOLD'],
+      ['BOLD'],
+      ['BOLD'],
+      ['BOLD'],
+      ['BOLD'],
+      [],
+      [],
+      [],
+      [],
+      [],
+    ]);
+
+    html = `<i>hello<span style="font-style:normal;">there</span></i>`;
+    output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    assertInlineStyles(output[0], [
+      ['ITALIC'],
+      ['ITALIC'],
+      ['ITALIC'],
+      ['ITALIC'],
+      ['ITALIC'],
+      [],
+      [],
+      [],
+      [],
+      [],
+    ]);
+
+    // nothing to remove. make sure we don't throw an error
+    html = `<span>hello<span style="font-style:normal;">there</span></span>`;
+    output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    assertInlineStyles(output[0], [
+      [],
+      [],
+      [],
+      [],
+      [],
+      [],
+      [],
+      [],
+      [],
+      [],
+    ]);
+  });
+
   it('must preserve list formatting', function() {
     var html = `
     what


### PR DESCRIPTION
Test cases pretty much explain what's going on. This will handle inline styles being unset further down in the dom tree. 

This fixes #481