### PR TITLE
Use the same wrapper for both ordered and unordered list. Maintain bl…

### DIFF
--- a/src/component/utils/DraftStyleDefault.css
+++ b/src/component/utils/DraftStyleDefault.css
@@ -35,8 +35,7 @@
 /**
  * Default spacing for list container elements. Override with CSS as needed.
  */
-.public/DraftStyleDefault/ul,
-.public/DraftStyleDefault/ol {
+.public/DraftStyleDefault/list {
   margin: 16px 0;
   padding: 0;
 }

--- a/src/model/immutable/DefaultDraftBlockRenderMap.js
+++ b/src/model/immutable/DefaultDraftBlockRenderMap.js
@@ -17,8 +17,7 @@ const React = require('React');
 
 const cx = require('cx');
 
-const UL_WRAP = <ul className={cx('public/DraftStyleDefault/ul')} />;
-const OL_WRAP = <ol className={cx('public/DraftStyleDefault/ol')} />;
+const LIST_WRAP = <ul className={cx('public/DraftStyleDefault/list')} />;
 const PRE_WRAP = <pre className={cx('public/DraftStyleDefault/pre')} />;
 
 module.exports = Map({
@@ -42,11 +41,11 @@ module.exports = Map({
   },
   'unordered-list-item': {
     element: 'li',
-    wrapper: UL_WRAP,
+    wrapper: LIST_WRAP,
   },
   'ordered-list-item': {
     element: 'li',
-    wrapper: OL_WRAP,
+    wrapper: LIST_WRAP,
   },
   'blockquote': {
     element: 'blockquote',

--- a/src/model/modifier/DraftModifier.js
+++ b/src/model/modifier/DraftModifier.js
@@ -211,7 +211,13 @@ var DraftModifier = {
     return modifyBlockForContentState(
       contentState,
       selectionState,
-      (block) => block.merge({type: blockType, depth: 0})
+      (block) => {
+        var depth = blockType === 'unordered-list-item' || blockType === 'ordered-list-item'
+                      ? block.getDepth()
+                      : 0;
+
+        return block.merge({ type: blockType, depth: depth });
+      }
     );
   },
 


### PR DESCRIPTION
**Summary**

Adds support for nesting ordered & unordered lists within one another, preserving the block depth when toggling between the two. This fixes https://github.com/facebook/draft-js/issues/443 in the process.

The enhancement is simple. Since DraftJS already uses classes in combination with the `::before` pseudo element to custom render ordered list numbering rather than depending on default browser functionality, there isn't actually any reason to render an `<ol>` vs `<ul>`. By giving both block types the same wrapper, we automatically gain support for nesting one within the other.

To maintaining block depth with toggling between the two list types, we simply merge in the block's current depth rather than 0.

**Test Plan**

Open up the `rich.html` example and create an ordered list. Indent a list item and convert it to an unordered list. It will remain nested at the same depth. Play around further, adding ordered and unordered lists throughout the list tree. Ordered list numbering will remain correct, restarting at new levels of depth and continuing from the last ordered list item at the same depth.

![image](https://cloud.githubusercontent.com/assets/253298/19831827/e74e8e6a-9dc8-11e6-9d8c-78b041910af8.png)
