### PR TITLE
Fix/tex example

### DIFF
--- a/examples/tex/js/components/TeXBlock.js
+++ b/examples/tex/js/components/TeXBlock.js
@@ -93,12 +93,12 @@ export default class TeXBlock extends React.Component {
 
     this._save = () => {
       var entityKey = this.props.block.getEntityAt(0);
-      Entity.mergeData(entityKey, {content: this.state.texValue});
+      var newContentState = this.props.contentState.mergeEntityData(entityKey, {content: this.state.texValue});
       this.setState({
         invalidTeX: false,
         editMode: false,
         texValue: null,
-      }, this._finishEdit);
+      }, this._finishEdit.bind(this, newContentState));
     };
 
     this._remove = () => {
@@ -107,14 +107,14 @@ export default class TeXBlock extends React.Component {
     this._startEdit = () => {
       this.props.blockProps.onStartEdit(this.props.block.getKey());
     };
-    this._finishEdit = () => {
-      this.props.blockProps.onFinishEdit(this.props.block.getKey());
+    this._finishEdit = (newContentState) => {
+      this.props.blockProps.onFinishEdit(this.props.block.getKey(), newContentState);
     };
   }
 
   _getValue() {
-    return Entity
-      .get(this.props.block.getEntityAt(0))
+    return this.props.contentState
+      .getEntity(this.props.block.getEntityAt(0))
       .getData()['content'];
   }
 

--- a/examples/tex/js/components/TeXBlock.js
+++ b/examples/tex/js/components/TeXBlock.js
@@ -16,7 +16,6 @@
 
 import katex from 'katex';
 import React from 'react';
-import {Entity} from 'draft-js';
 
 class KatexOutput extends React.Component {
   constructor(props) {

--- a/examples/tex/js/components/TeXEditorExample.js
+++ b/examples/tex/js/components/TeXEditorExample.js
@@ -43,9 +43,9 @@ export default class TeXEditorExample extends React.Component {
               var {liveTeXEdits} = this.state;
               this.setState({liveTeXEdits: liveTeXEdits.set(blockKey, true)});
             },
-            onFinishEdit: (blockKey) => {
+            onFinishEdit: (blockKey, newContentState) => {
               var {liveTeXEdits} = this.state;
-              this.setState({liveTeXEdits: liveTeXEdits.remove(blockKey)});
+              this.setState({liveTeXEdits: liveTeXEdits.remove(blockKey), editorState:EditorState.createWithContent(newContentState)});
             },
             onRemove: (blockKey) => this._removeTeX(blockKey),
           },

--- a/examples/tex/js/components/TeXEditorExample.js
+++ b/examples/tex/js/components/TeXEditorExample.js
@@ -45,7 +45,10 @@ export default class TeXEditorExample extends React.Component {
             },
             onFinishEdit: (blockKey, newContentState) => {
               var {liveTeXEdits} = this.state;
-              this.setState({liveTeXEdits: liveTeXEdits.remove(blockKey), editorState:EditorState.createWithContent(newContentState)});
+              this.setState({
+                liveTeXEdits: liveTeXEdits.remove(blockKey),
+                editorState:EditorState.createWithContent(newContentState),
+              });
             },
             onRemove: (blockKey) => this._removeTeX(blockKey),
           },


### PR DESCRIPTION
this pull request fixed broken Tex example by removing outdated syntax that changed
in #376.

refer issue to https://github.com/facebook/draft-js/issues/697

