### PR TITLE
fix #917, #849 - IE input event bug missing editOnInput

### DIFF
--- a/src/component/handlers/edit/editOnBeforeInput.js
+++ b/src/component/handlers/edit/editOnBeforeInput.js
@@ -75,6 +75,10 @@ function replaceText(
  * occurs on the relevant text nodes.
  */
 function editOnBeforeInput(editor: DraftEditor, e: SyntheticInputEvent): void {
+  if (editor._pendingStateFromBeforeInput !== undefined) {
+    editor.update(editor._pendingStateFromBeforeInput);
+    editor._pendingStateFromBeforeInput = undefined;
+  }
   var chars = e.data;
 
   // In some cases (ex: IE ideographic space insertion) no character data
@@ -161,8 +165,12 @@ function editOnBeforeInput(editor: DraftEditor, e: SyntheticInputEvent): void {
     // change the inserted text, we wait until the text is actually inserted
     // before we actually update our state. That way when we rerender, the text
     // we see in the DOM will already have been inserted properly.
-    editor._pendingStateFromBeforeInput = EditorState.set(newEditorState, {
-      nativelyRenderedContent: newEditorState.getCurrentContent(),
+    editor._pendingStateFromBeforeInput = newEditorState;
+    setImmediate(() => {
+      if (editor._pendingStateFromBeforeInput !== undefined) {
+        editor.update(editor._pendingStateFromBeforeInput);
+        editor._pendingStateFromBeforeInput = undefined;
+      }
     });
   }
 }


### PR DESCRIPTION
**Summary**

Fix #917 ; syncing from an internal fix to ensure Draft works properly on IE

**Test Plan**

Particularly on IE11, go to facebook.github.io/draft-js . Type in the editor, blur focus and then return; note that the text remains the same.

Select that text and hit backspace, note expected behavior (selected text is deleted, cursor position is where the deleted text had been).