### PR TITLE
Fixed using IME at the beginning of a soft newline.

### DIFF
--- a/examples/draft-0-10-0/rich/RichEditor.css
+++ b/examples/draft-0-10-0/rich/RichEditor.css
@@ -36,6 +36,10 @@
   padding: 10px 20px;
 }
 
+.RichEditor-editor .public-DraftStyleDefault-block {
+  margin-bottom: 16px;
+}
+
 .RichEditor-editor .public-DraftStyleDefault-pre {
   background-color: rgba(0, 0, 0, 0.05);
   font-family: 'Inconsolata', 'Menlo', 'Consolas', monospace;

--- a/examples/draft-0-9-1/rich/rich.html
+++ b/examples/draft-0-9-1/rich/rich.html
@@ -44,6 +44,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           this.onChange = (editorState) => this.setState({editorState});
 
           this.handleKeyCommand = (command) => this._handleKeyCommand(command);
+          this.handleReturn = (e) => this._handleReturn(e);
           this.onTab = (e) => this._onTab(e);
           this.toggleBlockType = (type) => this._toggleBlockType(type);
           this.toggleInlineStyle = (style) => this._toggleInlineStyle(style);
@@ -54,6 +55,15 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           const newState = RichUtils.handleKeyCommand(editorState, command);
           if (newState) {
             this.onChange(newState);
+            return true;
+          }
+          return false;
+        }
+
+        _handleReturn(e) {
+          if (e.shiftKey) {
+            const {editorState} = this.state;
+            this.onChange(RichUtils.insertSoftNewline(editorState));
             return true;
           }
           return false;
@@ -112,6 +122,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                   editorState={editorState}
                   handleKeyCommand={this.handleKeyCommand}
                   onChange={this.onChange}
+                  handleReturn={this.handleReturn}
                   onTab={this.onTab}
                   placeholder="Tell a story..."
                   ref="editor"

--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -18,6 +18,7 @@ const Keys = require('Keys');
 
 const getEntityKeyForSelection = require('getEntityKeyForSelection');
 const isSelectionAtLeafStart = require('isSelectionAtLeafStart');
+const isSelectionAtSoftNewlineStart = require('isSelectionAtSoftNewlineStart');
 
 import type DraftEditor from 'DraftEditor.react';
 
@@ -121,8 +122,9 @@ var DraftEditorCompositionHandler = {
    * If no characters were composed -- for instance, the user
    * deleted all composed characters and committed nothing new --
    * force a re-render. We also re-render when the composition occurs
-   * at the beginning of a leaf, to ensure that if the browser has
-   * created a new text node for the composition, we will discard it.
+   * at the beginning of a leaf or a soft new line, to ensure that
+   * if the browser has created a new text node for the composition,
+   * we will discard it.
    *
    * Resetting innerHTML will move focus to the beginning of the editor,
    * so we update to force it back to the correct place.
@@ -149,6 +151,7 @@ var DraftEditorCompositionHandler = {
     const mustReset = (
       !composedChars ||
       isSelectionAtLeafStart(editorState) ||
+      isSelectionAtSoftNewlineStart(editorState) ||
       currentStyle.size > 0 ||
       entityKey !== null
     );

--- a/src/component/selection/isSelectionAtSoftNewlineStart.js
+++ b/src/component/selection/isSelectionAtSoftNewlineStart.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule isSelectionAtSoftNewlineStart
+ * @typechecks
+ * @flow
+ */
+
+'use strict';
+
+import type EditorState from 'EditorState';
+
+function isSelectionAtSoftNewlineStart(editorState: EditorState): boolean {
+  const selection = editorState.getSelection();
+  const startKey = selection.getStartKey();
+  const startOffset = selection.getStartOffset();
+  const content = editorState.getCurrentContent();
+  const selectedBlock = content.getBlockForKey(startKey);
+  return selectedBlock.getText()[startOffset - 1] === '\n';
+}
+
+module.exports = isSelectionAtSoftNewlineStart;


### PR DESCRIPTION
**Summary**

In Webkit browsers, composition at the beginning of a soft newline will create new text nodes. 
Which makes the block leafs & selection into a strange state and lead to bugs. 
I guess it's just like the issue of composition at the beginning of a leaf.

Here is one of the bugs:

**Step**:
1. Open Facebook notes editor (because it can insert soft newline).
2. Type any words like `abcd`.
3. Press `shift+return` to insert a soft newline.
4. Enable IME (Chinese pinyin for example), type `caogao`, and press space.
5. Type `.`, you'll see the first line been removed.
6. Press `cmd+z` will recover the first line. (It was the `editOnInput` handle for `.`, that replace the whole block with the text after the `\n`)  

This GIF shows it.

![draft](https://cloud.githubusercontent.com/assets/657962/18838911/b5e435ba-843b-11e6-97b6-833dba8313b5.gif)

And the new text nodes it created after the composition:

<img width="299" alt="screen shot 2016-09-26 at 10 53 48 pm" src="https://cloud.githubusercontent.com/assets/657962/18839029/2234bdb6-843c-11e6-996d-b408af35b3a4.png">

To make it easy to test,    26dfa8e enabled soft new line in rich example. I can remove this commit after you tested it. If you'd like to keep it, I can sync it with the homepage.

**Test Plan**

Same as the **step** above.

Thanks for review!

**EDIT**:
Latest Chrome has fixed this bug, but it still exist in Chrome 54 & Safari 10.0.3