### PR TITLE
Update docs to remove 'React ContentEditable Warning' issue

### DIFF
--- a/docs/Advanced-Topics-Issues-and-Pitfalls.md
+++ b/docs/Advanced-Topics-Issues-and-Pitfalls.md
@@ -46,17 +46,6 @@ likely need to replicate much of the default styling.
 
 ## Known Issues
 
-### React ContentEditable Warning
-
-Within the React core, a warning is used to ward off engineers who wish to
-use ContentEditable within their components, since by default the
-browser-controlled nature of ContentEditable does not mesh with strict React
-control over the DOM. The Draft editor resolves this issue, so for our case,
-the warning is noise. You can ignore it for now.
-
-We are currently looking into removing or replacing the warning to alleviate
-the irritation it may cause: https://github.com/facebook/react/issues/6081
-
 ### Custom OSX Keybindings
 
 Because the browser has no access to OS-level custom keybindings, it is not


### PR DESCRIPTION

The issue with 'React ContentEditable Warning' was resolved when React
added the 'suppressContentEditableWarning' option([1]) and then we used it
in Draft.js([2]). This doesn't need to be in the docs any more.

[1]: https://github.com/facebook/react/pull/6112
[2]: https://github.com/facebook/draft-js/pull/98

![updated_documentation](https://cloud.githubusercontent.com/assets/1114467/18693014/5b1f6876-7f53-11e6-8782-14d428167015.png)