### PR TITLE
Fix lints and flow errors for v0.10

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -118,7 +118,7 @@ class DraftEditor extends React.Component {
   setMode: (mode: DraftEditorModes) => void;
   exitCurrentMode: () => void;
   restoreEditorDOM: (scrollPosition?: DraftScrollPosition) => void;
-  setClipboard: (clipboard?: BlockMap) => void;
+  setClipboard: (clipboard: ?BlockMap) => void;
   getClipboard: () => ?BlockMap;
   getEditorKey: () => string;
   update: (editorState: EditorState) => void;

--- a/src/component/contents/__tests__/DraftEditorBlock.react-test.js
+++ b/src/component/contents/__tests__/DraftEditorBlock.react-test.js
@@ -253,7 +253,7 @@ describe('DraftEditorBlock.react', () => {
       var newTree = BlockTree.generate(
         ContentState.createFromText(helloBlock.getText()),
         helloBlock,
-        decorator
+        decorator,
       );
       var nextProps = {...props, tree: newTree, decorator};
 

--- a/src/component/handlers/edit/editOnCompositionStart.js
+++ b/src/component/handlers/edit/editOnCompositionStart.js
@@ -23,7 +23,7 @@ import type DraftEditor from 'DraftEditor.react';
 function editOnCompositionStart(editor: DraftEditor, e: SyntheticEvent): void {
   editor.setMode('composite');
   editor.update(
-    EditorState.set(editor._latestEditorState, {inCompositionMode: true})
+    EditorState.set(editor._latestEditorState, {inCompositionMode: true}),
   );
   // Allow composition handler to interpret the compositionstart event
   editor._onCompositionStart(e);

--- a/src/component/handlers/edit/editOnPaste.js
+++ b/src/component/handlers/edit/editOnPaste.js
@@ -126,7 +126,7 @@ function editOnPaste(editor: DraftEditor, e: SyntheticClipboardEvent): void {
         )
       ) {
         editor.update(
-          insertFragment(editor._latestEditorState, internalClipboard)
+          insertFragment(editor._latestEditorState, internalClipboard),
         );
         return;
       }
@@ -140,7 +140,7 @@ function editOnPaste(editor: DraftEditor, e: SyntheticClipboardEvent): void {
       // Use the internalClipboard if present and equal to what is on
       // the clipboard. See https://bugs.webkit.org/show_bug.cgi?id=19893.
       editor.update(
-        insertFragment(editor._latestEditorState, internalClipboard)
+        insertFragment(editor._latestEditorState, internalClipboard),
       );
       return;
     }
@@ -149,14 +149,14 @@ function editOnPaste(editor: DraftEditor, e: SyntheticClipboardEvent): void {
     if (html) {
       var htmlFragment = DraftPasteProcessor.processHTML(
         html,
-        editor.props.blockRenderMap
+        editor.props.blockRenderMap,
       );
       if (htmlFragment) {
         const { contentBlocks, entityMap } = htmlFragment;
         if (contentBlocks) {
           var htmlMap = BlockMapBuilder.createFromArray(contentBlocks);
           editor.update(
-            insertFragment(editor._latestEditorState, htmlMap, entityMap)
+            insertFragment(editor._latestEditorState, htmlMap, entityMap),
           );
           return;
         }

--- a/src/component/handlers/edit/editOnSelect.js
+++ b/src/component/handlers/edit/editOnSelect.js
@@ -30,7 +30,7 @@ function editOnSelect(editor: DraftEditor): void {
   var editorState = editor.props.editorState;
   var documentSelection = getDraftEditorSelection(
     editorState,
-    ReactDOM.findDOMNode(editor.refs.editorContainer).firstChild
+    ReactDOM.findDOMNode(editor.refs.editorContainer).firstChild,
   );
   var updatedSelectionState = documentSelection.selectionState;
 
@@ -38,12 +38,12 @@ function editOnSelect(editor: DraftEditor): void {
     if (documentSelection.needsRecovery) {
       editorState = EditorState.forceSelection(
         editorState,
-        updatedSelectionState
+        updatedSelectionState,
       );
     } else {
       editorState = EditorState.acceptSelection(
         editorState,
-        updatedSelectionState
+        updatedSelectionState,
       );
     }
     editor.update(editorState);

--- a/src/model/encoding/__tests__/convertFromHTMLToContentBlocks-test.js
+++ b/src/model/encoding/__tests__/convertFromHTMLToContentBlocks-test.js
@@ -16,7 +16,7 @@ jest.disableAutomock();
 const convertFromHTMLToContentBlocks = require('convertFromHTMLToContentBlocks');
 
 function testConvertingAdjacentHtmlElementsToContentBlocks(
-  tag: string
+  tag: string,
 ) {
   it(`must not merge tags when converting adjacent <${tag} />`, () => {
     const html_string = `

--- a/src/model/encoding/__tests__/decodeEntityRanges-test.js
+++ b/src/model/encoding/__tests__/decodeEntityRanges-test.js
@@ -28,7 +28,7 @@ describe('decodeEntityRanges', () => {
         offset: 2,
         length: 2,
         key: '6',
-      }]
+      }],
     );
     expect(decoded).toEqual([null, null, '6', '6', null]);
   });

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -530,7 +530,7 @@ function getChunkForHTML(
   html: string,
   DOMBuilder: Function,
   blockRenderMap: DraftBlockRenderMap,
-  entityMap: EntityMap
+  entityMap: EntityMap,
 ): ?{chunk: Chunk, entityMap: EntityMap} {
   html = html
     .trim()
@@ -641,7 +641,7 @@ function convertFromHTMLtoContentBlocks(
               data.entity = entities[ii];
             }
             return CharacterMetadata.create(data);
-          })
+          }),
         );
         start = end + 1;
 
@@ -652,7 +652,7 @@ function convertFromHTMLtoContentBlocks(
           text: textBlock,
           characterList,
         });
-      }
+      },
     ),
     entityMap: newEntityMap,
   };

--- a/src/model/entity/DraftEntity.js
+++ b/src/model/entity/DraftEntity.js
@@ -37,6 +37,52 @@ function logWarning(oldMethodCall, newMethodCall) {
   );
 }
 
+export type DraftEntityMapObject = {
+  getLastCreatedEntityKey: () => string,
+
+  create: (
+    type: DraftEntityType,
+    mutability: DraftEntityMutability,
+    data?: Object,
+  ) => string,
+
+  add: (instance: DraftEntityInstance) => string,
+
+  get: (key: string) => DraftEntityInstance,
+
+  mergeData: (
+    key: string,
+    toMerge: {[key: string]: any},
+  ) => DraftEntityInstance,
+
+  replaceData: (
+    key: string,
+    newData: {[key: string]: any},
+  ) => DraftEntityInstance,
+
+  _getLastCreatedEntityKey: () => string,
+
+  _create: (
+    type: DraftEntityType,
+    mutability: DraftEntityMutability,
+    data?: Object,
+  ) => string,
+
+  _add: (instance: DraftEntityInstance) => string,
+
+  _get: (key: string) => DraftEntityInstance,
+
+  _mergeData: (
+    key: string,
+    toMerge: {[key: string]: any}
+  ) => DraftEntityInstance,
+
+  _replaceData: (
+    key: string,
+    newData: {[key: string]: any}
+  ) => DraftEntityInstance,
+};
+
 /**
  * A "document entity" is an object containing metadata associated with a
  * piece of text in a ContentBlock.
@@ -50,7 +96,7 @@ function logWarning(oldMethodCall, newMethodCall) {
  * generated via DraftEntity.create() and used to obtain entity metadata
  * via DraftEntity.get().
  */
-var DraftEntity = {
+var DraftEntity:DraftEntityMapObject = {
   /**
    * WARNING: This method will be deprecated soon!
    * Please use 'contentState.getLastCreatedEntityKey' instead.

--- a/src/model/entity/DraftEntity.js
+++ b/src/model/entity/DraftEntity.js
@@ -33,7 +33,7 @@ function logWarning(oldMethodCall, newMethodCall) {
     + oldMethodCall
     + ' will be deprecated soon!\nPlease use "'
     + newMethodCall
-    + '" instead.'
+    + '" instead.',
   );
 }
 
@@ -128,7 +128,7 @@ var DraftEntity = {
    */
   mergeData: function(
     key: string,
-    toMerge: {[key: string]: any}
+    toMerge: {[key: string]: any},
   ): DraftEntityInstance {
     logWarning(
       'DraftEntity.mergeData',
@@ -145,7 +145,7 @@ var DraftEntity = {
    */
   replaceData: function(
     key: string,
-    newData: {[key: string]: any}
+    newData: {[key: string]: any},
   ): DraftEntityInstance {
     logWarning(
       'DraftEntity.replaceData',

--- a/src/model/immutable/CharacterMetadata.js
+++ b/src/model/immutable/CharacterMetadata.js
@@ -21,9 +21,13 @@ var {
 
 import type {DraftInlineStyle} from 'DraftInlineStyle';
 
+// Immutable.map is typed such that the value for every key in the map
+// must be the same type
+type CharacterMetadataConfigValueType = DraftInlineStyle | ?string;
+
 type CharacterMetadataConfig = {
-  style?: DraftInlineStyle,
-  entity?: ?string,
+  style?: CharacterMetadataConfigValueType,
+  entity?: CharacterMetadataConfigValueType,
 };
 
 const EMPTY_SET = OrderedSet();
@@ -50,7 +54,7 @@ class CharacterMetadata extends CharacterMetadataRecord {
 
   static applyStyle(
     record: CharacterMetadata,
-    style: string
+    style: string,
   ): CharacterMetadata {
     var withStyle = record.set('style', record.getStyle().add(style));
     return CharacterMetadata.create(withStyle);
@@ -58,7 +62,7 @@ class CharacterMetadata extends CharacterMetadataRecord {
 
   static removeStyle(
     record: CharacterMetadata,
-    style: string
+    style: string,
   ): CharacterMetadata {
     var withoutStyle = record.set('style', record.getStyle().remove(style));
     return CharacterMetadata.create(withoutStyle);
@@ -66,7 +70,7 @@ class CharacterMetadata extends CharacterMetadataRecord {
 
   static applyEntity(
     record: CharacterMetadata,
-    entityKey: ?string
+    entityKey: ?string,
   ): CharacterMetadata {
     var withEntity = record.getEntity() === entityKey ?
       record :
@@ -85,9 +89,11 @@ class CharacterMetadata extends CharacterMetadataRecord {
       return EMPTY;
     }
 
+    const defaultConfig: CharacterMetadataConfig =
+      {style: EMPTY_SET, entity: (null: ?string)};
+
     // Fill in unspecified properties, if necessary.
-    var configMap =
-      Map({style: EMPTY_SET, entity: (null: ?string)}).merge(config);
+    var configMap = Map(defaultConfig).merge(config);
 
     var existing: ?CharacterMetadata = pool.get(configMap);
     if (existing) {

--- a/src/model/immutable/ContentState.js
+++ b/src/model/immutable/ContentState.js
@@ -136,7 +136,7 @@ class ContentState extends ContentStateRecord {
   createEntity(
     type: DraftEntityType,
     mutability: DraftEntityMutability,
-    data?: Object
+    data?: Object,
   ): ContentState {
     // TODO: update this when we fully remove DraftEntity
     DraftEntity._create(
@@ -149,7 +149,7 @@ class ContentState extends ContentStateRecord {
 
   mergeEntityData(
     key: string,
-    toMerge: {[key: string]: any}
+    toMerge: {[key: string]: any},
   ): ContentState {
     // TODO: update this when we fully remove DraftEntity
     DraftEntity._mergeData(key, toMerge);
@@ -158,7 +158,7 @@ class ContentState extends ContentStateRecord {
 
   replaceEntityData(
     key: string,
-    newData: {[key: string]: any}
+    newData: {[key: string]: any},
   ): ContentState {
     // TODO: update this when we fully remove DraftEntity
     DraftEntity._replaceData(key, newData);

--- a/src/model/immutable/EditorState.js
+++ b/src/model/immutable/EditorState.js
@@ -540,7 +540,7 @@ function regenerateTreeForNewBlocks(
     newBlockMap
       .toSeq()
       .filter((block, key) => block !== prevBlockMap.get(key))
-      .map(block => BlockTree.generate(contentState, block, decorator))
+      .map(block => BlockTree.generate(contentState, block, decorator)),
   );
 }
 
@@ -568,7 +568,7 @@ function regenerateTreeForNewDecorator(
           existingDecorator.getDecorations(content, block)
         );
       })
-      .map(block => BlockTree.generate(content, block, decorator))
+      .map(block => BlockTree.generate(content, block, decorator)),
   );
 }
 

--- a/src/model/immutable/EntityMap.js
+++ b/src/model/immutable/EntityMap.js
@@ -12,7 +12,9 @@
 
 'use strict';
 
-import type DraftEntityInstance from 'DraftEntityInstance';
-import type {OrderedMap} from 'immutable';
+import type {DraftEntityMapObject} from 'DraftEntity';
 
-export type EntityMap = OrderedMap<string, DraftEntityInstance>;
+// TODO: when removing the deprecated Entity api
+// change this to be
+// OrderedMap<string, DraftEntityInstance>;
+export type EntityMap = DraftEntityMapObject;

--- a/src/model/modifier/RichTextEditorUtil.js
+++ b/src/model/modifier/RichTextEditorUtil.js
@@ -55,7 +55,7 @@ const RichTextEditorUtil = {
 
   handleKeyCommand: function(
     editorState: EditorState,
-    command: DraftEditorCommand
+    command: DraftEditorCommand | string,
   ): ?EditorState {
     switch (command) {
       case 'bold':
@@ -74,7 +74,7 @@ const RichTextEditorUtil = {
       case 'delete-word':
       case 'delete-to-end-of-block':
         return RichTextEditorUtil.onDelete(editorState);
-      default:
+      default: // they may have custom editor commands; ignore those
         return null;
     }
   },

--- a/src/model/transaction/addEntityToContentState.js
+++ b/src/model/transaction/addEntityToContentState.js
@@ -24,7 +24,7 @@ function addEntityToContentState(
 ): ContentState {
   return contentState.set(
     'entityMap',
-    addEntityToEntityMap(contentState.getEntityMap(), instance)
+    addEntityToEntityMap(contentState.getEntityMap(), instance),
   );
 }
 

--- a/src/model/transaction/addEntityToEntityMap.js
+++ b/src/model/transaction/addEntityToEntityMap.js
@@ -14,14 +14,16 @@
 'use strict';
 
 import type DraftEntityInstance from 'DraftEntityInstance';
-import type {EntityMap} from 'EntityMap';
+import type {OrderedMap} from 'immutable';
+// TODO: when removing the deprecated API update this to use the EntityMap type
+// instead of OrderedMap
 
 let key = 0;
 
 function addEntityToEntityMap(
-  entityMap: EntityMap,
+  entityMap: OrderedMap<*, *>,
   instance: DraftEntityInstance,
-): EntityMap {
+): OrderedMap<*, *> {
   return entityMap.set(`${++key}`, instance);
 }
 

--- a/src/model/transaction/createEntityInContentState.js
+++ b/src/model/transaction/createEntityInContentState.js
@@ -25,11 +25,11 @@ function createEntityInContentState(
   contentState: ContentState,
   type: DraftEntityType,
   mutability: DraftEntityMutability,
-  data?: Object
+  data?: Object,
 ): ContentState {
   return addEntityToContentState(
     contentState,
-    new DraftEntityInstance({type, mutability, data: data || {}})
+    new DraftEntityInstance({type, mutability, data: data || {}}),
   );
 }
 

--- a/src/model/transaction/updateEntityDataInContentState.js
+++ b/src/model/transaction/updateEntityDataInContentState.js
@@ -19,7 +19,7 @@ function updateEntityDataInContentState(
   contentState: ContentState,
   key: string,
   data: {[key: string]: any},
-  merge: boolean
+  merge: boolean,
 ): ContentState {
   const instance = contentState.getEntity(key);
   const entityData = instance.getData();


### PR DESCRIPTION
This is a collection of flow and lint fixes that came up when testing the 0.10.0-stable branch internally.

I'm not completely sure why they don't show up when we run eslint and flow locally or in CI.

Hopefully nothing controversial, and in a couple of cases they are short-term fixes to accomodate supporting two APIs until we release 0.11.0. More info in each commit message.