### PR TITLE
Ensure selection is always valid

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -21,6 +21,7 @@ const DraftEditorContents = require('DraftEditorContents.react');
 const DraftEditorDragHandler = require('DraftEditorDragHandler');
 const DraftEditorEditHandler = require('DraftEditorEditHandler');
 const DraftEditorPlaceholder = require('DraftEditorPlaceholder.react');
+const ContentBlock = require('ContentBlock');
 const EditorState = require('EditorState');
 const React = require('React');
 const ReactDOM = require('ReactDOM');
@@ -88,7 +89,7 @@ class DraftEditor extends React.Component {
   _placeholderAccessibilityID: string;
   _latestEditorState: EditorState;
   _renderNativeContent: boolean;
-  _updatedNativeInsertionBlock: boolean;
+  _updatedNativeInsertionBlock: null | ContentBlock;
 
   /**
    * Define proxies that can route events to the current handler.

--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -88,7 +88,7 @@ class DraftEditor extends React.Component {
   _placeholderAccessibilityID: string;
   _latestEditorState: EditorState;
   _renderNativeContent: boolean;
-  _waitingOnInput: boolean;
+  _updatedNativeInsertionBlock: boolean;
 
   /**
    * Define proxies that can route events to the current handler.

--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -87,7 +87,8 @@ class DraftEditor extends React.Component {
   _editorKey: string;
   _placeholderAccessibilityID: string;
   _latestEditorState: EditorState;
-  _pendingStateFromBeforeInput: void | EditorState;
+  _renderNativeContent: boolean;
+  _waitingOnInput: boolean;
 
   /**
    * Define proxies that can route events to the current handler.
@@ -422,7 +423,8 @@ class DraftEditor extends React.Component {
    * an `onChange` prop to receive state updates passed along from this
    * function.
    */
-  _update(editorState: EditorState): void {
+  _update(editorState: EditorState, renderNativeContent: boolean = false): void {
+    this._renderNativeContent = renderNativeContent;
     this._latestEditorState = editorState;
     this.props.onChange(editorState);
   }

--- a/src/component/handlers/edit/editOnBeforeInput.js
+++ b/src/component/handlers/edit/editOnBeforeInput.js
@@ -172,10 +172,22 @@ function editOnBeforeInput(editor: DraftEditor, e: SyntheticInputEvent): void {
     editor._waitingOnInput = true;
     editor.update(newEditorState, true);
 
-    if (isIE) {
-      setImmediate(() => {
-        editOnInput(editor);
-      });
+    var finalEditorState = editor._latestEditorState;
+    var finalContent = finalEditorState.getCurrentContent();
+    var finalNativelyRenderedContent = finalEditorState.getNativelyRenderedContent();
+
+    if (finalNativelyRenderedContent && finalNativelyRenderedContent === finalContent) {
+      if (isIE) {
+        setImmediate(() => {
+          editOnInput(editor);
+        });
+      }
+    } else {
+      // Outside callers (via the editor.onChange prop) have changed the editorState
+      // No longer allow native insertion.
+      e.preventDefault();
+      editor._waitingOnInput = false;
+      editor._renderNativeContent = false;
     }
   }
 }

--- a/src/component/handlers/edit/editOnBeforeInput.js
+++ b/src/component/handlers/edit/editOnBeforeInput.js
@@ -22,6 +22,7 @@ var isSelectionAtLeafStart = require('isSelectionAtLeafStart');
 var nullthrows = require('nullthrows');
 var setImmediate = require('setImmediate');
 var editOnInput = require('editOnInput');
+var editOnSelect = require('editOnSelect');
 
 import type DraftEditor from 'DraftEditor.react';
 import type {DraftInlineStyle} from 'DraftInlineStyle';
@@ -78,6 +79,11 @@ function replaceText(
  * occurs on the relevant text nodes.
  */
 function editOnBeforeInput(editor: DraftEditor, e: SyntheticInputEvent): void {
+
+  // React doesn't fire a selection event until mouseUp, so it's possible to click to change selection, hold the mouse
+  // down, and type a character without React registering it. Let's sync the selection manually now.
+  editOnSelect(editor);
+
   var chars = e.data;
 
   // In some cases (ex: IE ideographic space insertion) no character data
@@ -164,19 +170,22 @@ function editOnBeforeInput(editor: DraftEditor, e: SyntheticInputEvent): void {
       nativelyRenderedContent: newEditorState.getCurrentContent(),
     });
 
+    editor._updatedNativeInsertionBlock = editorState.getCurrentContent().getBlockForKey(
+      editorState.getSelection().getAnchorKey()
+    );
+
     // Allow the native insertion to occur and update our internal state
     // to match. If editor.update() does something like changing a typed
     // 'x' to 'abc' in an onChange() handler, we don't want our editOnInput()
     // logic to squash that change in favor of the typed 'x'. Set a flag to
     // ignore the next editOnInput() event in favor of what's in our internal state.
-    editor._waitingOnInput = true;
     editor.update(newEditorState, true);
 
-    var finalEditorState = editor._latestEditorState;
-    var finalContent = finalEditorState.getCurrentContent();
-    var finalNativelyRenderedContent = finalEditorState.getNativelyRenderedContent();
+    var editorStateAfterUpdate = editor._latestEditorState;
+    var contentStateAfterUpdate = editorStateAfterUpdate.getCurrentContent();
+    var expectedContentStateAfterUpdate = editorStateAfterUpdate.getNativelyRenderedContent();
 
-    if (finalNativelyRenderedContent && finalNativelyRenderedContent === finalContent) {
+    if (expectedContentStateAfterUpdate && expectedContentStateAfterUpdate === contentStateAfterUpdate) {
       if (isIE) {
         setImmediate(() => {
           editOnInput(editor);
@@ -186,7 +195,7 @@ function editOnBeforeInput(editor: DraftEditor, e: SyntheticInputEvent): void {
       // Outside callers (via the editor.onChange prop) have changed the editorState
       // No longer allow native insertion.
       e.preventDefault();
-      editor._waitingOnInput = false;
+      editor._updatedNativeInsertionBlock = null;
       editor._renderNativeContent = false;
     }
   }

--- a/src/component/handlers/edit/editOnBeforeInput.js
+++ b/src/component/handlers/edit/editOnBeforeInput.js
@@ -21,6 +21,7 @@ var getEntityKeyForSelection = require('getEntityKeyForSelection');
 var isSelectionAtLeafStart = require('isSelectionAtLeafStart');
 var nullthrows = require('nullthrows');
 var setImmediate = require('setImmediate');
+var editOnInput = require('editOnInput');
 
 import type DraftEditor from 'DraftEditor.react';
 import type {DraftInlineStyle} from 'DraftInlineStyle';
@@ -36,6 +37,7 @@ const isEventHandled = require('isEventHandled');
 var FF_QUICKFIND_CHAR = '\'';
 var FF_QUICKFIND_LINK_CHAR = '\/';
 var isFirefox = UserAgent.isBrowser('Firefox');
+var isIE = UserAgent.isBrowser('IE');
 
 function mustPreventDefaultForCharacter(character: string): boolean {
   return (
@@ -76,11 +78,6 @@ function replaceText(
  * occurs on the relevant text nodes.
  */
 function editOnBeforeInput(editor: DraftEditor, e: SyntheticInputEvent): void {
-  if (editor._pendingStateFromBeforeInput !== undefined) {
-    editor.update(editor._pendingStateFromBeforeInput);
-    editor._pendingStateFromBeforeInput = undefined;
-  }
-
   var chars = e.data;
 
   // In some cases (ex: IE ideographic space insertion) no character data
@@ -166,17 +163,20 @@ function editOnBeforeInput(editor: DraftEditor, e: SyntheticInputEvent): void {
     newEditorState = EditorState.set(newEditorState, {
       nativelyRenderedContent: newEditorState.getCurrentContent(),
     });
-    // The native event is allowed to occur. To allow user onChange handlers to
-    // change the inserted text, we wait until the text is actually inserted
-    // before we actually update our state. That way when we rerender, the text
-    // we see in the DOM will already have been inserted properly.
-    editor._pendingStateFromBeforeInput = newEditorState;
-    setImmediate(() => {
-      if (editor._pendingStateFromBeforeInput !== undefined) {
-        editor.update(editor._pendingStateFromBeforeInput);
-        editor._pendingStateFromBeforeInput = undefined;
-      }
-    });
+
+    // Allow the native insertion to occur and update our internal state
+    // to match. If editor.update() does something like changing a typed
+    // 'x' to 'abc' in an onChange() handler, we don't want our editOnInput()
+    // logic to squash that change in favor of the typed 'x'. Set a flag to
+    // ignore the next editOnInput() event in favor of what's in our internal state.
+    editor._waitingOnInput = true;
+    editor.update(newEditorState, true);
+
+    if (isIE) {
+      setImmediate(() => {
+        editOnInput(editor);
+      });
+    }
   }
 }
 

--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -15,6 +15,7 @@
 var DraftModifier = require('DraftModifier');
 var DraftOffsetKey = require('DraftOffsetKey');
 var EditorState = require('EditorState');
+var UserAgent = require('UserAgent');
 
 var editOnSelect = require('editOnSelect');
 var EditorBidiService = require('EditorBidiService');

--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -15,7 +15,6 @@
 var DraftModifier = require('DraftModifier');
 var DraftOffsetKey = require('DraftOffsetKey');
 var EditorState = require('EditorState');
-var UserAgent = require('UserAgent');
 
 var editOnSelect = require('editOnSelect');
 var EditorBidiService = require('EditorBidiService');

--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -39,9 +39,14 @@ var DOUBLE_NEWLINE = '\n\n';
  * due to a spellcheck change, and we can incorporate it into our model.
  */
 function editOnInput(editor: DraftEditor): void {
-  if (editor._pendingStateFromBeforeInput !== undefined) {
-    editor.update(editor._pendingStateFromBeforeInput);
-    editor._pendingStateFromBeforeInput = undefined;
+
+  // We have already updated our internal state appropriately for this input
+  // event. See editOnBeforeInput() for more info
+  if (editor._waitingOnInput) {
+    if (!editor._renderNativeContent) {
+      return;
+    }
+    editor._waitingOnInput = false;
   }
 
   var domSelection = global.getSelection();

--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -17,12 +17,13 @@ var DraftOffsetKey = require('DraftOffsetKey');
 var EditorState = require('EditorState');
 var UserAgent = require('UserAgent');
 
+var editOnSelect = require('editOnSelect');
+var EditorBidiService = require('EditorBidiService');
+
 var findAncestorOffsetKey = require('findAncestorOffsetKey');
 var nullthrows = require('nullthrows');
 
 import type DraftEditor from 'DraftEditor.react';
-
-var isGecko = UserAgent.isEngine('Gecko');
 
 var DOUBLE_NEWLINE = '\n\n';
 
@@ -42,22 +43,56 @@ function editOnInput(editor: DraftEditor): void {
 
   // We have already updated our internal state appropriately for this input
   // event. See editOnBeforeInput() for more info
-  if (editor._waitingOnInput) {
-    if (!editor._renderNativeContent) {
-      return;
+  if (editor._updatedNativeInsertionBlock && !editor._renderNativeContent) {
+    editor._updatedNativeInsertionBlock = null;
+    return;
+  }
+
+  editOnSelect(editor);
+  var editorState = editor._latestEditorState;
+
+  if (editor._updatedNativeInsertionBlock) {
+    const oldBlock = editor._updatedNativeInsertionBlock;
+    if (editorState.getSelection().getFocusKey() !== oldBlock.getKey()) {
+
+      // The selection has changed between editOnBeforeInput and now, and our
+      // optimistically updated block is no longer valid.
+      // Replace it with the non-updated block and let the input fall through.
+      const currentContent = editorState.getCurrentContent();
+      const contentWithOldBlock = currentContent.merge({
+        blockMap: currentContent.getBlockMap().set(oldBlock.getKey(), oldBlock),
+        selectionBefore: currentContent.getSelectionBefore(),
+        selectionAfter: currentContent.getSelectionAfter(),
+      });
+
+      var directionMap = EditorBidiService.getDirectionMap(
+        contentWithOldBlock,
+        editorState.getDirectionMap()
+      );
+
+      editor.update(
+        EditorState.set(
+          editorState,
+          {
+            currentContent: contentWithOldBlock,
+            directionMap,
+          }
+        )
+      );
+
+      editorState = editor._latestEditorState;
     }
-    editor._waitingOnInput = false;
+    editor._updatedNativeInsertionBlock = null;
   }
 
   var domSelection = global.getSelection();
 
-  var {anchorNode, isCollapsed} = domSelection;
+  var {anchorNode} = domSelection;
   if (anchorNode.nodeType !== Node.TEXT_NODE) {
     return;
   }
 
   var domText = anchorNode.textContent;
-  var editorState = editor._latestEditorState;
   var offsetKey = nullthrows(findAncestorOffsetKey(anchorNode));
   var {blockKey, decoratorKey, leafKey} = DraftOffsetKey.decode(offsetKey);
 
@@ -102,51 +137,23 @@ function editOnInput(editor: DraftEditor): void {
   // native browser undo.
   const changeType = preserveEntity ? 'spellcheck-change' : 'apply-entity';
 
+  // Replace the full text of the leaf and set the selection to the value calculated in editOnSelect() above,
+  // because replacing the leaf will move the selection to the end of the leaf rather than the end of the
+  // changed text
   const newContent = DraftModifier.replaceText(
     content,
     targetRange,
     domText,
     block.getInlineStyleAt(start),
     preserveEntity ? block.getEntityAt(start) : null,
-  );
-
-  var anchorOffset, focusOffset, startOffset, endOffset;
-
-  if (isGecko) {
-    // Firefox selection does not change while the context menu is open, so
-    // we preserve the anchor and focus values of the DOM selection.
-    anchorOffset = domSelection.anchorOffset;
-    focusOffset = domSelection.focusOffset;
-    startOffset = start + Math.min(anchorOffset, focusOffset);
-    endOffset = startOffset + Math.abs(anchorOffset - focusOffset);
-    anchorOffset = startOffset;
-    focusOffset = endOffset;
-  } else {
-    // Browsers other than Firefox may adjust DOM selection while the context
-    // menu is open, and Safari autocorrect is prone to providing an inaccurate
-    // DOM selection. Don't trust it. Instead, use our existing SelectionState
-    // and adjust it based on the number of characters changed during the
-    // mutation.
-    var charDelta = domText.length - modelText.length;
-    startOffset = selection.getStartOffset();
-    endOffset = selection.getEndOffset();
-
-    anchorOffset = isCollapsed ? endOffset + charDelta : startOffset;
-    focusOffset = endOffset + charDelta;
-  }
-
-  // Segmented entities are completely or partially removed when their
-  // text content changes. For this case we do not want any text to be selected
-  // after the change, so we are not merging the selection.
-  var contentWithAdjustedDOMSelection = newContent.merge({
-    selectionBefore: content.getSelectionAfter(),
-    selectionAfter: selection.merge({anchorOffset, focusOffset}),
-  });
+  )
+    .set('selectionBefore', content.getSelectionBefore())
+    .set('selectionAfter', content.getSelectionAfter());
 
   editor.update(
     EditorState.push(
       editorState,
-      contentWithAdjustedDOMSelection,
+      newContent,
       changeType
     )
   );

--- a/src/model/immutable/EditorState.js
+++ b/src/model/immutable/EditorState.js
@@ -334,31 +334,6 @@ class EditorState {
   }
 
   /**
-   * Replace the contentState with the new one, without altering the undo stack
-   * This should only be used in limited circumstances where the selection is unaltered
-   * and the goal is to provide a silent transformation
-   */
-  static replace(
-    editorState: EditorState,
-    contentState: ContentState
-): EditorState {
-    var oldContent = editorState.getCurrentContent();
-    if (oldContent.getSelectionAfter() !== contentState.getSelectionAfter()) {
-      throw new Error('Cannot replace the content when the selection differs. Use push instead');
-    }
-
-    var directionMap = EditorBidiService.getDirectionMap(
-      contentState,
-      editorState.getDirectionMap()
-    );
-
-    return EditorState.set(editorState, {
-      currentContent: contentState,
-      directionMap,
-    });
-  }
-
-  /**
    * Push the current ContentState onto the undo stack if it should be
    * considered a boundary state, and set the provided ContentState as the
    * new current content.

--- a/src/model/immutable/EditorState.js
+++ b/src/model/immutable/EditorState.js
@@ -334,6 +334,31 @@ class EditorState {
   }
 
   /**
+   * Replace the contentState with the new one, without altering the undo stack
+   * This should only be used in limited circumstances where the selection is unaltered
+   * and the goal is to provide a silent transformation
+   */
+  static replace(
+    editorState: EditorState,
+    contentState: ContentState
+): EditorState {
+    var oldContent = editorState.getCurrentContent();
+    if (oldContent.getSelectionAfter() !== contentState.getSelectionAfter()) {
+      throw new Error('Cannot replace the content when the selection differs. Use push instead');
+    }
+
+    var directionMap = EditorBidiService.getDirectionMap(
+      contentState,
+      editorState.getDirectionMap()
+    );
+
+    return EditorState.set(editorState, {
+      currentContent: contentState,
+      directionMap,
+    });
+  }
+
+  /**
    * Push the current ContentState onto the undo stack if it should be
    * considered a boundary state, and set the provided ContentState as the
    * new current content.


### PR DESCRIPTION
**Summary**

Fixes https://github.com/facebook/draft-js/issues/1018
Fixes https://github.com/facebook/draft-js/issues/989

There are a couple fundamental problems with the typing loop and selection in Draft:

**React doesn't fire a `handleSelect` event until `mouseUp`**
This creates the following bad scenario:

1. Create two blocks with text
2. Place selection in the first block
3. Click on the second block to change selection, but hold the mouse down
4. Type a letter
5. Draft still thinks the selection is on the first block and performs its `onInput` block-matching logic, which makes wacky things happen like the blocks duplicating. Things quickly get out of sync.

**Internet Explorer has a timing window around using `setImmediate` to fake input events**
See https://github.com/facebook/draft-js/issues/1018

The core of this PR is based on two things:
1. Sync draft's internal selection with `window.getSelection()` more often.
2. Update the editorState optimistically `onBeforeInput` so as to not let the internal state get out of sync with the DOM. If something happens between `onBeforeInput` and `onInput` to change the optimistically-updated editorState, we fix that up `onInput`

**Test Plan**

I'd love to hear from the folks at Facebook (@flarnie?) about how to best test these scenarios. This code has been in production at Textio for about a week without issue, and I'm not seeing many existing tests in this area of code.
