### PR TITLE
Docs: Update return type for `tryToRemoveBlockStyle`

### DIFF
--- a/docs/APIReference-RichUtils.md
+++ b/docs/APIReference-RichUtils.md
@@ -120,5 +120,5 @@ toggleLink(
 ```
 tryToRemoveBlockStyle(
   editorState: EditorState
-): EditorState?
+): ContentState?
 ```


### PR DESCRIPTION
**Summary**
This is a small update to the docs to specify the proper return type for `tryToRemoveBlockStyle`.
