### PR TITLE
Tex example deps fix

### DIFF
--- a/examples/tex/package.json
+++ b/examples/tex/package.json
@@ -6,6 +6,7 @@
   },
   "dependencies": {
     "babel": "5.8.23",
+    "babel-core": "^6.8.0",
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",


### PR DESCRIPTION
Fixes an issue that occurred when trying to run `npm start` on the tex example.

`babel-loader@6.2.4 requires a peer of babel-core@^6.0.0 but none was installed.`