### PR TITLE
Update Flow comment supression regex

### DIFF
--- a/src/.flowconfig
+++ b/src/.flowconfig
@@ -16,7 +16,7 @@
 module.system=haste
 esproposal.class_static_fields=enable
 suppress_type=$FlowIssue
-suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe
+suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(2[0-8]\\|1[0-9]\\|[0-9]\\).[0-9]\\)? *\\).*\n
 
 [version]
 0.28.0


### PR DESCRIPTION
**Summary**

I'm not sure why we need to change this. The magic bit seems to be needing to match the newline, the rest of the changes just bring use more in line with the internal flowconfig. Maybe @jeffmo can tell us why?

**Test Plan**

`npm run flow`

