### PR TITLE
Upgrade eslint-config-fbjs & switch flow plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
     "envify": "^3.4.0",
     "es6-shim": "^0.34.4",
     "eslint": "^3.0.1",
-    "eslint-config-fbjs": "^1.0.0",
+    "eslint-config-fbjs": "^1.1.0",
     "eslint-plugin-babel": "^3.3.0",
-    "eslint-plugin-flow-vars": "^0.4.0",
+    "eslint-plugin-flowtype": "^2.17.1",
     "eslint-plugin-react": "^5.2.2",
     "fbjs-scripts": "^0.7.0",
     "flow-bin": "^0.28.0",
@@ -79,7 +79,9 @@
     "automock": true,
     "rootDir": "./",
     "scriptPreprocessor": "scripts/jest/preprocessor.js",
-    "setupFiles": ["node_modules/fbjs-scripts/jest/environment.js"],
+    "setupFiles": [
+      "node_modules/fbjs-scripts/jest/environment.js"
+    ],
     "modulePathIgnorePatterns": [
       "<rootDir>/lib/",
       "<rootDir>/node_modules/"


### PR DESCRIPTION
I upgraded eslint-config-fbjs recently which changed a peerDep for better Flow linting. New installs are going to pick that up and get a warning so we should fix it.

Fixes #645 