### PR TITLE
Add default value for type in convertFromRawToDraftState

### DIFF
--- a/src/model/encoding/__tests__/convertFromRawToDraftState-test.js
+++ b/src/model/encoding/__tests__/convertFromRawToDraftState-test.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+ui_infra
+ */
+
+'use strict';
+
+jest.disableAutomock();
+
+const convertFromRawToDraftState = require('convertFromRawToDraftState');
+
+describe('convertFromRawToDraftState', () => {
+  it('must map falsey block types to default value of unstyled', () => {
+    const rawState = {
+      blocks: [
+        {text: 'AAAA'},
+        {text: 'BBBB', type: null},
+        {text: 'CCCC', type: undefined},
+      ],
+      entityMap: {},
+    };
+
+    const contentState = convertFromRawToDraftState(rawState);
+    const blockMap = contentState.getBlockMap();
+    blockMap.forEach(block => expect(block.type).toEqual('unstyled'));
+  });
+});

--- a/src/model/encoding/convertFromRawToDraftState.js
+++ b/src/model/encoding/convertFromRawToDraftState.js
@@ -55,6 +55,7 @@ function convertFromRawToDraftState(
         data,
       } = block;
       key = key || generateRandomKey();
+      type = type || 'unstyled';
       depth = depth || 0;
       inlineStyleRanges = inlineStyleRanges || [];
       entityRanges = entityRanges || [];


### PR DESCRIPTION

**Summary**

In instances where type is undefined or null, this would be used as type due to the way type is destructured from each `block` in `contentBlocks`. This commit adds to a default value which ensure any falsey is changed to `unstyled` ensure the returned ContentBlock always has a valid DraftBlockType as its type. A similar approach in this file exists for all other values that are extracted from each block.

**Test Plan**

- As this change is within `model` the test plan is to use a unit test to validate the behavior that is expected after the change.
- Running the test without the change shows that this behavior was not present prior.
