### PR TITLE
Ensure `ContentState.createFromBlockArray` creates with an empty array

### DIFF
--- a/src/model/immutable/ContentState.js
+++ b/src/model/immutable/ContentState.js
@@ -172,7 +172,9 @@ class ContentState extends ContentStateRecord {
     entityMap: ?OrderedMap
   ): ContentState {
     var blockMap = BlockMapBuilder.createFromArray(blocks);
-    var selectionState = SelectionState.createEmpty(blockMap.first().getKey());
+    var selectionState = blockMap.isEmpty()
+      ? new SelectionState()
+      : SelectionState.createEmpty(blockMap.first().getKey());
     return new ContentState({
       blockMap,
       entityMap: entityMap || OrderedMap(),

--- a/src/model/immutable/__tests__/ContentState-test.js
+++ b/src/model/immutable/__tests__/ContentState-test.js
@@ -59,6 +59,11 @@ describe('ContentState', () => {
       var state = getSample(SINGLE_BLOCK);
       expect(state instanceof ContentState).toBe(true);
     });
+
+    it('must create properly with an empty block array', () => {
+      var state = ContentState.createFromBlockArray([]);
+      expect(state instanceof ContentState).toBe(true);
+    });
   });
 
   describe('key fetching', () => {


### PR DESCRIPTION
Fixes #720 by passing through an empty `SelectionState` when the created `blockMap` is empty.