### PR TITLE
added check for the range count to prevent IndexError from selection.getRangeAt(0)

### DIFF
--- a/src/component/selection/setDraftEditorSelection.js
+++ b/src/component/selection/setDraftEditorSelection.js
@@ -138,9 +138,11 @@ function addFocusToSelection(
     // Additionally, clone the selection range. IE11 throws an
     // InvalidStateError when attempting to access selection properties
     // after the range is detached.
-    var range = selection.getRangeAt(0);
-    range.setEnd(node, offset);
-    selection.addRange(range.cloneRange());
+    if (selection.rangeCount > 0) {
+      var range = selection.getRangeAt(0);
+      range.setEnd(node, offset);
+      selection.addRange(range.cloneRange());
+    }
   }
 }
 


### PR DESCRIPTION
Some times in chrome/chrome-extensions I have seen the error
`Failed to execute 'getRangeAt' on 'Selection': 0 is not a valid index.`

So the issue is when a new tab is opened id does not get focused automatically and
`window.getSelection().rangeCount` returns 0.

And according to spec of `getRangeAt()`

"A negative number or a number greater than or equal to Selection.rangeCount will result in an error."

So added this just as a sanity check. 