### PR TITLE
Strip html whitespace

### DIFF
--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -350,7 +350,8 @@ function genFragment(
   if (nodeName === '#text') {
     var text = node.textContent;
     if (text.trim() === '' && inBlock !== 'pre') {
-      if (!inBlock && !node.previousSibling) {
+      // whitespace after body or html comment
+      if (!inBlock && (!node.previousSibling || node.previousSibling.nodeName === '#comment')) {
         return { chunk: getEmptyChunk(), entityMap: entityMap };
       }
       return {chunk: getWhitespaceChunk(inEntity), entityMap};

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -350,6 +350,9 @@ function genFragment(
   if (nodeName === '#text') {
     var text = node.textContent;
     if (text.trim() === '' && inBlock !== 'pre') {
+      if (!inBlock && !node.previousSibling) {
+        return { chunk: getEmptyChunk(), entityMap: entityMap };
+      }
       return {chunk: getWhitespaceChunk(inEntity), entityMap};
     }
     if (inBlock !== 'pre') {

--- a/src/model/paste/__tests__/DraftPasteProcessor-test.js
+++ b/src/model/paste/__tests__/DraftPasteProcessor-test.js
@@ -374,13 +374,19 @@ describe('DraftPasteProcessor', function() {
     ]);
   });
 
-  it('Strip whitespace after block dividers', function() {
+  it('must strip whitespace between body and its first child element', function() {
+    var html = '<body> <p>hello</p></body>';
+    var {contentBlocks: output} = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    expect(output[0].getText()).toBe('hello');
+  });
+
+  it('must strip whitespace after block dividers', function() {
     var html = '<p>hello</p> <p> what</p>';
     var {contentBlocks: output} = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
     expect(output[1].getText()).toBe('what');
   });
 
-  it('Should detect when somthing is un-styled in a child', function() {
+  it('must detect when something is un-styled in a child', function() {
     let html = '<b>hello<span style="font-weight:400;">there</span></b>';
     let output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
     assertInlineStyles(output.contentBlocks[0], [

--- a/src/model/paste/__tests__/DraftPasteProcessor-test.js
+++ b/src/model/paste/__tests__/DraftPasteProcessor-test.js
@@ -375,7 +375,13 @@ describe('DraftPasteProcessor', function() {
   });
 
   it('must strip whitespace between body and its first child element', function() {
-    var html = '<body> <p>hello</p></body>';
+    var html = '<html><body> <p>hello</p></body></html>';
+    var {contentBlocks: output} = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+    expect(output[0].getText()).toBe('hello');
+  });
+
+  it('must strip whitespace between html comment and next element', function() {
+    var html = '<html><body><!--comment--> <p>hello</p></body></html>';
     var {contentBlocks: output} = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
     expect(output[0].getText()).toBe('hello');
   });


### PR DESCRIPTION
**Summary**

When pasting from word processors, such as MS Word, Apple Pages, LibreOffice Writer and so on, we get one empty text block at the beginning of draft-js content. That's caused by whitespace between `<body>` tag and its first child element in markup generated by word processor.

Example of Apple Pages markup (there's a line break after `<body>`):
```html
<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
<html>
<head>
<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
<meta http-equiv="Content-Style-Type" content="text/css">
<title></title>
<meta name="Generator" content="Cocoa HTML Writer">
<meta name="CocoaVersion" content="1404.47">
<style type="text/css">
p.p1 {margin: 0.0px 0.0px 0.0px 0.0px; font: 12.0px Helvetica; -webkit-text-stroke: #000000}
span.s1 {font-kerning: none}
</style>
</head>
<body>
<p class="p1"><span class="s1">Line1</span></p>
</body>
</html>
```

Example of MS Word 2016 markup (there's a line break, html comment and emtpy line after `<body>`):
```html
<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:w="urn:schemas-microsoft-com:office:word"
xmlns:m="http://schemas.microsoft.com/office/2004/12/omml"
xmlns="http://www.w3.org/TR/REC-html40">

<head>
[...]
</head>

<body bgcolor=white lang=RU style='tab-interval:35.4pt'>
<!--StartFragment-->

<p class=MsoNormal><span lang=EN-US style='mso-ansi-language:EN-US'>Line1<o:p></o:p></span></p>

<!--EndFragment-->
</body>

</html>
```

**Test Plan**

Copy/paste single line from word processor. Single line should be pasted, no leading whitespace.
