### PR TITLE
Add documentation page title to header data

### DIFF
--- a/website/core/Site.js
+++ b/website/core/Site.js
@@ -15,12 +15,13 @@ var HeaderLinks = require('HeaderLinks');
 
 var Site = React.createClass({
   render: function() {
+    const titlePrefix = this.props.pageTitle ? this.props.pageTitle.concat(' | ') : '';
     return (
       <html>
         <head>
           <meta charSet="utf-8" />
           <meta httpEquiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-          <title>Draft.js | Rich Text Editor Framework for React</title>
+          <title>{`${titlePrefix}Draft.js | Rich Text Editor Framework for React`}</title>
           <meta name="viewport" content="width=device-width" />
           <meta property="og:title" content="Draft.js | Rich Text Editor Framework for React" />
           <meta property="og:type" content="website" />

--- a/website/layout/DocsLayout.js
+++ b/website/layout/DocsLayout.js
@@ -19,7 +19,7 @@ var DocsLayout = React.createClass({
     var metadata = this.props.metadata;
     var content = this.props.children;
     return (
-      <Site section="docs">
+      <Site section="docs" pageTitle={metadata.title}>
         <section className="content wrap documentationContent">
           <DocsSidebar metadata={metadata} />
           <div className="inner-content">


### PR DESCRIPTION
Adds documentation page title as a prefix to `<title>` tag in site header as proposed in https://github.com/facebook/draft-js/issues/965. For example, "Custom Block Components | Draft.js | Rich Text Editor Framework for React" would be the title for the "Custom Block Components" page.

Implements `pageTitle` prop on the `Site` component to accomplish this. If `titlePrefix` is not available, it will fall back to "Draft.js | Rich Text Editor Framework for React".