### PR TITLE
Update Flow version to 0.32.0; fix flow error in DraftEditorDragHandler

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "eslint-plugin-flowtype": "^2.17.1",
     "eslint-plugin-react": "^5.2.2",
     "fbjs-scripts": "^0.7.0",
-    "flow-bin": "^0.28.0",
+    "flow-bin": "^0.32.0",
     "gulp": "^3.9.0",
     "gulp-babel": "^6.1.2",
     "gulp-browserify-thin": "^0.1.5",

--- a/src/.flowconfig
+++ b/src/.flowconfig
@@ -19,4 +19,4 @@ suppress_type=$FlowIssue
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(2[0-8]\\|1[0-9]\\|[0-9]\\).[0-9]\\)? *\\).*\n
 
 [version]
-0.28.0
+0.32.0

--- a/src/component/handlers/drag/DraftEditorDragHandler.js
+++ b/src/component/handlers/drag/DraftEditorDragHandler.js
@@ -35,7 +35,7 @@ function getSelectionForEvent(
   let node: ?Node = null;
   let offset: ?number = null;
 
-  if (document.caretRangeFromPoint) {
+  if (typeof document.caretRangeFromPoint === 'function') {
     var dropRange = document.caretRangeFromPoint(event.x, event.y);
     node = dropRange.startContainer;
     offset = dropRange.startOffset;


### PR DESCRIPTION
**Note:** This has already been included in [the 0.9.0-stable release branch](https://github.com/facebook/draft-js/tree/0.9-stable), but we need to keep master updated as well.

Version 0.32.0 of Flow introduced a flow error into Draft.js. We are
using 0.32.0 internally at Facebook and need to fix this Flow error in
order to upgrade to Draft.js 0.9.0 internally.