### PR TITLE
Fix race condition in website builder script

### DIFF
--- a/website/server/convert.js
+++ b/website/server/convert.js
@@ -29,85 +29,82 @@ function backtickify(str) {
 function execute() {
   var MD_DIR = '../docs/';
 
-  glob('src/docs/*.*', function(er, files) {
-    files.forEach(function(file) {
-      try {
-        fs.unlinkSync(file);
-      } catch(e) {
-        /* seriously, unlink throws when the file doesn't exist :( */
-      }
-    });
+  glob.sync('src/docs/*.*').forEach(function(file) {
+    try {
+      fs.unlinkSync(file);
+    } catch(e) {
+      /* seriously, unlink throws when the file doesn't exist :( */
+    }
   });
 
   var metadatas = {
     files: [],
   };
 
-  glob(MD_DIR + '**/*.*', function (er, files) {
-    files.forEach(function(file) {
-      var extension = path.extname(file);
-      if (extension === '.md' || extension === '.markdown') {
-        var content = fs.readFileSync(file, {encoding: 'utf8'});
-        var metadata = {};
+  var files = glob.sync(MD_DIR + '**/*.*');
+  files.forEach(function(file) {
+    var extension = path.extname(file);
+    if (extension === '.md' || extension === '.markdown') {
+      var content = fs.readFileSync(file, {encoding: 'utf8'});
+      var metadata = {};
 
-        // Extract markdown metadata header
-        var both = splitHeader(content);
-        var lines = both.header.split(os.EOL);
-        for (var i = 0; i < lines.length - 1; ++i) {
-          var keyvalue = lines[i].split(':');
-          var key = keyvalue[0].trim();
-          var value = keyvalue.slice(1).join(':').trim();
-          // Handle the case where you have "Community #10"
-          try { value = JSON.parse(value); } catch(e) { }
-          metadata[key] = value;
-        }
-        metadatas.files.push(metadata);
+      // Extract markdown metadata header
+      var both = splitHeader(content);
+      var lines = both.header.split(os.EOL);
+      for (var i = 0; i < lines.length - 1; ++i) {
+        var keyvalue = lines[i].split(':');
+        var key = keyvalue[0].trim();
+        var value = keyvalue.slice(1).join(':').trim();
+        // Handle the case where you have "Community #10"
+        try { value = JSON.parse(value); } catch(e) { }
+        metadata[key] = value;
+      }
+      metadatas.files.push(metadata);
 
-        if (metadata.permalink.match(/^https?:/)) {
-          return;
-        }
-
-        // Create a dummy .js version that just calls the associated layout
-        var layout = metadata.layout[0].toUpperCase() + metadata.layout.substr(1) + 'Layout';
-
-        var content = (
-          '/**\n' +
-          ' * @generated\n' +
-          ' */\n' +
-          'var React = require("React");\n' +
-          'var Layout = require("' + layout + '");\n' +
-          'var content = ' + backtickify(both.content) + '\n' +
-          'var Post = React.createClass({\n' +
-          '  statics: {\n' +
-          '    content: content\n' +
-          '  },\n' +
-          '  render: function() {\n' +
-          '    return <Layout metadata={' + JSON.stringify(metadata) + '}>{content}</Layout>;\n' +
-          '  }\n' +
-          '});\n' +
-          'module.exports = Post;\n'
-        );
-
-        var targetFile = 'src/' + metadata.permalink.replace(/\.html$/, '.js');
-        mkdirp.sync(targetFile.replace(new RegExp('/[^/]*$'), ''));
-        fs.writeFileSync(targetFile, content);
+      if (metadata.permalink.match(/^https?:/)) {
+        return;
       }
 
-      if (extension === '.json') {
-        var content = fs.readFileSync(file, {encoding: 'utf8'});
-        metadatas[path.basename(file, '.json')] = JSON.parse(content);
-      }
-    });
+      // Create a dummy .js version that just calls the associated layout
+      var layout = metadata.layout[0].toUpperCase() + metadata.layout.substr(1) + 'Layout';
 
-    fs.writeFileSync(
-      'core/metadata.js',
-      '/**\n' +
-      ' * @generated\n' +
-      ' * @providesModule Metadata\n' +
-      ' */\n' +
-      'module.exports = ' + JSON.stringify(metadatas, null, 2) + ';'
-    );
+      var content = (
+        '/**\n' +
+        ' * @generated\n' +
+        ' */\n' +
+        'var React = require("React");\n' +
+        'var Layout = require("' + layout + '");\n' +
+        'var content = ' + backtickify(both.content) + '\n' +
+        'var Post = React.createClass({\n' +
+        '  statics: {\n' +
+        '    content: content\n' +
+        '  },\n' +
+        '  render: function() {\n' +
+        '    return <Layout metadata={' + JSON.stringify(metadata) + '}>{content}</Layout>;\n' +
+        '  }\n' +
+        '});\n' +
+        'module.exports = Post;\n'
+      );
+
+      var targetFile = 'src/' + metadata.permalink.replace(/\.html$/, '.js');
+      mkdirp.sync(targetFile.replace(new RegExp('/[^/]*$'), ''));
+      fs.writeFileSync(targetFile, content);
+    }
+
+    if (extension === '.json') {
+      var content = fs.readFileSync(file, {encoding: 'utf8'});
+      metadatas[path.basename(file, '.json')] = JSON.parse(content);
+    }
   });
+
+  fs.writeFileSync(
+    'core/metadata.js',
+    '/**\n' +
+    ' * @generated\n' +
+    ' * @providesModule Metadata\n' +
+    ' */\n' +
+    'module.exports = ' + JSON.stringify(metadatas, null, 2) + ';'
+  );
 
   fs.writeFileSync('src/lib/Draft.css', fs.readFileSync('../dist/Draft.css'));
   fs.writeFileSync('src/lib/Draft.js', fs.readFileSync('../dist/Draft.js'));


### PR DESCRIPTION
There was a race condition in the website generation script (`generate.js`). It calls `convert.js` to convert Markdown to JavaScript, and then immediately looks for the resulting JavaScript files. However, `convert.js` uses the async version of `glob()`. This means that the code in generate.js that looks for these files can execute **before** the conversion in convert.js finishes, resulting in no pages being built. When this happens on TravisCI, it deletes all the pages on the site, due to the `rm -Rf *` in `publish.sh`.

I've simply switched `convert.js` to use the synchronous version of `glob()` so that it's guaranteed to finish before the generation happens.

This diff looks large, but most of it is changing the indentation level as the code is no longer in a callback.

References #1029 