### PR TITLE
Support UMD in dist output format

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -76,13 +76,28 @@ var buildDist = function(opts) {
   var webpackOpts = {
     debug: opts.debug,
     externals: {
-      immutable: 'Immutable',
-      react: 'React',
-      'react-dom': 'ReactDOM',
+      immutable: {
+        root: 'Immutable',
+        commonjs2: 'immutable',
+        commonjs: 'immutable',
+        amd: 'immutable',
+      },
+      react: {
+        root: 'React',
+        commonjs2: 'react',
+        commonjs: 'react',
+        amd: 'react',
+      },
+      'react-dom': {
+        root: 'ReactDOM',
+        commonjs2: 'react-dom',
+        commonjs: 'react-dom',
+        amd: 'react-dom',
+      },
     },
     output: {
       filename: opts.output,
-      libraryTarget: 'var',
+      libraryTarget: 'umd',
       library: 'Draft',
     },
     plugins: [


### PR DESCRIPTION
Currently the `dist/Draft.js` script requires window globals for its two primarily dependencies, `Immutable` and `React`. Both of these packages actually publish UMD compatible wrappers in addition to falling back to exporting window globals. It'd be great if Draft.js could do the same.

Effective changes to `dist/Draft.js` output.

``` diff
diff --git a/Draft.js b/Draft.js
index 143a811..b6d0b26 100644
--- a/Draft.js
+++ b/Draft.js
@@ -8,8 +8,17 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-var Draft =
-/******/ (function(modules) { // webpackBootstrap
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory(require("immutable"), require("react"), require("react-dom"));
+	else if(typeof define === 'function' && define.amd)
+		define(["immutable", "react", "react-dom"], factory);
+	else if(typeof exports === 'object')
+		exports["Draft"] = factory(require("immutable"), require("react"), require("react-dom"));
+	else
+		root["Draft"] = factory(root["Immutable"], root["React"], root["ReactDOM"]);
+})(this, function(__WEBPACK_EXTERNAL_MODULE_2__, __WEBPACK_EXTERNAL_MODULE_13__, __WEBPACK_EXTERNAL_MODULE_17__) {
+return /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache
 /******/ 	var installedModules = {};

@@ -699,7 +708,7 @@ var Draft =
 /* 2 */
 /***/ function(module, exports) {

-	module.exports = Immutable;
+	module.exports = __WEBPACK_EXTERNAL_MODULE_2__;

 /***/ },
 /* 3 */
@@ -1917,7 +1926,7 @@ var Draft =
 /* 13 */
 /***/ function(module, exports) {

-	module.exports = React;
+	module.exports = __WEBPACK_EXTERNAL_MODULE_13__;

 /***/ },
 /* 14 */
@@ -2049,7 +2058,7 @@ var Draft =
 /* 17 */
 /***/ function(module, exports) {

-	module.exports = ReactDOM;
+	module.exports = __WEBPACK_EXTERNAL_MODULE_17__;

 /***/ },
 /* 18 */
@@ -13910,4 +13919,6 @@ var Draft =
 	/* WEBPACK VAR INJECTION */}.call(exports, {}))

 /***/ }
-/******/ ]);
\ No newline at end of file
+/******/ ])
+});
+;
\ No newline at end of file
```