### PR TITLE
Fix Flow nits in DraftEditorProps

### DIFF
--- a/src/component/base/DraftEditorProps.js
+++ b/src/component/base/DraftEditorProps.js
@@ -48,12 +48,12 @@ export type DraftEditorProps = {
   blockRendererFn?: (block: ContentBlock) => ?Object,
 
   // Function that returns a cx map corresponding to block-level styles.
-  blockStyleFn?: (type: number) => string,
+  blockStyleFn?: (block: ContentBlock) => string,
 
   // A function that accepts a synthetic key event and returns
   // the matching DraftEditorCommand constant, or null if no command should
   // be invoked.
-  keyBindingFn: (e: SyntheticKeyboardEvent) => ?string,
+  keyBindingFn: (e: SyntheticKeyboardEvent) => ?DraftEditorCommand,
 
   // Set whether the `DraftEditor` component should be editable. Useful for
   // temporarily disabling edit behavior or allowing `DraftEditor` rendering


### PR DESCRIPTION
In one case it seems the return type was just incorrect.

In another case we were allowing 'string' instead of the more specific
'DraftEditorCommand'. To support the typing of 'getDefaultKeyBinding' we
should match the return type there.