### PR TITLE
Fix repeated backspace, other internal components

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -310,13 +310,13 @@ class DraftEditor extends React.Component {
    * programmatically. We only care about selection events that occur because
    * of browser interaction, not re-renders and forced selections.
    */
-  componentWillUpdate(): void {
+  componentWillUpdate(nextProps: DraftEditorProps): void {
     this._blockSelectEvents = true;
+    this._latestEditorState = nextProps.editorState;
   }
 
   componentDidUpdate(): void {
     this._blockSelectEvents = false;
-    this._latestEditorState = this.props.editorState;
   }
 
   /**

--- a/src/component/handlers/edit/editOnSelect.js
+++ b/src/component/handlers/edit/editOnSelect.js
@@ -22,7 +22,7 @@ function editOnSelect(): void {
     return;
   }
 
-  var editorState = this._latestEditorState;
+  var editorState = this.props.editorState;
   var documentSelection = getDraftEditorSelection(
     editorState,
     ReactDOM.findDOMNode(this.refs.editorContainer).firstChild


### PR DESCRIPTION
I can't describe entirely why the DraftEditor.react change here is necessary, but this is closer to what we had before #666.

The editOnSelect change fixes holding down Backspace in Firefox -- before this, the cursor would jump to the start of the input.