### PR TITLE
Add table styles to documentation

### DIFF
--- a/website/src/draft-js/css/draft.css
+++ b/website/src/draft-js/css/draft.css
@@ -106,6 +106,30 @@ a:focus {
   outline-offset: -2px;
 }
 
+table {
+  border-collapse: collapse;
+  margin: 15px 16px;
+}
+
+table tr {
+  background-color: #fff;
+  border-top: 1px solid #ccc;
+}
+
+table th, table td {
+  border: 1px solid #ddd;
+  padding: 6px 13px;
+  text-align: left;
+}
+
+table th {
+  font-weight: bold;
+}
+
+table tr:nth-child(2n) {
+  background-color: #f8f8f8;
+}
+
 .center {
   text-align: center;
 }


### PR DESCRIPTION

We have [a PR to add a new page to the docs,] and it includes a table
showing the mapping of block types to elements. However, we don't have
good styles for tables in the documentation.

[a PR to add a new page to the docs,]: https://github.com/facebook/draft-js/pull/387

Adding these styles should unblock that PR so we can merge it and update
the Draft.js website.

I've attached a 'before' and 'after' screenshot of the new docs to show how these styles will help:
**Before:**
<img width="647" alt="before_styles" src="https://cloud.githubusercontent.com/assets/1114467/18227928/2b3ab6d0-71eb-11e6-9af4-89f69f1df96f.png">

**After:**
<img width="521" alt="after_styles" src="https://cloud.githubusercontent.com/assets/1114467/18227930/2d5f987c-71eb-11e6-96ef-ce5ed7ecb6bc.png">

