### PR TITLE
Fix nested editable elements in readOnly editor

### DIFF
--- a/src/component/base/DraftEditor.css
+++ b/src/component/base/DraftEditor.css
@@ -13,7 +13,7 @@
   text-align: initial;
 }
 
-.public/DraftEditor/content {
+.public/DraftEditor/content[contenteditable="true"] {
   -webkit-user-modify: read-write-plaintext-only;
   user-modify: read-write-plaintext-only;
 }


### PR DESCRIPTION
**Summary**

The introduction of `user-modify: read-write-plaintext-only;` ends up breaking readOnly editors with nested editable content, as the cursor jumps back to the top-level editor when focus changes.

Fix this by applying the `user-modify` value only if the content node is editable.

**Test Plan**

  - Run TeX editor.
  - Click a formula. Type inside the textarea. Verify that I can do so.