### PR TITLE
Update ambiguous handlePastedText docs

### DIFF
--- a/docs/APIReference-Editor.md
+++ b/docs/APIReference-Editor.md
@@ -167,7 +167,7 @@ and to convert typed emoticons into images.
 ```
 handlePastedText?: (text: string, html?: string) => boolean
 ```
-Handle text and html(for rich text) that has been pasted directly into the editor.
+Handle text and html(for rich text) that has been pasted directly into the editor. Returning true will prevent the default paste behavior. 
 
 #### handlePastedFiles
 ```


### PR DESCRIPTION
handlePastedText docs don't say what the return value does. This came up in the slack.

