### PR TITLE
removes iOS format tooltips everywhere

### DIFF
--- a/src/component/base/DraftEditor.css
+++ b/src/component/base/DraftEditor.css
@@ -11,12 +11,12 @@
 .public/DraftEditor/content {
   height: inherit;
   text-align: initial;
+  -webkit-user-modify: read-write-plaintext-only;
+  user-modify: read-write-plaintext-only;
 }
 
 .DraftEditor/root {
   position: relative;
-  -webkit-user-modify: read-write-plaintext-only;
-  user-modify: read-write-plaintext-only;
 }
 
 /**

--- a/src/component/base/DraftEditor.css
+++ b/src/component/base/DraftEditor.css
@@ -15,6 +15,8 @@
 
 .DraftEditor/root {
   position: relative;
+  -webkit-user-modify: read-write-plaintext-only;
+  user-modify: read-write-plaintext-only;
 }
 
 /**


### PR DESCRIPTION
fixes #214

thanks to @bradleyayers excellent digging it turns out there's a
CSS property you can assign to disable the bold/italics/underline
for iOS. although you can techincally apply this style seperately
, since the editor breaks due to the unexpected dom mutations i
think it's best if this actually gets defaultly added to the root
of the editor. which this commit does.