### PR TITLE
Add H1 2017 Roadmap Update and '/meta' directory

### DIFF
--- a/meta/roadmaps/2017-h1.md
+++ b/meta/roadmaps/2017-h1.md
@@ -1,0 +1,51 @@
+# H1 2017 Roadmap Update
+
+**tldr:** Our first goal is to achieve stability by catching up on releases, bug fixes, issues, and PRs. Other work on Draft.js is helpful, but may not get prioritized until the project reaches stability goals.
+
+**Goal: project stability**
+
+* Stable, regular releases
+* Issues are triaged and closed regularly
+* PRs are responded to and closed regularly
+
+The Master Plan:
+
+**Phase 1:** 🔥 Fix
+**Phase 2:** 🔧  Refactor
+**Phase 3:** 💅  Polish
+
+More on each phase below;
+
+## Phase 1: Fixing the Problems
+
+### January - June 2017 Roadmap
+
+(NOTE: Imagine this as a timeline rather than an ordered list.)
+1. ~~Release 0.10.0~~ [v0.10.0 released](https://github.com/facebook/draft-js/releases/tag/v0.10.0)
+2. Release 0.11.0@next for beta testing by community
+3. Release any interim bug fixes as 0.10.1
+4. Release 0.11.0, fully deprecating DraftEntity module
+5. Start bi-weekly release cycle
+6. Increased focus on reducing open PR and issue count
+
+## Phase 2: Refactoring and Exploring
+
+After establishing a stable state for the Draft.js project, we look forward to exploring new features and approaches. Some possible examples:
+
+* Mobile browser support
+* Nested blocks and nested decorators, possibly using a tree block structure (https://github.com/facebook/draft-js/issues/143). This would be following up on the work started by SamyPesse and Mitermayer in https://github.com/facebook/draft-js/pull/388
+* Exploring collaborative editing as a possible feature
+* Improving copy/paste behavior
+
+## Phase 3: Improve All the Things
+
+Once we finish any significant refactors it's a safe time to focus on documentation, testing, and overall improvement of the codebase. Some possible examples:
+
+* Increasing test coverage
+* Improving documentation and writing tutorials
+* Adding increased linting and modernizing the codebase with codemods
+
+This could be when we consider a 1.0 release, if not sooner.
+
+Thanks to the community for all your support and feedback - we look forward to
+continuing to improve Draft.js.


### PR DESCRIPTION
This roadmap was reviewed by the core contributors during a weekly
meeting and represents our current ideas about project direction.

The roadmap will evolve over time, and we'll be adding weekly notes in
this 'meta' directory in order to provide more fresh and detailed
updates about project direction.

Why use the 'meta' directory instead of a 'blog' or 'wiki'?
- People following the repo can get notifications push to them when 'meta' is updated.
- Allows roadmap to be living, breathing document with updates as time goes by
- Allows collaboration/discussion from community
- We are taking weekly meeting notes anyway; let people know that we are meeting and making progress

Similar to the [Relay repository's 'meta' directory](https://github.com/facebook/relay/tree/master/meta).
Thanks to @wincent for advice about this.