### PR TITLE
EditorState.set()

### DIFF
--- a/docs/APIReference-EditorState.md
+++ b/docs/APIReference-EditorState.md
@@ -358,8 +358,8 @@ as the set of inline styles to be applied to the next inserted characters.
 ```
 static set(editorState: EditorState, options: EditorStateRecordType): EditorState
 ```
-Returns a new `EditorState` object with new options passed in. The method
-technically lives on the Immutable `record` API.
+Returns a new `EditorState` object with new options passed in. 'The method is
+inherited from the Immutable `record` API.
 
 ## Properties and Getters
 

--- a/docs/APIReference-EditorState.md
+++ b/docs/APIReference-EditorState.md
@@ -110,6 +110,11 @@ The list below includes the most commonly used instance methods for `EditorState
       <pre>static setInlineStyleOverride(editorState, inlineStyleOverride): EditorState</pre>
     </a>
   </li>
+  <li>
+    <a href="#set">
+      <pre>static set(editorState, EditorStateRecordType): EditorState</pre>
+    </a>
+  </li>
 </ul>
 
 *Properties*
@@ -347,6 +352,14 @@ static setInlineStyleOverride(editorState: EditorState, inlineStyleOverride: Dra
 ```
 Returns a new `EditorState` object with the specified `DraftInlineStyle` applied
 as the set of inline styles to be applied to the next inserted characters.
+
+### set
+
+```
+static set(editorState: EditorState, options: EditorStateRecordType): EditorState
+```
+Returns a new `EditorState` object with new options passed in. The method
+technically lives on the Immutable `record` API.
 
 ## Properties and Getters
 


### PR DESCRIPTION
**Summary**

We reference using `Editor.set()` in the docs, as well as in multiple examples. I've updated docs to reference it (#579). However, the reason it wasn't there is because it's a method that is on Immutable's `Record` class.  I know we don't want to recommend these methods, but since we are using it in the examples it may not be a bad idea to at least include a reference to it. That said, feel free to suggest a better way to word this, or to just reject it. 