### PR TITLE
Feature / Link Example: Pre-fill the URL Input with the Current URL (if any)

### DIFF
--- a/examples/link/link.html
+++ b/examples/link/link.html
@@ -76,8 +76,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           if (!selection.isCollapsed()) {
             const contentState = editorState.getCurrentContent();
             const startKey = editorState.getSelection().getStartKey();
+            const startOffset = editorState.getSelection().getStartOffset();
             const blockWithLinkAtBeginning = contentState.getBlockForKey(startKey);
-            const linkKey = blockWithLinkAtBeginning.getEntityAt(0);
+            const linkKey = blockWithLinkAtBeginning.getEntityAt(startOffset);
 
             let url = '';
             if (linkKey) {

--- a/examples/link/link.html
+++ b/examples/link/link.html
@@ -74,9 +74,20 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           const {editorState} = this.state;
           const selection = editorState.getSelection();
           if (!selection.isCollapsed()) {
+            const contentState = editorState.getCurrentContent();
+            const startKey = editorState.getSelection().getStartKey();
+            const blockWithLinkAtBeginning = contentState.getBlockForKey(startKey);
+            const linkKey = blockWithLinkAtBeginning.getEntityAt(0);
+
+            let url = '';
+            if (linkKey) {
+              const linkInstance = contentState.getEntity(linkKey);
+              url = linkInstance.getData().url;
+            }
+
             this.setState({
               showURLInput: true,
-              urlValue: '',
+              urlValue: url,
             }, () => {
               setTimeout(() => this.refs.url.focus(), 0);
             });


### PR DESCRIPTION
**Summary**

When adding a new link on top of another link, pre-fill the input with the current url value. Use-case described in details here: https://github.com/facebook/draft-js/issues/732

I believe the example enhancement will be useful for other developers too.

**Test Plan**

I loaded the example and manually tested on Chrome / Safari / Firefox / Opera latest.
