### PR TITLE
Add `select` to atomic block component props

### DIFF
--- a/src/component/contents/DraftEditorContents.react.js
+++ b/src/component/contents/DraftEditorContents.react.js
@@ -291,11 +291,17 @@ function selectionContainsAtomicBlock(editorState: EditorState): boolean {
   const endKey = selection.getEndKey();
   let blockKey = selection.getStartKey();
   let block = content.getBlockForKey(blockKey);
+  if (!block) {
+    return false;
+  }
   while (block.getType() !== 'atomic') {
     if (blockKey === endKey) {
       return false;
     }
     block = content.getBlockAfter(blockKey);
+    if (!block) {
+      return false;
+    }
     blockKey = block.getKey();
   }
   return true;


### PR DESCRIPTION
Add `select` to the properties passed to the component used to render atomic blocks.
It is a boolean parameter, true when the block is inside selection, false otherwise.
It can be used, for example, to customize atomic blocks aspect when they are selected.

The main change is that `DraftEditorContents` re-renders every time the editor state
changes and the old selection or the new one contain atomic blocks.

This PR is intended, essentially, to test if there is interest around such a proposal.
If yes, there are few aspects to be discussed.
