### PR TITLE
Add p tags to block render map

### DIFF
--- a/src/model/immutable/DefaultDraftBlockRenderMap.js
+++ b/src/model/immutable/DefaultDraftBlockRenderMap.js
@@ -61,4 +61,7 @@ module.exports = Map({
   'unstyled': {
     element: 'div',
   },
+  'paragraph': {
+    element: 'p',
+  },
 });

--- a/src/model/paste/__tests__/DraftPasteProcessor-test.js
+++ b/src/model/paste/__tests__/DraftPasteProcessor-test.js
@@ -14,38 +14,8 @@
 jest.disableAutomock();
 
 var DraftEntity = require('DraftEntity');
-var Immutable = require('immutable');
 
 var DraftPasteProcessor = require('DraftPasteProcessor');
-var CUSTOM_BLOCK_MAP = Immutable.Map({
-  'header-one': {
-    element: 'h1',
-  },
-  'header-two': {
-    element: 'h2',
-  },
-  'header-three': {
-    element: 'h3',
-  },
-  'unordered-list-item': {
-    element: 'li',
-  },
-  'ordered-list-item': {
-    element: 'li',
-  },
-  'blockquote': {
-    element: 'blockquote',
-  },
-  'code-block': {
-    element: 'pre',
-  },
-  'paragraph': {
-    element: 'p',
-  },
-  'unstyled': {
-    element: 'div',
-  },
-});
 
 describe('DraftPasteProcessor', function() {
   function assertInlineStyles(block, comparison) {
@@ -80,7 +50,7 @@ describe('DraftPasteProcessor', function() {
 
   it('must identify italics text', function() {
     var html = '<i>hello</i> hi';
-    var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    var output = DraftPasteProcessor.processHTML(html);
     var block = output[0];
     expect(block.getType()).toBe('unstyled');
     assertInlineStyles(block, [
@@ -98,7 +68,7 @@ describe('DraftPasteProcessor', function() {
 
   it('must identify overlapping inline styles', function() {
     var html = '<i><b>he</b>hi</i>';
-    var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    var output = DraftPasteProcessor.processHTML(html);
     var block = output[0];
     expect(block.getType()).toBe('unstyled');
     assertInlineStyles(block, [
@@ -112,7 +82,7 @@ describe('DraftPasteProcessor', function() {
 
   it('must identify block styles', function() {
     var html = '<ol><li>hi</li><li>there</li></ol>';
-    var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    var output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, [
       'ordered-list-item',
       'ordered-list-item',
@@ -121,7 +91,7 @@ describe('DraftPasteProcessor', function() {
 
   it('must collapse nested blocks to the topmost level', function() {
     var html = '<ul><li><h2>what</h2></li></ul>';
-    var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    var output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, [
       'unordered-list-item',
     ]);
@@ -133,7 +103,7 @@ describe('DraftPasteProcessor', function() {
    *
    * it('must suppress blocks nested inside other blocks', function() {
    *   var html = '<p><h2>Some text here</h2> more text here </p>';
-   *   var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+   *   var output = DraftPasteProcessor.processHTML(html);
    *   assertBlockTypes(output, [
    *   'unstyled',
    *   ]);
@@ -142,7 +112,7 @@ describe('DraftPasteProcessor', function() {
 
   it('must detect two touching blocks', function() {
     var html = '<h1>hi</h1>    <h2>hi</h2>';
-    var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    var output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, [
       'header-one',
       'header-two',
@@ -151,7 +121,7 @@ describe('DraftPasteProcessor', function() {
 
   it('must insert a block when needed', function() {
     var html = ' <h1> hi </h1><h1> </h1><span> whatever </span> <h2>hi </h2> ';
-    var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    var output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, [
       'header-one',
       'unstyled',
@@ -162,7 +132,7 @@ describe('DraftPasteProcessor', function() {
   it('must not generate fake blocks on heavy nesting', function() {
     var html = '<p><span><span><span>Word</span></span></span>' +
     '<span><span>,</span></span></p>';
-    var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    var output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, ['paragraph']);
   });
 
@@ -170,24 +140,24 @@ describe('DraftPasteProcessor', function() {
     var html, output;
 
     html = '<span>hello</span> <span>hi</span>';
-    output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    output = DraftPasteProcessor.processHTML(html);
     expect(output.length).toEqual(1);
     assertBlockTypes(output, ['unstyled']);
     var block = output[0];
     expect(block.getText()).toBe('hello hi');
 
     html = '<span>hello </span><span>hi</span>';
-    output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    output = DraftPasteProcessor.processHTML(html);
     expect(output[0].getText()).toBe('hello hi');
 
     html = '<span>hello</span><span> hi</span>';
-    output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    output = DraftPasteProcessor.processHTML(html);
     expect(output[0].getText()).toEqual('hello hi');
   });
 
   it('must treat divs as Ps when we do not have semantic markup', function() {
     var html = '<div>hi</div><div>hello</div>';
-    var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    var output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, [
       'unstyled',
       'unstyled',
@@ -196,7 +166,7 @@ describe('DraftPasteProcessor', function() {
 
   it('must NOT treat divs as Ps when we pave Ps', function() {
     var html = '<div><p>hi</p><p>hello</p></div>';
-    var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    var output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, [
       'paragraph',
       'paragraph',
@@ -205,25 +175,25 @@ describe('DraftPasteProcessor', function() {
 
   it('must replace br tags with soft newlines', function() {
     var html = 'hi<br>hello';
-    var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    var output = DraftPasteProcessor.processHTML(html);
     expect(output[0].getText()).toBe('hi\nhello');
   });
 
   it('must strip xml carriages and zero width spaces', function() {
     var html = 'hi&#13;&#8203;hello';
-    var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    var output = DraftPasteProcessor.processHTML(html);
     expect(output[0].getText()).toBe('hihello');
   });
 
   it('must split unstyled blocks on two br tags', function() {
     var html = 'hi<br><br>hello';
-    var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    var output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, [
       'unstyled',
       'unstyled',
     ]);
     html = '<div>hi<br><br>hello</div>';
-    output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, [
       'unstyled',
       'unstyled',
@@ -232,13 +202,13 @@ describe('DraftPasteProcessor', function() {
 
   it('must NOT split unstyled blocks inside a styled block', function() {
     var html = '<pre>hi<br><br>hello</pre>';
-    var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    var output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, ['code-block']);
   });
 
   it('must split unstyled blocks on two br tags', function() {
     var html = 'hi<br><br>hello';
-    var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    var output = DraftPasteProcessor.processHTML(html);
     expect(output[0].getText().length).toBe(3);
     expect(output[1].getText()).toBe('hello');
     assertBlockTypes(output, [
@@ -249,19 +219,19 @@ describe('DraftPasteProcessor', function() {
 
   it('must replace newlines in regular tags', function() {
     var html = '<div>hello\nthere</div>';
-    var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    var output = DraftPasteProcessor.processHTML(html);
     expect(output[0].getText()).toBe('hello there');
   });
 
   it('must preserve newlines in pre tags', function() {
     var html = '<pre>hello\nthere</pre>';
-    var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    var output = DraftPasteProcessor.processHTML(html);
     expect(output[0].getText()).toBe('hello\nthere');
   });
 
   it('must preserve newlines in whitespace in pre tags', function() {
     var html = '<pre><span>hello</span>\n<span>there</span></pre>';
-    var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    var output = DraftPasteProcessor.processHTML(html);
     expect(output[0].getText()).toBe('hello\nthere');
     assertBlockTypes(output, ['code-block']);
   });
@@ -269,7 +239,7 @@ describe('DraftPasteProcessor', function() {
   it('must parse based on style attribute', function() {
     var html = '<span style="font-weight: bold;">Bold '
     + '<span style="font-style: italic;">Italic</span></span>.';
-    var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    var output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, ['unstyled']);
     assertInlineStyles(output[0], [
       ['BOLD'],
@@ -290,7 +260,7 @@ describe('DraftPasteProcessor', function() {
 
   it('must detect links in pasted content', function() {
     var html = 'This is a <a href="http://www.facebook.com">link</a>, yep.';
-    var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    var output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, ['unstyled']);
     assertEntities(
       output[0],
@@ -304,7 +274,7 @@ describe('DraftPasteProcessor', function() {
 
   it('must preserve styles inside links in a good way', function() {
     var html = 'A <a href="http://www.facebook.com"><i>cool</i> link</a>, yep.';
-    var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    var output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, ['unstyled']);
     assertInlineStyles(
       output[0],
@@ -319,7 +289,7 @@ describe('DraftPasteProcessor', function() {
 
   it('must ignore links that do not actually link anywhere', function() {
     var html = 'This is a <a>link</a>, yep.';
-    var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    var output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, ['unstyled']);
     assertEntities(output[0], Array(20).fill(false));
     expect(output[0].getText()).toBe('This is a link, yep.');
@@ -327,7 +297,7 @@ describe('DraftPasteProcessor', function() {
 
   it('must ignore javascript: links', function() {
     var html = 'This is a <a href="javascript:void(0)">link</a>, yep.';
-    var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    var output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, ['unstyled']);
     assertEntities(output[0], Array(20).fill(false));
     expect(output[0].getText()).toBe('This is a link, yep.');
@@ -335,7 +305,7 @@ describe('DraftPasteProcessor', function() {
 
   it('must preserve mailto: links', function() {
     var html = 'This is a <a href="mailto:example@example.com">link</a>, yep.';
-    var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    var output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, ['unstyled']);
     assertEntities(
       output[0],
@@ -349,20 +319,20 @@ describe('DraftPasteProcessor', function() {
 
   it('Tolerate doule BR tags separated by whitespace', function() {
     var html = 'hi<br>  <br>hello';
-    var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    var output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, [
       'unstyled',
       'unstyled',
     ]);
     html = '<div>hi<br> <br>hello</div>';
-    output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, [
       'unstyled',
       'unstyled',
     ]);
 
     html = '<div>hi<br> good stuff here <br>hello</div>';
-    output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, [
       'unstyled',
     ]);
@@ -370,13 +340,13 @@ describe('DraftPasteProcessor', function() {
 
   it('Strip whitespace after block dividers', function() {
     var html = '<p>hello</p> <p> what</p>';
-    var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    var output = DraftPasteProcessor.processHTML(html);
     expect(output[1].getText()).toBe('what');
   });
 
   it('Should detect when somthing is un-styled in a child', function() {
     let html = '<b>hello<span style="font-weight:400;">there</span></b>';
-    let output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    let output = DraftPasteProcessor.processHTML(html);
     assertInlineStyles(output[0], [
       ['BOLD'],
       ['BOLD'],
@@ -391,7 +361,7 @@ describe('DraftPasteProcessor', function() {
     ]);
 
     html = '<i>hello<span style="font-style:normal;">there</span></i>';
-    output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    output = DraftPasteProcessor.processHTML(html);
     assertInlineStyles(output[0], [
       ['ITALIC'],
       ['ITALIC'],
@@ -407,7 +377,7 @@ describe('DraftPasteProcessor', function() {
 
     // nothing to remove. make sure we don't throw an error
     html = '<span>hello<span style="font-style:normal;">there</span></span>';
-    output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    output = DraftPasteProcessor.processHTML(html);
     assertInlineStyles(output[0], [
       [],
       [],
@@ -437,7 +407,7 @@ describe('DraftPasteProcessor', function() {
       <li>what</li>
     </ul>
     `;
-    var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    var output = DraftPasteProcessor.processHTML(html);
     assertBlockTypes(output, [
       'unstyled',
       'unordered-list-item',
@@ -448,4 +418,5 @@ describe('DraftPasteProcessor', function() {
     ]);
     assertDepths(output, [0, 0, 0, 1, 1, 0]);
   });
+
 });


### PR DESCRIPTION
**Summary**

Fixes #523 

There was some kind of diversion with the test cases using their own block map. I took that out and put p in the block map and everything worked. @mitermayer seems to have dealt with a lot of this last so would be good to get his opinion. 

This will alter paste behavior for people but they can change it back by passing a custom block map. 

**Test Plan**

`Draft.convertFromHTML("<p>A</p><p>B</p><p>C</p>");` returns 3 blocks
