### PR TITLE
documentation: fix links to the examples

### DIFF
--- a/docs/APIReference-Data-Conversion.md
+++ b/docs/APIReference-Data-Conversion.md
@@ -68,4 +68,4 @@ Given an HTML fragment, convert it to an object with two keys; one holding the
 array of `ContentBlock` objects, and the other holding a reference to the
 entityMap. Construct content state from the array of block elements and the
 entityMap, and then update the editor state with it. Full example available
-[here](https://github.com/facebook/draft-js/tree/master/examples/draft-0-10-1/convertFromHTML).
+[here](https://github.com/facebook/draft-js/tree/master/examples/draft-0-10-0/convertFromHTML).

--- a/docs/APIReference-Editor.md
+++ b/docs/APIReference-Editor.md
@@ -39,7 +39,7 @@ placeholder?: string
 Optional placeholder string to display when the editor is empty.
 
 Note: You can use CSS to style or hide your placeholder as needed. For instance,
-in the [rich editor example](https://github.com/facebook/draft-js/tree/master/examples/draft-0-10-1/rich),
+in the [rich editor example](https://github.com/facebook/draft-js/tree/master/examples/draft-0-10-0/rich),
 the placeholder is hidden when the user changes block styling in an empty editor.
 This is because the placeholder may not line up with the cursor when the style
 is changed.

--- a/docs/Advanced-Topics-Block-Components.md
+++ b/docs/Advanced-Topics-Block-Components.md
@@ -16,12 +16,12 @@ Facebook photos or by uploading new images from the desktop. To that end,
 the Draft framework supports custom rendering at the block level, to render
 content like rich media in place of plain text.
 
-The [TeX editor](https://github.com/facebook/draft-js/tree/master/examples/draft-0-10-1/tex)
+The [TeX editor](https://github.com/facebook/draft-js/tree/master/examples/draft-0-10-0/tex)
 in the Draft repository provides a live example of custom block rendering, with
 TeX syntax translated on the fly into editable embedded formula rendering via the
 [KaTeX library](https://khan.github.io/KaTeX/).
 
-A [media example](https://github.com/facebook/draft-js/tree/master/examples/draft-0-10-1/media) is also
+A [media example](https://github.com/facebook/draft-js/tree/master/examples/draft-0-10-0/media) is also
 available, which showcases custom block rendering of audio, image, and video.
 
 By using a custom block renderer, it is possible to introduce complex rich

--- a/docs/Advanced-Topics-Decorators.md
+++ b/docs/Advanced-Topics-Decorators.md
@@ -109,7 +109,7 @@ Note that `props.children` is passed through to the rendered output. This is
 done to ensure that the text is rendered within the decorated `span`.
 
 You can use the same approach for links, as demonstrated in our
-[link example](https://github.com/facebook/draft-js/tree/master/examples/draft-0-10-1/link).
+[link example](https://github.com/facebook/draft-js/tree/master/examples/draft-0-10-0/link).
 
 ### Beyond CompositeDecorator
 

--- a/docs/Advanced-Topics-Inline-Styles.md
+++ b/docs/Advanced-Topics-Inline-Styles.md
@@ -12,8 +12,8 @@ behavior that goes well beyond the bold/italic/underline basics. For instance,
 you may want to support variety with color, font families, font sizes, and more.
 Further, your desired styles may overlap or be mutually exclusive.
 
-The [Rich Editor](http://github.com/facebook/draft-js/tree/master/examples/draft-0-10-1/rich) and
-[Colorful Editor](http://github.com/facebook/draft-js/tree/master/examples/draft-0-10-1/color)
+The [Rich Editor](http://github.com/facebook/draft-js/tree/master/examples/draft-0-10-0/rich) and
+[Colorful Editor](http://github.com/facebook/draft-js/tree/master/examples/draft-0-10-0/color)
 examples demonstrate complex inline style behavior in action.
 
 ### Model
@@ -79,7 +79,7 @@ defaults, or you may override the default style objects for the basic styles.
 
 Within your `Editor` use case, you may provide the `customStyleMap` prop
 to define your style objects. (See
-[Colorful Editor](http://github.com/facebook/draft-js/tree/master/examples/draft-0-10-1/color)
+[Colorful Editor](http://github.com/facebook/draft-js/tree/master/examples/draft-0-10-0/color)
 for a live example.)
 
 For example, you may want to add a `'STRIKETHROUGH'` style. To do so, define a

--- a/docs/Advanced-Topics-Managing-Focus.md
+++ b/docs/Advanced-Topics-Managing-Focus.md
@@ -36,5 +36,5 @@ of the click event. It is therefore recommended that you use a click listener
 on your container component, and use the `focus()` method described above to
 apply focus to your editor.
 
-The [plaintext editor example](https://github.com/facebook/draft-js/tree/master/examples/draft-0-10-1/plaintext),
+The [plaintext editor example](https://github.com/facebook/draft-js/tree/master/examples/draft-0-10-0/plaintext),
 for instance, uses this pattern.

--- a/docs/QuickStart-API-Basics.md
+++ b/docs/QuickStart-API-Basics.md
@@ -8,7 +8,7 @@ permalink: docs/quickstart-api-basics.html
 ---
 
 This document provides an overview of the basics of the `Draft` API. A
-[working example](https://github.com/facebook/draft-js/tree/master/examples/draft-0-10-1/plaintext)
+[working example](https://github.com/facebook/draft-js/tree/master/examples/draft-0-10-0/plaintext)
 is also available to follow along.
 
 ## Controlled Inputs

--- a/docs/QuickStart-Rich-Styling.md
+++ b/docs/QuickStart-Rich-Styling.md
@@ -10,7 +10,7 @@ permalink: docs/quickstart-rich-styling.html
 Now that we have established the basics of the top-level API, we can go a step
 further and examine how basic rich styling can be added to a `Draft` editor.
 
-A [rich text example](https://github.com/facebook/draft-js/tree/master/examples/draft-0-10-1/rich)
+A [rich text example](https://github.com/facebook/draft-js/tree/master/examples/draft-0-10-0/rich)
 is also available to follow along.
 
 ## EditorState: Yours to Command


### PR DESCRIPTION
fix version of the draft.js in the links to the examples in the documentation