### PR TITLE
Don't merge sequential unstyled tags

### DIFF
--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -156,7 +156,6 @@ function getListBlockType(
 function getBlockMapSupportedTags(
   blockRenderMap: DraftBlockRenderMap
 ): Array<string> {
-  const unstyledElement = blockRenderMap.get('unstyled').element;
   let tags = new Set([]);
 
   blockRenderMap.forEach((draftBlock: DraftBlockRenderConfig) => {
@@ -170,7 +169,6 @@ function getBlockMapSupportedTags(
   });
 
   return tags
-    .filter((tag) => tag && tag !== unstyledElement)
     .toArray()
     .sort();
 }
@@ -430,7 +428,13 @@ function genFragment(
   }
 
   // Block Tags
-  if (!inBlock && blockTags.indexOf(nodeName) !== -1) {
+  if (
+      (
+        !inBlock ||
+        getBlockTypeForTag(inBlock, lastList, blockRenderMap) === 'unstyled'
+      ) &&
+      blockTags.indexOf(nodeName) !== -1
+    ) {
     chunk = getBlockDividerChunk(
       getBlockTypeForTag(nodeName, lastList, blockRenderMap),
       depth

--- a/src/model/paste/__tests__/DraftPasteProcessor-test.js
+++ b/src/model/paste/__tests__/DraftPasteProcessor-test.js
@@ -127,18 +127,22 @@ describe('DraftPasteProcessor', function() {
     ]);
   });
 
-  /**
-   * todo: azelenskiy
-   * Changes to the mocked DOM appear to have broken this.
-   *
-   * it('must suppress blocks nested inside other blocks', function() {
-   *   var html = '<p><h2>Some text here</h2> more text here </p>';
-   *   var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
-   *   assertBlockTypes(output, [
-   *   'unstyled',
-   *   ]);
-   * });
-   */
+  it('must suppress blocks nested inside other blocks', function() {
+    var html = '<h2><p>Some text here</p> more text here </h2>';
+    var {contentBlocks: output} = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    assertBlockTypes(output, [
+      'header-two',
+    ]);
+  });
+
+  it('must not suppress blocks nested inside unstyled blocks', function() {
+    var html = '<div><h2>Some text here</h2> more text here </div>';
+    var {contentBlocks: output} = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    assertBlockTypes(output, [
+      'header-two',
+      'unstyled',
+    ]);
+  });
 
   it('must detect two touching blocks', function() {
     var html = '<h1>hi</h1>    <h2>hi</h2>';
@@ -194,12 +198,22 @@ describe('DraftPasteProcessor', function() {
     ]);
   });
 
-  it('must NOT treat divs as Ps when we pave Ps', function() {
+  it('must NOT treat divs as Ps when they contain Ps', function() {
     var html = '<div><p>hi</p><p>hello</p></div>';
     var {contentBlocks: output} = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
     assertBlockTypes(output, [
       'paragraph',
       'paragraph',
+    ]);
+  });
+
+  it('must treat divs that do not contain Ps as Ps when we have Ps elsewhere', function() {
+    var html = '<p>hi</p><div>hello</div><div>hola</div>';
+    var {contentBlocks: output} = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    assertBlockTypes(output, [
+      'paragraph',
+      'unstyled',
+      'unstyled',
     ]);
   });
 


### PR DESCRIPTION
**Summary**

This change fixes #738 by ensuring that `convertFromHTMLToContentBlocks` counts unstyled blocks as blocks and by moving the logic to suppress a block's type into that function.

Previously the existence of any tag other than the unstyled tag would cause unstyled blocks not to be parsed as blocks (but, curiously, the aliases of the unstyled tag would be parsed as blocks). This is mean to handle a case like

```
<div><h2>Hello</h2></div>
```

ensuring that the final block is a `header-two` but breaks with examples like

```
<h2>Hello</h2>
<div>world!</div>
<div>Goodbye!</div>
```

which parses as two blocks with the two divs being combined into a single unstyled block.

The core issue is that not counting the unstyled tag when an interesting tag appears anywhere in the document is a global problem to a local issue: the fix is to instead consider each tree under a block individually with unstyled blocks deferring their final type to whatever the next lowest block type is.


**Test Plan**

Several tests were added including uncommenting a test that had existed before.

The ordering of tags in the uncommented test had to be revised because the HTML was invalid and so being parsed with three children under `body`. The corrected ordering keeps the goal of the test.