### PR TITLE
Fix tweet example: add missing contentState argument

### DIFF
--- a/examples/tweet/tweet.html
+++ b/examples/tweet/tweet.html
@@ -84,11 +84,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       const HANDLE_REGEX = /\@[\w]+/g;
       const HASHTAG_REGEX = /\#[\w\u0590-\u05ff]+/g;
 
-      function handleStrategy(contentBlock, callback) {
+      function handleStrategy(contentState, contentBlock, callback) {
         findWithRegex(HANDLE_REGEX, contentBlock, callback);
       }
 
-      function hashtagStrategy(contentBlock, callback) {
+      function hashtagStrategy(contentState, contentBlock, callback) {
         findWithRegex(HASHTAG_REGEX, contentBlock, callback);
       }
 


### PR DESCRIPTION
This PR fixes the broken "tweet" example.
The example ceased to function due to changes in #376.
`contentState` is now the first argument to the strategy functions.