### PR TITLE
Fix 0.10 compatibility break in getDecorations

### DIFF
--- a/src/model/decorators/CompositeDraftDecorator.js
+++ b/src/model/decorators/CompositeDraftDecorator.js
@@ -52,7 +52,7 @@ class CompositeDraftDecorator {
     this._decorators = decorators.slice();
   }
 
-  getDecorations(contentState: ContentState, block: ContentBlock): List<?string> {
+  getDecorations(block: ContentBlock, contentState: ContentState): List<?string> {
     var decorations = Array(block.getText().length).fill(null);
 
     this._decorators.forEach(

--- a/src/model/decorators/DraftDecoratorType.js
+++ b/src/model/decorators/DraftDecoratorType.js
@@ -26,7 +26,7 @@ export type DraftDecoratorType = {
   /**
    * Given a `ContentBlock`, return an immutable List of decorator keys.
    */
-  getDecorations(contentState: ContentState, block: ContentBlock): List<?string>,
+  getDecorations(block: ContentBlock, contentState: ContentState): List<?string>,
 
   /**
    * Given a decorator key, return the component to use when rendering

--- a/src/model/decorators/__tests__/CompositeDraftDecorator-test.js
+++ b/src/model/decorators/__tests__/CompositeDraftDecorator-test.js
@@ -83,7 +83,7 @@ describe('CompositeDraftDecorator', () => {
     var text = 'take a sad song and make it better';
     var content = new ContentBlock(text);
     var contentState = ContentState.createFromText(text);
-    var decorations = composite.getDecorations(contentState, content).toArray();
+    var decorations = composite.getDecorations(content, contentState).toArray();
     expect(decorations.length).toBe(text.length);
     expect(decorations).toEqual(Array(text.length).fill(null));
   });
@@ -93,7 +93,7 @@ describe('CompositeDraftDecorator', () => {
     var text = 'a footballing fool';
     var content = new ContentBlock(text);
     var contentState = ContentState.createFromText(text);
-    var decorations = composite.getDecorations(contentState, content).toArray();
+    var decorations = composite.getDecorations(content, contentState).toArray();
     expect(decorations.length).toBe(text.length);
 
     expect(isOccupied(decorations.slice(2, 5))).toBe(true);
@@ -112,7 +112,7 @@ describe('CompositeDraftDecorator', () => {
     var text = 'a foosball bar';
     var content = new ContentBlock(text);
     var contentState = ContentState.createFromText(text);
-    var decorations = composite.getDecorations(contentState, content).toArray();
+    var decorations = composite.getDecorations(content, contentState).toArray();
 
     // Match the "Foo" decorator.
     expect(isOccupied(decorations.slice(2, 5))).toBe(true);
@@ -134,7 +134,7 @@ describe('CompositeDraftDecorator', () => {
     var text = 'some bar food';
     var content = new ContentBlock(text);
     var contentState = ContentState.createFromText(text);
-    var decorations = composite.getDecorations(contentState, content).toArray();
+    var decorations = composite.getDecorations(content, contentState).toArray();
 
     // Match the "Foo" decorator.
     expect(isOccupied(decorations.slice(9, 12))).toBe(true);
@@ -154,7 +154,7 @@ describe('CompositeDraftDecorator', () => {
     var text = 'bart has a bar';
     var content = new ContentBlock(text);
     var contentState = ContentState.createFromText(text);
-    var decorations = composite.getDecorations(contentState, content).toArray();
+    var decorations = composite.getDecorations(content, contentState).toArray();
 
     // Even though "bart" matches our "bar" strategy, "bart" comes first
     // in our decoration order and will claim those letters first.
@@ -179,7 +179,7 @@ describe('CompositeDraftDecorator', () => {
     var text = 'bart has a bar';
     var content = new ContentBlock(text);
     var contentState = ContentState.createFromText(text);
-    var decorations = composite.getDecorations(contentState, content).toArray();
+    var decorations = composite.getDecorations(content, contentState).toArray();
 
     // "bar" comes first and claims two strings.
     expect(isOccupied(decorations.slice(0, 3))).toBe(true);
@@ -202,7 +202,7 @@ describe('CompositeDraftDecorator', () => {
     var text = 'barbarbar';
     var content = new ContentBlock(text);
     var contentState = ContentState.createFromText(text);
-    var decorations = composite.getDecorations(contentState, content).toArray();
+    var decorations = composite.getDecorations(content, contentState).toArray();
 
     expect(isOccupied(decorations.slice(0, 3))).toBe(true);
     expect(decorations[0]).toEqual(decorations[2]);

--- a/src/model/immutable/BlockTree.js
+++ b/src/model/immutable/BlockTree.js
@@ -81,7 +81,7 @@ var BlockTree = {
 
     var leafSets = [];
     var decorations = decorator ?
-      decorator.getDecorations(contentState, block) :
+      decorator.getDecorations(block, contentState) :
       List(Repeat(null, textLength));
 
     var chars = block.getCharacterList();

--- a/src/model/immutable/EditorState.js
+++ b/src/model/immutable/EditorState.js
@@ -564,8 +564,8 @@ function regenerateTreeForNewDecorator(
       .toSeq()
       .filter(block => {
         return (
-          decorator.getDecorations(content, block) !==
-          existingDecorator.getDecorations(content, block)
+          decorator.getDecorations(block, content) !==
+          existingDecorator.getDecorations(block, content)
         );
       })
       .map(block => BlockTree.generate(content, block, decorator))

--- a/src/model/immutable/__tests__/EditorState-test.js
+++ b/src/model/immutable/__tests__/EditorState-test.js
@@ -226,7 +226,7 @@ describe('EditorState', () => {
 
     beforeEach(() => {
       Decorator.prototype.getDecorations.mockClear();
-      Decorator.prototype.getDecorations.mockImplementation((c, v) => {
+      Decorator.prototype.getDecorations.mockImplementation((v, c) => {
         return v === boldBlock ? boldA : List(Repeat(undefined, v.getLength()));
       });
     });
@@ -236,11 +236,11 @@ describe('EditorState', () => {
       var editorState = getDecoratedEditorState(decorator);
       expect(decorator.getDecorations.mock.calls.length).toBe(2);
 
-      Decorator.prototype.getDecorations.mockImplementation((c, v) => {
+      Decorator.prototype.getDecorations.mockImplementation((v, c) => {
         return v === boldBlock ? boldB : List(Repeat(undefined, v.getLength()));
       });
       var newDecorator = new NextDecorator();
-      NextDecorator.prototype.getDecorations.mockImplementation((c, v) => {
+      NextDecorator.prototype.getDecorations.mockImplementation((v, c) => {
         return v === boldBlock ? boldB : List(Repeat(undefined, v.getLength()));
       });
 


### PR DESCRIPTION
This change fixes #859 by reversing the order of the arguments to `getDecorations`. Existing decorators will continue to function as they had in 0.9 since they can safely ignore the new `ContentState` parameter. Without this change existing decorators like `MultiDecorator` in `draft-js-plugins` will need to be broken making it more difficult to migrate to 0.10 for existing users of `draft-js-plugins`.

The backwards compatibility break appears to be unintentional as the other breaks introduced by #376 were fixed by #790. This closes a break missed by #790.