### PR TITLE
Add an example jsfiddle to the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 **What is the current behavior?**
 
-**If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem via https://jsfiddle.net or similar.**
+**If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem. You can use this jsfiddle to get started: https://jsfiddle.net/stopachka/m6z0xn4r/.**
 
 **What is the expected behavior?**
 


### PR DESCRIPTION
**Summary**

When users open new issues, they should have a basic jsfiddle that they can start with. Added a link to a base Draftjs example here (https://jsfiddle.net/stopachka/m6z0xn4r/)

**Test Plan**

- Verify that https://jsfiddle.net/stopachka/m6z0xn4r/ is indeed a sufficient jsfiddle to get started with Draft
- Verify that the issue template is based on the file being edited

