### PR TITLE
Fix link example

### DIFF
--- a/examples/entity/entity.html
+++ b/examples/entity/entity.html
@@ -36,7 +36,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         ContentState,
         Editor,
         EditorState,
-        Entity,
       } = Draft;
 
       const rawContent = {

--- a/examples/link/link.html
+++ b/examples/link/link.html
@@ -35,7 +35,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         ContentState,
         Editor,
         EditorState,
-        Entity,
         RichUtils,
       } = Draft;
 
@@ -88,7 +87,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           e.preventDefault();
           const {editorState, urlValue} = this.state;
           const contentState = editorState.getCurrentContent();
-          const contentStateWithEntity = Entity.create(contentState, 'LINK', 'MUTABLE', {url: urlValue});
+          const contentStateWithEntity = contentState.createEntity(
+            'LINK',
+            'MUTABLE',
+            {url: urlValue}
+          );
           const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
           const newEditorState = EditorState.set(editorState, { currentContent: contentStateWithEntity });
           this.setState({

--- a/examples/media/media.html
+++ b/examples/media/media.html
@@ -32,7 +32,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         AtomicBlockUtils,
         Editor,
         EditorState,
-        Entity,
         RichUtils,
         convertToRaw,
       } = Draft;
@@ -77,11 +76,21 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         _confirmMedia(e) {
           e.preventDefault();
           const {editorState, urlValue, urlType} = this.state;
-          const entityKey = Entity.create(urlType, 'IMMUTABLE', {src: urlValue})
+          const contentState = editorState.getCurrentContent();
+          const contentStateWithEntity = contentState.createEntity(
+            urlType,
+            'IMMUTABLE',
+            {src: urlValue}
+          );
+          const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
+          const newEditorState = EditorState.set(
+            editorState,
+            {currentContent: contentStateWithEntity}
+          );
 
           this.setState({
             editorState: AtomicBlockUtils.insertAtomicBlock(
-              editorState,
+              newEditorState,
               entityKey,
               ' '
             ),
@@ -210,7 +219,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       };
 
       const Media = (props) => {
-        const entity = Entity.get(props.block.getEntityAt(0));
+        const entity = props.contentState.getEntity(
+          props.block.getEntityAt(0)
+        );
         const {src} = entity.getData();
         const type = entity.getType();
 


### PR DESCRIPTION
**Edit: This now fixes the media example as well as the link example.**

The link and media examples were using an outdated syntax that changed
in [#376](https://github.com/facebook/draft-js/pull/376).

Old syntax:
```
const entityKey = Entity.create('LINK', 'MUTABLE', {url: urlValue});
```

Correct:
```
const contentStateWithEntity = contentState.createEntity(
  'LINK',
  'MUTABLE',
  {url: urlValue}
);
const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
```

Also while working on this, removed the 'require' of 'Entity' in the
'entity' example.

This closes #676 