### PR TITLE
Update failing example

### DIFF
--- a/docs/APIReference-Data-Conversion.md
+++ b/docs/APIReference-Data-Conversion.md
@@ -55,10 +55,7 @@ const sampleMarkup =
   '<img src="image.png" height="112" width="200" />';
 
 const blocksFromHTML = convertFromHTML(sampleMarkup);
-const state = ContentState.createFromBlockArray(
-  blocksFromHTML.contentBlocks,
-  blocksFromHTML.entityMap,
-);
+const state = ContentState.createFromBlockArray(blocksFromHTML);
 
 this.state = {
   editorState: EditorState.createWithContent(state),


### PR DESCRIPTION
**Summary**
This PR updates the ContentState.createFromBlockArray API example. 

**Description**
It seems that `convertFromHTML()` already returns the block array, which `ContentState.createFromBlockArray` is expecting.

**Changes**
Passing the following causes an error:
```javascript
const state = ContentState.createFromBlockArray(
  blocksFromHTML.contentBlocks,
  blocksFromHTML.entityMap
);
```

This works:
```javascript
const state = ContentState.createFromBlockArray(blocksFromHTML);
```