### PR TITLE
update handleKeyCommand docs to return DraftHandleValue

### DIFF
--- a/docs/Advanced-Topics-Block-Styling.md
+++ b/docs/Advanced-Topics-Block-Styling.md
@@ -18,7 +18,7 @@ to specify classes that should be applied to blocks at render time.
 
 The Draft library includes default block CSS styles within
 [DraftStyleDefault.css](https://github.com/facebook/draft-js/blob/master/src/component/utils/DraftStyleDefault.css). _(Note that the annotations on the CSS class names are
-artifacts of Facebook's internal CSS module management system._
+artifacts of Facebook's internal CSS module management system.)_
 
 These CSS rules are largely devoted to providing default styles for list items,
 without which callers would be responsible for managing their own default list

--- a/docs/QuickStart-Rich-Styling.md
+++ b/docs/QuickStart-Rich-Styling.md
@@ -57,9 +57,9 @@ class MyEditor extends React.Component {
     const newState = RichUtils.handleKeyCommand(this.state.editorState, command);
     if (newState) {
       this.onChange(newState);
-      return true;
+      return 'handled';
     }
-    return false;
+    return 'not-handled';
   }
   render() {
     return (
@@ -78,7 +78,7 @@ class MyEditor extends React.Component {
 > The `command` argument supplied to `handleKeyCommand` is a string value, the
 > name of the command to be executed. This is mapped from a DOM key event. See
 > [Advanced Topics - Key Binding](/draft-js/docs/advanced-topics-key-bindings.html) for more
-> on this, as well as details on why the function returns a boolean.
+> on this, as well as details on why the function returns `handled` or `not-handled`.
 
 ## Styling Controls in UI
 


### PR DESCRIPTION
Updating documentation to say handleKeyCommand returns 'handled' or 'not-handled' (the DraftHandleValue type) as opposed to true or false (boolean type)