### PR TITLE
Deprecate DraftEntity before removing

### DIFF
--- a/examples/convertFromHTML/convert.html
+++ b/examples/convertFromHTML/convert.html
@@ -103,7 +103,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         }
       }
 
-      function findLinkEntities(contentState, contentBlock, callback) {
+      function findLinkEntities(contentBlock, callback, contentState) {
         contentBlock.findEntityRanges(
           (character) => {
             const entityKey = character.getEntity();
@@ -125,7 +125,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         );
       };
 
-      function findImageEntities(contentState, contentBlock, callback) {
+      function findImageEntities(contentBlock, callback, contentState) {
         contentBlock.findEntityRanges(
           (character) => {
             const entityKey = character.getEntity();

--- a/examples/entity/entity.html
+++ b/examples/entity/entity.html
@@ -148,7 +148,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       }
 
       function getEntityStrategy(mutability) {
-        return function(contentState, contentBlock, callback) {
+        return function(contentBlock, callback, contentState) {
           contentBlock.findEntityRanges(
             (character) => {
               const entityKey = character.getEntity();
@@ -176,7 +176,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           props.contentState.getEntity(props.entityKey).getMutability()
         );
         return (
-          <span {...props} style={style}>
+          <span data-offset-key={props.offsetkey} style={style}>
             {props.children}
           </span>
         );

--- a/examples/link/link.html
+++ b/examples/link/link.html
@@ -191,7 +191,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         }
       }
 
-      function findLinkEntities(contentState, contentBlock, callback) {
+      function findLinkEntities(contentBlock, callback, contentState) {
         contentBlock.findEntityRanges(
           (character) => {
             const entityKey = character.getEntity();

--- a/examples/tweet/tweet.html
+++ b/examples/tweet/tweet.html
@@ -84,11 +84,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       const HANDLE_REGEX = /\@[\w]+/g;
       const HASHTAG_REGEX = /\#[\w\u0590-\u05ff]+/g;
 
-      function handleStrategy(contentState, contentBlock, callback) {
+      function handleStrategy(contentBlock, callback, contentState) {
         findWithRegex(HANDLE_REGEX, contentBlock, callback);
       }
 
-      function hashtagStrategy(contentState, contentBlock, callback) {
+      function hashtagStrategy(contentBlock, callback, contentState) {
         findWithRegex(HASHTAG_REGEX, contentBlock, callback);
       }
 

--- a/src/Draft.js
+++ b/src/Draft.js
@@ -21,6 +21,7 @@ const DefaultDraftBlockRenderMap = require('DefaultDraftBlockRenderMap');
 const DefaultDraftInlineStyle = require('DefaultDraftInlineStyle');
 const DraftEditor = require('DraftEditor.react');
 const DraftEditorBlock = require('DraftEditorBlock.react');
+const DraftEntity = require('DraftEntity');
 const DraftModifier = require('DraftModifier');
 const DraftEntityInstance = require('DraftEntityInstance');
 const EditorState = require('EditorState');
@@ -42,6 +43,7 @@ const DraftPublic = {
   EditorState,
 
   CompositeDecorator: CompositeDraftDecorator,
+  Entity: DraftEntity,
   EntityInstance: DraftEntityInstance,
 
   BlockMapBuilder,

--- a/src/component/handlers/edit/editOnPaste.js
+++ b/src/component/handlers/edit/editOnPaste.js
@@ -196,11 +196,13 @@ function insertFragment(
     editorState.getSelection(),
     fragment
   );
-  const mergedEntityMap = newContent.getEntityMap().merge(entityMap);
+  // TODO: merge the entity map once we stop using DraftEntity
+  // like this:
+  // const mergedEntityMap = newContent.getEntityMap().merge(entityMap);
 
   return EditorState.push(
     editorState,
-    newContent.set('entityMap', mergedEntityMap),
+    newContent.set('entityMap', entityMap),
     'insert-fragment'
   );
 }

--- a/src/model/decorators/CompositeDraftDecorator.js
+++ b/src/model/decorators/CompositeDraftDecorator.js
@@ -59,7 +59,7 @@ class CompositeDraftDecorator {
       (/*object*/ decorator, /*number*/ ii) => {
         var counter = 0;
         var strategy = decorator.strategy;
-        strategy(contentState, block, (/*number*/ start, /*number*/ end) => {
+        var callback  = (/*number*/ start, /*number*/ end) => {
           // Find out if any of our matching range is already occupied
           // by another decorator. If so, discard the match. Otherwise, store
           // the component key for rendering.
@@ -67,7 +67,8 @@ class CompositeDraftDecorator {
             occupySlice(decorations, start, end, ii + DELIMITER + counter);
             counter++;
           }
-        });
+        };
+        strategy(block, callback, contentState);
       }
     );
 

--- a/src/model/decorators/DraftDecorator.js
+++ b/src/model/decorators/DraftDecorator.js
@@ -32,9 +32,9 @@ import type ContentState from 'ContentState';
  */
 export type DraftDecorator = {
   strategy: (
-    contentState: ContentState,
     block: ContentBlock,
-    callback: (start: number, end: number) => void
+    callback: (start: number, end: number) => void,
+    contentState: ContentState,
   ) => void,
   component: Function,
   props?: Object,

--- a/src/model/decorators/__tests__/CompositeDraftDecorator-test.js
+++ b/src/model/decorators/__tests__/CompositeDraftDecorator-test.js
@@ -26,7 +26,7 @@ describe('CompositeDraftDecorator', () => {
   }
 
   function searchWith(regex) {
-    return function(contentState, block, callback) {
+    return function(block, callback, contentState) {
       var text = block.getText();
       text.replace(
         regex,

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -16,11 +16,10 @@
 const CharacterMetadata = require('CharacterMetadata');
 const ContentBlock = require('ContentBlock');
 const DefaultDraftBlockRenderMap = require('DefaultDraftBlockRenderMap');
-const DraftEntityInstance = require('DraftEntityInstance');
+const DraftEntity = require('DraftEntity');
 const Immutable = require('immutable');
 const URI = require('URI');
 
-const addEntityToEntityMap = require('addEntityToEntityMap');
 const generateRandomKey = require('generateRandomKey');
 const getSafeBodyFromHTML = require('getSafeBodyFromHTML');
 const invariant = require('invariant');
@@ -35,7 +34,6 @@ import type {EntityMap} from 'EntityMap';
 var {
   List,
   OrderedSet,
-  OrderedMap,
 } = Immutable;
 
 var NBSP = '&nbsp;';
@@ -390,15 +388,12 @@ function genFragment(
     const imageURI = new URI(entityConfig.src).toString();
     node.textContent = imageURI; // Output src if no decorator
 
-    newEntityMap = addEntityToEntityMap(
-      newEntityMap,
-      new DraftEntityInstance({
-        type: 'IMAGE',
-        mutability: 'MUTABLE',
-        data: entityConfig || {},
-      })
+    // TODO: update this when we remove DraftEntity entirely
+    inEntity = DraftEntity.create(
+      'IMAGE',
+      'MUTABLE',
+      entityConfig || {},
     );
-    inEntity = newEntityMap.keySeq().last();
   }
 
   var chunk = getEmptyChunk();
@@ -460,15 +455,12 @@ function genFragment(
       });
 
       entityConfig.url = new URI(anchor.href).toString();
-      newEntityMap = addEntityToEntityMap(
-        newEntityMap,
-        new DraftEntityInstance({
-          type: 'LINK',
-          mutability: 'MUTABLE',
-          data: entityConfig || {},
-        })
+      // TODO: update this when we remove DraftEntity completely
+      entityId = DraftEntity.create(
+        'LINK',
+        'MUTABLE',
+        entityConfig || {},
       );
-      entityId = newEntityMap.keySeq().last();
     } else {
       entityId = undefined;
     }
@@ -602,7 +594,8 @@ function convertFromHTMLtoContentBlocks(
   // arbitrary code in whatever environment you're running this in. For an
   // example of how we try to do this in-browser, see getSafeBodyFromHTML.
 
-  var chunkData = getChunkForHTML(html, DOMBuilder, blockRenderMap, OrderedMap());
+  // TODO: replace DraftEntity with an OrderedMap here
+  var chunkData = getChunkForHTML(html, DOMBuilder, blockRenderMap, DraftEntity);
 
   if (chunkData == null) {
     return null;

--- a/src/model/encoding/convertFromRawToDraftState.js
+++ b/src/model/encoding/convertFromRawToDraftState.js
@@ -14,15 +14,13 @@
 
 var ContentBlock = require('ContentBlock');
 var ContentState = require('ContentState');
-var DraftEntityInstance = require('DraftEntityInstance');
+var DraftEntity = require('DraftEntity');
 
-const addEntityToEntityMap = require('addEntityToEntityMap');
 var createCharacterList = require('createCharacterList');
 var decodeEntityRanges = require('decodeEntityRanges');
 var decodeInlineStyleRanges = require('decodeInlineStyleRanges');
 var generateRandomKey = require('generateRandomKey');
 var Immutable = require('immutable');
-var {OrderedMap} = Immutable;
 
 import type {RawDraftContentState} from 'RawDraftContentState';
 
@@ -35,17 +33,14 @@ function convertFromRawToDraftState(
 
   var fromStorageToLocal = {};
 
-  const newEntityMap = Object.keys(entityMap).reduce(
-    (updatedEntityMap, storageKey) => {
+  // TODO: Update this once we completely remove DraftEntity
+  Object.keys(entityMap).forEach(
+    storageKey => {
       var encodedEntity = entityMap[storageKey];
       var {type, mutability, data} = encodedEntity;
-      const instance = new DraftEntityInstance({type, mutability, data: data || {}});
-      const tempEntityMap = addEntityToEntityMap(updatedEntityMap, instance);
-      const newKey = tempEntityMap.keySeq().last();
+      var newKey = DraftEntity.create(type, mutability, data || {});
       fromStorageToLocal[storageKey] = newKey;
-      return tempEntityMap;
-    },
-    OrderedMap()
+    }
   );
 
   var contentBlocks = blocks.map(
@@ -81,7 +76,7 @@ function convertFromRawToDraftState(
     }
   );
 
-  return ContentState.createFromBlockArray(contentBlocks, newEntityMap);
+  return ContentState.createFromBlockArray(contentBlocks);
 }
 
 module.exports = convertFromRawToDraftState;

--- a/src/model/entity/DraftEntity.js
+++ b/src/model/entity/DraftEntity.js
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule DraftEntity
+ * @typechecks
+ * @flow
+ */
+
+var DraftEntityInstance = require('DraftEntityInstance');
+var Immutable = require('immutable');
+
+var invariant = require('invariant');
+
+import type {DraftEntityMutability} from 'DraftEntityMutability';
+import type {DraftEntityType} from 'DraftEntityType';
+
+var {Map} = Immutable;
+
+var instances: Map<string, DraftEntityInstance> = Map();
+var instanceKey = 0;
+
+/**
+ * A "document entity" is an object containing metadata associated with a
+ * piece of text in a ContentBlock.
+ *
+ * For example, a `link` entity might include a `uri` property. When a
+ * ContentBlock is rendered in the browser, text that refers to that link
+ * entity may be rendered as an anchor, with the `uri` as the href value.
+ *
+ * In a ContentBlock, every position in the text may correspond to zero
+ * or one entities. This correspondence is tracked using a key string,
+ * generated via DraftEntity.create() and used to obtain entity metadata
+ * via DraftEntity.get().
+ */
+var DraftEntity = {
+  /**
+   * Get the random key string from whatever entity was last created.
+   * We need this to support the new API, as part of transitioning to put Entity
+   * storage in contentState.
+   */
+  getLastCreatedEntityKey: function(): string {
+    return '' + instanceKey;
+  },
+
+  /**
+   * Create a DraftEntityInstance and store it for later retrieval.
+   *
+   * A random key string will be generated and returned. This key may
+   * be used to track the entity's usage in a ContentBlock, and for
+   * retrieving data about the entity at render time.
+   */
+  create: function(
+    type: DraftEntityType,
+    mutability: DraftEntityMutability,
+    data?: Object,
+  ): string {
+    return DraftEntity.add(
+      new DraftEntityInstance({type, mutability, data: data || {}})
+    );
+  },
+
+  /**
+   * Add an existing DraftEntityInstance to the DraftEntity map. This is
+   * useful when restoring instances from the server.
+   */
+  add: function(instance: DraftEntityInstance): string {
+    var key = '' + (++instanceKey);
+    instances = instances.set(key, instance);
+    return key;
+  },
+
+  /**
+   * Retrieve the entity corresponding to the supplied key string.
+   */
+  get: function(key: string): DraftEntityInstance {
+    var instance = instances.get(key);
+    invariant(!!instance, 'Unknown DraftEntity key.');
+    return instance;
+  },
+
+  /**
+   * Entity instances are immutable. If you need to update the data for an
+   * instance, this method will merge your data updates and return a new
+   * instance.
+   */
+  mergeData: function(
+    key: string,
+    toMerge: {[key: string]: any}
+  ): DraftEntityInstance {
+    var instance = DraftEntity.get(key);
+    var newData = {...instance.getData(), ...toMerge};
+    var newInstance = instance.set('data', newData);
+    instances = instances.set(key, newInstance);
+    return newInstance;
+  },
+
+  /**
+   * Completely replace the data for a given instance.
+   */
+  replaceData: function(
+    key: string,
+    newData: {[key: string]: any}
+  ): DraftEntityInstance {
+    const instance = DraftEntity.get(key);
+    const newInstance = instance.set('data', newData);
+    instances = instances.set(key, newInstance);
+    return newInstance;
+  },
+};
+
+module.exports = DraftEntity;

--- a/src/model/entity/__mocks__/DraftEntity.js
+++ b/src/model/entity/__mocks__/DraftEntity.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+var DraftEntity = jest.genMockFromModule('DraftEntity');
+
+var DraftEntityInstance = {
+  getType: jest.fn(() => ''),
+  getMutability: jest.fn(() => ''),
+  getData: jest.fn(() => ({})),
+};
+
+var count = 0;
+
+DraftEntity.create = jest.fn(function() {
+  count++;
+  return '' + count;
+});
+
+DraftEntity.get = jest.fn(function() {
+  return DraftEntityInstance;
+});
+
+module.exports = DraftEntity;

--- a/src/model/entity/__tests__/DraftEntity-test.js
+++ b/src/model/entity/__tests__/DraftEntity-test.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails isaac, oncall+ui_infra
+ */
+
+'use strict';
+
+jest.disableAutomock();
+
+var DraftEntity = require('DraftEntity');
+
+describe('DraftEntity', () => {
+  beforeEach(() => {
+    jest.resetModuleRegistry();
+  });
+
+  function createLink() {
+    return DraftEntity.create('LINK', 'MUTABLE', {uri: 'zombo.com'});
+  }
+
+  it('must create instances', () => {
+    var key = createLink();
+    expect(typeof key).toBe('string');
+  });
+
+  it('must retrieve an instance given a key', () => {
+    var key = createLink();
+    var retrieved = DraftEntity.get(key);
+    expect(retrieved.getType()).toBe('LINK');
+    expect(retrieved.getMutability()).toBe('MUTABLE');
+    expect(retrieved.getData()).toEqual({uri: 'zombo.com'});
+  });
+
+  it('must throw when retrieving for an invalid key', () => {
+    createLink();
+    expect(() => DraftEntity.get('asdfzxcvqweriuop')).toThrow();
+    expect(() => DraftEntity.get(null)).toThrow();
+  });
+
+  it('must merge data', () => {
+    var key = createLink();
+
+    // Merge new property.
+    var newData = {foo: 'bar'};
+    DraftEntity.mergeData(key, newData);
+    var newEntity = DraftEntity.get(key);
+    expect(newEntity.getData()).toEqual({
+      uri: 'zombo.com',
+      foo: 'bar',
+    });
+
+    // Replace existing property.
+    var withNewURI = {uri: 'homestarrunner.com'};
+    DraftEntity.mergeData(key, withNewURI);
+    var entityWithNewURI = DraftEntity.get(key);
+    expect(entityWithNewURI.getData()).toEqual({
+      uri: 'homestarrunner.com',
+      foo: 'bar',
+    });
+  });
+});

--- a/src/model/immutable/ContentState.js
+++ b/src/model/immutable/ContentState.js
@@ -16,26 +16,22 @@
 const BlockMapBuilder = require('BlockMapBuilder');
 const CharacterMetadata = require('CharacterMetadata');
 const ContentBlock = require('ContentBlock');
+const DraftEntity = require('DraftEntity');
 const Immutable = require('immutable');
 const SelectionState = require('SelectionState');
 
-const invariant = require('invariant');
 const generateRandomKey = require('generateRandomKey');
 const sanitizeDraftText = require('sanitizeDraftText');
-const createEntityInContentState = require('createEntityInContentState');
-const addEntityToContentState = require('addEntityToContentState');
-const updateEntityDataInContentState = require('updateEntityDataInContentState');
 
 import type {BlockMap} from 'BlockMap';
-import type {EntityMap} from 'EntityMap';
 import type DraftEntityInstance from 'DraftEntityInstance';
-import type {DraftEntityType} from 'DraftEntityType';
 import type {DraftEntityMutability} from 'DraftEntityMutability';
+import type {DraftEntityType} from 'DraftEntityType';
 
-const {List, Record, Repeat, OrderedMap} = Immutable;
+const {List, Record, Repeat} = Immutable;
 
 const defaultRecord: {
-  entityMap: ?EntityMap,
+  entityMap: ?any,
   blockMap: ?BlockMap,
   selectionBefore: ?SelectionState,
   selectionAfter: ?SelectionState,
@@ -50,8 +46,9 @@ const ContentStateRecord = Record(defaultRecord);
 
 class ContentState extends ContentStateRecord {
 
-  getEntityMap(): EntityMap {
-    return this.get('entityMap');
+  getEntityMap(): any {
+    // TODO: update this when we fully remove DraftEntity
+    return DraftEntity;
   }
 
   getBlockMap(): BlockMap {
@@ -124,7 +121,8 @@ class ContentState extends ContentStateRecord {
   }
 
   getLastCreatedEntityKey() {
-    return this.getEntityMap().keySeq().last();
+    // TODO: update this when we fully remove DraftEntity
+    return DraftEntity.getLastCreatedEntityKey();
   }
 
   hasText(): boolean {
@@ -140,36 +138,47 @@ class ContentState extends ContentStateRecord {
     mutability: DraftEntityMutability,
     data?: Object
   ): ContentState {
-    return createEntityInContentState(this, type, mutability, data);
+    // TODO: update this when we fully remove DraftEntity
+    DraftEntity.create(
+      type,
+      mutability,
+      data,
+    );
+    return this;
   }
 
   mergeEntityData(
     key: string,
     toMerge: {[key: string]: any}
   ): ContentState {
-    return updateEntityDataInContentState(this, key, toMerge, true);
+    // TODO: update this when we fully remove DraftEntity
+    DraftEntity.mergeData(key, toMerge);
+    return this;
   }
 
   replaceEntityData(
     key: string,
     newData: {[key: string]: any}
   ): ContentState {
-    return updateEntityDataInContentState(this, key, newData, false);
+    // TODO: update this when we fully remove DraftEntity
+    DraftEntity.replaceData(key, newData);
+    return this;
   }
 
   addEntity(instance: DraftEntityInstance): ContentState {
-    return addEntityToContentState(this, instance);
+    // TODO: update this when we fully remove DraftEntity
+    DraftEntity.add(instance);
+    return this;
   }
 
   getEntity(key: string): DraftEntityInstance {
-    const instance = this.getEntityMap().get(key);
-    invariant(!!instance, 'Unknown DraftEntity key.');
-    return instance;
+    // TODO: update this when we fully remove DraftEntity
+    return DraftEntity.get(key);
   }
 
   static createFromBlockArray(
     blocks: Array<ContentBlock>,
-    entityMap: ?OrderedMap
+    entityMap: ?any,
   ): ContentState {
     var blockMap = BlockMapBuilder.createFromArray(blocks);
     var selectionState = blockMap.isEmpty()
@@ -177,7 +186,7 @@ class ContentState extends ContentStateRecord {
       : SelectionState.createEmpty(blockMap.first().getKey());
     return new ContentState({
       blockMap,
-      entityMap: entityMap || OrderedMap(),
+      entityMap: entityMap || DraftEntity,
       selectionBefore: selectionState,
       selectionAfter: selectionState,
     });

--- a/src/stubs/ComposedEntityType.js
+++ b/src/stubs/ComposedEntityType.js
@@ -16,6 +16,7 @@ var ComposedEntityType = {
   'LINK': true,
   'TOKEN': true,
   'PHOTO': true,
+  'IMAGE': true,
 };
 
 module.exports = ComposedEntityType;


### PR DESCRIPTION
**Summary**

A previous PR had completely removed 'DraftEntity' the module and moved
control over entities into ContentState.[1] This changed several public
APIs of Draft.js in a non-backwards compabible way.

[1]: https://github.com/facebook/draft-js/pull/376

To make it easier to migrate multiple use cases to the new Draft.js API,
and because the transition is too complex for a simple codemod, we are
releasing a version that supports both the new and the old API and then
later releasing a version that breaks the old API completely.

In order to renew support for the old API while also supporting the new
API, this PR
 - restores the DraftEntity module and associated tests/mocks
 - calls into DraftEntity methods under the hood of the new API

We tried to leave as much of the new API code in place and unchanged as
possible, so that things will be easier when we are fully removing
DraftEntity and switching to the new approach.

**Test Plan:**
This should pass unit tests and I did some manual testing.
Still TODO: 
- manually test in other browsers (will do before landing)
- increase test coverage for 'convertFromHTML', which broke at one point even though tests were all passing. (follow-up PR)
- Add some 'deprecated_examples' that demonstrate we are still supporting the deprecated API, for manual testing of the old API. (follow-up PR)

**Next steps:**
 - PR to add missing test coverage and examples
 - A PR to add warnings and comments about the deprecation of the old
   API
 - Add all these related PRs to 0.10.0 alpha version
 - Add documentation about migrating from deprecated to new API
 - Release 0.10.0; support both APIs
 - Make PR that basically undoes this one, moving entity control into
   ContentState, and release that as version 0.11.0, with warning that
   it no longer supports the deprecated API.