### PR TITLE
Add default text direction

### DIFF
--- a/docs/APIReference-EditorState.md
+++ b/docs/APIReference-EditorState.md
@@ -136,6 +136,11 @@ The list below includes the most commonly used instance methods for `EditorState
     </a>
   </li>
   <li>
+    <a href="#defaultdirection">
+      <pre>defaultDirection</pre>
+    </a>
+  </li>
+  <li>
     <a href="#directionmap">
       <pre>directionMap</pre>
     </a>
@@ -392,6 +397,19 @@ The current decorator object, if any.
 
 Note that the `ContentState` is independent of your decorator. If a decorator
 is provided, it will be used to decorate ranges of text for rendering.
+
+### defaultDirection
+
+```
+defaultDirection: ?DraftDirectionType;
+getDefaultDirection()
+```
+The default text direction sent to UnicodeBidiService when creating
+directionMap. This will be used if no direction can be detected from the text
+(e.g. for empty texts).
+
+This value should be a strong direction, which is either `'LTR'` or `'LTR'`. The
+default value is `'LTR'`.
 
 ### directionMap
 

--- a/docs/Advanced-Topics-Text-Direction.md
+++ b/docs/Advanced-Topics-Text-Direction.md
@@ -20,6 +20,11 @@ text alignment and direction on a per-block basis.
 Text is rendered with an LTR or RTL direction automatically as the user types.
 You should not need to do anything to set direction yourself.
 
+When it is not possible to detect text direction from the text (for example,
+when the content is empty), a default text direction is used. The initial value
+for this default direction is LTR, but you can change it by setting
+`defaultDirection` property of `EditorState`.
+
 ## Text Alignment
 
 While languages are automatically aligned to the left or right during composition,

--- a/src/model/constants/DraftDirectionType.js
+++ b/src/model/constants/DraftDirectionType.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule DraftDirectionType
+ * @flow
+ */
+
+'use strict';
+
+/**
+ * A type to use when only a strong text direction is allowed.
+ */
+export type DraftDirectionType = 'LTR' | 'RTL';

--- a/src/model/immutable/EditorBidiService.js
+++ b/src/model/immutable/EditorBidiService.js
@@ -19,21 +19,25 @@ var UnicodeBidiService = require('UnicodeBidiService');
 var nullthrows = require('nullthrows');
 
 import type ContentState from 'ContentState';
+import type {DraftDirectionType} from 'DraftDirectionType';
 
 var {OrderedMap} = Immutable;
 
-var bidiService;
+// Holds one bidi service for each default direction ('LTR' or 'RTL').
+var bidiServices = {};
 
 var EditorBidiService = {
   getDirectionMap: function(
     content: ContentState,
+    defaultDir: DraftDirectionType,
     prevBidiMap: ?OrderedMap<any, any>
   ): OrderedMap<any, any> {
-    if (!bidiService) {
-      bidiService = new UnicodeBidiService();
+    if (!bidiServices[defaultDir]) {
+      bidiServices[defaultDir] = new UnicodeBidiService(defaultDir);
     } else {
-      bidiService.reset();
+      bidiServices[defaultDir].reset();
     }
+    var bidiService = bidiServices[defaultDir];
 
     var blockMap = content.getBlockMap();
     var nextBidi = blockMap

--- a/src/model/immutable/__tests__/EditorBidiService-test.js
+++ b/src/model/immutable/__tests__/EditorBidiService-test.js
@@ -52,7 +52,7 @@ describe('EditorBidiService', () => {
 
   it('must create a new map', () => {
     var state = getContentState([ltr]);
-    var directions = EditorBidiService.getDirectionMap(state);
+    var directions = EditorBidiService.getDirectionMap(state, LTR);
     expect(
       directions.keySeq().toArray()
     ).toEqual(
@@ -67,11 +67,12 @@ describe('EditorBidiService', () => {
 
   it('must return the same map if no changes', () => {
     var state = getContentState([ltr]);
-    var directions = EditorBidiService.getDirectionMap(state);
+    var directions = EditorBidiService.getDirectionMap(state, LTR);
 
     var nextState = getContentState([ltr]);
     var nextDirections = EditorBidiService.getDirectionMap(
       nextState,
+      LTR,
       directions
     );
 
@@ -81,7 +82,7 @@ describe('EditorBidiService', () => {
 
   it('must return the same map if no text changes', () => {
     var state = getContentState([ltr]);
-    var directions = EditorBidiService.getDirectionMap(state);
+    var directions = EditorBidiService.getDirectionMap(state, LTR);
 
     var newLTR = new ContentBlock({
       key: 'a',
@@ -92,6 +93,7 @@ describe('EditorBidiService', () => {
     var nextState = getContentState([newLTR]);
     var nextDirections = EditorBidiService.getDirectionMap(
       nextState,
+      LTR,
       directions
     );
 
@@ -101,7 +103,7 @@ describe('EditorBidiService', () => {
 
   it('must return the same map if no directions change', () => {
     var state = getContentState([ltr]);
-    var directions = EditorBidiService.getDirectionMap(state);
+    var directions = EditorBidiService.getDirectionMap(state, LTR);
 
     var newLTR = new ContentBlock({
       key: 'a',
@@ -112,6 +114,7 @@ describe('EditorBidiService', () => {
     var nextState = getContentState([newLTR]);
     var nextDirections = EditorBidiService.getDirectionMap(
       nextState,
+      LTR,
       directions
     );
 
@@ -121,7 +124,7 @@ describe('EditorBidiService', () => {
 
   it('must return a new map if block keys change', () => {
     var state = getContentState([ltr]);
-    var directions = EditorBidiService.getDirectionMap(state);
+    var directions = EditorBidiService.getDirectionMap(state, LTR);
 
     var newLTR = new ContentBlock({
       key: 'asdf',
@@ -131,6 +134,7 @@ describe('EditorBidiService', () => {
     var nextState = getContentState([newLTR]);
     var nextDirections = EditorBidiService.getDirectionMap(
       nextState,
+      LTR,
       directions
     );
 
@@ -151,7 +155,7 @@ describe('EditorBidiService', () => {
 
   it('must return a new map if direction changes', () => {
     var state = getContentState([ltr, empty]);
-    var directions = EditorBidiService.getDirectionMap(state);
+    var directions = EditorBidiService.getDirectionMap(state, LTR);
 
     expect(
       directions.valueSeq().toArray()
@@ -162,6 +166,7 @@ describe('EditorBidiService', () => {
     var nextState = getContentState([ltr, rtl]);
     var nextDirections = EditorBidiService.getDirectionMap(
       nextState,
+      LTR,
       directions
     );
 
@@ -171,6 +176,24 @@ describe('EditorBidiService', () => {
       nextDirections.valueSeq().toArray()
     ).toEqual(
       [LTR, RTL]
+    );
+  });
+
+  it('must use default direction for empty content', () => {
+    var state = getContentState([empty]);
+
+    var directions = EditorBidiService.getDirectionMap(state, LTR);
+    expect(
+      directions.valueSeq().toArray()
+    ).toEqual(
+      [LTR]
+    );
+
+    var nextDirections = EditorBidiService.getDirectionMap(state, RTL);
+    expect(
+      nextDirections.valueSeq().toArray()
+    ).toEqual(
+      [RTL]
     );
   });
 });


### PR DESCRIPTION
**Summary**

By default, Draft.js sets direction to LTR when text has no direction. In an RTL environment, it means that empty editors show the cursor on the wrong side, until the user starts typing some RTL text.

The new `defaultDirection` property of `EditorState` is used for that. It is sent to UnicodeBidiService as default direction.

**Test Plan**

A new tests is added for covering this change. For manual testing, you can set the `defaultDirection` of `EditorState` to `RTL` and expect to see the cursor on the right when the editor is empty.

Closes #634.