### PR TITLE
Small update keybinding docs.

### DIFF
--- a/docs/Advanced-Topics-Key-Bindings.md
+++ b/docs/Advanced-Topics-Key-Bindings.md
@@ -70,9 +70,8 @@ In our editor component, we can then make use of the command via the
 import {Editor} from 'draft-js';
 class MyEditor extends React.Component {
 
-    constructor(props) {
+  constructor(props) {
     super(props);
-
     this.handleKeyCommand = this.handleKeyCommand.bind(this);
   }
   // ...

--- a/docs/Advanced-Topics-Key-Bindings.md
+++ b/docs/Advanced-Topics-Key-Bindings.md
@@ -69,8 +69,14 @@ In our editor component, we can then make use of the command via the
 ```js
 import {Editor} from 'draft-js';
 class MyEditor extends React.Component {
-  // ...
 
+    constructor(props) {
+    super(props);
+
+    this.handleKeyCommand = this.handleKeyCommand.bind(this);
+  }
+  // ...
+  
   handleKeyCommand(command: string): DraftHandleValue {
     if (command === 'myeditor-save') {
       // Perform a request to save your contents, set
@@ -84,7 +90,7 @@ class MyEditor extends React.Component {
     return (
       <Editor
         editorState={this.state.editorState}
-        handleKeyCommand={this.handleKeyCommand.bind(this)}
+        handleKeyCommand={this.handleKeyCommand}
         keyBindingFn={myKeyBindingFn}
         ...
       />


### PR DESCRIPTION
**Summary**
Updated docs to show proper way to bind functions when using them inside render. By binding them in the constructor it prevents bind from getting called on each render.

Some more thoughts on proper binding:
https://daveceddia.com/avoid-bind-when-passing-props/

**Test Plan**
No Test Plan needed. Just updated docs.