### PR TITLE
Add contentState argument to decorator

### DIFF
--- a/src/model/decorators/CompositeDraftDecorator.js
+++ b/src/model/decorators/CompositeDraftDecorator.js
@@ -16,6 +16,7 @@
 var Immutable = require('immutable');
 
 import type ContentBlock from 'ContentBlock';
+import type ContentState from 'ContentState';
 import type {DraftDecorator} from 'DraftDecorator';
 
 var {List} = Immutable;
@@ -51,7 +52,7 @@ class CompositeDraftDecorator {
     this._decorators = decorators.slice();
   }
 
-  getDecorations(block: ContentBlock): List<?string> {
+  getDecorations(block: ContentBlock, newContent: ContentState): List<?string> {
     var decorations = Array(block.getText().length).fill(null);
 
     this._decorators.forEach(
@@ -66,7 +67,7 @@ class CompositeDraftDecorator {
             occupySlice(decorations, start, end, ii + DELIMITER + counter);
             counter++;
           }
-        });
+        }, newContent);
       }
     );
 

--- a/src/model/decorators/DraftDecoratorType.js
+++ b/src/model/decorators/DraftDecoratorType.js
@@ -13,6 +13,7 @@
 'use strict';
 
 import type ContentBlock from 'ContentBlock';
+import type ContentState from 'ContentState';
 import type {List} from 'immutable';
 
 /**
@@ -25,7 +26,7 @@ export type DraftDecoratorType = {
   /**
    * Given a `ContentBlock`, return an immutable List of decorator keys.
    */
-  getDecorations(block: ContentBlock): List<?string>,
+  getDecorations(block: ContentBlock, newContent: ContentState): List<?string>,
 
   /**
    * Given a decorator key, return the component to use when rendering

--- a/src/model/immutable/BlockTree.js
+++ b/src/model/immutable/BlockTree.js
@@ -19,6 +19,7 @@ var findRangesImmutable = require('findRangesImmutable');
 
 import type CharacterMetadata from 'CharacterMetadata';
 import type ContentBlock from 'ContentBlock';
+import type ContentState from 'ContentState';
 import type {DraftDecoratorType} from 'DraftDecoratorType';
 
 var {
@@ -61,7 +62,8 @@ var BlockTree = {
    */
   generate: function(
     block: ContentBlock,
-    decorator: ?DraftDecoratorType
+    decorator: ?DraftDecoratorType,
+    newContent: ContentState
   ): List<DecoratorRange> {
     var textLength = block.getLength();
     if (!textLength) {
@@ -79,7 +81,7 @@ var BlockTree = {
 
     var leafSets = [];
     var decorations = decorator ?
-      decorator.getDecorations(block) :
+      decorator.getDecorations(block, newContent) :
       List(Repeat(null, textLength));
 
     var chars = block.getCharacterList();

--- a/src/model/immutable/EditorState.js
+++ b/src/model/immutable/EditorState.js
@@ -122,7 +122,8 @@ class EditorState {
             newContent.getBlockMap(),
             treeMap,
             decorator,
-            existingDecorator
+            existingDecorator,
+            newContent
           );
         } else {
           newTreeMap = generateNewTreeMap(newContent, decorator);
@@ -515,7 +516,7 @@ function generateNewTreeMap(
 ): OrderedMap<string, List<any>> {
   return contentState
     .getBlockMap()
-    .map(block => BlockTree.generate(block, decorator))
+    .map(block => BlockTree.generate(block, decorator, contentState))
     .toOrderedMap();
 }
 
@@ -535,7 +536,7 @@ function regenerateTreeForNewBlocks(
     newBlockMap
       .toSeq()
       .filter((block, key) => block !== prevBlockMap.get(key))
-      .map(block => BlockTree.generate(block, decorator))
+      .map(block => BlockTree.generate(block, decorator, editorState.getCurrentContent()))
   );
 }
 
@@ -551,18 +552,19 @@ function regenerateTreeForNewDecorator(
   blockMap: BlockMap,
   previousTreeMap: OrderedMap<string, List<any>>,
   decorator: DraftDecoratorType,
-  existingDecorator: DraftDecoratorType
+  existingDecorator: DraftDecoratorType,
+  newContent: ContentState
 ): OrderedMap<string, List<any>> {
   return previousTreeMap.merge(
     blockMap
       .toSeq()
       .filter(block => {
         return (
-          decorator.getDecorations(block) !==
-          existingDecorator.getDecorations(block)
+          decorator.getDecorations(block, newContent) !==
+          existingDecorator.getDecorations(block, newContent)
         );
       })
-      .map(block => BlockTree.generate(block, decorator))
+      .map(block => BlockTree.generate(block, decorator, newContent))
   );
 }
 


### PR DESCRIPTION
This is a proposal and document and test are imperfect yet.

**Summary**

Add contentState to decorator callback.

Example

```js
    strategy(contentBlock, callback, newContent) {
       // ... use newContent to decide what contentBlock is
    }
```

** Reason **

I need to know whole newState in decorator to decide itself but has no clue now.

Example

```
--- start-block
yey, here is block what i want to decorate
--- end-block
```

These are 3 block but middle one need to know upper and below lines.

My personal trigger is here http://stackoverflow.com/questions/38893815/how-do-i-make-multiline-hilighter-on-draft-js

... but I don't know this is correct way. Anyone has better way? or need this?