### PR TITLE
Fixes weird scroll position issues with Asian IMEs on. 

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -388,7 +388,11 @@ class DraftEditor extends React.Component {
    * state (cut command, IME) and we want to make sure that reconciliation
    * occurs on a version of the DOM that is synchronized with our EditorState.
    */
-  _restoreEditorDOM(scrollPosition?: DraftScrollPosition): void {
+  _restoreEditorDOM(scrollPosition?: DraftScrollPosition): void {    
+    if (!scrollPosition) {
+      const scrollParent = Style.getScrollParent(ReactDOM.findDOMNode(this.refs.editor));
+      scrollPosition = getScrollPosition(scrollParent);
+    }
     this.setState({containerKey: this.state.containerKey + 1}, () => {
       this._focus(scrollPosition);
     });


### PR DESCRIPTION

Asian IME sometimes makes draft-js editor scrolls to an unintentional position.

The `restoreEditorDOM` function was called to force a re-render when the character composition is being done at the first position of a leaf, etc. However, not like with the case of cut action, `scrollPosition` is not passed, and `restoreEditorDOM` might need a fallback to figure out the scroll position. 


