### PR TITLE
fix typo in convertFromRawToDraftState

### DIFF
--- a/src/model/encoding/convertFromRawToDraftState.js
+++ b/src/model/encoding/convertFromRawToDraftState.js
@@ -41,7 +41,7 @@ function convertFromRawToDraftState(
       var {type, mutability, data} = encodedEntity;
       const instance = new DraftEntityInstance({type, mutability, data: data || {}});
       const tempEntityMap = addEntityToEntityMap(updatedEntityMap, instance);
-      const newKey = tempEntityMap.keyseq().last();
+      const newKey = tempEntityMap.keySeq().last();
       fromStorageToLocal[storageKey] = newKey;
       return tempEntityMap;
     },


### PR DESCRIPTION
**Summary**

`convertFromRawToDraftState` had a typo in the code, `keyseq` should have been `keySeq`.  Seen on #660

**Test Plan**

- Run the `entity` example, and make sure the convertFromRaw function works

