### PR TITLE
Update docs for v0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ for scalable memory usage.
 
 ## API Notice
 
-Before getting started, please be aware that we are changing the API of Entity storage in Draft. Currently, the master branch supports both the old and new API. We hope to release this soon, as `v0.10.0`. Following that up will be `v0.11.0` which will remove the old API. This update will also include documentation on how to upgrade. If you are interested in helping out, or tracking the progress, please follow  [issue 839](https://github.com/facebook/draft-js/issues/839).
+Before getting started, please be aware that we recently changed the API of
+Entity storage in Draft. The latest version, `v0.10.0`, supports both the old
+and new API.  Following that up will be `v0.11.0` which will remove the old API.
+If you are interested in helping out, or tracking the progress, please follow
+[issue 839](https://github.com/facebook/draft-js/issues/839).
 
 ## Getting Started
 

--- a/docs/APIReference-APIMigration.md
+++ b/docs/APIReference-APIMigration.md
@@ -1,0 +1,155 @@
+---
+id: v0-10-api-migration
+title: v0.10 API Migration
+layout: docs
+category: Advanced Topics
+next: advanced-topics-decorators
+permalink: docs/v0-10-api-migration.html
+---
+
+The Draft.js v0.10 release includes a change to the API for managing
+`DraftEntity` data; the global 'DraftEntity' module is being deprecated and
+`DraftEntity` instances will be managed as part of `ContentState`. This means
+that the methods which were previously accessed on `DraftEntity` are now moved
+to the `ContentState` record.
+
+This API improvement unlocks the path for many benefits that will be available in v0.11:
+
+* DraftEntity instances and storage will be immutable.
+* DraftEntity will no longer be globally accessible.
+* Any changes to entity data will trigger a re-render.
+
+## Quick Overview
+
+Here is a quick list of what has been changed and how to update your application:
+
+### Creating an entity
+
+**Old Syntax**
+
+```
+const entityKey = Entity.create(
+  urlType,
+  'IMMUTABLE',
+  {src: urlValue},
+);
+```
+
+**New Syntax**
+
+```
+const contentStateWithEntity = contentState.createEntity(
+  urlType,
+  'IMMUTABLE',
+  {src: urlValue},
+);
+const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
+```
+
+### Getting an Entity
+
+**Old Syntax**
+
+```
+const entityInstance = Entity.get(entityKey);
+// entityKey is a string key associated with that entity when it was created
+```
+
+**New Syntax**
+
+```
+const entityInstance = contentState.getEntity(entityKey);
+// entityKey is a string key associated with that entity when it was created
+```
+
+### Decorator Strategy arguments change
+
+**Old Syntax**
+
+```
+const compositeDecorator = new CompositeDecorator([
+  {
+    strategy: (contentBlock, callback) => exampleFindTextRange(contentBlock, callback),
+    component: ExampleTokenComponent,
+  },
+]);
+```
+
+**New Syntax**
+
+```
+const compositeDecorator = new CompositeDecorator([
+  {
+    strategy: (
+      contentState,
+      contentBlock,
+      callback
+    ) => exampleFindTextRange(contentBlock, callback),
+    component: ExampleTokenComponent,
+  },
+]);
+```
+
+Note that ExampleTokenComponent will receive contentState as a prop.
+
+Why does the 'contentState' get passed into the decorator strategy now? Because we may need it if our strategy is to  find certain entities in the contentBlock:
+
+```
+const mutableEntityStrategy = function(contentBlock, callback, contentState) {
+  contentBlock.findEntityRanges(
+    (character) => {
+      const entityKey = character.getEntity();
+      if (entityKey === null) {
+        return false;
+      }
+      // To look for certain types of entities,
+      // or entities with a certain mutability,
+      // you may need to get the entity from contentState.
+      // In this example we get only mutable entities.
+      return contentState.getEntity(entityKey).getMutability() === 'MUTABLE';
+    },
+    callback,
+  );
+};
+```
+
+### Decorator Strategies that find Entities
+
+**Old Syntax**
+
+```
+function findLinkEntities(contentBlock, callback) {
+  contentBlock.findEntityRanges(
+    (character) => {
+      const entityKey = character.getEntity();
+      return (
+        entityKey !== null &&
+        Entity.get(entityKey).getType() === 'LINK'
+      );
+    },
+    callback,
+  );
+};
+```
+
+**New Syntax**
+
+```
+function findLinkEntities(contentState, contentBlock, callback) {
+  contentBlock.findEntityRanges(
+    (character) => {
+      const entityKey = character.getEntity();
+      return (
+        entityKey !== null &&
+        contentState.getEntity(entityKey).getType() === 'LINK'
+      );
+    },
+    callback,
+  );
+};
+```
+
+## More Information
+
+For more information see the [updated examples](https://github.com/facebook/draft-js/tree/master/examples/draft-0-10-0).
+

--- a/docs/APIReference-ContentState.md
+++ b/docs/APIReference-ContentState.md
@@ -41,6 +41,11 @@ objects.
 
 <ul class="apiIndex">
   <li>
+    <a href="#getentitymap">
+      <pre>getEntityMap()</pre>
+    </a>
+  </li>
+  <li>
     <a href="#getblockmap">
       <pre>getBlockMap()</pre>
     </a>
@@ -101,8 +106,43 @@ objects.
     </a>
   </li>
   <li>
+    <a href="#getlastcreatedentitykey">
+      <pre>getLastCreatedEntityKey()</pre>
+    </a>
+  </li>
+  <li>
     <a href="#hastext">
       <pre>hasText()</pre>
+    </a>
+  </li>
+  <li>
+    <a href="#createEntity">
+      <pre>createEntity(...)</pre>
+    </a>
+  </li>
+  <li>
+    <a href="#getEntity">
+      <pre>getEntity(...)</pre>
+    </a>
+  </li>
+  <li>
+    <a href="#mergeEntityData">
+      <pre>mergeEntityData(...)</pre>
+    </a>
+  </li>
+  <li>
+    <a href="#replaceEntityData">
+      <pre>replaceEntityData(...)</pre>
+    </a>
+  </li>
+  <li>
+    <a href="#addEntity">
+      <pre>addEntity(...)</pre>
+    </a>
+  </li>
+  <li>
+    <a href="#getEntity">
+      <pre>getEntity(...)</pre>
     </a>
   </li>
 </ul>
@@ -146,13 +186,30 @@ into `ContentBlock` objects. If no delimiter is provided, '`\n`' is used.
 ### createFromBlockArray
 
 ```
-static createFromBlockArray(blocks: Array<ContentBlock>): ContentState
+static createFromBlockArray(
+  blocks: Array<ContentBlock>,
+  entityMap: ?OrderedMap
+): ContentState
 ```
 Generates a `ContentState` from an array of `ContentBlock` objects. The default
 `selectionBefore` and `selectionAfter` states have the cursor at the start of
 the content.
 
 ## Methods
+
+### getBlockMap
+
+```
+getEntityMap(): EntityMap
+```
+_New in v0.10.0:_
+Returns an object store containing all `DraftEntity` records that have been
+created.  In upcoming v0.11.0 the map returned will be an Immutable ordered map
+of `DraftEntity` records.
+
+In most cases, you should be able to use the convenience methods below to target
+specific `DraftEntity` records or obtain information about the state of the
+content.
 
 ### getBlockMap
 
@@ -203,21 +260,21 @@ var selectedBlockType = editorState
   .getType();
 ```
 
-### getKeyBefore()
+### getKeyBefore
 
 ```
 getKeyBefore(key: string): ?string
 ```
 Returns the key before the specified key in `blockMap`, or null if this is the first key.
 
-### getKeyAfter()
+### getKeyAfter
 
 ```
 getKeyAfter(key: string): ?string
 ```
 Returns the key after the specified key in `blockMap`, or null if this is the last key.
 
-### getBlockBefore()
+### getBlockBefore
 
 ```
 getBlockBefore(key: string): ?ContentBlock
@@ -225,14 +282,14 @@ getBlockBefore(key: string): ?ContentBlock
 Returns the `ContentBlock` before the specified key in `blockMap`, or null if this is
 the first key.
 
-### getBlockAfter()
+### getBlockAfter
 
 ```
 getBlockAfter(key: string): ?ContentBlock
 ```
 Returns the `ContentBlock` after the specified key in `blockMap`, or null if this is the last key.
 
-### getBlocksAsArray()
+### getBlocksAsArray
 
 ```
 getBlocksAsArray(): Array<ContentBlock>
@@ -241,21 +298,21 @@ Returns the values of `blockMap` as an array.
 
 You generally won't need to use this method, since `getBlockMap` provides an `OrderedMap` that you should use for iteration.
 
-### getFirstBlock()
+### getFirstBlock
 
 ```
 getFirstBlock(): ContentBlock
 ```
 Returns the first `ContentBlock`.
 
-### getLastBlock()
+### getLastBlock
 
 ```
 getLastBlock(): ContentBlock
 ```
 Returns the last `ContentBlock`.
 
-### getPlainText()
+### getPlainText
 
 ```
 getPlainText(delimiter?: string): string
@@ -263,12 +320,78 @@ getPlainText(delimiter?: string): string
 Returns the full plaintext value of the contents, joined with a delimiter. If no
 delimiter is specified, the line feed character (`\u000A`) is used.
 
-### hasText()
+### getLastCreatedEntityKey
+
+```
+getLastCreatedEntityKey(): string
+```
+Returns the string key that can be used to reference the most recently created
+`DraftEntity` record. This is because entities are referenced by their string
+key in ContentState. The string value should be used within CharacterMetadata
+objects to track the entity for annotated characters.
+
+### hasText
 
 ```
 hasText(): boolean
 ```
 Returns whether the contents contain any text at all.
+
+### createEntity
+
+```
+createEntity(
+  type: DraftEntityType,
+  mutability: DraftEntityMutability,
+  data?: Object
+): ContentState
+```
+Returns new `ContentState` record updated to include the newly created
+DraftEntity record in it's `EntityMap`. Call `getLastCreatedEntityKey` to get
+the key of the newly created `DraftEntity` record.
+
+### getEntity
+
+```
+getEntity(key: string): DraftEntityInstance
+```
+Returns the DraftEntityInstance for the specified key. Throws if no instance exists for that key.
+
+### mergeEntityData
+
+```
+mergeEntityData(
+  key: string,
+  toMerge: {[key: string]: any}
+): ContentState
+```
+Since DraftEntityInstance objects are immutable, you cannot update an entity's
+metadata through typical mutative means.
+
+The mergeData method allows you to apply updates to the specified entity.
+
+### replaceEntityData
+
+```
+replaceEntityData(
+  key: string,
+  newData: {[key: string]: any}
+): ContentState
+```
+The replaceData method is similar to the mergeData method, except it will totally discard the existing data value for the instance and replace it with the specified newData.
+
+### addEntity
+
+```
+addEntity(instance: DraftEntityInstance): ContentState
+```
+In most cases, you will use contentState.createEntity(). This is a convenience
+method that you probably will not need in typical Draft usage.
+
+The add function is useful in cases where the instances have already been
+created, and now need to be added to the Entity store. This may occur in cases
+where a vanilla JavaScript representation of a ContentState is being revived for
+editing.
 
 ## Properties
 

--- a/docs/APIReference-ContentState.md
+++ b/docs/APIReference-ContentState.md
@@ -202,7 +202,6 @@ the content.
 ```
 getEntityMap(): EntityMap
 ```
-_New in v0.10.0:_
 Returns an object store containing all `DraftEntity` records that have been
 created.  In upcoming v0.11.0 the map returned will be an Immutable ordered map
 of `DraftEntity` records.

--- a/docs/APIReference-Data-Conversion.md
+++ b/docs/APIReference-Data-Conversion.md
@@ -54,11 +54,18 @@ const sampleMarkup =
   '<a href="http://www.facebook.com">Example link</a>';
 
 const blocksFromHTML = convertFromHTML(sampleMarkup);
-const state = ContentState.createFromBlockArray(blocksFromHTML);
+const state = ContentState.createFromBlockArray(
+  blocksFromHTML.contentBlocks,
+  blocksFromHTML.entityMap
+);
 
 this.state = {
   editorState: EditorState.createWithContent(state),
 };
 ```
 
-Given an HTML fragment, convert it to an array of `ContentBlock` objects. Construct content state from the array of block elements and then update the editor state with it. Full example available [here](https://github.com/facebook/draft-js/tree/master/examples/draft-0-9-1/convertFromHTML).
+Given an HTML fragment, convert it to an object with two keys; one holding the
+array of `ContentBlock` objects, and the other holding a reference to the
+entityMap. Construct content state from the array of block elements and the
+entityMap, and then update the editor state with it. Full example available
+[here](https://github.com/facebook/draft-js/tree/master/examples/draft-0-10-1/convertFromHTML).

--- a/docs/APIReference-Editor.md
+++ b/docs/APIReference-Editor.md
@@ -39,7 +39,7 @@ placeholder?: string
 Optional placeholder string to display when the editor is empty.
 
 Note: You can use CSS to style or hide your placeholder as needed. For instance,
-in the [rich editor example](https://github.com/facebook/draft-js/tree/master/examples/draft-0-9-1/rich),
+in the [rich editor example](https://github.com/facebook/draft-js/tree/master/examples/draft-0-10-1/rich),
 the placeholder is hidden when the user changes block styling in an empty editor.
 This is because the placeholder may not line up with the cursor when the style
 is changed.
@@ -176,7 +176,7 @@ and to convert typed emoticons into images.
 ```
 handlePastedText?: (text: string, html?: string) => DraftHandleValue
 ```
-Handle text and html(for rich text) that has been pasted directly into the editor. Returning true will prevent the default paste behavior. 
+Handle text and html(for rich text) that has been pasted directly into the editor. Returning true will prevent the default paste behavior.
 
 #### handlePastedFiles
 ```

--- a/docs/APIReference-Entity.md
+++ b/docs/APIReference-Entity.md
@@ -15,6 +15,10 @@ This article is dedicated to covering the details of the API. See the
 [advanced topics article on entities](/draft-js/docs/advanced-topics-entities.html)
 for more detail on how entities may be used.
 
+Please note that the API for entity storage and management has changed recently;
+for details on updating your application
+[see our v0.10 API Migration Guide](http://localhost:8080/draft-js/docs/v0-10-api-migration.html#content).
+
 Entity objects returned by `Entity` methods are represented as
 [DraftEntityInstance](https://github.com/facebook/draft-js/blob/master/src/model/entity/DraftEntityInstance.js) immutable records. These have a simple set of getter functions and should
 be used only for retrieval.

--- a/docs/Advanced-Topics-Block-Components.md
+++ b/docs/Advanced-Topics-Block-Components.md
@@ -16,12 +16,12 @@ Facebook photos or by uploading new images from the desktop. To that end,
 the Draft framework supports custom rendering at the block level, to render
 content like rich media in place of plain text.
 
-The [TeX editor](https://github.com/facebook/draft-js/tree/master/examples/draft-0-9-1/tex)
+The [TeX editor](https://github.com/facebook/draft-js/tree/master/examples/draft-0-10-1/tex)
 in the Draft repository provides a live example of custom block rendering, with
 TeX syntax translated on the fly into editable embedded formula rendering via the
 [KaTeX library](https://khan.github.io/KaTeX/).
 
-A [media example](https://github.com/facebook/draft-js/tree/master/examples/draft-0-9-1/media) is also
+A [media example](https://github.com/facebook/draft-js/tree/master/examples/draft-0-10-1/media) is also
 available, which showcases custom block rendering of audio, image, and video.
 
 By using a custom block renderer, it is possible to introduce complex rich
@@ -90,21 +90,20 @@ then retrieve the metadata for that key in your custom component `render()`
 code.
 
 ```js
-import {Entity} from 'draft-js';
 class MediaComponent extends React.Component {
   render() {
-    const {block} = this.props;
+    const {block, contentState} = this.props;
     const {foo} = this.props.blockProps;
-    const data = Entity.get(block.getEntityAt(0)).getData();
+    const data = contentState.getEntity(block.getEntityAt(0)).getData();
     // Return a <figure> or some other content using this data.
   }
 }
 ```
 
-The `ContentBlock` object is made available within the custom component, along
-with the props defined at the top level. By extracting entity information from
-the `ContentBlock` and the `Entity` map, you can obtain the metadata required to
-render your custom component.
+The `ContentBlock` object and the `ContentState` record are made available
+within the custom component, along with the props defined at the top level. By
+extracting entity information from the `ContentBlock` and the `Entity` map, you
+can obtain the metadata required to render your custom component.
 
 _Retrieving the entity from the block is admittedly a bit of an awkward API,
 and is worth revisiting._

--- a/docs/Advanced-Topics-Decorators.md
+++ b/docs/Advanced-Topics-Decorators.md
@@ -12,7 +12,7 @@ want to add to our editor. The Facebook comment input, for example, provides
 blue background highlights for mentions and hashtags.
 
 To support flexibility for custom rich text, Draft provides a "decorator"
-system. The [tweet example](https://github.com/facebook/draft-js/tree/master/examples/draft-0-9-1/tweet)
+system. The [tweet example](https://github.com/facebook/draft-js/tree/master/examples/draft-0-10-1/tweet)
 offers a live example of decorators in action.
 
 ## CompositeDecorator
@@ -64,11 +64,11 @@ matches, then for hashtag matches.
 const HANDLE_REGEX = /\@[\w]+/g;
 const HASHTAG_REGEX = /\#[\w\u0590-\u05ff]+/g;
 
-function handleStrategy(contentBlock, callback) {
+function handleStrategy(contentState, contentBlock, callback) {
   findWithRegex(HANDLE_REGEX, contentBlock, callback);
 }
 
-function hashtagStrategy(contentBlock, callback) {
+function hashtagStrategy(contentState, contentBlock, callback) {
   findWithRegex(HASHTAG_REGEX, contentBlock, callback);
 }
 
@@ -109,7 +109,7 @@ Note that `props.children` is passed through to the rendered output. This is
 done to ensure that the text is rendered within the decorated `span`.
 
 You can use the same approach for links, as demonstrated in our
-[link example](https://github.com/facebook/draft-js/tree/master/examples/draft-0-9-1/link).
+[link example](https://github.com/facebook/draft-js/tree/master/examples/draft-0-10-1/link).
 
 ### Beyond CompositeDecorator
 

--- a/docs/Advanced-Topics-Entities.md
+++ b/docs/Advanced-Topics-Entities.md
@@ -3,7 +3,7 @@ id: advanced-topics-entities
 title: Entities
 layout: docs
 category: Advanced Topics
-next: advanced-topics-decorators
+next: v0-10-api-migration
 permalink: docs/advanced-topics-entities.html
 ---
 
@@ -22,6 +22,10 @@ as their built-in behavior.
 The [Entity API Reference](/draft-js/docs/api-reference-entity.html) provides
 details on the static methods to be used when creating, retrieving, or updating
 entity objects.
+
+For information about recent changes to the Entity API, and examples of how to
+update your application,
+[see our v0.10 API Migration Guide](http://localhost:8080/draft-js/docs/v0-10-api-migration.html#content).
 
 ## Introduction
 

--- a/docs/Advanced-Topics-Entities.md
+++ b/docs/Advanced-Topics-Entities.md
@@ -38,10 +38,12 @@ greater detail below.
 a `'LINK'` entity might contain a `data` object that contains the `href` value
 for that link.
 
-All entities are stored in a single object store within the `Entity` module,
-and are referenced by key within `ContentState` and React components used to
-decorate annotated ranges. _(We are considering future changes to bring
-the entity store into `EditorState` or `ContentState`.)_
+All entities are stored in the ContentState record. The entites  are referenced
+by key within `ContentState` and React components used to decorate annotated
+ranges. (We are currently deprecating a previous API for accessing Entities; see
+issue
+[#839](https://github.com/facebook/draft-js/issues/839)
+.)
 
 Using [decorators](/draft-js/docs/advanced-topics-decorators.html) or
 [custom block components](/draft-js/docs/advanced-topics-block-components.html), you can
@@ -49,15 +51,21 @@ add rich rendering to your editor based on entity metadata.
 
 ## Creating and Retrieving Entities
 
-Entities should be created using `Entity.create`, which accepts the three
-properties above as arguments. This method returns a string key, which can then
-be used to refer to the entity.
+Entities should be created using `contentState.createEntity`, which accepts the
+three properties above as arguments. This method returns a string key, which can
+then be used to refer to the entity.
 
 This key is the value that should be used when applying entities to your
 content. For instance, the `Modifier` module contains an `applyEntity` method:
 
 ```js
-const key = Entity.create('LINK', 'MUTABLE', {href: 'http://www.zombo.com'});
+const contentState = editorState.getCurrentContent();
+const contentStateWithEntity = constentState.createEntity(
+  'LINK',
+  'MUTABLE',
+  {href: 'http://www.zombo.com'}
+);
+const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
 const contentStateWithLink = Modifier.applyEntity(
   contentState,
   selectionState,
@@ -72,7 +80,8 @@ offset value.
 ```js
 const blockWithLinkAtBeginning = contentState.getBlockForKey('...');
 const linkKey = blockWithLinkAtBeginning.getEntityAt(0);
-const linkInstance = Entity.get(linkKey);
+const contentState = editorState.getCurrentContent();
+const linkInstance = contentState.getEntity(linkKey);
 const {href} = linkInstance.getData();
 ```
 ## "Mutability"

--- a/docs/Advanced-Topics-Inline-Styles.md
+++ b/docs/Advanced-Topics-Inline-Styles.md
@@ -12,8 +12,8 @@ behavior that goes well beyond the bold/italic/underline basics. For instance,
 you may want to support variety with color, font families, font sizes, and more.
 Further, your desired styles may overlap or be mutually exclusive.
 
-The [Rich Editor](http://github.com/facebook/draft-js/tree/master/examples/draft-0-9-1/rich) and
-[Colorful Editor](http://github.com/facebook/draft-js/tree/master/examples/draft-0-9-1/color)
+The [Rich Editor](http://github.com/facebook/draft-js/tree/master/examples/draft-0-10-1/rich) and
+[Colorful Editor](http://github.com/facebook/draft-js/tree/master/examples/draft-0-10-1/color)
 examples demonstrate complex inline style behavior in action.
 
 ### Model
@@ -79,7 +79,7 @@ defaults, or you may override the default style objects for the basic styles.
 
 Within your `Editor` use case, you may provide the `customStyleMap` prop
 to define your style objects. (See
-[Colorful Editor](http://github.com/facebook/draft-js/tree/master/examples/draft-0-9-1/color)
+[Colorful Editor](http://github.com/facebook/draft-js/tree/master/examples/draft-0-10-1/color)
 for a live example.)
 
 For example, you may want to add a `'STRIKETHROUGH'` style. To do so, define a

--- a/docs/Advanced-Topics-Managing-Focus.md
+++ b/docs/Advanced-Topics-Managing-Focus.md
@@ -36,5 +36,5 @@ of the click event. It is therefore recommended that you use a click listener
 on your container component, and use the `focus()` method described above to
 apply focus to your editor.
 
-The [plaintext editor example](https://github.com/facebook/draft-js/tree/master/examples/draft-0-9-1/plaintext),
+The [plaintext editor example](https://github.com/facebook/draft-js/tree/master/examples/draft-0-10-1/plaintext),
 for instance, uses this pattern.

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -23,9 +23,13 @@ Currently Draft.js is distributed via npm. It depends on React and React DOM whi
 npm install --save draft-js react react-dom
 ```
 
-### API Notice
+### API Changes Notice
 
-Before getting started, please be aware that we are changing the API of Entity storage in Draft. Currently, the master branch supports both the old and new API. We hope to release this soon, as `v0.10.0`. Following that up will be `v0.11.0` which will remove the old API. This update will also include documentation on how to upgrade. If you are interested in helping out, or tracking the progress, please follow  [issue 839](https://github.com/facebook/draft-js/issues/839).
+Before getting started, please be aware that we recently changed the API of
+Entity storage in Draft. The latest version, `v0.10.0`, supports both the old
+and new API.  Following that up will be `v0.11.0` which will remove the old API.
+If you are interested in helping out, or tracking the progress, please follow
+[issue 839](https://github.com/facebook/draft-js/issues/839).
 
 ### Usage
 

--- a/docs/QuickStart-API-Basics.md
+++ b/docs/QuickStart-API-Basics.md
@@ -8,7 +8,7 @@ permalink: docs/quickstart-api-basics.html
 ---
 
 This document provides an overview of the basics of the `Draft` API. A
-[working example](https://github.com/facebook/draft-js/tree/master/examples/draft-0-9-1/plaintext)
+[working example](https://github.com/facebook/draft-js/tree/master/examples/draft-0-10-1/plaintext)
 is also available to follow along.
 
 ## Controlled Inputs

--- a/docs/QuickStart-Rich-Styling.md
+++ b/docs/QuickStart-Rich-Styling.md
@@ -10,7 +10,7 @@ permalink: docs/quickstart-rich-styling.html
 Now that we have established the basics of the top-level API, we can go a step
 further and examine how basic rich styling can be added to a `Draft` editor.
 
-A [rich text example](https://github.com/facebook/draft-js/tree/master/examples/draft-0-9-1/rich)
+A [rich text example](https://github.com/facebook/draft-js/tree/master/examples/draft-0-10-1/rich)
 is also available to follow along.
 
 ## EditorState: Yours to Command


### PR DESCRIPTION
I haven't proof-read this yet, so reviews are very welcome.

Planning to merge this immediately after releasing 0.10.0, so within the next 24 hours or so. This updates all the documentation to use the new v0.10 syntax for Entity management, and points example links to the v0.10 examples.

It also adds an API Upgrade guide, under 'Advanced Topics'. I'd really love feedback on that, and improvements are welcome even after we land this! 🌱 

Thanks to everyone who has other documentation PRs open, and to everyone who has been patient while we test and prepare v0.10.