### PR TITLE
Fix autocomplete behavior for Android chrome.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /website/src/draft-js/lib/
 /website/src/draft-js/docs/
 npm-debug.log
+.idea/

--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -42,6 +42,7 @@ const RESOLVE_DELAY = 20;
 let resolved = false;
 let stillComposing = false;
 let textInputData = '';
+let formerTextInputData = '';
 
 var DraftEditorCompositionHandler = {
   onBeforeInput: function(editor: DraftEditor, e: SyntheticInputEvent): void {
@@ -52,7 +53,8 @@ var DraftEditorCompositionHandler = {
    * A `compositionstart` event has fired while we're still in composition
    * mode. Continue the current composition session to prevent a re-render.
    */
-  onCompositionStart: function(editor: DraftEditor): void {
+  onCompositionStart: function(editor: DraftEditor, e: SyntheticInputEvent): void {
+    formerTextInputData = e.data;
     stillComposing = true;
   },
 
@@ -136,6 +138,9 @@ var DraftEditorCompositionHandler = {
     const composedChars = textInputData;
     textInputData = '';
 
+    const formerComposedChars = formerTextInputData;
+    formerTextInputData = '';
+
     const editorState = EditorState.set(editor._latestEditorState, {
       inCompositionMode: false,
     });
@@ -159,12 +164,28 @@ var DraftEditorCompositionHandler = {
 
     editor.exitCurrentMode();
 
+    let contentState = editorState.getCurrentContent();
+    let selection = editorState.getSelection();
+    if (formerComposedChars && selection.isCollapsed()) {
+      let anchorOffset = selection.getAnchorOffset() - formerComposedChars.length;
+      if (anchorOffset < 0) {
+        anchorOffset = 0;
+      }
+      const toRemoveSel = selection.merge({anchorOffset});
+      contentState = DraftModifier.removeRange(
+        editorState.getCurrentContent(),
+        toRemoveSel,
+        'backward',
+      );
+      selection = contentState.getSelectionAfter();
+    }
+
     if (composedChars) {
       // If characters have been composed, re-rendering with the update
       // is sufficient to reset the editor.
-      const contentState = DraftModifier.replaceText(
-        editorState.getCurrentContent(),
-        editorState.getSelection(),
+      contentState = DraftModifier.replaceText(
+        contentState,
+        selection,
         composedChars,
         currentStyle,
         entityKey

--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -23,6 +23,7 @@ var nullthrows = require('nullthrows');
 import type DraftEditor from 'DraftEditor.react';
 
 var isGecko = UserAgent.isEngine('Gecko');
+var isAndroid = UserAgent.isPlatform('Android');
 
 var DOUBLE_NEWLINE = '\n\n';
 
@@ -47,7 +48,7 @@ function editOnInput(editor: DraftEditor): void {
   var domSelection = global.getSelection();
 
   var {anchorNode, isCollapsed} = domSelection;
-  if (anchorNode.nodeType !== Node.TEXT_NODE) {
+  if (anchorNode.nodeType !== Node.TEXT_NODE && anchorNode.nodeType !== Node.ELEMENT_NODE) {
     return;
   }
 
@@ -107,7 +108,7 @@ function editOnInput(editor: DraftEditor): void {
 
   var anchorOffset, focusOffset, startOffset, endOffset;
 
-  if (isGecko) {
+  if (isAndroid || isGecko) {
     // Firefox selection does not change while the context menu is open, so
     // we preserve the anchor and focus values of the DOM selection.
     anchorOffset = domSelection.anchorOffset;


### PR DESCRIPTION
This is essentially the same as https://github.com/facebook/draft-js/pull/175, which was closed due to inactivity. A couple minor adjustments were made to the original PR in order to have it fit with the latest version of Draft. 

This commit fixes some issues with autocomplete behavior on Android Chrome.

## Problem 1: Keyboard loses focus

Refers to #907 and repro steps are listed there. This PR addresses the problem listed there, albeit in a different way.

## Problem 2: Replacing a word with autocomplete is broken

Steps to repro:
1. Type a few words
1. Place cursor inside a word
1. Choose a different autocomplete word
1. The resulting composition is mangled.
