### PR TITLE
Replace reference to headers to headings H-elements

### DIFF
--- a/docs/Advanced-Topics-Custom-Block-Render.md
+++ b/docs/Advanced-Topics-Custom-Block-Render.md
@@ -20,13 +20,12 @@ by matching the Draft block render map with the matched tag.
 
 |  HTML element   |            Draft block type             |
 | --------------- | --------------------------------------- |
-|     `<h1/>`     |               header-one                |
-|     `<h2/>`     |               header-two                |
-|     `<h3/>`     |              header-three               |
-|     `<h4/>`     |               header-four               |
-|     `<h5/>`     |               header-five               |
-|     `<h6/>`     |               header-six                |
-|     `<h6/>`     |               header-six                |
+|     `<h1/>`     |               heading-one                |
+|     `<h2/>`     |               heading-two                |
+|     `<h3/>`     |              heading-three               |
+|     `<h4/>`     |               heading-four               |
+|     `<h5/>`     |               heading-five               |
+|     `<h6/>`     |               heading-six                |
 | `<blockquote/>` |               blockquote                |
 |    `<pre/>`     |               code-block                |
 |   `<figure/>`   |                 atomic                  |
@@ -50,7 +49,7 @@ the editor blockRender props.
 // 'heading-two' as the only valid block type and
 // updates the unstyled element to also become a h2.
 const blockRenderMap = Immutable.Map({
-  'header-two': {
+  'heading-two': {
    element: 'h2'
   },
   'unstyled': {

--- a/examples/rich/rich.html
+++ b/examples/rich/rich.html
@@ -164,12 +164,12 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       }
 
       const BLOCK_TYPES = [
-        {label: 'H1', style: 'header-one'},
-        {label: 'H2', style: 'header-two'},
-        {label: 'H3', style: 'header-three'},
-        {label: 'H4', style: 'header-four'},
-        {label: 'H5', style: 'header-five'},
-        {label: 'H6', style: 'header-six'},
+        {label: 'H1', style: 'heading-one'},
+        {label: 'H2', style: 'heading-two'},
+        {label: 'H3', style: 'heading-three'},
+        {label: 'H4', style: 'heading-four'},
+        {label: 'H5', style: 'heading-five'},
+        {label: 'H6', style: 'heading-six'},
         {label: 'Blockquote', style: 'blockquote'},
         {label: 'UL', style: 'unordered-list-item'},
         {label: 'OL', style: 'ordered-list-item'},

--- a/src/model/constants/DraftBlockType.js
+++ b/src/model/constants/DraftBlockType.js
@@ -18,12 +18,12 @@
 export type DraftBlockType = (
   'unstyled' |
   'paragraph' |
-  'header-one' |
-  'header-two' |
-  'header-three' |
-  'header-four' |
-  'header-five' |
-  'header-six' |
+  'heading-one' |
+  'heading-two' |
+  'heading-three' |
+  'heading-four' |
+  'heading-five' |
+  'heading-six' |
   'unordered-list-item' |
   'ordered-list-item' |
   'blockquote' |

--- a/src/model/immutable/DefaultDraftBlockRenderMap.js
+++ b/src/model/immutable/DefaultDraftBlockRenderMap.js
@@ -22,22 +22,22 @@ const OL_WRAP = <ol className={cx('public/DraftStyleDefault/ol')} />;
 const PRE_WRAP = <pre className={cx('public/DraftStyleDefault/pre')} />;
 
 module.exports = Map({
-  'header-one': {
+  'heading-one': {
     element: 'h1',
   },
-  'header-two': {
+  'heading-two': {
     element: 'h2',
   },
-  'header-three': {
+  'heading-three': {
     element: 'h3',
   },
-  'header-four': {
+  'heading-four': {
     element: 'h4',
   },
-  'header-five': {
+  'heading-five': {
     element: 'h5',
   },
-  'header-six': {
+  'heading-six': {
     element: 'h6',
   },
   'unordered-list-item': {

--- a/src/model/paste/__tests__/DraftPasteProcessor-test.js
+++ b/src/model/paste/__tests__/DraftPasteProcessor-test.js
@@ -17,13 +17,13 @@ var Immutable = require('immutable');
 
 var DraftPasteProcessor = require('DraftPasteProcessor');
 var CUSTOM_BLOCK_MAP = Immutable.Map({
-  'header-one': {
+  'heading-one': {
     element: 'h1',
   },
-  'header-two': {
+  'heading-two': {
     element: 'h2',
   },
-  'header-three': {
+  'heading-three': {
     element: 'h3',
   },
   'unordered-list-item': {
@@ -144,8 +144,8 @@ describe('DraftPasteProcessor', function() {
     var html = '<h1>hi</h1>    <h2>hi</h2>';
     var {contentBlocks: output} = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
     assertBlockTypes(output, [
-      'header-one',
-      'header-two',
+      'heading-one',
+      'heading-two',
     ]);
   });
 
@@ -153,9 +153,9 @@ describe('DraftPasteProcessor', function() {
     var html = ' <h1> hi </h1><h1> </h1><span> whatever </span> <h2>hi </h2> ';
     var {contentBlocks: output} = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
     assertBlockTypes(output, [
-      'header-one',
+      'heading-one',
       'unstyled',
-      'header-two',
+      'heading-two',
     ]);
   });
 

--- a/website/src/draft-js/index.js
+++ b/website/src/draft-js/index.js
@@ -152,12 +152,12 @@ class StyleButton extends React.Component {
 }
 
 const BLOCK_TYPES = [
-  {label: 'H1', style: 'header-one'},
-  {label: 'H2', style: 'header-two'},
-  {label: 'H3', style: 'header-three'},
-  {label: 'H4', style: 'header-four'},
-  {label: 'H5', style: 'header-five'},
-  {label: 'H6', style: 'header-six'},
+  {label: 'H1', style: 'heading-one'},
+  {label: 'H2', style: 'heading-two'},
+  {label: 'H3', style: 'heading-three'},
+  {label: 'H4', style: 'heading-four'},
+  {label: 'H5', style: 'heading-five'},
+  {label: 'H6', style: 'heading-six'},
   {label: 'Blockquote', style: 'blockquote'},
   {label: 'UL', style: 'unordered-list-item'},
   {label: 'OL', style: 'ordered-list-item'},


### PR DESCRIPTION
This PR fixes #724 ,  which aims to replace references to `H1 - H2` as headers to headings.