### PR TITLE
#648 - Include endKey selected block on hasAtomicBlock analysis

### DIFF
--- a/src/model/modifier/RichTextEditorUtil.js
+++ b/src/model/modifier/RichTextEditorUtil.js
@@ -286,7 +286,8 @@ const RichTextEditorUtil = {
 
     var hasAtomicBlock = content.getBlockMap()
       .skipWhile((_, k) => k !== startKey)
-      .takeWhile((_, k) => k !== endKey)
+      .reverse()
+      .skipWhile((_, k) => k !== endKey)
       .some(v => v.getType() === 'atomic');
 
     if (hasAtomicBlock) {


### PR DESCRIPTION
**Summary**
When i make a selection when the last block is an atomic block and put an H2 style, it broke the block because "hasAtomicBlock" evaluates to false.

1 - write some text "this is a text block"
2 - add atomic block
3 - push shift and up arrow key to select the atomic block and the text "this is a text block"
4 - select H2 or another blockType.
5 - atomic block brokes

With this changes the last block selected is also analysed in search of atomic block.

**Test Plan**

1 - write some text "this is a text block"
2 - add atomic block
3 - push shift and up arrow key to select the atomic block and the text "this is a text block"
4 - select H2 or another blockType.
5 - atomic block is not broken

