### PR TITLE
Updating selection between rendering can crash

### DIFF
--- a/src/component/selection/getUpdatedSelectionState.js
+++ b/src/component/selection/getUpdatedSelectionState.js
@@ -43,8 +43,11 @@ function getUpdatedSelectionState(
 
   var anchorPath = DraftOffsetKey.decode(anchorKey);
   var anchorBlockKey = anchorPath.blockKey;
-  var anchorLeaf = editorState
-    .getBlockTree(anchorBlockKey)
+  var anchorBlockTree = editorState.getBlockTree(anchorBlockKey);
+  if (!anchorBlockTree) {
+    return selection;
+  }
+  var anchorLeaf = anchorBlockTree
     .getIn([
       anchorPath.decoratorKey,
       'leaves',
@@ -53,8 +56,11 @@ function getUpdatedSelectionState(
 
   var focusPath = DraftOffsetKey.decode(focusKey);
   var focusBlockKey = focusPath.blockKey;
-  var focusLeaf = editorState
-    .getBlockTree(focusBlockKey)
+  var focusBlockTree = editorState.getBlockTree(focusBlockKey);
+  if (!focusBlockTree) {
+    return selection;
+  }
+  var focusLeaf = focusBlockTree
     .getIn([
       focusPath.decoratorKey,
       'leaves',


### PR DESCRIPTION
There is a timing window that exists from when a new editorState is passed into draftjs as a prop until that new state is rendered. If an onSelect event fires in this time, then the code will throw because the editorState doesn't yet match the DOM state. getUpdatedSelectionState should detect this case and just return editorState.getSelection() in this scenario.

This is a port of https://github.com/textioHQ/draft-js/pull/2 and fixes https://github.com/facebook/draft-js/issues/473. #473 is closed because the original poster no longer repros the issue but others in Slack have said they are hitting the issue and that this fixes their repro.