### PR TITLE
ignore onBlur if focus is shifting inside contentEditable

### DIFF
--- a/src/component/handlers/edit/editOnBlur.js
+++ b/src/component/handlers/edit/editOnBlur.js
@@ -14,6 +14,7 @@
 
 var EditorState = require('EditorState');
 var UserAgent = require('UserAgent');
+var ReactDOM = require('ReactDOM');
 
 var getActiveElement = require('getActiveElement');
 
@@ -22,6 +23,11 @@ import type DraftEditor from 'DraftEditor.react';
 var isWebKit = UserAgent.isEngine('WebKit');
 
 function editOnBlur(editor: DraftEditor, e: SyntheticEvent): void {
+    // only process onBlur if focus is shifting outside of the editor
+  if (e.relatedTarget && ReactDOM.findDOMNode(editor.refs.editorContainer).contains(e.relatedTarget)) {
+    return
+  }
+
   // Webkit has a bug in which blurring a contenteditable by clicking on
   // other active elements will trigger the `blur` event but will not remove
   // the DOM selection from the contenteditable. We therefore force the


### PR DESCRIPTION
**Summary**

In cases where custom atomic blocks contain elements like `<input>` or `<textarea>`, Draft processes the onBlur event fired when the user focuses the input element and wipes away the selection, setting hasFocus to false.

For my use case (and it seems like most others') it doesn't make a lot of sense for the editor to lose focus if an element inside the editor is actually focused. This PR corrects for this issue by only processing onBlur if the element gaining focus is outside the Editor container.

**Caveats**

I've been working with Draft for nearly 8 months now and have [made some contributions](https://github.com/facebook/draft-js/pull/613) but I still am a little bit wary of messing with `SelectionState` code. If this is an extraordinarily dumb suggestion that will corrupt the editorState/break all of Facebook/unleash the elder gods, I am quite sorry.

**Test Plan**

- under normal operating circumstances (no custom blocks), the editor focus/onBlur behavior should remain the same
- in the case where an `<input>` element inside the editor gains focus, the editor should not fire onChange events with `hasFocus: false`
- in the case where an `<input>` element inside the editor gains focus, the editor should not execute `global.getSelection().removeAllRanges()`