### PR TITLE
Test that `getDecorations` is called with correct arguments

### DIFF
--- a/src/model/immutable/__tests__/EditorState-test.js
+++ b/src/model/immutable/__tests__/EditorState-test.js
@@ -299,6 +299,15 @@ describe('EditorState', () => {
       );
     });
 
+    it('must call decorator with correct argument types and order', () => {
+      var decorator = new Decorator();
+      var editorState = getDecoratedEditorState(decorator);
+      decorator.getDecorations.mock.calls.forEach((call) => {
+        expect(call[0] instanceof ContentBlock).toBe(true);
+        expect(call[1] instanceof ContentState).toBe(true);
+      });
+    });
+
     it('must correctly remove a decorator', () => {
       var decorator = new Decorator();
       var editorState = getDecoratedEditorState(decorator);

--- a/src/model/immutable/__tests__/EditorState-test.js
+++ b/src/model/immutable/__tests__/EditorState-test.js
@@ -301,7 +301,7 @@ describe('EditorState', () => {
 
     it('must call decorator with correct argument types and order', () => {
       var decorator = new Decorator();
-      var editorState = getDecoratedEditorState(decorator);
+      getDecoratedEditorState(decorator);
       decorator.getDecorations.mock.calls.forEach((call) => {
         expect(call[0] instanceof ContentBlock).toBe(true);
         expect(call[1] instanceof ContentState).toBe(true);


### PR DESCRIPTION
For issue https://github.com/facebook/draft-js/issues/873, adds test to `EditorState` to check that `getDecorations` is called with desired argument types and in the proper order.