### PR TITLE
Add onLeftArrow and onRightArrow props

### DIFF
--- a/docs/APIReference-Editor.md
+++ b/docs/APIReference-Editor.md
@@ -226,7 +226,6 @@ onUpArrow?: (e: SyntheticKeyboardEvent) => void
 onRightArrow?: (e: SyntheticKeyboardEvent) => DraftHandleValue
 ```
 
-
 #### onDownArrow
 ```
 onDownArrow?: (e: SyntheticKeyboardEvent) => void

--- a/docs/APIReference-Editor.md
+++ b/docs/APIReference-Editor.md
@@ -211,10 +211,21 @@ onEscape?: (e: SyntheticKeyboardEvent) => void
 onTab?: (e: SyntheticKeyboardEvent) => void
 ```
 
+#### onLeftArrow
+```
+onLeftArrow?: (e: SyntheticKeyboardEvent) => DraftHandleValue
+```
+
 #### onUpArrow
 ```
 onUpArrow?: (e: SyntheticKeyboardEvent) => void
 ```
+
+#### onRightArrow
+```
+onRightArrow?: (e: SyntheticKeyboardEvent) => DraftHandleValue
+```
+
 
 #### onDownArrow
 ```

--- a/src/component/base/DraftEditorProps.js
+++ b/src/component/base/DraftEditorProps.js
@@ -123,7 +123,9 @@ export type DraftEditorProps = {
    */
   onEscape?: (e: SyntheticKeyboardEvent) => void,
   onTab?: (e: SyntheticKeyboardEvent) => void,
+  onLeftArrow?: (e: SyntheticKeyboardEvent) => DraftHandleValue,
   onUpArrow?: (e: SyntheticKeyboardEvent) => void,
+  onRightArrow?: (e: SyntheticKeyboardEvent) => DraftHandleValue,
   onDownArrow?: (e: SyntheticKeyboardEvent) => void,
 
   onBlur?: (e: SyntheticEvent) => void,

--- a/src/component/handlers/edit/editOnKeyDown.js
+++ b/src/component/handlers/edit/editOnKeyDown.js
@@ -106,9 +106,25 @@ function editOnKeyDown(editor: DraftEditor, e: SyntheticKeyboardEvent): void {
     case Keys.TAB:
       editor.props.onTab && editor.props.onTab(e);
       return;
+    case Keys.LEFT:
+      if (
+        editor.props.onLeftArrow && 
+        isEventHandled(editor.props.onLeftArrow(e))
+      ) {
+        return;
+      }
+      break;
     case Keys.UP:
       editor.props.onUpArrow && editor.props.onUpArrow(e);
       return;
+    case Keys.RIGHT:
+      if (
+        editor.props.onRightArrow && 
+        isEventHandled(editor.props.onRightArrow(e))
+      ) {
+        return;
+      }
+      break;
     case Keys.DOWN:
       editor.props.onDownArrow && editor.props.onDownArrow(e);
       return;

--- a/src/component/handlers/edit/editOnKeyDown.js
+++ b/src/component/handlers/edit/editOnKeyDown.js
@@ -108,7 +108,7 @@ function editOnKeyDown(editor: DraftEditor, e: SyntheticKeyboardEvent): void {
       return;
     case Keys.LEFT:
       if (
-        editor.props.onLeftArrow && 
+        editor.props.onLeftArrow &&
         isEventHandled(editor.props.onLeftArrow(e))
       ) {
         return;
@@ -119,7 +119,7 @@ function editOnKeyDown(editor: DraftEditor, e: SyntheticKeyboardEvent): void {
       return;
     case Keys.RIGHT:
       if (
-        editor.props.onRightArrow && 
+        editor.props.onRightArrow &&
         isEventHandled(editor.props.onRightArrow(e))
       ) {
         return;


### PR DESCRIPTION
**Summary**

While implementing some custom selection logic, I found it somewhat unintuitive that `onUpArrow` and `onDownArrow` are exposed as props, but `onLeftArrow` and `onRightArrow` are not.

Given the added complexity due to [the workaround needed by firefox for handling CMD+LEFT/RIGHT](https://github.com/facebook/draft-js/blob/master/src/component/utils/getDefaultKeyBinding.js#L113-L124), it seems to me that it may make sense to have these handlers return `DraftHandleValue` (like `handleReturn`, etc) so that they can still fall through to `getDefaultKeyBinding`. 

Is this appropriate? If so, would these props be better named `handleLeftArrow` and `handleRightArrow`? Should any other `on*` props be refactored to use this logic?

**Test Plan**

As far as I can tell there are no existing tests for the modified files. Did I miss any? Should any be added?




⚠️  This is my first OSS PR, so I apologize in advance if I've missed any PR etiquette and such. Love draft-js and hope I'm able to help contribute to it 😄

Thanks for taking the time to check out this PR!