### PR TITLE
Remove react import, use React$Element

### DIFF
--- a/src/model/immutable/DraftBlockRenderConfig.js
+++ b/src/model/immutable/DraftBlockRenderConfig.js
@@ -12,9 +12,7 @@
 
 'use strict';
 
-import type React from 'react';
-
 export type DraftBlockRenderConfig = {
   element: string,
-  wrapper?: React.Element<any>,
+  wrapper?: React$Element<any>,
 };


### PR DESCRIPTION
This is currently getting rewritten as `./react`. We could probably do this by adding react to the alias list but Flow currently has global types for React. It will for some time so we can just use them.

Note: internally at FB we alias this type to `ReactElement` directly so this will be a bit out of place but there are some uses. I chose to use this here since the resulting type is being used in the outside world.