### PR TITLE
Fix dead key deletion

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -80,7 +80,6 @@ class DraftEditor extends React.Component {
 
   _blockSelectEvents: boolean;
   _clipboard: ?BlockMap;
-  _guardAgainstRender: boolean;
   _handler: ?Object;
   _dragCount: number;
   _editorKey: string;
@@ -115,8 +114,6 @@ class DraftEditor extends React.Component {
   setMode: (mode: DraftEditorModes) => void;
   exitCurrentMode: () => void;
   restoreEditorDOM: (scrollPosition: DraftScrollPosition) => void;
-  setRenderGuard: () => void;
-  removeRenderGuard: () => void;
   setClipboard: (clipboard?: BlockMap) => void;
   getClipboard: () => ?BlockMap;
   getEditorKey: () => string;
@@ -129,7 +126,6 @@ class DraftEditor extends React.Component {
 
     this._blockSelectEvents = false;
     this._clipboard = null;
-    this._guardAgainstRender = false;
     this._handler = null;
     this._dragCount = 0;
     this._editorKey = generateRandomKey();
@@ -162,8 +158,6 @@ class DraftEditor extends React.Component {
     this.setMode = this._setMode.bind(this);
     this.exitCurrentMode = this._exitCurrentMode.bind(this);
     this.restoreEditorDOM = this._restoreEditorDOM.bind(this);
-    this.setRenderGuard = this._setRenderGuard.bind(this);
-    this.removeRenderGuard = this._removeRenderGuard.bind(this);
     this.setClipboard = this._setClipboard.bind(this);
     this.getClipboard = this._getClipboard.bind(this);
     this.getEditorKey = () => this._editorKey;
@@ -392,19 +386,6 @@ class DraftEditor extends React.Component {
     this.setState({containerKey: this.state.containerKey + 1}, () => {
       this._focus(scrollPosition);
     });
-  }
-
-  /**
-   * Guard against rendering. Intended for use when we need to manually
-   * reset editor contents, to ensure that no outside influences lead to
-   * React reconciliation when we are in an uncertain state.
-   */
-  _setRenderGuard(): void {
-    this._guardAgainstRender = true;
-  }
-
-  _removeRenderGuard(): void {
-    this._guardAgainstRender = false;
   }
 
   /**

--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -9,6 +9,7 @@
  * @providesModule DraftEditor.react
  * @typechecks
  * @flow
+ * @preventMunge
  */
 
 'use strict';
@@ -84,6 +85,7 @@ class DraftEditor extends React.Component {
   _dragCount: number;
   _editorKey: string;
   _placeholderAccessibilityID: string;
+  _latestEditorState: EditorState;
 
   /**
    * Define proxies that can route events to the current handler.
@@ -130,6 +132,7 @@ class DraftEditor extends React.Component {
     this._dragCount = 0;
     this._editorKey = generateRandomKey();
     this._placeholderAccessibilityID = 'placeholder-' + this._editorKey;
+    this._latestEditorState = props.editorState;
 
     this._onBeforeInput = this._buildHandler('onBeforeInput');
     this._onBlur = this._buildHandler('onBlur');
@@ -313,6 +316,7 @@ class DraftEditor extends React.Component {
 
   componentDidUpdate(): void {
     this._blockSelectEvents = false;
+    this._latestEditorState = this.props.editorState;
   }
 
   /**
@@ -416,6 +420,7 @@ class DraftEditor extends React.Component {
    * function.
    */
   _update(editorState: EditorState): void {
+    this._latestEditorState = editorState;
     this.props.onChange(editorState);
   }
 

--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -84,6 +84,15 @@ var DraftEditorCompositionHandler = {
    * doesn't move, otherwise it will jump back noticeably on re-render.
    */
   onKeyDown: function(e: SyntheticKeyboardEvent): void {
+    if (!stillComposing) {
+      // If a keydown event is received after compositionend but before the
+      // 20ms timer expires (ex: type option-E then backspace, or type A then
+      // backspace in 2-Set Korean), we should immediately resolve the
+      // composition and reinterpret the key press in edit mode.
+      DraftEditorCompositionHandler.resolveComposition.call(this);
+      this._onKeyDown(e);
+      return;
+    }
     if (e.which === Keys.RIGHT || e.which === Keys.LEFT) {
       e.preventDefault();
     }
@@ -125,7 +134,7 @@ var DraftEditorCompositionHandler = {
     const composedChars = textInputData;
     textInputData = '';
 
-    const editorState = EditorState.set(this.props.editorState, {
+    const editorState = EditorState.set(this._latestEditorState, {
       inCompositionMode: false,
     });
 

--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -147,7 +147,6 @@ var DraftEditorCompositionHandler = {
     }
 
     this.exitCurrentMode();
-    this.removeRenderGuard();
 
     if (composedChars) {
       // If characters have been composed, re-rendering with the update

--- a/src/component/handlers/drag/DraftEditorDragHandler.js
+++ b/src/component/handlers/drag/DraftEditorDragHandler.js
@@ -73,7 +73,7 @@ var DraftEditorDragHandler = {
   onDrop: function(e: Object): void {
     const data = new DataTransfer(e.nativeEvent.dataTransfer);
 
-    const editorState: EditorState = this.props.editorState;
+    const editorState: EditorState = this._latestEditorState;
     const dropSelection: ?SelectionState = getSelectionForEvent(
       e.nativeEvent,
       editorState

--- a/src/component/handlers/edit/editOnBeforeInput.js
+++ b/src/component/handlers/edit/editOnBeforeInput.js
@@ -98,7 +98,7 @@ function editOnBeforeInput(e: SyntheticInputEvent): void {
   // If selection is collapsed, conditionally allow native behavior. This
   // reduces re-renders and preserves spellcheck highlighting. If the selection
   // is not collapsed, we will re-render.
-  var editorState = this.props.editorState;
+  var editorState = this._latestEditorState;
   var selection = editorState.getSelection();
 
   if (!selection.isCollapsed()) {

--- a/src/component/handlers/edit/editOnBlur.js
+++ b/src/component/handlers/edit/editOnBlur.js
@@ -30,7 +30,7 @@ function editOnBlur(e: SyntheticEvent): void {
     global.getSelection().removeAllRanges();
   }
 
-  var editorState = this.props.editorState;
+  var editorState = this._latestEditorState;
   var currentSelection = editorState.getSelection();
   if (!currentSelection.getHasFocus()) {
     return;

--- a/src/component/handlers/edit/editOnCompositionStart.js
+++ b/src/component/handlers/edit/editOnCompositionStart.js
@@ -18,11 +18,13 @@ var EditorState = require('EditorState');
  * The user has begun using an IME input system. Switching to `composite` mode
  * allows handling composition input and disables other edit behavior.
  */
-function editOnCompositionStart(): void {
+function editOnCompositionStart(e: SyntheticEvent): void {
   this.setMode('composite');
   this.update(
-    EditorState.set(this.props.editorState, {inCompositionMode: true})
+    EditorState.set(this._latestEditorState, {inCompositionMode: true})
   );
+  // Allow composition handler to interpret the compositionstart event
+  this._onCompositionStart(e);
 }
 
 module.exports = editOnCompositionStart;

--- a/src/component/handlers/edit/editOnCompositionStart.js
+++ b/src/component/handlers/edit/editOnCompositionStart.js
@@ -19,7 +19,6 @@ var EditorState = require('EditorState');
  * allows handling composition input and disables other edit behavior.
  */
 function editOnCompositionStart(): void {
-  this.setRenderGuard();
   this.setMode('composite');
   this.update(
     EditorState.set(this.props.editorState, {inCompositionMode: true})

--- a/src/component/handlers/edit/editOnCopy.js
+++ b/src/component/handlers/edit/editOnCopy.js
@@ -20,7 +20,7 @@ var getFragmentFromSelection = require('getFragmentFromSelection');
  * fragment if no external clipboard data is supplied.
  */
 function editOnCopy(e: SyntheticClipboardEvent): void {
-  var editorState = this.props.editorState;
+  var editorState = this._latestEditorState;
   var selection = editorState.getSelection();
 
   // No selection, so there's nothing to copy.
@@ -29,7 +29,7 @@ function editOnCopy(e: SyntheticClipboardEvent): void {
     return;
   }
 
-  this.setClipboard(getFragmentFromSelection(this.props.editorState));
+  this.setClipboard(getFragmentFromSelection(this._latestEditorState));
 }
 
 module.exports = editOnCopy;

--- a/src/component/handlers/edit/editOnCut.js
+++ b/src/component/handlers/edit/editOnCut.js
@@ -29,7 +29,7 @@ const getScrollPosition = require('getScrollPosition');
  * styles and entities, for use as an internal paste.
  */
 function editOnCut(e: SyntheticClipboardEvent): void {
-  const editorState = this.props.editorState;
+  const editorState = this._latestEditorState;
   const selection = editorState.getSelection();
 
   // No selection, so there's nothing to cut.

--- a/src/component/handlers/edit/editOnCut.js
+++ b/src/component/handlers/edit/editOnCut.js
@@ -47,13 +47,11 @@ function editOnCut(e: SyntheticClipboardEvent): void {
   this.setClipboard(fragment);
 
   // Set `cut` mode to disable all event handling temporarily.
-  this.setRenderGuard();
   this.setMode('cut');
 
   // Let native `cut` behavior occur, then recover control.
   setTimeout(() => {
     this.restoreEditorDOM({x, y});
-    this.removeRenderGuard();
     this.exitCurrentMode();
     this.update(removeFragment(editorState));
   }, 0);

--- a/src/component/handlers/edit/editOnFocus.js
+++ b/src/component/handlers/edit/editOnFocus.js
@@ -15,7 +15,7 @@
 var EditorState = require('EditorState');
 
 function editOnFocus(e: SyntheticFocusEvent): void {
-  var editorState = this.props.editorState;
+  var editorState = this._latestEditorState;
   var currentSelection = editorState.getSelection();
   if (currentSelection.getHasFocus()) {
     return;

--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -45,7 +45,7 @@ function editOnInput(): void {
   }
 
   var domText = anchorNode.textContent;
-  var {editorState} = this.props;
+  var editorState = this._latestEditorState;
   var offsetKey = nullthrows(findAncestorOffsetKey(anchorNode));
   var {blockKey, decoratorKey, leafKey} = DraftOffsetKey.decode(offsetKey);
 

--- a/src/component/handlers/edit/editOnKeyDown.js
+++ b/src/component/handlers/edit/editOnKeyDown.js
@@ -84,7 +84,7 @@ function onKeyCommand(
  */
 function editOnKeyDown(e: SyntheticKeyboardEvent): void {
   var keyCode = e.which;
-  var editorState = this.props.editorState;
+  var editorState = this._latestEditorState;
 
   switch (keyCode) {
     case Keys.RETURN:

--- a/src/component/handlers/edit/editOnPaste.js
+++ b/src/component/handlers/edit/editOnPaste.js
@@ -53,7 +53,7 @@ function editOnPaste(e: SyntheticClipboardEvent): void {
           return;
         }
 
-        var {editorState} = this.props;
+        var editorState = this._latestEditorState;
         var blocks = splitTextIntoTextBlocks(fileText);
         var character = CharacterMetadata.create({
           style: editorState.getCurrentInlineStyle(),
@@ -124,7 +124,7 @@ function editOnPaste(e: SyntheticClipboardEvent): void {
         )
       ) {
         this.update(
-          insertFragment(this.props.editorState, internalClipboard)
+          insertFragment(this._latestEditorState, internalClipboard)
         );
         return;
       }
@@ -138,7 +138,7 @@ function editOnPaste(e: SyntheticClipboardEvent): void {
       // Use the internalClipboard if present and equal to what is on
       // the clipboard. See https://bugs.webkit.org/show_bug.cgi?id=19893.
       this.update(
-        insertFragment(this.props.editorState, internalClipboard)
+        insertFragment(this._latestEditorState, internalClipboard)
       );
       return;
     }
@@ -154,7 +154,7 @@ function editOnPaste(e: SyntheticClipboardEvent): void {
         if (contentBlocks) {
           var htmlMap = BlockMapBuilder.createFromArray(contentBlocks);
           this.update(
-            insertFragment(this.props.editorState, htmlMap, entityMap)
+            insertFragment(this._latestEditorState, htmlMap, entityMap)
           );
           return;
         }
@@ -167,7 +167,7 @@ function editOnPaste(e: SyntheticClipboardEvent): void {
   }
 
   if (textBlocks.length) {
-    var {editorState} = this.props;
+    var editorState = this._latestEditorState;
     var character = CharacterMetadata.create({
       style: editorState.getCurrentInlineStyle(),
       entity: getEntityKeyForSelection(
@@ -182,7 +182,7 @@ function editOnPaste(e: SyntheticClipboardEvent): void {
     );
 
     var textMap = BlockMapBuilder.createFromArray(textFragment);
-    this.update(insertFragment(this.props.editorState, textMap));
+    this.update(insertFragment(this._latestEditorState, textMap));
   }
 }
 

--- a/src/component/handlers/edit/editOnSelect.js
+++ b/src/component/handlers/edit/editOnSelect.js
@@ -22,7 +22,7 @@ function editOnSelect(): void {
     return;
   }
 
-  var editorState = this.props.editorState;
+  var editorState = this._latestEditorState;
   var documentSelection = getDraftEditorSelection(
     editorState,
     ReactDOM.findDOMNode(this.refs.editorContainer).firstChild


### PR DESCRIPTION
If you type Option-E, Backspace, then the in-progress accented character should be deleted. Similarly, in 2-Set Korean, if you press A, Backspace, the character should be deleted. Both of these don't work correctly yet, but this commit fixes it.

Currently, when you press Backspace, we are in composition mode and we receive a compositionend event then a keydown event for the backspace. Our composition handler doesn't exist composition mode immediately but rather waits 20ms to see if it gets a compositionstart event immediately (and if so, does not exit). It seems like if we receive a compositionend event then a keydown, we always want to exit composition mode immediately and re-interpret the keydown in edit mode. Here I do so.

This change is made trickier by the fact that each event handler reads from `this.props.editorState`, which doesn't get updated until the next rerender (that is, not synchronously). To combat this, we store the most current editor state in an instance variable and refer to it from all of the event handlers. (If we don't do this then the backspace isn't interpreted correctly by editOnKeyDown because the character data from compositionend hasn't been inserted into the editor state, so we'd end up effectively dropping the entire composition as well as deleting the preceding character.) In this commit, only editOnKeyDown needs the latest state but I changed the others for consistency. In cases where the parent always updates editorState in the same tick (as we recommend in the docs), there should be no behavior change.

Note: This also brings us closer to being able to handle cases where we don't always receive editorState synchronously -- instead we could store our own copy of the editorState locally but overwrite it with props when we receive new ones. It doesn't work yet though.

Test Plan: In plaintext example, type Option-E, Backspace (with US keyboard) or A, O, Backspace, Backspace (with 2-Set Korean keyboard). In both cases, the entire composition is deleted correctly.

cc @hellendag