### PR TITLE
Accept pasted mailto: links

### DIFF
--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -286,7 +286,7 @@ function hasValidLinkText(link: Node): boolean {
     'Link must be an HTMLAnchorElement.'
   );
   var protocol = link.protocol;
-  return protocol === 'http:' || protocol === 'https:';
+  return protocol === 'http:' || protocol === 'https:' || protocol === 'mailto:';
 }
 
 function genFragment(


### PR DESCRIPTION
**Summary**

`mailto:` links were being stripped to plaintext on paste because they failed the protocol check.

For now I added it to the list of accepted protocols, but I was wondering if it might be reasonable to remove this check altogether and allow pasting links with any protocol? Or perhaps making this configurable.

**Test Plan**

There are no tests for `convertFromHTMLToContentBlocks` yet. I'd prefer to add cases to an existing test file rather than starting a new one, unless absolutely necessary.