### PR TITLE
Make contentState.createFromBlockArray work with old and new API

### DIFF
--- a/src/model/immutable/ContentState.js
+++ b/src/model/immutable/ContentState.js
@@ -177,10 +177,13 @@ class ContentState extends ContentStateRecord {
   }
 
   static createFromBlockArray(
-    blocks: Array<ContentBlock>,
+    // TODO: update flow type when we completely deprecate the old entity API
+    blocks: Array<ContentBlock> | {contentBlocks: Array<ContentBlock>},
     entityMap: ?any,
   ): ContentState {
-    var blockMap = BlockMapBuilder.createFromArray(blocks);
+    // TODO: remove this when we completely deprecate the old entity API
+    const theBlocks = Array.isArray(blocks) ? blocks : blocks.contentBlocks;
+    var blockMap = BlockMapBuilder.createFromArray(theBlocks);
     var selectionState = blockMap.isEmpty()
       ? new SelectionState()
       : SelectionState.createEmpty(blockMap.first().getKey());


### PR DESCRIPTION
As part of the changing API the signature of
contentState.createFromBlockArray changed.

At some point (recently I think) this was changed to no longer support
the old API, and we didn't quite have the 0.9.1 style examples in place,
so it wasn't caught.

This adjusts the 'createFromBlockArray' to work with both the old and
new APIs.