### PR TITLE
Update fbjs dep to 0.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test-ci": "NODE_ENV=test npm run lint && npm run flow && npm run test"
   },
   "dependencies": {
-    "fbjs": "^0.8.1",
+    "fbjs": "^0.8.3",
     "immutable": "~3.7.4"
   },
   "peerDependencies": {


### PR DESCRIPTION
This should ensure that Flow will pass and nobody should get stuck with
a version of fbjs that isn't compatible with the version of Flow we use.