### PR TITLE
Overwrite correct block when handling spellcheck/autocorrect changes

### DIFF
--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -76,7 +76,9 @@ function editOnInput(editor: DraftEditor): void {
 
   // We'll replace the entire leaf with the text content of the target.
   var targetRange = selection.merge({
+    anchorKey: blockKey,
     anchorOffset: start,
+    focusKey: blockKey,
     focusOffset: end,
     isBackward: false,
   });
@@ -118,8 +120,8 @@ function editOnInput(editor: DraftEditor): void {
     // and adjust it based on the number of characters changed during the
     // mutation.
     var charDelta = domText.length - modelText.length;
-    startOffset = selection.getStartOffset();
-    endOffset = selection.getEndOffset();
+    startOffset = targetRange.getStartOffset();
+    endOffset = targetRange.getEndOffset();
 
     anchorOffset = isCollapsed ? endOffset + charDelta : startOffset;
     focusOffset = endOffset + charDelta;
@@ -130,7 +132,7 @@ function editOnInput(editor: DraftEditor): void {
   // after the change, so we are not merging the selection.
   var contentWithAdjustedDOMSelection = newContent.merge({
     selectionBefore: content.getSelectionAfter(),
-    selectionAfter: selection.merge({anchorOffset, focusOffset}),
+    selectionAfter: targetRange.merge({anchorOffset, focusOffset}),
   });
 
   editor.update(


### PR DESCRIPTION
- dom selection and draft selection can be out of sync when the browser updates
- currently we translate dom selection to find the content block being changed but *don't* use that translation to figure out where to apply the change
- this PR forces the new editor selection to match the dom selection being used for the change (ensuring that the changes are targeted to the correct block)