### PR TITLE
Removed duplicate table entry and fixed broken link

### DIFF
--- a/docs/APIReference-Data-Conversion.md
+++ b/docs/APIReference-Data-Conversion.md
@@ -65,4 +65,4 @@ this.state = {
 };
 ```
 
-Given an HTML fragment, convert it to an array of `ContentBlock` objects. Construct content state from the array of block elements and then update the editor state with it. Full example available <a href="https://github.com/facebook/draft-js/blob/8ac72f723fb2d9102db833a9b060dfd66df65652/examples/convertFromHTML/convert.html">here</a>.
+Given an HTML fragment, convert it to an array of `ContentBlock` objects. Construct content state from the array of block elements and then update the editor state with it. Full example available [here](https://github.com/facebook/draft-js/blob/8ac72f723fb2d9102db833a9b060dfd66df65652/examples/convertFromHTML/convert.html).

--- a/docs/Advanced-Topics-Custom-Block-Render.md
+++ b/docs/Advanced-Topics-Custom-Block-Render.md
@@ -26,7 +26,6 @@ by matching the Draft block render map with the matched tag.
 |     `<h4/>`     |               header-four               |
 |     `<h5/>`     |               header-five               |
 |     `<h6/>`     |               header-six                |
-|     `<h6/>`     |               header-six                |
 | `<blockquote/>` |               blockquote                |
 |    `<pre/>`     |               code-block                |
 |   `<figure/>`   |                 atomic                  |


### PR DESCRIPTION
**Summary**

The website doesn't render HTML links inside markdown, see bottom of http://facebook.github.io/draft-js/docs/api-reference-data-conversion.html#convertfromhtml
