### PR TITLE
Convert string refs to callback refs

### DIFF
--- a/examples/draft-0-10-0/color/color.html
+++ b/examples/draft-0-10-0/color/color.html
@@ -42,7 +42,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           super(props);
           this.state = {editorState: EditorState.createEmpty()};
 
-          this.focus = () => this.refs.editor.focus();
+          this.focus = () => this.editor.focus();
           this.onChange = (editorState) => this.setState({editorState});
           this.toggleColor = (toggledColor) => this._toggleColor(toggledColor);
         }
@@ -97,7 +97,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                   editorState={editorState}
                   onChange={this.onChange}
                   placeholder="Write something colorful..."
-                  ref="editor"
+                  ref={(ref) => this.editor = ref}
                 />
               </div>
             </div>

--- a/examples/draft-0-9-1/entity/entity.html
+++ b/examples/draft-0-9-1/entity/entity.html
@@ -118,7 +118,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             editorState: EditorState.createWithContent(blocks, decorator),
           };
 
-          this.focus = () => this.refs.editor.focus();
+          this.focus = () => this.editor.focus();
           this.onChange = (editorState) => this.setState({editorState});
           this.logState = () => {
             const content = this.state.editorState.getCurrentContent();
@@ -134,7 +134,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                   editorState={this.state.editorState}
                   onChange={this.onChange}
                   placeholder="Enter some text..."
-                  ref="editor"
+                  ref={(ref) => this.editor = ref}
                 />
               </div>
               <input

--- a/examples/draft-0-9-1/link/link.html
+++ b/examples/draft-0-9-1/link/link.html
@@ -56,7 +56,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             urlValue: '',
           };
 
-          this.focus = () => this.refs.editor.focus();
+          this.focus = () => this.editor.focus();
           this.onChange = (editorState) => this.setState({editorState});
           this.logState = () => {
             const content = this.state.editorState.getCurrentContent();
@@ -79,7 +79,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
               showURLInput: true,
               urlValue: '',
             }, () => {
-              setTimeout(() => this.refs.url.focus(), 0);
+              setTimeout(() => this.url.focus(), 0);
             });
           }
         }
@@ -97,7 +97,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             showURLInput: false,
             urlValue: '',
           }, () => {
-            setTimeout(() => this.refs.editor.focus(), 0);
+            setTimeout(() => this.editor.focus(), 0);
           });
         }
 
@@ -159,7 +159,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                   editorState={this.state.editorState}
                   onChange={this.onChange}
                   placeholder="Enter some text..."
-                  ref="editor"
+                  ref={(ref) => this.editor = ref}
                 />
               </div>
               <input

--- a/examples/draft-0-9-1/media/media.html
+++ b/examples/draft-0-9-1/media/media.html
@@ -49,7 +49,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             urlType: '',
           };
 
-          this.focus = () => this.refs.editor.focus();
+          this.focus = () => this.editor.focus();
           this.logState = () => {
             const content = this.state.editorState.getCurrentContent();
             console.log(convertToRaw(content));
@@ -106,7 +106,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             urlValue: '',
             urlType: type,
           }, () => {
-            setTimeout(() => this.refs.url.focus(), 0);
+            setTimeout(() => this.url.focus(), 0);
           });
         }
 
@@ -173,7 +173,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                   handleKeyCommand={this.handleKeyCommand}
                   onChange={this.onChange}
                   placeholder="Enter some text..."
-                  ref="editor"
+                  ref={(ref) => this.editor = ref}
                 />
               </div>
               <input

--- a/examples/draft-0-9-1/plaintext/plaintext.html
+++ b/examples/draft-0-9-1/plaintext/plaintext.html
@@ -36,7 +36,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           super(props);
           this.state = {editorState: EditorState.createEmpty()};
 
-          this.focus = () => this.refs.editor.focus();
+          this.focus = () => this.editor.focus();
           this.onChange = (editorState) => this.setState({editorState});
           this.logState = () => console.log(this.state.editorState.toJS());
         }
@@ -49,7 +49,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                   editorState={this.state.editorState}
                   onChange={this.onChange}
                   placeholder="Enter some text..."
-                  ref="editor"
+                  ref={(ref) => this.editor = ref}
                 />
               </div>
               <input

--- a/examples/draft-0-9-1/rich/rich.html
+++ b/examples/draft-0-9-1/rich/rich.html
@@ -40,7 +40,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           super(props);
           this.state = {editorState: EditorState.createEmpty()};
 
-          this.focus = () => this.refs.editor.focus();
+          this.focus = () => this.editor.focus();
           this.onChange = (editorState) => this.setState({editorState});
 
           this.handleKeyCommand = (command) => this._handleKeyCommand(command);
@@ -114,7 +114,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                   onChange={this.onChange}
                   onTab={this.onTab}
                   placeholder="Tell a story..."
-                  ref="editor"
+                  ref={(ref) => this.editor = ref}
                   spellCheck={true}
                 />
               </div>

--- a/examples/draft-0-9-1/tex/js/components/TeXBlock.js
+++ b/examples/draft-0-9-1/tex/js/components/TeXBlock.js
@@ -32,7 +32,7 @@ class KatexOutput extends React.Component {
     this._timer = setTimeout(() => {
       katex.render(
         this.props.content,
-        this.refs.container,
+        this.container,
         {displayMode: true},
       );
     }, 0);
@@ -54,7 +54,12 @@ class KatexOutput extends React.Component {
   }
 
   render() {
-    return <div ref="container" onClick={this.props.onClick} />;
+    return (
+      <div
+        ref={(ref) => this.container = ref}
+        onClick={this.props.onClick}
+      />
+    );
   }
 }
 
@@ -147,7 +152,7 @@ export default class TeXBlock extends React.Component {
           <textarea
             className="TeXEditor-texValue"
             onChange={this._onValueChange}
-            ref="textarea"
+            ref={(ref) => this.textarea = ref}
             value={this.state.texValue}
           />
           <div className="TeXEditor-buttons">

--- a/examples/draft-0-9-1/tex/js/components/TeXEditorExample.js
+++ b/examples/draft-0-9-1/tex/js/components/TeXEditorExample.js
@@ -54,7 +54,7 @@ export default class TeXEditorExample extends React.Component {
       return null;
     };
 
-    this._focus = () => this.refs.editor.focus();
+    this._focus = () => this.editor.focus();
     this._onChange = (editorState) => this.setState({editorState});
 
     this._handleKeyCommand = command => {
@@ -99,7 +99,7 @@ export default class TeXEditorExample extends React.Component {
               onChange={this._onChange}
               placeholder="Start a document..."
               readOnly={this.state.liveTeXEdits.count()}
-              ref="editor"
+              ref={(ref) => this.editor = ref}
               spellCheck={true}
             />
           </div>

--- a/examples/draft-0-9-1/tweet/tweet.html
+++ b/examples/draft-0-9-1/tweet/tweet.html
@@ -49,7 +49,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             editorState: EditorState.createEmpty(compositeDecorator),
           };
 
-          this.focus = () => this.refs.editor.focus();
+          this.focus = () => this.editor.focus();
           this.onChange = (editorState) => this.setState({editorState});
           this.logState = () => console.log(this.state.editorState.toJS());
         }
@@ -62,7 +62,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                   editorState={this.state.editorState}
                   onChange={this.onChange}
                   placeholder="Write a tweet..."
-                  ref="editor"
+                  ref={(ref) => this.editor = ref}
                   spellCheck={true}
                 />
               </div>

--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -112,6 +112,8 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
   _onPaste: Function;
   _onSelect: Function;
 
+  editor: () => void;
+  editorContainer: () => void;
   focus: () => void;
   blur: () => void;
   setMode: (mode: DraftEditorModes) => void;

--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -112,8 +112,8 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
   _onPaste: Function;
   _onSelect: Function;
 
-  editor: HTMLElement;
-  editorContainer: HTMLElement;
+  editor: ?HTMLElement;
+  editorContainer: ?HTMLElement;
   focus: () => void;
   blur: () => void;
   setMode: (mode: DraftEditorModes) => void;

--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -112,8 +112,8 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
   _onPaste: Function;
   _onSelect: Function;
 
-  editor: () => void;
-  editorContainer: () => void;
+  editor: HTMLElement;
+  editorContainer: HTMLElement;
   focus: () => void;
   blur: () => void;
   setMode: (mode: DraftEditorModes) => void;

--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -401,18 +401,12 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
   }
 
   _blur(): void {
-<<<<<<< HEAD
-    const editorNode = ReactDOM.findDOMNode(this.refs.editor);
+    const editorNode = ReactDOM.findDOMNode(this.editor);
     invariant(
       editorNode instanceof HTMLElement,
       'editorNode is not an HTMLElement',
     );
     editorNode.blur();
-||||||| parent of 59c9776... Remove string refs
-    ReactDOM.findDOMNode(this.refs.editor).blur();
-=======
-    ReactDOM.findDOMNode(this.editor).blur();
->>>>>>> 59c9776... Remove string refs
   }
 
   /**

--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -244,7 +244,7 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
         {this._renderPlaceholder()}
         <div
           className={cx('DraftEditor/editorContainer')}
-          ref="editorContainer">
+          ref={(ref) => this.editorContainer = ref}>
           <div
             aria-activedescendant={
               readOnly ? null : this.props.ariaActiveDescendantID
@@ -290,7 +290,7 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
             onMouseUp={this._onMouseUp}
             onPaste={this._onPaste}
             onSelect={this._onSelect}
-            ref="editor"
+            ref={(ref) => this.editor = ref}
             role={readOnly ? null : ariaRole}
             spellCheck={allowSpellCheck && this.props.spellCheck}
             style={contentStyle}
@@ -366,7 +366,7 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
   _focus(scrollPosition?: DraftScrollPosition): void {
     const {editorState} = this.props;
     const alreadyHasFocus = editorState.getSelection().getHasFocus();
-    const editorNode = ReactDOM.findDOMNode(this.refs.editor);
+    const editorNode = ReactDOM.findDOMNode(this.editor);
 
     const scrollParent = Style.getScrollParent(editorNode);
     const {x, y} = scrollPosition || getScrollPosition(scrollParent);
@@ -399,12 +399,18 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
   }
 
   _blur(): void {
+<<<<<<< HEAD
     const editorNode = ReactDOM.findDOMNode(this.refs.editor);
     invariant(
       editorNode instanceof HTMLElement,
       'editorNode is not an HTMLElement',
     );
     editorNode.blur();
+||||||| parent of 59c9776... Remove string refs
+    ReactDOM.findDOMNode(this.refs.editor).blur();
+=======
+    ReactDOM.findDOMNode(this.editor).blur();
+>>>>>>> 59c9776... Remove string refs
   }
 
   /**

--- a/src/component/contents/DraftEditorLeaf.react.js
+++ b/src/component/contents/DraftEditorLeaf.react.js
@@ -75,6 +75,9 @@ class DraftEditorLeaf extends React.Component<Props> {
    * DOM structure of the DraftEditor component. If leaves had multiple
    * text nodes, this would be harder.
    */
+
+  leaf: () => void;
+
   _setSelection(): void {
     const {selection} = this.props;
 

--- a/src/component/contents/DraftEditorLeaf.react.js
+++ b/src/component/contents/DraftEditorLeaf.react.js
@@ -76,7 +76,7 @@ class DraftEditorLeaf extends React.Component<Props> {
    * text nodes, this would be harder.
    */
 
-  leaf: () => void;
+  leaf: HTMLElement;
 
   _setSelection(): void {
     const {selection} = this.props;

--- a/src/component/contents/DraftEditorLeaf.react.js
+++ b/src/component/contents/DraftEditorLeaf.react.js
@@ -76,7 +76,7 @@ class DraftEditorLeaf extends React.Component<Props> {
    * text nodes, this would be harder.
    */
 
-  leaf: HTMLElement;
+  leaf: ?HTMLElement;
 
   _setSelection(): void {
     const {selection} = this.props;

--- a/src/component/contents/DraftEditorLeaf.react.js
+++ b/src/component/contents/DraftEditorLeaf.react.js
@@ -112,7 +112,7 @@ class DraftEditorLeaf extends React.Component<Props> {
   }
 
   shouldComponentUpdate(nextProps: Props): boolean {
-    const leafNode = ReactDOM.findDOMNode(this.refs.leaf);
+    const leafNode = ReactDOM.findDOMNode(this.leaf);
     invariant(leafNode, 'Missing leafNode');
     return (
       leafNode.textContent !== nextProps.text ||
@@ -166,7 +166,7 @@ class DraftEditorLeaf extends React.Component<Props> {
     return (
       <span
         data-offset-key={offsetKey}
-        ref="leaf"
+        ref={(ref) => this.leaf = ref}
         style={styleObj}>
         <DraftEditorTextNode>{text}</DraftEditorTextNode>
       </span>

--- a/src/component/handlers/edit/editOnSelect.js
+++ b/src/component/handlers/edit/editOnSelect.js
@@ -27,7 +27,7 @@ function editOnSelect(editor: DraftEditor): void {
   }
 
   var editorState = editor.props.editorState;
-  const editorNode = ReactDOM.findDOMNode(editor.refs.editorContainer);
+  const editorNode = ReactDOM.findDOMNode(this.editorContainer);
   invariant(editorNode, 'Missing editorNode');
   invariant(
     editorNode.firstChild instanceof HTMLElement,

--- a/website/src/index.js
+++ b/website/src/index.js
@@ -28,7 +28,7 @@ class RichEditorExample extends React.Component {
     super(props);
     this.state = {editorState: EditorState.createEmpty()};
 
-    this.focus = () => this.refs.editor.focus();
+    this.focus = () => this.editor.focus();
     this.onChange = (editorState) => this.setState({editorState});
 
     this.handleKeyCommand = this._handleKeyCommand.bind(this);
@@ -101,7 +101,7 @@ class RichEditorExample extends React.Component {
             onChange={this.onChange}
             onTab={this.onTab}
             placeholder="Tell a story..."
-            ref="editor"
+            ref={(ref) => this.editor = ref}
             spellCheck={true}
           />
         </div>


### PR DESCRIPTION
**Summary**
Convert string refs to callback refs based on React team statements of likely future deprecation of string refs.  https://facebook.github.io/react/docs/more-about-refs.html#the-ref-string-attribute

**Test Plan**
No additional testing needed.
