### PR TITLE
Improve typing in Korean on Windows

### DIFF
--- a/src/component/handlers/edit/editOnSelect.js
+++ b/src/component/handlers/edit/editOnSelect.js
@@ -21,6 +21,9 @@ function editOnSelect(): void {
   if (this._blockSelectEvents) {
     return;
   }
+  if (this._latestEditorState !== this.props.editorState) {
+    return;
+  }
 
   var editorState = this.props.editorState;
   var documentSelection = getDraftEditorSelection(


### PR DESCRIPTION
(Landed at Facebook as D4056089 over a month ago, copying back out.)

Summary:
If we have a state update enqueued but the rerender hasn't happened, and a select event comes in, we can't do anything useful with it because although we could compare the last rendered editor state with the DOM selection, we can't make a rational choice for how to update the latest queued editor state with the DOM selection. (Previously, this code was throwing away any content change which would lead to a loss of inserted chars in many Windows IME scenarios.)

In particular, if you type in Korean w/ Windows IME then press space,

* compositionend arrives, causing us to set a 20ms timeout for resolving the composition,
* at that time, the text is already inserted in the DOM
* then keydown 32 comes in, which (due to my recent changes) makes the composition resolve immediately
* we enqueue a rerender with the composed text
* our 'select' polyfill also turns the keydown into a select event, and that select event has the *new* cursor position corresponding to the text that is already inserted to the DOM

Basically, the DOM has 안녕하세요, the last editorstate is "" with selection [0, 0], the queued editorstate is "안녕하세요" with selection [5, 5], and you get a selection event [5, 5].

Since there's nothing useful we can do with this, we now ignore the selection event. The risk here is that we now are ignoring important selection events and the editor state selection lags behind the DOM selection. isaac and I don't know of any scenarios in which this would matter -- if we do find some, we might be able to instead change this code to re-check the selection after a rerender to make sure that we have the latest selection.

Test Plan:
Type dkssudgktpdy then Space with Korean keyboard on Windows Chrome, Windows Firefox, Windows IE, Windows Edge, Mac Chrome, Mac Firefox. It either does the right thing (inserting "안녕하세요 ") or it does the same thing as cstools which doesn't have any of my changes from this week.

Type normally, move the cursor, select all, copy, backspace, repeated backspace in the same browsers.