### PR TITLE
RichUtils onBackspace: remove entire atomic block

### DIFF
--- a/src/model/modifier/RichTextEditorUtil.js
+++ b/src/model/modifier/RichTextEditorUtil.js
@@ -119,26 +119,10 @@ const RichTextEditorUtil = {
     var blockBefore = content.getBlockBefore(startKey);
 
     if (blockBefore && blockBefore.getType() === 'atomic') {
-      var atomicBlockTarget = selection.merge({
-        anchorKey: blockBefore.getKey(),
-        anchorOffset: 0,
-      });
-      var asCurrentStyle = DraftModifier.setBlockType(
-        content,
-        atomicBlockTarget,
-        content.getBlockForKey(startKey).getType()
-      );
-      var withoutAtomicBlock = DraftModifier.removeRange(
-        asCurrentStyle,
-        atomicBlockTarget,
-        'backward'
-      );
+      const blockMap = content.getBlockMap().delete(blockBefore.getKey())
+      var withoutAtomicBlock = content.merge({blockMap, selectionAfter: selection});
       if (withoutAtomicBlock !== content) {
-        return EditorState.push(
-          editorState,
-          withoutAtomicBlock,
-          'remove-range'
-        );
+        return EditorState.push(editorState, withoutAtomicBlock, 'remove-range');
       }
     }
 


### PR DESCRIPTION
**Summary**

Previously, RichUtils "removed" atomic blocks via removeRangeFromContentState. This was problematic, because it preserves the atomic block properties and merges the end block content, resulting in behavior where atomic block data would transfer to unstyled blocks.

This change addresses those issues by removing the atomic block entirely from the blockMap and preserving the existing selection.

**Test Plan**

given the following blockMap in an Editor which is using RichUtils' handleKeyCommand

```
[
  {
    "key": "2124c",
    "text": "abc",
    "type": "unstyled",
    "depth": 0,
    "inlineStyleRanges": [],
    "entityRanges": [],
    "data": {}
  },
  {
    "key": "6ud8",
    "text": "",
    "type": "atomic",
    "depth": 0,
    "inlineStyleRanges": [],
    "entityRanges": [],
    "data": {
      "type": "image",
      "src": 1684980,
      "operation": null
    }
  },
  {
    "key": "a8vr5",
    "text": "def",
    "type": "unstyled",
    "depth": 0,
    "inlineStyleRanges": [],
    "entityRanges": [],
    "data": {}
  }
]
```

positioning the cursor before 'd' and pressing backspace should result in a blockMap which looks like this, with the cursor positioned before the 'd'

```
[
  {
    "key": "2124c",
    "text": "abc",
    "type": "unstyled",
    "depth": 0,
    "inlineStyleRanges": [],
    "entityRanges": [],
    "data": {}
  },
  {
    "key": "a8vr5",
    "text": "def",
    "type": "unstyled",
    "depth": 0,
    "inlineStyleRanges": [],
    "entityRanges": [],
    "data": {}
  }
]
```

*you can see what happened before this change [here](https://gist.github.com/qrohlf/4d3fa3c26c06503cdc10c2b03fa11937) for comparison*

Since the `if` conditions in onBackspace ensure that this code will run only in the case where the selection is collapsed and positioned at the start of a block which is preceded by an atomic block, no other behavior is impacted.  

Fixes #554