### PR TITLE
handle scrolling by Y nodePosition

### DIFF
--- a/src/component/contents/DraftEditorBlock.react.js
+++ b/src/component/contents/DraftEditorBlock.react.js
@@ -106,7 +106,8 @@ class DraftEditorBlock extends React.Component {
       if (scrollDelta > 0) {
         window.scrollTo(
           scrollPosition.x,
-          scrollPosition.y + scrollDelta + SCROLL_BUFFER
+          nodePosition.y + SCROLL_BUFFER
+          //scrollPosition.y + scrollDelta + SCROLL_BUFFER
         );
       }
     } else {

--- a/src/component/contents/DraftEditorBlock.react.js
+++ b/src/component/contents/DraftEditorBlock.react.js
@@ -100,15 +100,11 @@ class DraftEditorBlock extends React.Component {
 
     if (scrollParent === window) {
       var nodePosition = getElementPosition(blockNode);
-      var nodeBottom = nodePosition.y + nodePosition.height;
       var viewportHeight = getViewportDimensions().height;
-      scrollDelta = nodeBottom - viewportHeight;
+      scrollDelta = nodePosition.y - viewportHeight;
       if (scrollDelta > 0) {
-        window.scrollTo(
-          scrollPosition.x,
-          nodePosition.y + SCROLL_BUFFER
-          //scrollPosition.y + scrollDelta + SCROLL_BUFFER
-        );
+        window.scrollTo(scrollPosition.x, 
+          scrollPosition.y + scrollDelta + SCROLL_BUFFER * 3);
       }
     } else {
       var blockBottom = blockNode.offsetHeight + blockNode.offsetTop;


### PR DESCRIPTION
TODO:
  * fix 1 failing spec

**Summary**

tackles issue #304 

**Test Plan**

When you have a big paragraph and you press enter in the middle, instead of keeping the focus in the middle of the page, the editor scrolls all the way to the bottom.

### Steps to reproduce bug in current draft :

+ Go to https://facebook.github.io/draft-js/
+ Copy paste in a large continuous paragraph without any newlines in between.
+ Scroll to the middle of the big paragraph and press enter.
+ The editor will have scrolled to the bottom
+ This doesn't seem to happen consistently all the time, but I've seen it come up enough times on big paragraphs.
