### PR TITLE
Change underscore method names to bypass lint about private methods

### DIFF
--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -408,7 +408,7 @@ function genFragment(
     node.textContent = imageURI; // Output src if no decorator
 
     // TODO: update this when we remove DraftEntity entirely
-    inEntity = DraftEntity._create(
+    inEntity = DraftEntity.__create(
       'IMAGE',
       'MUTABLE',
       entityConfig || {},
@@ -475,7 +475,7 @@ function genFragment(
 
       entityConfig.url = new URI(anchor.href).toString();
       // TODO: update this when we remove DraftEntity completely
-      entityId = DraftEntity._create(
+      entityId = DraftEntity.__create(
         'LINK',
         'MUTABLE',
         entityConfig || {},

--- a/src/model/encoding/convertFromRawToDraftState.js
+++ b/src/model/encoding/convertFromRawToDraftState.js
@@ -38,7 +38,7 @@ function convertFromRawToDraftState(
     storageKey => {
       var encodedEntity = entityMap[storageKey];
       var {type, mutability, data} = encodedEntity;
-      var newKey = DraftEntity._create(type, mutability, data || {});
+      var newKey = DraftEntity.__create(type, mutability, data || {});
       fromStorageToLocal[storageKey] = newKey;
     }
   );

--- a/src/model/entity/DraftEntity.js
+++ b/src/model/entity/DraftEntity.js
@@ -60,24 +60,24 @@ export type DraftEntityMapObject = {
     newData: {[key: string]: any},
   ) => DraftEntityInstance,
 
-  _getLastCreatedEntityKey: () => string,
+  __getLastCreatedEntityKey: () => string,
 
-  _create: (
+  __create: (
     type: DraftEntityType,
     mutability: DraftEntityMutability,
     data?: Object,
   ) => string,
 
-  _add: (instance: DraftEntityInstance) => string,
+  __add: (instance: DraftEntityInstance) => string,
 
-  _get: (key: string) => DraftEntityInstance,
+  __get: (key: string) => DraftEntityInstance,
 
-  _mergeData: (
+  __mergeData: (
     key: string,
     toMerge: {[key: string]: any}
   ) => DraftEntityInstance,
 
-  _replaceData: (
+  __replaceData: (
     key: string,
     newData: {[key: string]: any}
   ) => DraftEntityInstance,
@@ -110,7 +110,7 @@ var DraftEntity:DraftEntityMapObject = {
       'DraftEntity.getLastCreatedEntityKey',
       'contentState.getLastCreatedEntityKey',
     );
-    return DraftEntity._getLastCreatedEntityKey();
+    return DraftEntity.__getLastCreatedEntityKey();
   },
 
   /**
@@ -132,7 +132,7 @@ var DraftEntity:DraftEntityMapObject = {
       'DraftEntity.create',
       'contentState.createEntity',
     );
-    return DraftEntity._create(type, mutability, data);
+    return DraftEntity.__create(type, mutability, data);
   },
 
   /**
@@ -147,7 +147,7 @@ var DraftEntity:DraftEntityMapObject = {
       'DraftEntity.add',
       'contentState.addEntity',
     );
-    return DraftEntity._add(instance);
+    return DraftEntity.__add(instance);
   },
 
   /**
@@ -161,7 +161,7 @@ var DraftEntity:DraftEntityMapObject = {
       'DraftEntity.get',
       'contentState.getEntity',
     );
-    return DraftEntity._get(key);
+    return DraftEntity.__get(key);
   },
 
   /**
@@ -180,7 +180,7 @@ var DraftEntity:DraftEntityMapObject = {
       'DraftEntity.mergeData',
       'contentState.mergeEntityData',
     );
-    return DraftEntity._mergeData(key, toMerge);
+    return DraftEntity.__mergeData(key, toMerge);
   },
 
   /**
@@ -197,7 +197,7 @@ var DraftEntity:DraftEntityMapObject = {
       'DraftEntity.replaceData',
       'contentState.replaceEntityData',
     );
-    return DraftEntity._replaceData(key, newData);
+    return DraftEntity.__replaceData(key, newData);
   },
 
   // ***********************************WARNING******************************
@@ -209,7 +209,7 @@ var DraftEntity:DraftEntityMapObject = {
    * We need this to support the new API, as part of transitioning to put Entity
    * storage in contentState.
    */
-  _getLastCreatedEntityKey: function(): string {
+  __getLastCreatedEntityKey: function(): string {
     return '' + instanceKey;
   },
 
@@ -220,12 +220,12 @@ var DraftEntity:DraftEntityMapObject = {
    * be used to track the entity's usage in a ContentBlock, and for
    * retrieving data about the entity at render time.
    */
-  _create: function(
+  __create: function(
     type: DraftEntityType,
     mutability: DraftEntityMutability,
     data?: Object,
   ): string {
-    return DraftEntity._add(
+    return DraftEntity.__add(
       new DraftEntityInstance({type, mutability, data: data || {}})
     );
   },
@@ -234,7 +234,7 @@ var DraftEntity:DraftEntityMapObject = {
    * Add an existing DraftEntityInstance to the DraftEntity map. This is
    * useful when restoring instances from the server.
    */
-  _add: function(instance: DraftEntityInstance): string {
+  __add: function(instance: DraftEntityInstance): string {
     var key = '' + (++instanceKey);
     instances = instances.set(key, instance);
     return key;
@@ -243,7 +243,7 @@ var DraftEntity:DraftEntityMapObject = {
   /**
    * Retrieve the entity corresponding to the supplied key string.
    */
-  _get: function(key: string): DraftEntityInstance {
+  __get: function(key: string): DraftEntityInstance {
     var instance = instances.get(key);
     invariant(!!instance, 'Unknown DraftEntity key.');
     return instance;
@@ -254,11 +254,11 @@ var DraftEntity:DraftEntityMapObject = {
    * instance, this method will merge your data updates and return a new
    * instance.
    */
-  _mergeData: function(
+  __mergeData: function(
     key: string,
     toMerge: {[key: string]: any}
   ): DraftEntityInstance {
-    var instance = DraftEntity._get(key);
+    var instance = DraftEntity.__get(key);
     var newData = {...instance.getData(), ...toMerge};
     var newInstance = instance.set('data', newData);
     instances = instances.set(key, newInstance);
@@ -268,11 +268,11 @@ var DraftEntity:DraftEntityMapObject = {
   /**
    * Completely replace the data for a given instance.
    */
-  _replaceData: function(
+  __replaceData: function(
     key: string,
     newData: {[key: string]: any}
   ): DraftEntityInstance {
-    const instance = DraftEntity._get(key);
+    const instance = DraftEntity.__get(key);
     const newInstance = instance.set('data', newData);
     instances = instances.set(key, newInstance);
     return newInstance;

--- a/src/model/entity/__tests__/DraftEntity-test.js
+++ b/src/model/entity/__tests__/DraftEntity-test.js
@@ -21,7 +21,7 @@ describe('DraftEntity', () => {
   });
 
   function createLink() {
-    return DraftEntity._create('LINK', 'MUTABLE', {uri: 'zombo.com'});
+    return DraftEntity.__create('LINK', 'MUTABLE', {uri: 'zombo.com'});
   }
 
   it('must create instances', () => {
@@ -31,7 +31,7 @@ describe('DraftEntity', () => {
 
   it('must retrieve an instance given a key', () => {
     var key = createLink();
-    var retrieved = DraftEntity._get(key);
+    var retrieved = DraftEntity.__get(key);
     expect(retrieved.getType()).toBe('LINK');
     expect(retrieved.getMutability()).toBe('MUTABLE');
     expect(retrieved.getData()).toEqual({uri: 'zombo.com'});
@@ -39,8 +39,8 @@ describe('DraftEntity', () => {
 
   it('must throw when retrieving for an invalid key', () => {
     createLink();
-    expect(() => DraftEntity._get('asdfzxcvqweriuop')).toThrow();
-    expect(() => DraftEntity._get(null)).toThrow();
+    expect(() => DraftEntity.__get('asdfzxcvqweriuop')).toThrow();
+    expect(() => DraftEntity.__get(null)).toThrow();
   });
 
   it('must merge data', () => {
@@ -48,8 +48,8 @@ describe('DraftEntity', () => {
 
     // Merge new property.
     var newData = {foo: 'bar'};
-    DraftEntity._mergeData(key, newData);
-    var newEntity = DraftEntity._get(key);
+    DraftEntity.__mergeData(key, newData);
+    var newEntity = DraftEntity.__get(key);
     expect(newEntity.getData()).toEqual({
       uri: 'zombo.com',
       foo: 'bar',
@@ -57,8 +57,8 @@ describe('DraftEntity', () => {
 
     // Replace existing property.
     var withNewURI = {uri: 'homestarrunner.com'};
-    DraftEntity._mergeData(key, withNewURI);
-    var entityWithNewURI = DraftEntity._get(key);
+    DraftEntity.__mergeData(key, withNewURI);
+    var entityWithNewURI = DraftEntity.__get(key);
     expect(entityWithNewURI.getData()).toEqual({
       uri: 'homestarrunner.com',
       foo: 'bar',

--- a/src/model/entity/__tests__/getEntityKeyForSelection-test.js
+++ b/src/model/entity/__tests__/getEntityKeyForSelection-test.js
@@ -25,7 +25,7 @@ selectionState = selectionState.merge({
 });
 
 function setEntityMutability(mutability) {
-  contentState.getEntityMap()._get = () => ({
+  contentState.getEntityMap().__get = () => ({
     getMutability: () => mutability,
   });
 }

--- a/src/model/entity/getEntityKeyForSelection.js
+++ b/src/model/entity/getEntityKeyForSelection.js
@@ -58,7 +58,7 @@ function filterKey(
   entityKey: ?string
 ): ?string {
   if (entityKey) {
-    var entity = entityMap._get(entityKey);
+    var entity = entityMap.__get(entityKey);
     return entity.getMutability() === 'MUTABLE' ? entityKey : null;
   }
   return null;

--- a/src/model/immutable/ContentState.js
+++ b/src/model/immutable/ContentState.js
@@ -122,7 +122,7 @@ class ContentState extends ContentStateRecord {
 
   getLastCreatedEntityKey() {
     // TODO: update this when we fully remove DraftEntity
-    return DraftEntity._getLastCreatedEntityKey();
+    return DraftEntity.__getLastCreatedEntityKey();
   }
 
   hasText(): boolean {
@@ -139,7 +139,7 @@ class ContentState extends ContentStateRecord {
     data?: Object,
   ): ContentState {
     // TODO: update this when we fully remove DraftEntity
-    DraftEntity._create(
+    DraftEntity.__create(
       type,
       mutability,
       data,
@@ -152,7 +152,7 @@ class ContentState extends ContentStateRecord {
     toMerge: {[key: string]: any},
   ): ContentState {
     // TODO: update this when we fully remove DraftEntity
-    DraftEntity._mergeData(key, toMerge);
+    DraftEntity.__mergeData(key, toMerge);
     return this;
   }
 
@@ -161,19 +161,19 @@ class ContentState extends ContentStateRecord {
     newData: {[key: string]: any},
   ): ContentState {
     // TODO: update this when we fully remove DraftEntity
-    DraftEntity._replaceData(key, newData);
+    DraftEntity.__replaceData(key, newData);
     return this;
   }
 
   addEntity(instance: DraftEntityInstance): ContentState {
     // TODO: update this when we fully remove DraftEntity
-    DraftEntity._add(instance);
+    DraftEntity.__add(instance);
     return this;
   }
 
   getEntity(key: string): DraftEntityInstance {
     // TODO: update this when we fully remove DraftEntity
-    return DraftEntity._get(key);
+    return DraftEntity.__get(key);
   }
 
   static createFromBlockArray(

--- a/src/model/modifier/RichTextEditorUtil.js
+++ b/src/model/modifier/RichTextEditorUtil.js
@@ -38,7 +38,7 @@ const RichTextEditorUtil = {
       .slice(selection.getStartOffset(), selection.getEndOffset())
       .some(v => {
         var entity = v.getEntity();
-        return !!entity && entityMap._get(entity).getType() === 'LINK';
+        return !!entity && entityMap.__get(entity).getType() === 'LINK';
       });
   },
 

--- a/src/model/modifier/getCharacterRemovalRange.js
+++ b/src/model/modifier/getCharacterRemovalRange.js
@@ -45,7 +45,7 @@ function getCharacterRemovalRange(
     return selectionState;
   }
 
-  var entity = entityMap._get(entityKey);
+  var entity = entityMap.__get(entityKey);
   var mutability = entity.getMutability();
 
   // `MUTABLE` entities can just have the specified range of text removed

--- a/src/model/paste/__tests__/DraftPasteProcessor-test.js
+++ b/src/model/paste/__tests__/DraftPasteProcessor-test.js
@@ -301,7 +301,7 @@ describe('DraftPasteProcessor', function() {
     );
     expect(output[0].getText()).toBe('This is a link, yep.');
     var entityId = output[0].getCharacterList().get(12).getEntity();
-    var entity = entityMap._get(entityId);
+    var entity = entityMap.__get(entityId);
     expect(entity.getData().url).toBe('http://www.facebook.com/');
   });
 
@@ -349,7 +349,7 @@ describe('DraftPasteProcessor', function() {
     );
     expect(output[0].getText()).toBe('This is a link, yep.');
     var entityId = output[0].getCharacterList().get(12).getEntity();
-    var entity = entityMap._get(entityId);
+    var entity = entityMap.__get(entityId);
     expect(entity.getData().url).toBe('mailto:example@example.com');
   });
 

--- a/src/model/transaction/__tests__/removeEntitiesAtEdges-test.js
+++ b/src/model/transaction/__tests__/removeEntitiesAtEdges-test.js
@@ -54,7 +54,7 @@ describe('removeEntitiesAtEdges', () => {
   }
 
   function setEntityMutability(mutability) {
-    contentState.getEntityMap()._get = () => ({
+    contentState.getEntityMap().__get = () => ({
       getMutability: () => mutability,
     });
   }

--- a/src/model/transaction/removeEntitiesAtEdges.js
+++ b/src/model/transaction/removeEntitiesAtEdges.js
@@ -99,7 +99,7 @@ function removeForBlock(
   var entityAfterCursor = charAfter ? charAfter.getEntity() : undefined;
 
   if (entityAfterCursor && entityAfterCursor === entityBeforeCursor) {
-    var entity = entityMap._get(entityAfterCursor);
+    var entity = entityMap.__get(entityAfterCursor);
     if (entity.getMutability() !== 'MUTABLE') {
       var {start, end} = getRemovalRange(chars, entityAfterCursor, offset);
       var current;


### PR DESCRIPTION
Private methods should not be called as public methods. A recent PR
(https://github.com/facebook/draft-js/pull/814) added warnings to the
public-but-deprecated API of DraftEntity, and then moved the logic for
those methods into private methods that can be called within the
Draft.js framework.

These methods are "private" in the sense that we are only calling them
within Draft. They should not be used outside of the Draft library,
because they will be removed in an upcoming version of the library.

We have a transform step that causes issues when an underscore-prefixed
method is called outside of it's module, so changing the method names
seems like the easiest way to deal with this issue and still send the
message that they are private.