### PR TITLE
Upgrade babel-preset-fbjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "babel-core": "^6.8.0",
     "babel-eslint": "^6.1.2",
-    "babel-preset-fbjs": "^2.0.0",
+    "babel-preset-fbjs": "^2.1.0",
     "del": "^2.2.0",
     "envify": "^3.4.0",
     "es6-shim": "^0.34.4",


### PR DESCRIPTION
This fixes 2 issues when Draft is a dependency of a project that is
using Flow.
- `typeof` import now rewritten correctly
- `__DEV__` declaration is now inlined

Here's the diff on master right now: https://gist.github.com/zpao/641b31feae17be7e3e1fabc9aecd10a3

Note: this doesn't impact anything internal and is only for the npm package.