### PR TITLE
Add isCommandKeyCommand to KeyBindingUtil

### DIFF
--- a/docs/APIReference-KeyBindingUtil.md
+++ b/docs/APIReference-KeyBindingUtil.md
@@ -32,6 +32,14 @@ isOptionKeyCommand: function(
 ): boolean
 ```
 
+### isCommandKeyCommand
+
+```
+isCommandKeyCommand: function(
+  e: SyntheticKeyboardEvent
+): boolean
+```
+
 ### hasCommandModifier
 
 ```

--- a/src/component/utils/KeyBindingUtil.js
+++ b/src/component/utils/KeyBindingUtil.js
@@ -31,7 +31,7 @@ var KeyBindingUtil = {
     return isOSX && e.altKey;
   },
 
-  isCommandKeyCommand: function isCommandKeyCommand(e) {
+  isCommandKeyCommand: function isCommandKeyCommand(e: SyntheticKeyboardEvent): boolean {
     return isOSX && !!e.metaKey && !e.altKey;
   },
 

--- a/src/component/utils/KeyBindingUtil.js
+++ b/src/component/utils/KeyBindingUtil.js
@@ -31,6 +31,10 @@ var KeyBindingUtil = {
     return isOSX && e.altKey;
   },
 
+  isCommandKeyCommand: function isCommandKeyCommand(e) {
+    return isOSX && !!e.metaKey && !e.altKey;
+  },
+
   hasCommandModifier: function(e: SyntheticKeyboardEvent): boolean {
     return isOSX ?
       (!!e.metaKey && !e.altKey) :


### PR DESCRIPTION
**Summary**

`KeyBindingUtil#hasCommandModifier` is not enough when you want to implement keyboard shortcuts set strictly, like

* Mac : `⌘+S` **only** (excluding `⌘+CTRL+S`, `⌘+⌥+S`, etc)
* Windows:  `CTRL+S` **only**

This is because, `KeyBindingUtil#hasCommandModifier` returns `KeyBindingUtil.isCtrlKeyCommand()` when the OS is not Mac. Therefore, this library needs a method for judging whether the key command is `⌘` or not ( and this returns `false` when the OS is not Mac).

**Example**

key | Windows | Mac
---|----|---
`⌘+s`| false | true
`CTRL+s`| **false**(this is supposed to be true) | true
`⌘+CTRL+s`| false| false

Below code snippet does not work in this case:

* Mac : `⌘+S` **only** (excluding `⌘+CTRL+S`, `⌘+⌥+S`, etc)
* Windows:  `CTRL+S` **only**

```javascript
  isSaveKeyEvent(keyboardEvent) {
    return keyboardEvent.keyCode === KeyCode.KEY_S
      && !keyboardEvent.shiftKey
      && !KeyBindingUtil.isOptionKeyCommand(keyboardEvent)
      && !KeyBindingUtil.isCtrlKeyCommand(keyboardEvent) 
      && KeyBindingUtil.hasCommandModifier(keyboardEvent);
  }
```


