### PR TITLE
Add a way to prevent replaced content to be added onto UndoStack

### DIFF
--- a/docs/APIReference-EditorState.md
+++ b/docs/APIReference-EditorState.md
@@ -72,7 +72,7 @@ The list below includes the most commonly used instance methods for `EditorState
   </li>
   <li>
     <a href="#push">
-      <pre>static push(editorState, contentState, changeType): EditorState</pre>
+      <pre>static push(editorState, contentState, changeType, ?boundaryState): EditorState</pre>
     </a>
   </li>
   <li>
@@ -262,12 +262,14 @@ if you need custom configuration not available via the methods above.
 static push(
   editorState: EditorState,
   contentState: ContentState,
-  changeType: EditorChangeType
+  changeType: EditorChangeType,
+  ?boundaryState: boolean
 ): EditorState
 ```
 Returns a new `EditorState` object with the specified `ContentState` applied
-as the new `currentContent`. Based on the `changeType`, this `ContentState`
-may be regarded as a boundary state for undo/redo behavior.
+as the new `currentContent`. Based on `boundaryState`, if given, or on
+the `changeType`, if not, this `ContentState`may be regarded as a boundary
+state for undo/redo behavior.
 
 All content changes must be applied to the EditorState with this method.
 

--- a/src/model/immutable/EditorState.js
+++ b/src/model/immutable/EditorState.js
@@ -331,14 +331,16 @@ class EditorState {
   }
 
   /**
-   * Push the current ContentState onto the undo stack if it should be
-   * considered a boundary state, and set the provided ContentState as the
-   * new current content.
+   * Set the provided ContentState as the new current content.
+   * The old ContentState is pushed onto the undo stack or not, depending on
+   * the value of boundaryState optional parameter, if it is given, or on
+   * the base of changeType, if it is not.
    */
   static push(
     editorState: EditorState,
     contentState: ContentState,
-    changeType: EditorChangeType
+    changeType: EditorChangeType,
+    boundaryState: ?boolean
   ): EditorState {
     if (editorState.getCurrentContent() === contentState) {
       return editorState;
@@ -366,17 +368,16 @@ class EditorState {
     var undoStack = editorState.getUndoStack();
     var newContent = contentState;
 
-    if (
-      selection !== currentContent.getSelectionAfter() ||
-      mustBecomeBoundary(editorState, changeType)
-    ) {
+
+    if (boundaryState === undefined) {
+      boundaryState = selection !== currentContent.getSelectionAfter() ||
+        mustBecomeBoundary(editorState, changeType);
+    }
+
+    if (boundaryState) {
       undoStack = undoStack.push(currentContent);
       newContent = newContent.set('selectionBefore', selection);
-    } else if (
-      changeType === 'insert-characters' ||
-      changeType === 'backspace-character' ||
-      changeType === 'delete-character'
-    ) {
+    } else {
       // Preserve the previous selection.
       newContent = newContent.set(
         'selectionBefore',


### PR DESCRIPTION
This pull request is a proposal to fix issue #491.

It adds an optional boolean parameter, `boundaryState`,  to `EditorState` `push` method.
If `boudaryState` is given, depending on its value, the replaced content is considered a boundary state and added onto `UndoStack` or not.
Otherwise, as before, the choice of adding replaced content onto `UndoStack` is based of the `changeType`.
