### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/Advanced-Topics-Entities.md
+++ b/docs/Advanced-Topics-Entities.md
@@ -64,7 +64,7 @@ content. For instance, the `Modifier` module contains an `applyEntity` method:
 
 ```js
 const contentState = editorState.getCurrentContent();
-const contentStateWithEntity = constentState.createEntity(
+const contentStateWithEntity = contentState.createEntity(
   'LINK',
   'MUTABLE',
   {href: 'http://www.zombo.com'}


### PR DESCRIPTION
**Summary**
Fix runtime error in the example code caused by typo.

**Test Plan**
No functional changes.
