### PR TITLE
Fix array lookup to .includes rather than .has

### DIFF
--- a/src/model/immutable/CharacterMetadata.js
+++ b/src/model/immutable/CharacterMetadata.js
@@ -49,7 +49,7 @@ class CharacterMetadata extends CharacterMetadataRecord {
   }
 
   hasStyle(style: string): boolean {
-    return this.getStyle().has(style);
+    return this.getStyle().includes(style);
   }
 
   static applyStyle(


### PR DESCRIPTION
**Summary**

In the CharacterMeta file, to lookup if a certain CharacterMeta had a style, we were using .has, which looks up keys in an array, while something like 'ITALIC' is stored as a value, so Immutable's .includes function would be more appropriate here.