### PR TITLE
Preserve depth of all block types when converting to raw

### DIFF
--- a/src/model/encoding/convertFromDraftStateToRaw.js
+++ b/src/model/encoding/convertFromDraftStateToRaw.js
@@ -18,7 +18,6 @@ var DraftStringKey = require('DraftStringKey');
 var encodeEntityRanges = require('encodeEntityRanges');
 var encodeInlineStyleRanges = require('encodeInlineStyleRanges');
 
-import type ContentBlock from 'ContentBlock';
 import type ContentState from 'ContentState';
 import type {RawDraftContentState} from 'RawDraftContentState';
 
@@ -47,7 +46,7 @@ function convertFromDraftStateToRaw(
       key: blockKey,
       text: block.getText(),
       type: block.getType(),
-      depth: canHaveDepth(block) ? block.getDepth() : 0,
+      depth: block.getDepth(),
       inlineStyleRanges: encodeInlineStyleRanges(block),
       entityRanges: encodeEntityRanges(block, entityStorageMap),
       data: block.getData().toObject(),
@@ -71,11 +70,6 @@ function convertFromDraftStateToRaw(
     entityMap: flippedStorageMap,
     blocks: rawBlocks,
   };
-}
-
-function canHaveDepth(block: ContentBlock): boolean {
-  var type = block.getType();
-  return type === 'ordered-list-item' || type === 'unordered-list-item';
 }
 
 module.exports = convertFromDraftStateToRaw;


### PR DESCRIPTION
**Summary**
Previously, `convertFromDraftStateToRaw` stripped the depth of all non-list blocks, making it difficult to implement custom block types that support depth/indentation. This seems a bit arbitrary since `convertFromDraftStateToRaw` is the only code in Draft with this restriction; the rest of the code does allow depth to be set on any block, and convertFromRawToDraftState` does allow depths to be specified at import time on any block type.

This change causes `convertFromDraftStateToRaw` to always export the block depth regardless of block type.

**Test Plan**

All existing tests pass, and I don't believe this change warrants any additional test coverage.

fixes #381