### PR TITLE
Initial fix for text insertion bugs in Android 5.1

### DIFF
--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -47,7 +47,10 @@ function editOnInput(editor: DraftEditor): void {
   var domSelection = global.getSelection();
 
   var {anchorNode, isCollapsed} = domSelection;
-  if (anchorNode.nodeType !== Node.TEXT_NODE) {
+
+  const isNotTextOrElementNode = anchorNode.nodeType !== Node.TEXT_NODE
+    && anchorNode.nodeType !== Node.ELEMENT_NODE;
+  if (isNotTextOrElementNode) {
     return;
   }
 


### PR DESCRIPTION
Related to issue #1011

There is a bug in Android 5.1 (not 5.0 oddly enough) that makes text
entry nearly unusable. It's documented in detail here -
https://github.com/facebook/draft-js/issues/1011

Logging everything shows that;
 - when we have a block with text and spaces, and start deleting the
   characters one by one, there is an 'onInput' for each deletion that
   updates the text.
 - when you delete the very last character, the 'anchorNode' of the
   domSelection has a type that is not a text node. So we skip updating
   at all, and that means the last character doesn't actually get
   properly deleted from editorState.
 - Then the next time something fully updates the editorState, that last
   character shows up again.

The root issue is that Android 5.1, when we tested it, was in
"composition" mode and the current handlers are not really built to
handle text deletion properly in composition mode.

We're looking forward to finding a more complete solution to the root
cause - for now this change improves the usability on mobile and doesn't
break anything.

*Before* submitting a pull request, please make sure the following is done...

1. Fork the repo and create your branch from `master`.
2. If you've added code that should be tested, add tests!
3. If you've changed APIs, update the documentation.
4. Ensure that:
  * The test suite passes (`npm test`)
  * Your code lints (`npm run lint`) and passes Flow (`npm run flow`)
  * You have followed the [testing guidelines](https://github.com/facebook/draft-js/wiki/Testing-for-Pull-Requests)
5. If you haven't already, complete the [CLA](https://code.facebook.com/cla).

Please use the simple form below as a guideline for describing your pull request.

Thanks for contributing to Draft.js!

-

**Summary**

[...]

**Test Plan**

[...]
