### PR TITLE
Need ability to "not continue" a mutable entity #430

### DIFF
--- a/examples/link/link.html
+++ b/examples/link/link.html
@@ -87,7 +87,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         _confirmLink(e) {
           e.preventDefault();
           const {editorState, urlValue} = this.state;
-          const entityKey = Entity.create('LINK', 'MUTABLE', {url: urlValue});
+          const entityKey = Entity.create('LINK', 'MUTABLE', {url: urlValue}, false);
           this.setState({
             editorState: RichUtils.toggleLink(
               editorState,

--- a/src/model/entity/DraftEntity.js
+++ b/src/model/entity/DraftEntity.js
@@ -52,7 +52,7 @@ var DraftEntity = {
     data?: Object
   ): string {
     return DraftEntity.add(
-      new DraftEntityInstance({type, mutability, contiguous: true, data: data || {}})
+      new DraftEntityInstance({type, mutability, contiguous: contiguous || true, data: data || {}})
     );
   },
 

--- a/src/model/entity/DraftEntity.js
+++ b/src/model/entity/DraftEntity.js
@@ -51,8 +51,9 @@ var DraftEntity = {
     data?: Object,
     contiguous?: bool,
   ): string {
+    var isContiguous = (typeof contiguous !== undefined) ? contiguous : true;
     return DraftEntity.add(
-      new DraftEntityInstance({type, mutability, data: data || {}, contiguous})
+      new DraftEntityInstance({type, mutability, data: data || {}, contiguous: isContiguous})
     );
   },
 

--- a/src/model/entity/DraftEntity.js
+++ b/src/model/entity/DraftEntity.js
@@ -48,10 +48,11 @@ var DraftEntity = {
   create: function(
     type: DraftEntityType,
     mutability: DraftEntityMutability,
+    contiguous?: bool,
     data?: Object
   ): string {
     return DraftEntity.add(
-      new DraftEntityInstance({type, mutability, data: data || {}})
+      new DraftEntityInstance({type, mutability, contiguous: true, data: data || {}})
     );
   },
 

--- a/src/model/entity/DraftEntity.js
+++ b/src/model/entity/DraftEntity.js
@@ -48,11 +48,11 @@ var DraftEntity = {
   create: function(
     type: DraftEntityType,
     mutability: DraftEntityMutability,
+    data?: Object,
     contiguous?: bool,
-    data?: Object
   ): string {
     return DraftEntity.add(
-      new DraftEntityInstance({type, mutability, contiguous: contiguous || true, data: data || {}})
+      new DraftEntityInstance({type, mutability, data: data || {}, contiguous})
     );
   },
 

--- a/src/model/entity/DraftEntityInstance.js
+++ b/src/model/entity/DraftEntityInstance.js
@@ -41,6 +41,10 @@ class DraftEntityInstance extends DraftEntityInstanceRecord {
     return this.get('type');
   }
 
+  getContiguity(): DraftEntityMutability {
+    return this.get('contiguous');
+  }
+
   getMutability(): DraftEntityMutability {
     return this.get('mutability');
   }

--- a/src/model/entity/DraftEntityInstance.js
+++ b/src/model/entity/DraftEntityInstance.js
@@ -23,6 +23,7 @@ var DraftEntityInstanceRecord = Record({
   type: 'TOKEN',
   mutability: 'IMMUTABLE',
   data: Object,
+  contiguous: true,
 });
 
 /**
@@ -41,16 +42,16 @@ class DraftEntityInstance extends DraftEntityInstanceRecord {
     return this.get('type');
   }
 
-  getContiguity(): DraftEntityMutability {
-    return this.get('contiguous');
-  }
-
   getMutability(): DraftEntityMutability {
     return this.get('mutability');
   }
 
   getData(): Object {
     return this.get('data');
+  }
+
+  getContiguity(): bool {
+    return this.get('contiguous');
   }
 }
 

--- a/src/model/entity/__tests__/getEntityKeyForSelection-test.js
+++ b/src/model/entity/__tests__/getEntityKeyForSelection-test.js
@@ -55,15 +55,35 @@ describe('getEntityKeyForSelection', () => {
       expect(key).toBe('123');
     });
 
+    it('must return key if caret inside mutable & non-contiguous', () => {
+      var specialSelection = selectionState.merge({
+        anchorOffset: 4,
+        focusOffset: 4,
+      });
 
-    it('must not return key if mutable & non-contiguous', () => {
       DraftEntity.get.mockImplementation(() => {
         return {
           getMutability: () => 'MUTABLE',
           getContiguity: () => false,
         };
       });
-      var key = getEntityKeyForSelection(contentState, collapsed);
+      var key = getEntityKeyForSelection(contentState, specialSelection);
+      expect(key).toBe('123');
+    });
+
+    it('must not return key if mutable & non-contiguous', () => {
+      var specialSelection = selectionState.merge({
+        anchorOffset: 5,
+        focusOffset: 5,
+      });
+
+      DraftEntity.get.mockImplementation(() => {
+        return {
+          getMutability: () => 'MUTABLE',
+          getContiguity: () => false,
+        };
+      });
+      var key = getEntityKeyForSelection(contentState, specialSelection);
       expect(key).toBe(null);
     });
 
@@ -112,17 +132,6 @@ describe('getEntityKeyForSelection', () => {
       });
       var key = getEntityKeyForSelection(contentState, nonCollapsed);
       expect(key).toBe('123');
-    });
-
-    it('must not return key if mutable & non-contiguous', () => {
-      DraftEntity.get.mockImplementation(() => {
-        return {
-          getMutability: () => 'MUTABLE',
-          getContiguity: () => false,
-        };
-      });
-      var key = getEntityKeyForSelection(contentState, nonCollapsed);
-      expect(key).toBe(null);
     });
 
     it('must not return key if immutable', () => {

--- a/src/model/entity/__tests__/getEntityKeyForSelection-test.js
+++ b/src/model/entity/__tests__/getEntityKeyForSelection-test.js
@@ -46,10 +46,25 @@ describe('getEntityKeyForSelection', () => {
 
     it('must return key if mutable', () => {
       DraftEntity.get.mockImplementation(() => {
-        return {getMutability: () => 'MUTABLE'};
+        return {
+          getMutability: () => 'MUTABLE',
+          getContiguity: () => true,
+        };
       });
       var key = getEntityKeyForSelection(contentState, collapsed);
       expect(key).toBe('123');
+    });
+
+
+    it('must not return key if mutable & non-contiguous', () => {
+      DraftEntity.get.mockImplementation(() => {
+        return {
+          getMutability: () => 'MUTABLE',
+          getContiguity: () => false,
+        };
+      });
+      var key = getEntityKeyForSelection(contentState, collapsed);
+      expect(key).toBe(null);
     });
 
     it('must not return key if immutable', () => {
@@ -90,10 +105,24 @@ describe('getEntityKeyForSelection', () => {
 
     it('must return key if mutable', () => {
       DraftEntity.get.mockImplementation(() => {
-        return {getMutability: () => 'MUTABLE'};
+        return {
+          getMutability: () => 'MUTABLE',
+          getContiguity: () => true,
+        };
       });
       var key = getEntityKeyForSelection(contentState, nonCollapsed);
       expect(key).toBe('123');
+    });
+
+    it('must not return key if mutable & non-contiguous', () => {
+      DraftEntity.get.mockImplementation(() => {
+        return {
+          getMutability: () => 'MUTABLE',
+          getContiguity: () => false,
+        };
+      });
+      var key = getEntityKeyForSelection(contentState, nonCollapsed);
+      expect(key).toBe(null);
     });
 
     it('must not return key if immutable', () => {

--- a/src/model/entity/getEntityKeyForSelection.js
+++ b/src/model/entity/getEntityKeyForSelection.js
@@ -59,7 +59,7 @@ function filterKey(
 ): ?string {
   if (entityKey) {
     var entity = DraftEntity.get(entityKey);
-    return entity.getMutability() === 'MUTABLE' ? entityKey : null;
+    return (entity.getMutability() === 'MUTABLE' || entity.getContiguity()) ? entityKey : null;
   }
   return null;
 }

--- a/src/model/entity/getEntityKeyForSelection.js
+++ b/src/model/entity/getEntityKeyForSelection.js
@@ -59,7 +59,7 @@ function filterKey(
 ): ?string {
   if (entityKey) {
     var entity = DraftEntity.get(entityKey);
-    return (entity.getMutability() === 'MUTABLE' || entity.getContiguity()) ? entityKey : null;
+    return (entity.getMutability() === 'MUTABLE' && entity.getContiguity()) ? entityKey : null;
   }
   return null;
 }


### PR DESCRIPTION
Sometimes, we do not want MUTABLE entities to be continued when they are on the left of
the cursor, for example when creating a LINK entity that we do not want to continue after
pressing the space key, this proposal adds a "Contiguous" setting set to true by default that
we can set to false to get the desired behavior

Please note this is a WIP and not yet ready to be merged
- [x] Rework example for link.html
- [x] Rewrite tests with selection states
- [ ] Figure out why exported state does not output contiguous prop
