### PR TITLE
fixes selection-state with -webkit-user-modify

### DIFF
--- a/src/component/base/DraftEditor.css
+++ b/src/component/base/DraftEditor.css
@@ -11,6 +11,9 @@
 .public/DraftEditor/content {
   height: inherit;
   text-align: initial;
+}
+
+.public/DraftEditor/content {
   -webkit-user-modify: read-write-plaintext-only;
   user-modify: read-write-plaintext-only;
 }


### PR DESCRIPTION
**Summary**
turns out chrome (at least) would incorrectly not erase the placeholders
with -webkit-user-modify being applied where it was.
this was totally an oversight on my part not testing after taking
the lucidity designs comment in PR 509.

Testing this time in my normal suite of browsers (firefox, chrome, safari)
this commit moving the selection state to just target .public/DraftEditor/content
fixes the selection state problem.

**Test-Plan**
1. Build the project.
2. Open up the rich content example.
3. Notice the placeholder text goes away when you type.