### PR TITLE
Add `inputTags` as an option to blockerRenderMap config

### DIFF
--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -141,15 +141,28 @@ function getListBlockType(
   return null;
 }
 
+function getInputTags(
+  config: {
+    inputTags: ?Array<string>,
+    element: ?string,
+  }
+): Array<string> {
+  if (config.inputTags) {
+    return config.inputTags;
+  } else if (config.element) {
+    return [config.element];
+  } else {
+    return [];
+  }
+}
+
 function getBlockMapSupportedTags(
   blockRenderMap: DraftBlockRenderMap
 ): Array<string> {
-  const unstyledElement = blockRenderMap.get('unstyled').element;
   return blockRenderMap
-    .map((config) => config.element)
     .valueSeq()
+    .flatMap((config) => getInputTags(config))
     .toSet()
-    .filter((tag) => tag && tag !== unstyledElement)
     .toArray()
     .sort();
 }
@@ -175,7 +188,10 @@ function getBlockTypeForTag(
   blockRenderMap: DraftBlockRenderMap
 ): DraftBlockType {
   const matchedTypes = blockRenderMap
-    .filter((config) => config.element === tag || config.wrapper === tag)
+    .filter((config) =>
+      getInputTags(config).includes(tag) ||
+      config.wrapper === tag
+    )
     .keySeq()
     .toSet()
     .toArray()

--- a/src/model/immutable/DefaultDraftBlockRenderMap.js
+++ b/src/model/immutable/DefaultDraftBlockRenderMap.js
@@ -60,5 +60,6 @@ module.exports = Map({
   },
   'unstyled': {
     element: 'div',
+    inputTags: ['div', 'p'],
   },
 });

--- a/src/model/paste/__tests__/DraftPasteProcessor-test.js
+++ b/src/model/paste/__tests__/DraftPasteProcessor-test.js
@@ -448,4 +448,52 @@ describe('DraftPasteProcessor', function() {
     ]);
     assertDepths(output, [0, 0, 0, 1, 1, 0]);
   });
+
+  it('must respect inputTags when present', function() {
+    /**
+     * As a contrived example, h1 and h2 tags are mapped to header-one, and
+     * h3 tags are mapped to header-two.
+     */
+    var blockMapWithInputTags = Immutable.Map({
+      'header-one': {
+        element: 'h1',
+        inputTags: ['h1', 'h2'],
+      },
+      'header-two': {
+        element: 'h2',
+        inputTags: ['h3'],
+      },
+    });
+
+    var html = '<h1>Hello</h1><h2>World</h2><h3>!</h3>';
+    var output = DraftPasteProcessor.processHTML(html, blockMapWithInputTags);
+    assertBlockTypes(output, [
+      'header-one',
+      'header-one',
+      'header-two',
+    ]);
+  });
+
+  it('defaults to element when inputTags is blank', function() {
+    /**
+     * As a contrived example, h1 tags are mapped to header-one, and
+     * h3 tags are mapped to header-two.
+     */
+    var blockMapWithElement = Immutable.Map({
+      'header-one': {
+        element: 'h1',
+      },
+      'header-two': {
+        element: 'h3',
+      },
+    });
+
+    var html = '<h1>Hello</h1><h2>World</h2><h3>!</h3>';
+    var output = DraftPasteProcessor.processHTML(html, blockMapWithElement);
+    assertBlockTypes(output, [
+      'header-one',
+      'unstyled',
+      'header-two',
+    ]);
+  });
 });


### PR DESCRIPTION
This PR addresses the same concerns as https://github.com/facebook/draft-js/pull/488 and https://github.com/facebook/draft-js/pull/571. I saw a suggestion to add an `inputTags` option to `blockRenderMap`, but it didn't look like anybody had gotten around to implementing it.

This commit also introduces a failing test

```
it('must NOT treat divs as Ps when we pave Ps')
```

I wasn't sure of the background behind this test so I left it failing for now.

**Summary**

Allow user to specify `inputTags` as an array of tag names that will
get mapped to draft js block types. If `inputTags` are not specified,
fall back to `element`.

Change default blockRenderMap to support `p` and `div` as unstyled blocks.

For example, a blockRenderMap of

```
{
  'header-one': {
    element: 'h1',
    inputTags: ['h2, 'h3'],
  },
  header-two': {
    element: 'h2',
    inputTags: ['h1'],
  },
}
```

will map

```
<h2>Hello world!</h2>
```

and

```
<h3>Hello world!</h3>
```

to a `header-one` block, and will map

```
<h1>Hello world!</h1>
```

to a `header-two` block.

**Test Plan**
1. Copy paste text with `<p>` tags into draft js editor. Each paragraph should be split up into a separate block.
