### PR TITLE
Pass `block` to `customStyleFn` callback

### DIFF
--- a/docs/APIReference-Editor.md
+++ b/docs/APIReference-Editor.md
@@ -85,7 +85,7 @@ for details on usage.
 
 #### customStyleFn
 ```
-customStyleFn?: (style: DraftInlineStyle) => ?Object
+customStyleFn?: (style: DraftInlineStyle, block: ContentBlock) => ?Object
 ```
 Optionally define a function to transform inline styles to CSS objects that are applied
 to spans of text. See

--- a/src/component/base/DraftEditorProps.js
+++ b/src/component/base/DraftEditorProps.js
@@ -135,7 +135,7 @@ export type DraftEditorProps = {
 
   // Provide a function that will construct CSS style objects given inline
   // style names.
-  customStyleFn?: (style: DraftInlineStyle) => ?Object,
+  customStyleFn?: (style: DraftInlineStyle, block: ContentBlock) => ?Object,
 
   // Provide a map of block rendering configurations. Each block type maps to
   // an element tag and an optional react element wrapper. This configuration

--- a/src/component/contents/DraftEditorBlock.react.js
+++ b/src/component/contents/DraftEditorBlock.react.js
@@ -140,7 +140,7 @@ class DraftEditorBlock extends React.Component {
           <DraftEditorLeaf
             key={offsetKey}
             offsetKey={offsetKey}
-            blockKey={blockKey}
+            block={block}
             start={start}
             selection={hasSelection ? this.props.selection : undefined}
             forceSelection={this.props.forceSelection}

--- a/src/component/contents/DraftEditorLeaf.react.js
+++ b/src/component/contents/DraftEditorLeaf.react.js
@@ -13,6 +13,7 @@
 
 'use strict';
 
+var ContentBlock = require('ContentBlock');
 var DraftEditorTextNode = require('DraftEditorTextNode.react');
 var React = require('React');
 var ReactDOM = require('ReactDOM');
@@ -23,9 +24,8 @@ var setDraftEditorSelection = require('setDraftEditorSelection');
 import type {DraftInlineStyle} from 'DraftInlineStyle';
 
 type Props = {
-  // A function passed through from the the top level to define a cx
-  // style map for the provided style value.
-  blockKey: string,
+  // The block that contains this leaf.
+  block: ContentBlock,
 
   // Mapping of style names to CSS declarations.
   customStyleMap: Object,
@@ -81,7 +81,8 @@ class DraftEditorLeaf extends React.Component {
       return;
     }
 
-    const {blockKey, start, text} = this.props;
+    const {block, start, text} = this.props;
+    const blockKey = block.getKey();
     const end = start + text.length;
     if (!selection.hasEdgeWithin(blockKey, start, end)) {
       return;
@@ -122,6 +123,7 @@ class DraftEditorLeaf extends React.Component {
   }
 
   render(): React.Element<any> {
+    const {block} = this.props;
     let {text} = this.props;
 
     // If the leaf is at the end of its block and ends in a soft newline, append
@@ -150,7 +152,7 @@ class DraftEditorLeaf extends React.Component {
     }, {});
 
     if (customStyleFn) {
-      const newStyles = customStyleFn(styleSet);
+      const newStyles = customStyleFn(styleSet, block);
       styleObj = Object.assign(styleObj, newStyles);
     }
 


### PR DESCRIPTION
Recently, `customStyleFn` was added for more flexibility to specify styles: https://github.com/facebook/draft-js/issues/342 / https://github.com/facebook/draft-js/pull/354

This PR proposes an addition to that same API, to allow the block type to be taken into consideration, as well. Block type is important for cases where, for example, bold requires a different CSS object result for different font families:

```
const customStyleFn = (style, block) => {
  const isBold = style.has('BOLD')
  if (isBold) {
    if (block.getType() === 'code-block') {
      return {
        // fontFamily remains as normal (monospace)
        fontWeight: '700',
      }
    } else {
      return {
        // fontFamily changes from normal to demi
        fontFamily: 'MyFont-Demi',
        fontWeight: '700',
      }
    }
  }

  return {}
}
```

By adding `block` to the callback, it opens avenues for more flexible styling.

Before:
`customStyleFn?: (style: DraftInlineStyle) => ?Object`

After:
`customStyleFn?: (style: DraftInlineStyle, block: ContentBlock) => ?Object`

- [x] Updated the documentation for API.
- [x] The test suite passes (`npm test`)
- [x] Code lints (`npm run lint`) and passes Flow (`npm run flow`)
- [x] Completed the corporate [CLA](https://code.facebook.com/cla).

cc @hellendag, @davidbyttow