### PR TITLE
Improved version of "Fix modifying state during onChange ... #667"

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test-ci": "NODE_ENV=test npm run lint && npm run flow && npm run test"
   },
   "dependencies": {
-    "fbjs": "^0.8.3",
+    "fbjs": "^0.8.7",
     "immutable": "~3.7.4",
     "object-assign": "^4.1.0"
   },

--- a/src/.flowconfig
+++ b/src/.flowconfig
@@ -19,6 +19,7 @@ esproposal.class_static_fields=enable
 suppress_type=$FlowIssue
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(2[0-8]\\|1[0-9]\\|[0-9]\\).[0-9]\\)? *\\).*\n
 module.name_mapper='ReactDOM' -> 'react-dom'
+module.name_mapper='setImmediate' -> 'fbjs/lib/setImmediate'
 
 [version]
 0.32.0

--- a/src/component/handlers/edit/editOnSelect.js
+++ b/src/component/handlers/edit/editOnSelect.js
@@ -20,10 +20,8 @@ var getDraftEditorSelection = require('getDraftEditorSelection');
 import type DraftEditor from 'DraftEditor.react';
 
 function editOnSelect(editor: DraftEditor): void {
-  if (editor._blockSelectEvents) {
-    return;
-  }
-  if (editor._latestEditorState !== editor.props.editorState) {
+  if (editor._blockSelectEvents ||
+      editor._latestEditorState !== editor.props.editorState) {
     return;
   }
 

--- a/website/package.json
+++ b/website/package.json
@@ -7,7 +7,7 @@
     "compression": "1.2.2",
     "connect": "3.3.3",
     "errorhandler": "1.3.0",
-    "fbjs": "^0.8.0-alpha.1",
+    "fbjs": "^0.8.7",
     "fs.extra": "*",
     "glob": "*",
     "immutable": "^3.7.6",


### PR DESCRIPTION
This fixes some issues with the fix originally merged from PR #667

Credit to @spicyj  and @srmcconomy for this fix. 
For now I'm just getting 'www' and github back in sync.

We also had to tweak this compared to the current internal version to
accomodate a recent change that makes 'editOnBeforeInput' and the other
handlers take 'editor' as an explicit argument instead of assumming
'this' will be the editor;
https://github.com/facebook/draft-js/commit/e64c2c3f2a3654b925b18baff448100cfbbf3738

**Update:**

**Also thanks to @davidchang for pinging me about landing this, @colinjeane for reporting this bug in #917 and submitting a nearly identical fix: https://github.com/facebook/draft-js/pull/919**

The delay on landing this was until 'setImmediate' was available in fbjs.[1]
[1]: https://github.com/facebook/fbjs/pull/208

Note that we are updating the version of 'fbjs' required in order to get access to the 'setImmediate' polyfill.