### PR TITLE
Fix flow typing of 'ReactDOM'

### DIFF
--- a/src/.flowconfig
+++ b/src/.flowconfig
@@ -8,6 +8,7 @@
 ../node_modules/fbjs/lib/
 ../node_modules/immutable
 ../node_modules/react
+../node_modules/react-dom/
 
 [libs]
 ../node_modules/fbjs/flow/lib
@@ -17,6 +18,7 @@ module.system=haste
 esproposal.class_static_fields=enable
 suppress_type=$FlowIssue
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(2[0-8]\\|1[0-9]\\|[0-9]\\).[0-9]\\)? *\\).*\n
+module.name_mapper='ReactDOM' -> 'react-dom'
 
 [version]
 0.32.0


### PR DESCRIPTION
Flow wasn't finding the 'ReactDOM' node module. In the past it was (I
assume) finding this dependency inside of the React package - but in
React 15.4.0 the "secret" copy of ReactDOM was split out completely
into it's own module.[1]

It seems like we should be able to use `scripts/module_map.js` to
specify the mapping of `ReactDOM` to `react-dom` but updating that was
not making a difference to Flow, so I added a mapping option to the flow
config.

[1]: https://facebook.github.io/react/blog/2016/11/16/react-v15.4.0.html#separating-react-and-react-dom