### PR TITLE
Part two deprecate but dont delete old entity api

### DIFF
--- a/examples/draft-0-10-0/tex/js/modifiers/insertTeXBlock.js
+++ b/examples/draft-0-10-0/tex/js/modifiers/insertTeXBlock.js
@@ -16,7 +16,7 @@
 
 import {
   AtomicBlockUtils,
-  Entity,
+  EditorState,
 } from 'draft-js';
 
 let count = 0;
@@ -36,12 +36,17 @@ const examples = [
 ];
 
 export function insertTeXBlock(editorState) {
+  const contentState = editorState.getCurrentContent();
   const nextFormula = count++ % examples.length;
-  const entityKey = Entity.create(
+  const contentStateWithEntity = contentState.createEntity(
     'TOKEN',
     'IMMUTABLE',
-    {content: examples[nextFormula]}
+    {content: examples[nextFormula]},
   );
-
-  return AtomicBlockUtils.insertAtomicBlock(editorState, entityKey, ' ');
+  const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
+  const newEditorState = EditorState.set(
+    editorState,
+    {currentContent: contentStateWithEntity}
+  );
+  return AtomicBlockUtils.insertAtomicBlock(newEditorState, entityKey, ' ');
 }

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -408,7 +408,7 @@ function genFragment(
     node.textContent = imageURI; // Output src if no decorator
 
     // TODO: update this when we remove DraftEntity entirely
-    inEntity = DraftEntity.create(
+    inEntity = DraftEntity._create(
       'IMAGE',
       'MUTABLE',
       entityConfig || {},
@@ -475,7 +475,7 @@ function genFragment(
 
       entityConfig.url = new URI(anchor.href).toString();
       // TODO: update this when we remove DraftEntity completely
-      entityId = DraftEntity.create(
+      entityId = DraftEntity._create(
         'LINK',
         'MUTABLE',
         entityConfig || {},

--- a/src/model/encoding/convertFromRawToDraftState.js
+++ b/src/model/encoding/convertFromRawToDraftState.js
@@ -38,7 +38,7 @@ function convertFromRawToDraftState(
     storageKey => {
       var encodedEntity = entityMap[storageKey];
       var {type, mutability, data} = encodedEntity;
-      var newKey = DraftEntity.create(type, mutability, data || {});
+      var newKey = DraftEntity._create(type, mutability, data || {});
       fromStorageToLocal[storageKey] = newKey;
     }
   );

--- a/src/model/entity/__tests__/DraftEntity-test.js
+++ b/src/model/entity/__tests__/DraftEntity-test.js
@@ -21,7 +21,7 @@ describe('DraftEntity', () => {
   });
 
   function createLink() {
-    return DraftEntity.create('LINK', 'MUTABLE', {uri: 'zombo.com'});
+    return DraftEntity._create('LINK', 'MUTABLE', {uri: 'zombo.com'});
   }
 
   it('must create instances', () => {
@@ -31,7 +31,7 @@ describe('DraftEntity', () => {
 
   it('must retrieve an instance given a key', () => {
     var key = createLink();
-    var retrieved = DraftEntity.get(key);
+    var retrieved = DraftEntity._get(key);
     expect(retrieved.getType()).toBe('LINK');
     expect(retrieved.getMutability()).toBe('MUTABLE');
     expect(retrieved.getData()).toEqual({uri: 'zombo.com'});
@@ -39,8 +39,8 @@ describe('DraftEntity', () => {
 
   it('must throw when retrieving for an invalid key', () => {
     createLink();
-    expect(() => DraftEntity.get('asdfzxcvqweriuop')).toThrow();
-    expect(() => DraftEntity.get(null)).toThrow();
+    expect(() => DraftEntity._get('asdfzxcvqweriuop')).toThrow();
+    expect(() => DraftEntity._get(null)).toThrow();
   });
 
   it('must merge data', () => {
@@ -48,8 +48,8 @@ describe('DraftEntity', () => {
 
     // Merge new property.
     var newData = {foo: 'bar'};
-    DraftEntity.mergeData(key, newData);
-    var newEntity = DraftEntity.get(key);
+    DraftEntity._mergeData(key, newData);
+    var newEntity = DraftEntity._get(key);
     expect(newEntity.getData()).toEqual({
       uri: 'zombo.com',
       foo: 'bar',
@@ -57,8 +57,8 @@ describe('DraftEntity', () => {
 
     // Replace existing property.
     var withNewURI = {uri: 'homestarrunner.com'};
-    DraftEntity.mergeData(key, withNewURI);
-    var entityWithNewURI = DraftEntity.get(key);
+    DraftEntity._mergeData(key, withNewURI);
+    var entityWithNewURI = DraftEntity._get(key);
     expect(entityWithNewURI.getData()).toEqual({
       uri: 'homestarrunner.com',
       foo: 'bar',

--- a/src/model/entity/__tests__/getEntityKeyForSelection-test.js
+++ b/src/model/entity/__tests__/getEntityKeyForSelection-test.js
@@ -25,7 +25,7 @@ selectionState = selectionState.merge({
 });
 
 function setEntityMutability(mutability) {
-  contentState.getEntityMap().get = () => ({
+  contentState.getEntityMap()._get = () => ({
     getMutability: () => mutability,
   });
 }

--- a/src/model/entity/getEntityKeyForSelection.js
+++ b/src/model/entity/getEntityKeyForSelection.js
@@ -58,7 +58,7 @@ function filterKey(
   entityKey: ?string
 ): ?string {
   if (entityKey) {
-    var entity = entityMap.get(entityKey);
+    var entity = entityMap._get(entityKey);
     return entity.getMutability() === 'MUTABLE' ? entityKey : null;
   }
   return null;

--- a/src/model/immutable/ContentState.js
+++ b/src/model/immutable/ContentState.js
@@ -122,7 +122,7 @@ class ContentState extends ContentStateRecord {
 
   getLastCreatedEntityKey() {
     // TODO: update this when we fully remove DraftEntity
-    return DraftEntity.getLastCreatedEntityKey();
+    return DraftEntity._getLastCreatedEntityKey();
   }
 
   hasText(): boolean {
@@ -139,7 +139,7 @@ class ContentState extends ContentStateRecord {
     data?: Object
   ): ContentState {
     // TODO: update this when we fully remove DraftEntity
-    DraftEntity.create(
+    DraftEntity._create(
       type,
       mutability,
       data,
@@ -152,7 +152,7 @@ class ContentState extends ContentStateRecord {
     toMerge: {[key: string]: any}
   ): ContentState {
     // TODO: update this when we fully remove DraftEntity
-    DraftEntity.mergeData(key, toMerge);
+    DraftEntity._mergeData(key, toMerge);
     return this;
   }
 
@@ -161,19 +161,19 @@ class ContentState extends ContentStateRecord {
     newData: {[key: string]: any}
   ): ContentState {
     // TODO: update this when we fully remove DraftEntity
-    DraftEntity.replaceData(key, newData);
+    DraftEntity._replaceData(key, newData);
     return this;
   }
 
   addEntity(instance: DraftEntityInstance): ContentState {
     // TODO: update this when we fully remove DraftEntity
-    DraftEntity.add(instance);
+    DraftEntity._add(instance);
     return this;
   }
 
   getEntity(key: string): DraftEntityInstance {
     // TODO: update this when we fully remove DraftEntity
-    return DraftEntity.get(key);
+    return DraftEntity._get(key);
   }
 
   static createFromBlockArray(

--- a/src/model/modifier/RichTextEditorUtil.js
+++ b/src/model/modifier/RichTextEditorUtil.js
@@ -38,7 +38,7 @@ const RichTextEditorUtil = {
       .slice(selection.getStartOffset(), selection.getEndOffset())
       .some(v => {
         var entity = v.getEntity();
-        return !!entity && entityMap.get(entity).getType() === 'LINK';
+        return !!entity && entityMap._get(entity).getType() === 'LINK';
       });
   },
 

--- a/src/model/modifier/getCharacterRemovalRange.js
+++ b/src/model/modifier/getCharacterRemovalRange.js
@@ -45,7 +45,7 @@ function getCharacterRemovalRange(
     return selectionState;
   }
 
-  var entity = entityMap.get(entityKey);
+  var entity = entityMap._get(entityKey);
   var mutability = entity.getMutability();
 
   // `MUTABLE` entities can just have the specified range of text removed

--- a/src/model/paste/__tests__/DraftPasteProcessor-test.js
+++ b/src/model/paste/__tests__/DraftPasteProcessor-test.js
@@ -301,7 +301,7 @@ describe('DraftPasteProcessor', function() {
     );
     expect(output[0].getText()).toBe('This is a link, yep.');
     var entityId = output[0].getCharacterList().get(12).getEntity();
-    var entity = entityMap.get(entityId);
+    var entity = entityMap._get(entityId);
     expect(entity.getData().url).toBe('http://www.facebook.com/');
   });
 
@@ -349,7 +349,7 @@ describe('DraftPasteProcessor', function() {
     );
     expect(output[0].getText()).toBe('This is a link, yep.');
     var entityId = output[0].getCharacterList().get(12).getEntity();
-    var entity = entityMap.get(entityId);
+    var entity = entityMap._get(entityId);
     expect(entity.getData().url).toBe('mailto:example@example.com');
   });
 

--- a/src/model/transaction/__tests__/removeEntitiesAtEdges-test.js
+++ b/src/model/transaction/__tests__/removeEntitiesAtEdges-test.js
@@ -54,7 +54,7 @@ describe('removeEntitiesAtEdges', () => {
   }
 
   function setEntityMutability(mutability) {
-    contentState.getEntityMap().get = () => ({
+    contentState.getEntityMap()._get = () => ({
       getMutability: () => mutability,
     });
   }

--- a/src/model/transaction/removeEntitiesAtEdges.js
+++ b/src/model/transaction/removeEntitiesAtEdges.js
@@ -99,7 +99,7 @@ function removeForBlock(
   var entityAfterCursor = charAfter ? charAfter.getEntity() : undefined;
 
   if (entityAfterCursor && entityAfterCursor === entityBeforeCursor) {
-    var entity = entityMap.get(entityAfterCursor);
+    var entity = entityMap._get(entityAfterCursor);
     if (entity.getMutability() !== 'MUTABLE') {
       var {start, end} = getRemovalRange(chars, entityAfterCursor, offset);
       var current;


### PR DESCRIPTION
We are deprecating the old DraftEntity API and this adds warnings for folks still using the outdated syntax.

Why is the API changing? Because
 - currently changing or adding entities won't trigger a re-render
 - the use of a non-Immutable storage for entities doesn't fit well with
   the rest of the Draft architecture
 - moves Entity storage out of global module; this just makes more sense
   as an API, rather than having it globally available.

This moves the logic for the old API into private methods, and adds
warnings and comments around the public-but-deprecated API methods.

We then use the private methods internally while we still support both
APIs.

A future version of Draft will actually remove the old API completely,
and these warnings and comments will help folks make updates to their
code to prepare.

We will release more documentation about this soon.

This PR also updates syntax in one example, since the warnings made it clear that the API had not been updated there yet.