### PR TITLE
Fix handleBeforeInput not working problem when typing in IME

### DIFF
--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -18,6 +18,7 @@ const Keys = require('Keys');
 
 const getEntityKeyForSelection = require('getEntityKeyForSelection');
 const isSelectionAtLeafStart = require('isSelectionAtLeafStart');
+const isEventHandled = require('isEventHandled');
 
 /**
  * Millisecond delay to allow `compositionstart` to fire again upon
@@ -43,7 +44,21 @@ let textInputData = '';
 
 var DraftEditorCompositionHandler = {
   onBeforeInput: function(e: SyntheticInputEvent): void {
-    textInputData = (textInputData || '') + e.data;
+    var chars = e.data;
+
+    // Allow the top-level component to handle the insertion manually. This is
+    // useful when triggering interesting behaviors for a character insertion,
+    // Simple examples: replacing a raw text 'ㅅ_ㅅ' with a smile emoji or image
+    // decorator
+    if (
+      this.props.handleBeforeInput &&
+      isEventHandled(this.props.handleBeforeInput(chars))
+    ) {
+      e.preventDefault();
+      return;
+    }
+
+    textInputData = (textInputData || '') + chars;
   },
 
   /**


### PR DESCRIPTION
**Summary**

[handleBeforeInput](https://facebook.github.io/draft-js/docs/api-reference-editor.html#handlebeforeinput), one of Editor's props, doesn't work when typing in [IME](https://en.wikipedia.org/wiki/Input_method) like Japanese and korean. 

`Related Issues`
1. handleBeforeInput is not trigger when input using an IME #819 
2. How to detect unicode input event? #693 
3. HandleBeforeInput doesn't work when typing in Japanese. #631

The cause of this problem is that `this.props.handleBeforeInput` is used in `edit` mode but it is not used in `composite` mode.

More specifically, `editOnBeforeInput`(onBeforeInput handler) in `/src/handler/edit/editOnBeforeInput.js` use `this.props.handleBeforeInput`, but `onBeforeInput` in `/src/handler/composition/DraftEditorCompositionHandler.js` doesn't use it.

I solved this problem by adding the `edit` mode logic to the `composite` mode.

close #819, #631 

**Test Plan**

- Add `handelBeforeInput` to Editor's props of example.
```javascript
_handleBeforeInput(chars) {
  console.log(':: handleBeforeInput :: ', chars);
  return false; // or return true;
}
```
- Typing Korean and Japanese.
- Check `handleBeforeInput` working correctly 


