### PR TITLE
Only include files in glob, not directory.

### DIFF
--- a/website/server/generate.js
+++ b/website/server/generate.js
@@ -22,7 +22,7 @@ server.noconvert = true;
 // requests.
 var queue = Promise.resolve();
 
-glob('src/**/*', function(er, files) {
+glob('src/**/*', {nodir: true}, function(er, files) {
   files.forEach(function(file) {
     var targetFile = file.replace(/^src/, 'build');
 


### PR DESCRIPTION
This should fix #1029. The glob pattern in `website/server/generate.js` was including directories when it really only cares about files.