### PR TITLE
Re-apply current inline style after splitting a block with the return key

### DIFF
--- a/src/component/handlers/edit/commands/keyCommandInsertNewline.js
+++ b/src/component/handlers/edit/commands/keyCommandInsertNewline.js
@@ -20,7 +20,16 @@ function keyCommandInsertNewline(editorState: EditorState): EditorState {
     editorState.getCurrentContent(),
     editorState.getSelection()
   );
-  return EditorState.push(editorState, contentState, 'split-block');
+
+  var newEditorState = EditorState.push(
+    editorState,
+    contentState,
+    'split-block');
+
+  // Make sure that any inline style overrides are re-applied.
+  return EditorState.setInlineStyleOverride(
+    newEditorState,
+    editorState.getCurrentInlineStyle());
 }
 
 module.exports = keyCommandInsertNewline;


### PR DESCRIPTION
Fixes #672.
