### PR TITLE
Immutable update

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "fbjs": "^0.8.3",
-    "immutable": "~3.7.4",
+    "immutable": "~3.8.1",
     "object-assign": "^4.1.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
**Summary**

Updates the version of Immutable draft is using to `3.8.1` in order to remove unnecessary console logs

**Test Plan**

Rebuilt and ran through all examples to verify they still worked.

#607 