### PR TITLE
Prevent discarding style override on split-block

### DIFF
--- a/src/model/immutable/EditorState.js
+++ b/src/model/immutable/EditorState.js
@@ -389,8 +389,10 @@ class EditorState {
 
     let inlineStyleOverride = editorState.getInlineStyleOverride();
 
-    // Don't discard inline style overrides on block type or depth changes.
-    if (changeType !== 'adjust-depth' && changeType !== 'change-block-type') {
+    // Don't discard inline style overrides for the following change types:
+    var overrideChangeTypes = ['adjust-depth', 'change-block-type', 'split-block'];
+
+    if (overrideChangeTypes.indexOf(changeType) === -1) {
       inlineStyleOverride = null;
     }
 

--- a/src/model/immutable/__tests__/EditorState-test.js
+++ b/src/model/immutable/__tests__/EditorState-test.js
@@ -16,6 +16,7 @@ jest.disableAutomock();
 var CharacterMetadata = require('CharacterMetadata');
 var ContentBlock = require('ContentBlock');
 var ContentState = require('ContentState');
+var DraftModifier = require('DraftModifier');
 var EditorState = require('EditorState');
 var Immutable = require('immutable');
 var SelectionState = require('SelectionState');
@@ -156,6 +157,31 @@ describe('EditorState', () => {
         expect(editor.getCurrentInlineStyle().toJS()).toEqual(['BOLD']);
 
         editor = RichTextEditorUtil.toggleBlockType(editor, 'test-block');
+        expect(editor.getCurrentInlineStyle().toJS()).toEqual(['BOLD']);
+      });
+
+      it('does not discard style override when adjusting depth', () => {
+        var editor = EditorState.createEmpty();
+
+        editor = RichTextEditorUtil.toggleInlineStyle(editor, 'BOLD');
+        expect(editor.getCurrentInlineStyle().toJS()).toEqual(['BOLD']);
+
+        editor = RichTextEditorUtil.onTab({ preventDefault: () => {} }, editor, 1);
+        expect(editor.getCurrentInlineStyle().toJS()).toEqual(['BOLD']);
+      });
+
+      it('does not discard style override when splitting block', () => {
+        var editor = EditorState.createEmpty();
+
+        editor = RichTextEditorUtil.toggleInlineStyle(editor, 'BOLD');
+        expect(editor.getCurrentInlineStyle().toJS()).toEqual(['BOLD']);
+
+        var contentState = DraftModifier.splitBlock(
+          editor.getCurrentContent(),
+          editor.getSelection()
+        );
+
+        editor = EditorState.push(editor, contentState, 'split-block');
         expect(editor.getCurrentInlineStyle().toJS()).toEqual(['BOLD']);
       });
     });


### PR DESCRIPTION
Another attempt at fixing #412 and #672 and added a test for not discarding override styles when adjusting depth.

![mm](https://cloud.githubusercontent.com/assets/56288/21375724/1bc2e164-c6f5-11e6-8dca-b2bfd31d9d99.gif)
