### PR TITLE
[documentation] Include reference to example for convertFromHTML

### DIFF
--- a/docs/APIReference-Data-Conversion.md
+++ b/docs/APIReference-Data-Conversion.md
@@ -55,7 +55,11 @@ const sampleMarkup =
   '<img src="image.png" height="112" width="200" />';
 
 const blocksFromHTML = convertFromHTML(sampleMarkup);
-const state = ContentState.createFromBlockArray(blocksFromHTML);
+const state = ContentState.createFromBlockArray(
+  blocksFromHTML.contentBlocks,
+  blocksFromHTML.entityMap,
+);
+
 this.state = {
   editorState: EditorState.createWithContent(state),
 };

--- a/docs/APIReference-Data-Conversion.md
+++ b/docs/APIReference-Data-Conversion.md
@@ -49,11 +49,16 @@ other usage within an application.
 ### convertFromHTML
 
 ```
-convertFromHTML(
-  html: string,
-  DOMBuilder: Function = getSafeBodyFromHTML,
-  blockRenderMap?: DraftBlockRenderMap = DefaultDraftBlockRenderMap
-): ?Array<ContentBlock>
+const sampleMarkup =
+  '<b>Bold text</b>, <i>Italic text</i><br/ ><br />' +
+  '<a href="http://www.facebook.com">Example link</a><br /><br/ >' +
+  '<img src="image.png" height="112" width="200" />';
+
+const blocksFromHTML = convertFromHTML(sampleMarkup);
+const state = ContentState.createFromBlockArray(blocksFromHTML);
+this.state = {
+  editorState: EditorState.createWithContent(state),
+};
 ```
 
-Given an HTML fragment, convert it to an array of `ContentBlock` objects.
+Given an HTML fragment, convert it to an array of `ContentBlock` objects. Construct content state from the array of block elements and then update the editor state with it. Full example available <a href="https://github.com/facebook/draft-js/blob/8ac72f723fb2d9102db833a9b060dfd66df65652/examples/convertFromHTML/convert.html">here</a>.


### PR DESCRIPTION
**Summary**
This doc page is the first place people find when looking for information on convertFromHTML but the original code sample is not very useful. This hopefully will give people a better idea of how to use the function and then a reference to where I found the code snippet.

Should close #236 as well.