### PR TITLE
Fake the input event for IE

### DIFF
--- a/src/component/handlers/edit/editOnBeforeInput.js
+++ b/src/component/handlers/edit/editOnBeforeInput.js
@@ -17,6 +17,7 @@ var DraftModifier = require('DraftModifier');
 var EditorState = require('EditorState');
 var UserAgent = require('UserAgent');
 
+var editOnInput = require('editOnInput');
 var getEntityKeyForSelection = require('getEntityKeyForSelection');
 var isSelectionAtLeafStart = require('isSelectionAtLeafStart');
 var nullthrows = require('nullthrows');
@@ -35,6 +36,8 @@ const isEventHandled = require('isEventHandled');
 var FF_QUICKFIND_CHAR = '\'';
 var FF_QUICKFIND_LINK_CHAR = '\/';
 var isFirefox = UserAgent.isBrowser('Firefox');
+
+var isIE = UserAgent.isBrowser('IE');
 
 function mustPreventDefaultForCharacter(character: string): boolean {
   return (
@@ -164,6 +167,17 @@ function editOnBeforeInput(editor: DraftEditor, e: SyntheticInputEvent): void {
     editor._pendingStateFromBeforeInput = EditorState.set(newEditorState, {
       nativelyRenderedContent: newEditorState.getCurrentContent(),
     });
+
+    if (isIE) {
+      // Internet Explorer doesn't support the input event for contenteditable.
+      // in all other browsers this function would return and we'd bubble back
+      // up to the root scope to give the browser a chance to perform the
+      // insertion and to send the input event. We'll have to kick the event
+      // ourselves in this case.
+      setTimeout(function() {
+        editOnInput(editor);
+      }, 0);
+    }
   }
 }
 

--- a/src/component/handlers/edit/editOnBeforeInput.js
+++ b/src/component/handlers/edit/editOnBeforeInput.js
@@ -21,6 +21,7 @@ var editOnInput = require('editOnInput');
 var getEntityKeyForSelection = require('getEntityKeyForSelection');
 var isSelectionAtLeafStart = require('isSelectionAtLeafStart');
 var nullthrows = require('nullthrows');
+var setImmediate = require('setImmediate');
 
 import type DraftEditor from 'DraftEditor.react';
 import type {DraftInlineStyle} from 'DraftInlineStyle';
@@ -174,9 +175,7 @@ function editOnBeforeInput(editor: DraftEditor, e: SyntheticInputEvent): void {
       // up to the root scope to give the browser a chance to perform the
       // insertion and to send the input event. We'll have to kick the event
       // ourselves in this case.
-      setTimeout(function() {
-        editOnInput(editor);
-      }, 0);
+      setImmediate(() => editOnInput(editor));
     }
   }
 }

--- a/src/component/handlers/edit/editOnSelect.js
+++ b/src/component/handlers/edit/editOnSelect.js
@@ -26,6 +26,9 @@ function editOnSelect(editor: DraftEditor): void {
   if (editor._latestEditorState !== editor.props.editorState) {
     return;
   }
+  if (editor._pendingStateFromBeforeInput !== undefined) {
+    return;
+  }
 
   var editorState = editor.props.editorState;
   var documentSelection = getDraftEditorSelection(


### PR DESCRIPTION
**Summary**

This fixes https://github.com/facebook/draft-js/issues/917.

When `_pendingStateFromBeforeInput` was added it defered some work in updating the editor's state until the next `input` event is received. Unfortunately, IE 11 doesn't support this event on contenteditable elements and React does not handle this inconsistency and so the defered work was never processed.

This change kicks off timer to fire as soon as we hand control back to the browser and so simulate the event occuring on IE.

**Test Plan**

The automated tests currently don't handle this so I performed quite a bit of manual testing. The change is restricted to IE (and not Edge which correctly supports the event). I was particularly concerned that `setTimeout` wouldn't be a close enough approximation to the actual event after watching the code flow in several browsers as well as in IE with this fix it appears to me that this executes the same code in the same order across these browsers.