### PR TITLE
Temporary fix to unbreak ESLint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,5 +8,5 @@
  */
 
 module.exports = {
-  extends: 'fbjs/strict',
+  extends: 'fbjs',
 };


### PR DESCRIPTION
There is some issue with ["Use a stricter lint config"](https://github.com/facebook/draft-js/commit/5473e5b375574f01591de98ce8c0645ee1b57dd6) that is breaking in Travis and when I run eslint locally.

We want at least some linting running on new PRs, and the failing lint
would be a blocker for new PRs landing.

We do want the stricter linting config, so I am opening an issue and
coming back to this as soon as I can. For now I don't have time to do
much debugging.