### PR TITLE
Change website main font-weight to normal.

### DIFF
--- a/website/src/css/draft.css
+++ b/website/src/css/draft.css
@@ -3,7 +3,7 @@ html {
   color: #484848;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-family: proxima-nova, "Helvetica Neue", Helvetica, Arial, sans-serif;
-  font-weight: 300;
+  font-weight: normal;
   line-height: 1.28;
 }
 


### PR DESCRIPTION
This pull request changes the base font-weight in the website docs from 300 to normal. These old eyes find it easier to read and it is the same font-weight as the React website docs.
