### PR TITLE
Fix advanced topics custom block render docs: Remove extra line in de…

### DIFF
--- a/docs/Advanced-Topics-Custom-Block-Render.md
+++ b/docs/Advanced-Topics-Custom-Block-Render.md
@@ -26,7 +26,6 @@ by matching the Draft block render map with the matched tag.
 |     `<h4/>`     |               header-four               |
 |     `<h5/>`     |               header-five               |
 |     `<h6/>`     |               header-six                |
-|     `<h6/>`     |               header-six                |
 | `<blockquote/>` |               blockquote                |
 |    `<pre/>`     |               code-block                |
 |   `<figure/>`   |                 atomic                  |


### PR DESCRIPTION
**Summary**

Remove extra line from [default block render map](https://facebook.github.io/draft-js/docs/advanced-topics-custom-block-render-map.html#content) list (copy-past?)

![screenshot](https://lh4.googleusercontent.com/-AYwqaMiSrRJpM_s4T0-6nL1Rf-G5Fa4_e0Y_IZG6BOCm-k_naVS1EwCyCic7hJC7ZKKz6vWs5REa8Y=w2560-h1452)