### PR TITLE
Fix line breaks when pasting from word to draft

### DIFF
--- a/docs/Advanced-Topics-Custom-Block-Render.md
+++ b/docs/Advanced-Topics-Custom-Block-Render.md
@@ -97,6 +97,19 @@ class RichEditor extends React.Component {
 }
 ```
 
+There are cases where you want to define an alias for block elements.
+For example we use this internally on the `unstyled` block type
+in order to allow it to also match paragraphs
+
+*example of unstyled block type alias usage*
+
+```
+'unstyled': {
+  element: 'div',
+  aliasedElements: ['p'],
+}
+```
+
 ## Custom block wrappers
 
 By default the html element is used to wrap block types however a react component

--- a/docs/Advanced-Topics-Custom-Block-Render.md
+++ b/docs/Advanced-Topics-Custom-Block-Render.md
@@ -97,11 +97,11 @@ class RichEditor extends React.Component {
 }
 ```
 
-There are cases where you want to define an alias for block elements.
-For example we use this internally on the `unstyled` block type
-in order to allow it to also match paragraphs
+When Draft parses pasted HTML, it maps from HTML elements back into
+Draft block types. If you want to specify other HTML elements that map to a
+particular block type, you can add an array `aliasedElements` to the block config.
 
-*example of unstyled block type alias usage*
+*example of unstyled block type alias usage:*
 
 ```
 'unstyled': {

--- a/src/model/encoding/__tests__/convertFromHTMLToContentBlocks-test.js
+++ b/src/model/encoding/__tests__/convertFromHTMLToContentBlocks-test.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails isaac, oncall+ui_infra
+ */
+
+'use strict';
+
+jest.disableAutomock();
+
+const convertFromHTMLToContentBlocks = require('convertFromHTMLToContentBlocks');
+const DefaultDraftBlockRenderMap = require('DefaultDraftBlockRenderMap');
+
+function testConvertingAdjacentHtmlElementsToContentBlocks(
+  tag: string
+) {
+  it(`must not merge tags when converting adjacent <${tag} />`, () => {
+    const html_string = `
+      <${tag}>a</${tag}>
+      <${tag}>b</${tag}>
+    `;
+
+    const blocks = convertFromHTMLToContentBlocks(html_string);
+
+    expect(blocks.contentBlocks.length).toBe(2);
+  });
+}
+
+function performTestWithDefaultDraftBlockTags(
+  testSpec: Array<Function>
+) {
+  DefaultDraftBlockRenderMap
+    .map((config) => config.element)
+    .valueSeq()
+    .toSet()
+    .toArray()
+    .forEach(tag => testSpec.forEach(func => func(tag)));
+}
+
+describe('convertFromHTMLToContentBlocks', () => {
+  performTestWithDefaultDraftBlockTags([
+    testConvertingAdjacentHtmlElementsToContentBlocks,
+  ]);
+
+  testConvertingAdjacentHtmlElementsToContentBlocks('p');
+});

--- a/src/model/encoding/__tests__/convertFromHTMLToContentBlocks-test.js
+++ b/src/model/encoding/__tests__/convertFromHTMLToContentBlocks-test.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails isaac, oncall+ui_infra
+ * @emails oncall+ui_infra
  */
 
 'use strict';
@@ -14,7 +14,6 @@
 jest.disableAutomock();
 
 const convertFromHTMLToContentBlocks = require('convertFromHTMLToContentBlocks');
-const DefaultDraftBlockRenderMap = require('DefaultDraftBlockRenderMap');
 
 function testConvertingAdjacentHtmlElementsToContentBlocks(
   tag: string
@@ -31,21 +30,19 @@ function testConvertingAdjacentHtmlElementsToContentBlocks(
   });
 }
 
-function performTestWithDefaultDraftBlockTags(
-  testSpec: Array<Function>
-) {
-  DefaultDraftBlockRenderMap
-    .map((config) => config.element)
-    .valueSeq()
-    .toSet()
-    .toArray()
-    .forEach(tag => testSpec.forEach(func => func(tag)));
-}
-
 describe('convertFromHTMLToContentBlocks', () => {
-  performTestWithDefaultDraftBlockTags([
-    testConvertingAdjacentHtmlElementsToContentBlocks,
-  ]);
-
-  testConvertingAdjacentHtmlElementsToContentBlocks('p');
+  [
+    'blockquote',
+    'div',
+    'figure',
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'li',
+    'p',
+    'pre',
+  ].forEach(tag => testConvertingAdjacentHtmlElementsToContentBlocks(tag));
 });

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -156,17 +156,19 @@ function getBlockMapSupportedTags(
   blockRenderMap: DraftBlockRenderMap
 ): Array<string> {
   const unstyledElement = blockRenderMap.get('unstyled').element;
-  return blockRenderMap
-    .reduce((accum, draftBlock, key) => {
-      if (draftBlock.aliasedElements) {
-        draftBlock.aliasedElements.forEach(
-          (alias) => {
-            accum = accum.add(alias);
-          }
-        );
-      }
-      return accum.add(draftBlock.element);
-    }, new Set([]))
+  let tags = new Set([]);
+
+  blockRenderMap.forEach((draftBlock: any) => {
+    if (draftBlock.aliasedElements) {
+      draftBlock.aliasedElements.forEach((tag) => {
+        tags = tags.add(tag);
+      });
+    }
+
+    tags = tags.add(draftBlock.element);
+  });
+
+  return tags
     .filter((tag) => tag && tag !== unstyledElement)
     .toArray()
     .sort();
@@ -193,7 +195,7 @@ function getBlockTypeForTag(
   blockRenderMap: DraftBlockRenderMap
 ): DraftBlockType {
   const matchedTypes = blockRenderMap
-    .filter((config) => (
+    .filter((config: any) => (
       config.element === tag ||
       config.wrapper === tag ||
       (

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -29,6 +29,7 @@ const sanitizeDraftText = require('sanitizeDraftText');
 const {Set} = require('immutable');
 
 import type {DraftBlockRenderMap} from 'DraftBlockRenderMap';
+import type {DraftBlockRenderConfig} from 'DraftBlockRenderConfig';
 import type {DraftBlockType} from 'DraftBlockType';
 import type {DraftInlineStyle} from 'DraftInlineStyle';
 import type {EntityMap} from 'EntityMap';
@@ -158,7 +159,7 @@ function getBlockMapSupportedTags(
   const unstyledElement = blockRenderMap.get('unstyled').element;
   let tags = new Set([]);
 
-  blockRenderMap.forEach((draftBlock: any) => {
+  blockRenderMap.forEach((draftBlock: DraftBlockRenderConfig) => {
     if (draftBlock.aliasedElements) {
       draftBlock.aliasedElements.forEach((tag) => {
         tags = tags.add(tag);
@@ -195,12 +196,12 @@ function getBlockTypeForTag(
   blockRenderMap: DraftBlockRenderMap
 ): DraftBlockType {
   const matchedTypes = blockRenderMap
-    .filter((config: any) => (
-      config.element === tag ||
-      config.wrapper === tag ||
+    .filter((draftBlock: DraftBlockRenderConfig) => (
+      draftBlock.element === tag ||
+      draftBlock.wrapper === tag ||
       (
-        config.aliasedElements &&
-        config.aliasedElements.some(alias => alias === tag)
+        draftBlock.aliasedElements &&
+        draftBlock.aliasedElements.some(alias => alias === tag)
       )
     ))
     .keySeq()

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -44,7 +44,6 @@ var SPACE = ' ';
 // Arbitrary max indent
 var MAX_DEPTH = 4;
 
-//asd
 // used for replacing characters in HTML
 var REGEX_CR = new RegExp('\r', 'g');
 var REGEX_LF = new RegExp('\n', 'g');

--- a/src/model/immutable/DefaultDraftBlockRenderMap.js
+++ b/src/model/immutable/DefaultDraftBlockRenderMap.js
@@ -60,5 +60,6 @@ module.exports = Map({
   },
   'unstyled': {
     element: 'div',
+    aliasedElements: ['p'],
   },
 });

--- a/src/model/immutable/DraftBlockRenderConfig.js
+++ b/src/model/immutable/DraftBlockRenderConfig.js
@@ -15,4 +15,5 @@
 export type DraftBlockRenderConfig = {
   element: string,
   wrapper?: React$Element<any>,
+  aliasedElements?: Array<string>,
 };


### PR DESCRIPTION
**Summary**

When pasting adjacent paragraphs were converged into a single paragraph, by introducing the idea of alias for an element we can then keep there rendering elements at the same time as provide different element matches.

This issue is also referenced at: https://github.com/facebook/draft-js/issues/523 and https://github.com/facebook/draft-js/issues/395

**Test Plan**

We can test by running `npm test` or by pasting content from a word processing tool such as word into draft. Paragraphs should be now treated as a separate blocks and should no longer get converged into a single one.
