### PR TITLE
Fix missing commas

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,5 @@ dist/
 docs/
 node_modules/
 website/
+gulpfile.js
+scripts/module-map.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,4 +9,13 @@
 
 module.exports = {
   extends: 'fbjs/strict',
+  rules: {
+    'comma-dangle': [2, {
+      arrays: 'always-multiline',
+      objects: 'always-multiline',
+      imports: 'always-multiline',
+      exports: 'always-multiline',
+      functions: 'always-multiline',
+    }],
+  },
 };

--- a/examples/draft-0-10-0/tex/js/app.js
+++ b/examples/draft-0-10-0/tex/js/app.js
@@ -21,5 +21,5 @@ import ReactDOM from 'react-dom';
 
 ReactDOM.render(
   <TeXEditorExample />,
-  document.getElementById('target')
+  document.getElementById('target'),
 );

--- a/examples/draft-0-10-0/tex/js/components/TeXBlock.js
+++ b/examples/draft-0-10-0/tex/js/components/TeXBlock.js
@@ -32,7 +32,7 @@ class KatexOutput extends React.Component {
       katex.render(
         this.props.content,
         this.refs.container,
-        {displayMode: true}
+        {displayMode: true},
       );
     }, 0);
   }

--- a/examples/draft-0-10-0/tex/js/modifiers/insertTeXBlock.js
+++ b/examples/draft-0-10-0/tex/js/modifiers/insertTeXBlock.js
@@ -46,7 +46,7 @@ export function insertTeXBlock(editorState) {
   const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
   const newEditorState = EditorState.set(
     editorState,
-    {currentContent: contentStateWithEntity}
+    {currentContent: contentStateWithEntity},
   );
   return AtomicBlockUtils.insertAtomicBlock(newEditorState, entityKey, ' ');
 }

--- a/examples/draft-0-10-0/tex/js/modifiers/removeTeXBlock.js
+++ b/examples/draft-0-10-0/tex/js/modifiers/removeTeXBlock.js
@@ -31,7 +31,7 @@ export function removeTeXBlock(editorState, blockKey) {
   var resetBlock = Modifier.setBlockType(
     withoutTeX,
     withoutTeX.getSelectionAfter(),
-    'unstyled'
+    'unstyled',
   );
 
   var newState = EditorState.push(editorState, resetBlock, 'remove-range');

--- a/examples/draft-0-9-1/tex/js/app.js
+++ b/examples/draft-0-9-1/tex/js/app.js
@@ -21,5 +21,5 @@ import ReactDOM from 'react-dom';
 
 ReactDOM.render(
   <TeXEditorExample />,
-  document.getElementById('target')
+  document.getElementById('target'),
 );

--- a/examples/draft-0-9-1/tex/js/components/TeXBlock.js
+++ b/examples/draft-0-9-1/tex/js/components/TeXBlock.js
@@ -33,7 +33,7 @@ class KatexOutput extends React.Component {
       katex.render(
         this.props.content,
         this.refs.container,
-        {displayMode: true}
+        {displayMode: true},
       );
     }, 0);
   }

--- a/examples/draft-0-9-1/tex/js/modifiers/insertTeXBlock.js
+++ b/examples/draft-0-9-1/tex/js/modifiers/insertTeXBlock.js
@@ -40,7 +40,7 @@ export function insertTeXBlock(editorState) {
   const entityKey = Entity.create(
     'TOKEN',
     'IMMUTABLE',
-    {content: examples[nextFormula]}
+    {content: examples[nextFormula]},
   );
 
   return AtomicBlockUtils.insertAtomicBlock(editorState, entityKey, ' ');

--- a/examples/draft-0-9-1/tex/js/modifiers/removeTeXBlock.js
+++ b/examples/draft-0-9-1/tex/js/modifiers/removeTeXBlock.js
@@ -31,7 +31,7 @@ export function removeTeXBlock(editorState, blockKey) {
   var resetBlock = Modifier.setBlockType(
     withoutTeX,
     withoutTeX.getSelectionAfter(),
-    'unstyled'
+    'unstyled',
   );
 
   var newState = EditorState.push(editorState, resetBlock, 'remove-range');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -88,7 +88,7 @@ var buildDist = function(opts) {
     plugins: [
       new webpackStream.webpack.DefinePlugin({
         'process.env.NODE_ENV': JSON.stringify(
-          opts.debug ? 'development' : 'production'
+          opts.debug ? 'development' : 'production',
         ),
       }),
       new webpackStream.webpack.optimize.OccurenceOrderPlugin(),
@@ -103,7 +103,7 @@ var buildDist = function(opts) {
           screw_ie8: true,
           warnings: false,
         },
-      })
+      }),
     );
   }
   return webpackStream(webpackOpts, null, function(err, stats) {
@@ -152,7 +152,7 @@ gulp.task('css', function() {
           } else {
             return match;
           }
-        }
+        },
       );
       replaced = replaced.replace(
         // MakeHasteCssVariablesTransform
@@ -167,7 +167,7 @@ gulp.task('css', function() {
           } else {
             throw new Error('Unknown CSS variable ' + name);
           }
-        }
+        },
       );
       file.contents = new Buffer(replaced);
       callback(null, file);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -88,7 +88,7 @@ var buildDist = function(opts) {
     plugins: [
       new webpackStream.webpack.DefinePlugin({
         'process.env.NODE_ENV': JSON.stringify(
-          opts.debug ? 'development' : 'production',
+          opts.debug ? 'development' : 'production'
         ),
       }),
       new webpackStream.webpack.optimize.OccurenceOrderPlugin(),
@@ -103,7 +103,7 @@ var buildDist = function(opts) {
           screw_ie8: true,
           warnings: false,
         },
-      }),
+      })
     );
   }
   return webpackStream(webpackOpts, null, function(err, stats) {
@@ -152,7 +152,7 @@ gulp.task('css', function() {
           } else {
             return match;
           }
-        },
+        }
       );
       replaced = replaced.replace(
         // MakeHasteCssVariablesTransform
@@ -167,7 +167,7 @@ gulp.task('css', function() {
           } else {
             throw new Error('Unknown CSS variable ' + name);
           }
-        },
+        }
       );
       file.contents = new Buffer(replaced);
       callback(null, file);

--- a/scripts/module-map.js
+++ b/scripts/module-map.js
@@ -18,5 +18,5 @@ module.exports = Object.assign(
     reactComponentExpect: 'react-dom/lib/reactComponentExpect',
   },
   require('fbjs/module-map'),
-  require('fbjs-scripts/third-party-module-map'),
+  require('fbjs-scripts/third-party-module-map')
 );

--- a/scripts/module-map.js
+++ b/scripts/module-map.js
@@ -18,5 +18,5 @@ module.exports = Object.assign(
     reactComponentExpect: 'react-dom/lib/reactComponentExpect',
   },
   require('fbjs/module-map'),
-  require('fbjs-scripts/third-party-module-map')
+  require('fbjs-scripts/third-party-module-map'),
 );

--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -355,8 +355,8 @@ class DraftEditor extends React.Component {
       this.update(
         EditorState.forceSelection(
           editorState,
-          editorState.getSelection()
-        )
+          editorState.getSelection(),
+        ),
       );
     }
   }

--- a/src/component/base/__tests__/DraftEditor.react-test.js
+++ b/src/component/base/__tests__/DraftEditor.react-test.js
@@ -31,7 +31,7 @@ describe('DraftEditor.react', () => {
   describe('Basic rendering', () => {
     it('must has generated editorKey', () => {
       shallow.render(
-        <DraftEditor />
+        <DraftEditor />,
       );
      
       var key = shallow._instance._instance.getEditorKey();
@@ -41,7 +41,7 @@ describe('DraftEditor.react', () => {
 
     it('must has editorKey same as props', () => {
       shallow.render(
-        <DraftEditor editorKey="hash" />
+        <DraftEditor editorKey="hash" />,
       );
       
       var key = shallow._instance._instance.getEditorKey();

--- a/src/component/contents/DraftEditorBlock.react.js
+++ b/src/component/contents/DraftEditorBlock.react.js
@@ -67,7 +67,7 @@ class DraftEditorBlock extends React.Component {
       (
         isBlockOnSelectionEdge(
           nextProps.selection,
-          nextProps.block.getKey()
+          nextProps.block.getKey(),
         ) &&
         nextProps.forceSelection
       )
@@ -106,7 +106,7 @@ class DraftEditorBlock extends React.Component {
       if (scrollDelta > 0) {
         window.scrollTo(
           scrollPosition.x,
-          scrollPosition.y + scrollDelta + SCROLL_BUFFER
+          scrollPosition.y + scrollDelta + SCROLL_BUFFER,
         );
       }
     } else {
@@ -116,7 +116,7 @@ class DraftEditorBlock extends React.Component {
       if (scrollDelta > 0) {
         Scroll.setTop(
           scrollParent,
-          Scroll.getTop(scrollParent) + scrollDelta + SCROLL_BUFFER
+          Scroll.getTop(scrollParent) + scrollDelta + SCROLL_BUFFER,
         );
       }
     }
@@ -173,7 +173,7 @@ class DraftEditorBlock extends React.Component {
       var decoratorOffsetKey = DraftOffsetKey.encode(blockKey, ii, 0);
       var decoratedText = text.slice(
         leavesForLeafSet.first().get('start'),
-        leavesForLeafSet.last().get('end')
+        leavesForLeafSet.last().get('end'),
       );
 
       // Resetting dir to the same value on a child node makes Chrome/Firefox
@@ -219,7 +219,7 @@ class DraftEditorBlock extends React.Component {
  */
 function isBlockOnSelectionEdge(
   selection: SelectionState,
-  key: string
+  key: string,
 ): boolean {
   return (
     selection.getAnchorKey() === key ||

--- a/src/component/contents/DraftEditorContents.react.js
+++ b/src/component/contents/DraftEditorContents.react.js
@@ -161,7 +161,7 @@ class DraftEditorContents extends React.Component {
         );
         className = joinClasses(
           className,
-          getListItemClasses(blockType, depth, shouldResetCount, direction)
+          getListItemClasses(blockType, depth, shouldResetCount, direction),
         );
       }
 
@@ -221,7 +221,7 @@ class DraftEditorContents extends React.Component {
             key: info.key + '-wrap',
             'data-offset-key': info.offsetKey,
           },
-          blocks
+          blocks,
         );
         outputBlocks.push(wrapperElement);
       } else {
@@ -244,7 +244,7 @@ function getListItemClasses(
   type: string,
   depth: number,
   shouldResetCount: boolean,
-  direction: BidiDirection
+  direction: BidiDirection,
 ): string {
   return cx({
     'public/DraftStyleDefault/unorderedListItem':

--- a/src/component/contents/__tests__/DraftEditorBlock.react-test.js
+++ b/src/component/contents/__tests__/DraftEditorBlock.react-test.js
@@ -67,7 +67,7 @@ jest.setMock(
     render: function() {
       return mockLeafRender();
     },
-  })
+  }),
 );
 
 var DraftEditorLeaf = require('DraftEditorLeaf.react');
@@ -82,7 +82,7 @@ function getHelloBlock() {
     type: 'unstyled',
     text: 'hello',
     characterList: Immutable.List(
-      Immutable.Repeat(CharacterMetadata.EMPTY, 5)
+      Immutable.Repeat(CharacterMetadata.EMPTY, 5),
     ),
   });
 }
@@ -114,7 +114,7 @@ function getProps(block, decorator) {
 function arePropsEqual(renderedChild, leafPropSet) {
   Object.keys(leafPropSet).forEach(key => {
     expect(
-      Immutable.is(leafPropSet[key], renderedChild.instance().props[key])
+      Immutable.is(leafPropSet[key], renderedChild.instance().props[key]),
     ).toBeTruthy();
   });
 }
@@ -149,7 +149,7 @@ describe('DraftEditorBlock.react', () => {
     it('must render a leaf node', () => {
       var props = getProps(getHelloBlock());
       var block = ReactTestUtils.renderIntoDocument(
-        <DraftEditorBlock {...props} />
+        <DraftEditorBlock {...props} />,
       );
 
       var rendered = reactComponentExpect(block)
@@ -180,7 +180,7 @@ describe('DraftEditorBlock.react', () => {
 
       var props = getProps(helloBlock);
       var block = ReactTestUtils.renderIntoDocument(
-        <DraftEditorBlock {...props} />
+        <DraftEditorBlock {...props} />,
       );
 
       var rendered = reactComponentExpect(block)
@@ -214,7 +214,7 @@ describe('DraftEditorBlock.react', () => {
       var container = document.createElement('div');
       ReactDOM.render(
         <DraftEditorBlock {...props} />,
-        container
+        container,
       );
 
       expect(mockLeafRender.mock.calls.length).toBe(1);
@@ -227,7 +227,7 @@ describe('DraftEditorBlock.react', () => {
 
       ReactDOM.render(
         <DraftEditorBlock {...nextProps} />,
-        container
+        container,
       );
 
       expect(mockLeafRender.mock.calls.length).toBe(2);
@@ -240,13 +240,13 @@ describe('DraftEditorBlock.react', () => {
       var container = document.createElement('div');
       ReactDOM.render(
         <DraftEditorBlock {...props} />,
-        container
+        container,
       );
 
       expect(mockLeafRender.mock.calls.length).toBe(1);
 
       mockGetDecorations.mockReturnValue(
-        Immutable.List.of('x', 'x', null, null, null)
+        Immutable.List.of('x', 'x', null, null, null),
       );
       var decorator = new Decorator();
 
@@ -261,7 +261,7 @@ describe('DraftEditorBlock.react', () => {
 
       ReactDOM.render(
         <DraftEditorBlock {...nextProps} />,
-        container
+        container,
       );
 
       expect(mockLeafRender.mock.calls.length).toBe(3);
@@ -274,7 +274,7 @@ describe('DraftEditorBlock.react', () => {
       var container = document.createElement('div');
       ReactDOM.render(
         <DraftEditorBlock {...props} />,
-        container
+        container,
       );
 
       expect(mockLeafRender.mock.calls.length).toBe(1);
@@ -284,7 +284,7 @@ describe('DraftEditorBlock.react', () => {
 
       ReactDOM.render(
         <DraftEditorBlock {...nextProps} />,
-        container
+        container,
       );
 
       expect(mockLeafRender.mock.calls.length).toBe(2);
@@ -297,7 +297,7 @@ describe('DraftEditorBlock.react', () => {
       var container = document.createElement('div');
       ReactDOM.render(
         <DraftEditorBlock {...props} />,
-        container
+        container,
       );
 
       expect(mockLeafRender.mock.calls.length).toBe(1);
@@ -310,7 +310,7 @@ describe('DraftEditorBlock.react', () => {
 
       ReactDOM.render(
         <DraftEditorBlock {...nextProps} />,
-        container
+        container,
       );
 
       expect(mockLeafRender.mock.calls.length).toBe(2);
@@ -323,7 +323,7 @@ describe('DraftEditorBlock.react', () => {
       var container = document.createElement('div');
       ReactDOM.render(
         <DraftEditorBlock {...props} />,
-        container
+        container,
       );
 
       expect(mockLeafRender.mock.calls.length).toBe(1);
@@ -331,7 +331,7 @@ describe('DraftEditorBlock.react', () => {
       // Render again with the exact same props as before.
       ReactDOM.render(
         <DraftEditorBlock {...props} />,
-        container
+        container,
       );
 
       // No new leaf renders.
@@ -345,7 +345,7 @@ describe('DraftEditorBlock.react', () => {
       var container = document.createElement('div');
       ReactDOM.render(
         <DraftEditorBlock {...props} />,
-        container
+        container,
       );
 
       expect(mockLeafRender.mock.calls.length).toBe(1);
@@ -362,7 +362,7 @@ describe('DraftEditorBlock.react', () => {
       // unchanged.
       ReactDOM.render(
         <DraftEditorBlock {...newProps} />,
-        container
+        container,
       );
 
       // No new leaf renders.
@@ -375,7 +375,7 @@ describe('DraftEditorBlock.react', () => {
       var helloBlock = getHelloBlock();
 
       mockGetDecorations.mockReturnValue(
-        Immutable.List.of('x', 'x', null, null, null)
+        Immutable.List.of('x', 'x', null, null, null),
       );
       var decorator = new Decorator();
       var props = getProps(helloBlock, decorator);
@@ -383,7 +383,7 @@ describe('DraftEditorBlock.react', () => {
       var container = document.createElement('div');
       var block = ReactDOM.render(
         <DraftEditorBlock {...props} />,
-        container
+        container,
       );
 
       expect(mockLeafRender.mock.calls.length).toBe(2);
@@ -409,7 +409,7 @@ describe('DraftEditorBlock.react', () => {
       var helloBlock = getHelloBlock();
 
       mockGetDecorations.mockReturnValue(
-        Immutable.List.of('x', 'x', 'y', 'y', 'y')
+        Immutable.List.of('x', 'x', 'y', 'y', 'y'),
       );
 
       var decorator = new Decorator();
@@ -418,7 +418,7 @@ describe('DraftEditorBlock.react', () => {
       var container = document.createElement('div');
       var block = ReactDOM.render(
         <DraftEditorBlock {...props} />,
-        container
+        container,
       );
 
       expect(mockLeafRender.mock.calls.length).toBe(2);
@@ -453,7 +453,7 @@ describe('DraftEditorBlock.react', () => {
       var container = document.createElement('div');
       var block = ReactDOM.render(
         <DraftEditorBlock {...props} />,
-        container
+        container,
       );
 
       expect(mockLeafRender.mock.calls.length).toBe(2);
@@ -482,7 +482,7 @@ describe('DraftEditorBlock.react', () => {
       helloBlock = helloBlock.set('characterList', Immutable.List(newChars));
 
       mockGetDecorations.mockReturnValue(
-        Immutable.List.of('x', 'x', null, null, null)
+        Immutable.List.of('x', 'x', null, null, null),
       );
       var decorator = new Decorator();
       var props = getProps(helloBlock, decorator);
@@ -490,7 +490,7 @@ describe('DraftEditorBlock.react', () => {
       var container = document.createElement('div');
       var block = ReactDOM.render(
         <DraftEditorBlock {...props} />,
-        container
+        container,
       );
 
       expect(mockLeafRender.mock.calls.length).toBe(3);
@@ -534,7 +534,7 @@ describe('DraftEditorBlock.react', () => {
         var container = document.createElement('div');
         ReactDOM.render(
           <DraftEditorBlock {...props} />,
-          container
+          container,
         );
 
         var scrollCalls = window.scrollTo.mock.calls;
@@ -549,7 +549,7 @@ describe('DraftEditorBlock.react', () => {
         var container = document.createElement('div');
         ReactDOM.render(
           <DraftEditorBlock {...props} />,
-          container
+          container,
         );
 
         var scrollCalls = window.scrollTo.mock.calls;

--- a/src/component/contents/__tests__/DraftEditorTextNode-test.js
+++ b/src/component/contents/__tests__/DraftEditorTextNode-test.js
@@ -53,7 +53,7 @@ describe('DraftEditorTextNode', function() {
   it('must initialize correctly with an empty string, non-IE', function() {
     initializeAsNonIE();
     var stub = renderIntoContainer(
-      <DraftEditorTextNode>{''}</DraftEditorTextNode>
+      <DraftEditorTextNode>{''}</DraftEditorTextNode>,
     );
     expect(ReactDOM.findDOMNode(stub).tagName).toBe('BR');
   });
@@ -61,7 +61,7 @@ describe('DraftEditorTextNode', function() {
   it('must initialize correctly with an empty string, IE', function() {
     initializeAsIE();
     var stub = renderIntoContainer(
-      <DraftEditorTextNode>{''}</DraftEditorTextNode>
+      <DraftEditorTextNode>{''}</DraftEditorTextNode>,
     );
     expectPopulatedSpan(stub, BLOCK_DELIMITER_CHAR);
   });
@@ -69,7 +69,7 @@ describe('DraftEditorTextNode', function() {
   it('must initialize correctly with a string, non-IE', function() {
     initializeAsNonIE();
     var stub = renderIntoContainer(
-      <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>
+      <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>,
     );
     expectPopulatedSpan(stub, TEST_A);
   });
@@ -77,7 +77,7 @@ describe('DraftEditorTextNode', function() {
   it('must initialize correctly with a string, IE', function() {
     initializeAsIE();
     var stub = renderIntoContainer(
-      <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>
+      <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>,
     );
     expectPopulatedSpan(stub, TEST_A);
   });
@@ -85,7 +85,7 @@ describe('DraftEditorTextNode', function() {
   it('must update from empty to non-empty, non-IE', function() {
     initializeAsNonIE();
     var stub = renderIntoContainer(
-      <DraftEditorTextNode>{''}</DraftEditorTextNode>
+      <DraftEditorTextNode>{''}</DraftEditorTextNode>,
     );
 
     renderIntoContainer(<DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>);
@@ -95,7 +95,7 @@ describe('DraftEditorTextNode', function() {
   it('must update from empty to non-empty, IE', function() {
     initializeAsIE();
     var stub = renderIntoContainer(
-      <DraftEditorTextNode>{''}</DraftEditorTextNode>
+      <DraftEditorTextNode>{''}</DraftEditorTextNode>,
     );
 
     renderIntoContainer(<DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>);
@@ -105,11 +105,11 @@ describe('DraftEditorTextNode', function() {
   it('must update from non-empty to non-empty, non-IE', function() {
     initializeAsNonIE();
     var stub = renderIntoContainer(
-      <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>
+      <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>,
     );
 
     renderIntoContainer(
-      <DraftEditorTextNode>{TEST_A + TEST_B}</DraftEditorTextNode>
+      <DraftEditorTextNode>{TEST_A + TEST_B}</DraftEditorTextNode>,
     );
 
     expectPopulatedSpan(stub, TEST_A + TEST_B);
@@ -121,11 +121,11 @@ describe('DraftEditorTextNode', function() {
   it('must update from non-empty to non-empty, non-IE', function() {
     initializeAsIE();
     var stub = renderIntoContainer(
-      <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>
+      <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>,
     );
 
     renderIntoContainer(
-      <DraftEditorTextNode>{TEST_A + TEST_B}</DraftEditorTextNode>
+      <DraftEditorTextNode>{TEST_A + TEST_B}</DraftEditorTextNode>,
     );
     expectPopulatedSpan(stub, TEST_A + TEST_B);
 
@@ -136,7 +136,7 @@ describe('DraftEditorTextNode', function() {
   it('must skip updates if text already matches DOM, non-IE', function() {
     initializeAsNonIE();
     var stub = renderIntoContainer(
-      <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>
+      <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>,
     );
 
     spyOn(stub, 'render').and.callThrough();
@@ -154,7 +154,7 @@ describe('DraftEditorTextNode', function() {
   it('must skip updates if text already matches DOM, IE', function() {
     initializeAsIE();
     var stub = renderIntoContainer(
-      <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>
+      <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>,
     );
 
     spyOn(stub, 'render').and.callThrough();
@@ -172,7 +172,7 @@ describe('DraftEditorTextNode', function() {
   it('must update from non-empty to empty, non-IE', function() {
     initializeAsNonIE();
     var stub = renderIntoContainer(
-      <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>
+      <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>,
     );
 
     renderIntoContainer(<DraftEditorTextNode>{''}</DraftEditorTextNode>);
@@ -183,7 +183,7 @@ describe('DraftEditorTextNode', function() {
   it('must update from non-empty to empty, IE', function() {
     initializeAsIE();
     var stub = renderIntoContainer(
-      <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>
+      <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>,
     );
 
     renderIntoContainer(<DraftEditorTextNode>{''}</DraftEditorTextNode>);
@@ -194,14 +194,14 @@ describe('DraftEditorTextNode', function() {
   it('must render properly into a parent DOM node', function() {
     initializeAsNonIE();
     renderIntoContainer(
-      <div><DraftEditorTextNode>{TEST_A}</DraftEditorTextNode></div>
+      <div><DraftEditorTextNode>{TEST_A}</DraftEditorTextNode></div>,
     );
   });
 
   it('must force unchanged text back into the DOM', function() {
     initializeAsNonIE();
     var stub = renderIntoContainer(
-      <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>
+      <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>,
     );
 
     ReactDOM.findDOMNode(stub).textContent = TEST_B;

--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -143,7 +143,7 @@ var DraftEditorCompositionHandler = {
     const currentStyle = editorState.getCurrentInlineStyle();
     const entityKey = getEntityKeyForSelection(
       editorState.getCurrentContent(),
-      editorState.getSelection()
+      editorState.getSelection(),
     );
 
     const mustReset = (
@@ -167,14 +167,14 @@ var DraftEditorCompositionHandler = {
         editorState.getSelection(),
         composedChars,
         currentStyle,
-        entityKey
+        entityKey,
       );
       editor.update(
         EditorState.push(
           editorState,
           contentState,
-          'insert-characters'
-        )
+          'insert-characters',
+        ),
       );
       return;
     }
@@ -184,7 +184,7 @@ var DraftEditorCompositionHandler = {
         EditorState.set(editorState, {
           nativelyRenderedContent: null,
           forceSelection: true,
-        })
+        }),
       );
     }
   },

--- a/src/component/handlers/drag/DraftEditorDragHandler.js
+++ b/src/component/handlers/drag/DraftEditorDragHandler.js
@@ -31,7 +31,7 @@ const isEventHandled = require('isEventHandled');
  */
 function getSelectionForEvent(
   event: Object,
-  editorState: EditorState
+  editorState: EditorState,
 ): ?SelectionState {
   let node: ?Node = null;
   let offset: ?number = null;
@@ -56,7 +56,7 @@ function getSelectionForEvent(
     offsetKey,
     offset,
     offsetKey,
-    offset
+    offset,
   );
 }
 
@@ -77,7 +77,7 @@ var DraftEditorDragHandler = {
     const editorState: EditorState = editor._latestEditorState;
     const dropSelection: ?SelectionState = getSelectionForEvent(
       e.nativeEvent,
-      editorState
+      editorState,
     );
 
     e.preventDefault();
@@ -101,8 +101,8 @@ var DraftEditorDragHandler = {
           insertTextAtSelection(
             editorState,
             nullthrows(dropSelection), // flow wtf
-            fileText
-          )
+            fileText,
+          ),
         );
       });
       return;
@@ -122,7 +122,7 @@ var DraftEditorDragHandler = {
     }
 
     editor.update(
-      insertTextAtSelection(editorState, dropSelection, data.getText())
+      insertTextAtSelection(editorState, dropSelection, data.getText()),
     );
   },
 
@@ -130,17 +130,17 @@ var DraftEditorDragHandler = {
 
 function moveText(
   editorState: EditorState,
-  targetSelection: SelectionState
+  targetSelection: SelectionState,
 ): EditorState {
   const newContentState = DraftModifier.moveText(
     editorState.getCurrentContent(),
     editorState.getSelection(),
-    targetSelection
+    targetSelection,
   );
   return EditorState.push(
     editorState,
     newContentState,
-    'insert-fragment'
+    'insert-fragment',
   );
 }
 
@@ -150,18 +150,18 @@ function moveText(
 function insertTextAtSelection(
   editorState: EditorState,
   selection: SelectionState,
-  text: string
+  text: string,
 ): EditorState {
   const newContentState = DraftModifier.insertText(
     editorState.getCurrentContent(),
     selection,
     text,
-    editorState.getCurrentInlineStyle()
+    editorState.getCurrentInlineStyle(),
   );
   return EditorState.push(
     editorState,
     newContentState,
-    'insert-fragment'
+    'insert-fragment',
   );
 }
 

--- a/src/component/handlers/edit/commands/SecondaryClipboard.js
+++ b/src/component/handlers/edit/commands/SecondaryClipboard.js
@@ -52,7 +52,7 @@ var SecondaryClipboard = {
     var afterRemoval = DraftModifier.removeRange(
       content,
       targetRange,
-      'forward'
+      'forward',
     );
 
     if (afterRemoval === content) {
@@ -70,7 +70,7 @@ var SecondaryClipboard = {
     var newContent = DraftModifier.replaceWithFragment(
       editorState.getCurrentContent(),
       editorState.getSelection(),
-      clipboard
+      clipboard,
     );
 
     return EditorState.push(editorState, newContent, 'insert-fragment');

--- a/src/component/handlers/edit/commands/keyCommandBackspaceToStartOfLine.js
+++ b/src/component/handlers/edit/commands/keyCommandBackspaceToStartOfLine.js
@@ -20,7 +20,7 @@ var moveSelectionBackward = require('moveSelectionBackward');
 var removeTextWithStrategy = require('removeTextWithStrategy');
 
 function keyCommandBackspaceToStartOfLine(
-  editorState: EditorState
+  editorState: EditorState,
 ): EditorState {
   var afterRemoval = removeTextWithStrategy(
     editorState,
@@ -40,10 +40,10 @@ function keyCommandBackspaceToStartOfLine(
         range.endContainer,
         range.endOffset,
         range.startContainer,
-        range.startOffset
+        range.startOffset,
       ).selectionState;
     },
-    'backward'
+    'backward',
   );
 
   if (afterRemoval === editorState.getCurrentContent()) {
@@ -53,7 +53,7 @@ function keyCommandBackspaceToStartOfLine(
   return EditorState.push(
     editorState,
     afterRemoval,
-    'remove-range'
+    'remove-range',
   );
 }
 

--- a/src/component/handlers/edit/commands/keyCommandBackspaceWord.js
+++ b/src/component/handlers/edit/commands/keyCommandBackspaceWord.js
@@ -38,10 +38,10 @@ function keyCommandBackspaceWord(editorState: EditorState): EditorState {
       var toRemove = DraftRemovableWord.getBackward(text);
       return moveSelectionBackward(
         strategyState,
-        toRemove.length || 1
+        toRemove.length || 1,
       );
     },
-    'backward'
+    'backward',
   );
 
   if (afterRemoval === editorState.getCurrentContent()) {

--- a/src/component/handlers/edit/commands/keyCommandDeleteWord.js
+++ b/src/component/handlers/edit/commands/keyCommandDeleteWord.js
@@ -36,10 +36,10 @@ function keyCommandDeleteWord(editorState: EditorState): EditorState {
       // If there are no words in front of the cursor, remove the newline.
       return moveSelectionForward(
         strategyState,
-        toRemove.length || 1
+        toRemove.length || 1,
       );
     },
-    'forward'
+    'forward',
   );
 
   if (afterRemoval === editorState.getCurrentContent()) {

--- a/src/component/handlers/edit/commands/keyCommandInsertNewline.js
+++ b/src/component/handlers/edit/commands/keyCommandInsertNewline.js
@@ -18,7 +18,7 @@ var EditorState = require('EditorState');
 function keyCommandInsertNewline(editorState: EditorState): EditorState {
   var contentState = DraftModifier.splitBlock(
     editorState.getCurrentContent(),
-    editorState.getSelection()
+    editorState.getSelection(),
   );
   return EditorState.push(editorState, contentState, 'split-block');
 }

--- a/src/component/handlers/edit/commands/keyCommandMoveSelectionToEndOfBlock.js
+++ b/src/component/handlers/edit/commands/keyCommandMoveSelectionToEndOfBlock.js
@@ -18,7 +18,7 @@ var EditorState = require('EditorState');
  * See comment for `moveSelectionToStartOfBlock`.
  */
 function keyCommandMoveSelectionToEndOfBlock(
-  editorState: EditorState
+  editorState: EditorState,
 ): EditorState {
   var selection = editorState.getSelection();
   var endKey = selection.getEndKey();

--- a/src/component/handlers/edit/commands/keyCommandMoveSelectionToStartOfBlock.js
+++ b/src/component/handlers/edit/commands/keyCommandMoveSelectionToStartOfBlock.js
@@ -20,7 +20,7 @@ var EditorState = require('EditorState');
  * moving the cursor. Other browsers are able to move the cursor natively.
  */
 function keyCommandMoveSelectionToStartOfBlock(
-  editorState: EditorState
+  editorState: EditorState,
 ): EditorState {
   var selection = editorState.getSelection();
   var startKey = selection.getStartKey();

--- a/src/component/handlers/edit/commands/keyCommandPlainBackspace.js
+++ b/src/component/handlers/edit/commands/keyCommandPlainBackspace.js
@@ -34,10 +34,10 @@ function keyCommandPlainBackspace(editorState: EditorState): EditorState {
       var charBehind = content.getBlockForKey(key).getText()[offset - 1];
       return moveSelectionBackward(
         strategyState,
-        charBehind ? UnicodeUtils.getUTF16Length(charBehind, 0) : 1
+        charBehind ? UnicodeUtils.getUTF16Length(charBehind, 0) : 1,
       );
     },
-    'backward'
+    'backward',
   );
 
   if (afterRemoval === editorState.getCurrentContent()) {
@@ -48,7 +48,7 @@ function keyCommandPlainBackspace(editorState: EditorState): EditorState {
   return EditorState.push(
     editorState,
     afterRemoval.set('selectionBefore', selection),
-    selection.isCollapsed() ? 'backspace-character' : 'remove-range'
+    selection.isCollapsed() ? 'backspace-character' : 'remove-range',
   );
 }
 

--- a/src/component/handlers/edit/commands/keyCommandPlainDelete.js
+++ b/src/component/handlers/edit/commands/keyCommandPlainDelete.js
@@ -34,10 +34,10 @@ function keyCommandPlainDelete(editorState: EditorState): EditorState {
       var charAhead = content.getBlockForKey(key).getText()[offset];
       return moveSelectionForward(
         strategyState,
-        charAhead ? UnicodeUtils.getUTF16Length(charAhead, 0) : 1
+        charAhead ? UnicodeUtils.getUTF16Length(charAhead, 0) : 1,
       );
     },
-    'forward'
+    'forward',
   );
 
   if (afterRemoval === editorState.getCurrentContent()) {
@@ -49,7 +49,7 @@ function keyCommandPlainDelete(editorState: EditorState): EditorState {
   return EditorState.push(
     editorState,
     afterRemoval.set('selectionBefore', selection),
-    selection.isCollapsed() ? 'delete-character' : 'remove-range'
+    selection.isCollapsed() ? 'delete-character' : 'remove-range',
   );
 }
 

--- a/src/component/handlers/edit/commands/keyCommandTransposeCharacters.js
+++ b/src/component/handlers/edit/commands/keyCommandTransposeCharacters.js
@@ -61,7 +61,7 @@ function keyCommandTransposeCharacters(editorState: EditorState): EditorState {
   var afterRemoval = DraftModifier.removeRange(
     content,
     removalRange,
-    'backward'
+    'backward',
   );
 
   // After the removal, the insertion target is one character back.
@@ -75,13 +75,13 @@ function keyCommandTransposeCharacters(editorState: EditorState): EditorState {
   var afterInsert = DraftModifier.replaceWithFragment(
     afterRemoval,
     targetRange,
-    movedFragment
+    movedFragment,
   );
 
   var newEditorState = EditorState.push(
     editorState,
     afterInsert,
-    'insert-fragment'
+    'insert-fragment',
   );
 
   return EditorState.acceptSelection(newEditorState, finalSelection);

--- a/src/component/handlers/edit/commands/keyCommandUndo.js
+++ b/src/component/handlers/edit/commands/keyCommandUndo.js
@@ -17,7 +17,7 @@ var EditorState = require('EditorState');
 function keyCommandUndo(
   e: SyntheticKeyboardEvent,
   editorState: EditorState,
-  updateFn: (editorState: EditorState) => void
+  updateFn: (editorState: EditorState) => void,
 ): void {
   var undoneState = EditorState.undo(editorState);
 

--- a/src/component/handlers/edit/commands/moveSelectionBackward.js
+++ b/src/component/handlers/edit/commands/moveSelectionBackward.js
@@ -25,7 +25,7 @@ import type SelectionState from 'SelectionState';
  */
 function moveSelectionBackward(
   editorState: EditorState,
-  maxDistance: number
+  maxDistance: number,
 ): SelectionState {
   var selection = editorState.getSelection();
   var content = editorState.getCurrentContent();

--- a/src/component/handlers/edit/commands/moveSelectionForward.js
+++ b/src/component/handlers/edit/commands/moveSelectionForward.js
@@ -25,7 +25,7 @@ import type SelectionState from 'SelectionState';
  */
 function moveSelectionForward(
   editorState: EditorState,
-  maxDistance: number
+  maxDistance: number,
 ): SelectionState {
   var selection = editorState.getSelection();
   var key = selection.getStartKey();

--- a/src/component/handlers/edit/commands/removeTextWithStrategy.js
+++ b/src/component/handlers/edit/commands/removeTextWithStrategy.js
@@ -26,7 +26,7 @@ import type SelectionState from 'SelectionState';
 function removeTextWithStrategy(
   editorState: EditorState,
   strategy: (editorState: EditorState) => SelectionState,
-  direction: DraftRemovalDirection
+  direction: DraftRemovalDirection,
 ): ContentState {
   var selection = editorState.getSelection();
   var content = editorState.getCurrentContent();

--- a/src/component/handlers/edit/editOnBeforeInput.js
+++ b/src/component/handlers/edit/editOnBeforeInput.js
@@ -54,14 +54,14 @@ function replaceText(
   editorState: EditorState,
   text: string,
   inlineStyle: DraftInlineStyle,
-  entityKey: ?string
+  entityKey: ?string,
 ): EditorState {
   var contentState = DraftModifier.replaceText(
     editorState.getCurrentContent(),
     editorState.getSelection(),
     text,
     inlineStyle,
-    entityKey
+    entityKey,
   );
   return EditorState.push(editorState, contentState, 'insert-characters');
 }
@@ -117,9 +117,9 @@ function editOnBeforeInput(editor: DraftEditor, e: SyntheticInputEvent): void {
         editorState.getCurrentInlineStyle(),
         getEntityKeyForSelection(
           editorState.getCurrentContent(),
-          editorState.getSelection()
-        )
-      )
+          editorState.getSelection(),
+        ),
+      ),
     );
     return;
   }
@@ -131,8 +131,8 @@ function editOnBeforeInput(editor: DraftEditor, e: SyntheticInputEvent): void {
     editorState.getCurrentInlineStyle(),
     getEntityKeyForSelection(
       editorState.getCurrentContent(),
-      editorState.getSelection()
-    )
+      editorState.getSelection(),
+    ),
   );
 
   if (!mayAllowNative) {
@@ -149,7 +149,7 @@ function editOnBeforeInput(editor: DraftEditor, e: SyntheticInputEvent): void {
   // in which case we would prevent the native character insertion.
   var originalFingerprint = BlockTree.getFingerprint(anchorTree);
   var newFingerprint = BlockTree.getFingerprint(
-    newEditorState.getBlockTree(anchorKey)
+    newEditorState.getBlockTree(anchorKey),
   );
 
   if (

--- a/src/component/handlers/edit/editOnCut.js
+++ b/src/component/handlers/edit/editOnCut.js
@@ -63,7 +63,7 @@ function removeFragment(editorState: EditorState): EditorState {
   const newContent = DraftModifier.removeRange(
     editorState.getCurrentContent(),
     editorState.getSelection(),
-    'forward'
+    'forward',
   );
   return EditorState.push(editorState, newContent, 'remove-range');
 }

--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -155,8 +155,8 @@ function editOnInput(editor: DraftEditor): void {
     EditorState.push(
       editorState,
       contentWithAdjustedDOMSelection,
-      changeType
-    )
+      changeType,
+    ),
   );
 }
 

--- a/src/component/handlers/edit/editOnKeyDown.js
+++ b/src/component/handlers/edit/editOnKeyDown.js
@@ -42,7 +42,7 @@ var isChrome = UserAgent.isBrowser('Chrome');
  */
 function onKeyCommand(
   command: DraftEditorCommand | string,
-  editorState: EditorState
+  editorState: EditorState,
 ): EditorState {
   switch (command) {
     case 'redo':
@@ -120,14 +120,14 @@ function editOnKeyDown(editor: DraftEditor, e: SyntheticKeyboardEvent): void {
         const contentState = DraftModifier.replaceText(
           editorState.getCurrentContent(),
           editorState.getSelection(),
-          '\u00a0'
+          '\u00a0',
         );
         editor.update(
           EditorState.push(
             editorState,
             contentState,
-            'insert-characters'
-          )
+            'insert-characters',
+          ),
         );
         return;
       }

--- a/src/component/handlers/edit/editOnPaste.js
+++ b/src/component/handlers/edit/editOnPaste.js
@@ -61,7 +61,7 @@ function editOnPaste(editor: DraftEditor, e: SyntheticClipboardEvent): void {
           style: editorState.getCurrentInlineStyle(),
           entity: getEntityKeyForSelection(
             editorState.getCurrentContent(),
-            editorState.getSelection()
+            editorState.getSelection(),
           ),
         });
 
@@ -71,15 +71,15 @@ function editOnPaste(editor: DraftEditor, e: SyntheticClipboardEvent): void {
         var withInsertedText = DraftModifier.replaceWithFragment(
           editorState.getCurrentContent(),
           editorState.getSelection(),
-          fragment
+          fragment,
         );
 
         editor.update(
           EditorState.push(
             editorState,
             withInsertedText,
-            'insert-fragment'
-          )
+            'insert-fragment',
+          ),
         );
       });
 
@@ -174,13 +174,13 @@ function editOnPaste(editor: DraftEditor, e: SyntheticClipboardEvent): void {
       style: editorState.getCurrentInlineStyle(),
       entity: getEntityKeyForSelection(
         editorState.getCurrentContent(),
-        editorState.getSelection()
+        editorState.getSelection(),
       ),
     });
 
     var textFragment = DraftPasteProcessor.processText(
       textBlocks,
-      character
+      character,
     );
 
     var textMap = BlockMapBuilder.createFromArray(textFragment);
@@ -196,7 +196,7 @@ function insertFragment(
   var newContent = DraftModifier.replaceWithFragment(
     editorState.getCurrentContent(),
     editorState.getSelection(),
-    fragment
+    fragment,
   );
   // TODO: merge the entity map once we stop using DraftEntity
   // like this:
@@ -205,13 +205,13 @@ function insertFragment(
   return EditorState.push(
     editorState,
     newContent.set('entityMap', entityMap),
-    'insert-fragment'
+    'insert-fragment',
   );
 }
 
 function areTextBlocksAndClipboardEqual(
   textBlocks: Array<string>,
-  blockMap: BlockMap
+  blockMap: BlockMap,
 ): boolean {
   return (
     textBlocks.length === blockMap.size &&

--- a/src/component/handlers/edit/getFragmentFromSelection.js
+++ b/src/component/handlers/edit/getFragmentFromSelection.js
@@ -26,7 +26,7 @@ function getFragmentFromSelection(editorState: EditorState): ?BlockMap {
 
   return getContentStateFragment(
     editorState.getCurrentContent(),
-    selectionState
+    selectionState,
   );
 }
 

--- a/src/component/selection/DraftOffsetKey.js
+++ b/src/component/selection/DraftOffsetKey.js
@@ -20,7 +20,7 @@ var DraftOffsetKey = {
   encode: function(
     blockKey: string,
     decoratorKey: number,
-    leafKey: number
+    leafKey: number,
   ): string {
     return blockKey + KEY_DELIMITER + decoratorKey + KEY_DELIMITER + leafKey;
   },

--- a/src/component/selection/__tests__/getDraftEditorSelection-test.js
+++ b/src/component/selection/__tests__/getDraftEditorSelection-test.js
@@ -66,18 +66,18 @@ describe('getDraftEditorSelection', function() {
     var boldChar = CharacterMetadata.create({style: BOLD});
     var aChars = Immutable.List(
       Immutable.Repeat(EMPTY, text[0].length).concat(
-        Immutable.Repeat(boldChar, text[1].length)
-      )
+        Immutable.Repeat(boldChar, text[1].length),
+      ),
     );
     var bChars = Immutable.List(
       Immutable.Repeat(EMPTY, text[2].length).concat(
-        Immutable.Repeat(boldChar, text[3].length)
-      )
+        Immutable.Repeat(boldChar, text[3].length),
+      ),
     );
     var cChars = Immutable.List(
       Immutable.Repeat(EMPTY, text[4].length).concat(
-        Immutable.Repeat(boldChar, text[5].length)
-      )
+        Immutable.Repeat(boldChar, text[5].length),
+      ),
     );
 
     var contentBlocks = [
@@ -108,7 +108,7 @@ describe('getDraftEditorSelection', function() {
       .map(
         function(text) {
           return document.createTextNode(text);
-        }
+        },
       );
     leafChildren = textNodes
       .map(
@@ -116,7 +116,7 @@ describe('getDraftEditorSelection', function() {
           var span = document.createElement('span');
           span.appendChild(textNode);
           return span;
-        }
+        },
       );
     leafs = ['a-0-0', 'a-0-1', 'b-0-0', 'b-0-1', 'c-0-0', 'c-0-1']
       .map(
@@ -125,7 +125,7 @@ describe('getDraftEditorSelection', function() {
           span.setAttribute('data-offset-key', '' + blockKey);
           span.appendChild(leafChildren[ii]);
           return span;
-        }
+        },
       );
     decorators = ['a-0-0', 'b-0-0', 'c-0-0']
       .map(
@@ -136,7 +136,7 @@ describe('getDraftEditorSelection', function() {
           span.appendChild(leafs[(ii * 2)]);
           span.appendChild(leafs[(ii * 2) + 1]);
           return span;
-        }
+        },
       );
     blocks = ['a-0-0', 'b-0-0', 'c-0-0']
       .map(
@@ -145,12 +145,12 @@ describe('getDraftEditorSelection', function() {
           blockElement.setAttribute('data-offset-key', '' + blockKey);
           blockElement.appendChild(decorators[ii]);
           return blockElement;
-        }
+        },
       );
     blocks.forEach(
       function(blockElem) {
         contents.appendChild(blockElem);
-      }
+      },
     );
   });
 

--- a/src/component/selection/expandRangeToStartOfLine.js
+++ b/src/component/selection/expandRangeToStartOfLine.js
@@ -34,7 +34,7 @@ function getLineHeightPx(element: Element): number {
   
   invariant(
     documentBody,
-    'Unexpected empty document.body.'
+    'Unexpected empty document.body.',
   );
 
   // forced layout here
@@ -59,7 +59,7 @@ function getLineHeightPx(element: Element): number {
  */
 function areRectsOnOneLine(
   rects: Array<ClientRect>,
-  lineHeight: number
+  lineHeight: number,
 ): boolean {
   var minTop = Infinity;
   var minBottom = Infinity;
@@ -114,7 +114,7 @@ function getNodeLength(node: Node): number {
 function expandRangeToStartOfLine(range: Range): Range {
   invariant(
     range.collapsed,
-    'expandRangeToStartOfLine: Provided range is not collapsed.'
+    'expandRangeToStartOfLine: Provided range is not collapsed.',
   );
   range = range.cloneRange();
 
@@ -144,7 +144,7 @@ function expandRangeToStartOfLine(range: Range): Range {
     bestOffset = range.startOffset;
     invariant(
       bestContainer.parentNode,
-      'Found unexpected detached subtree when traversing.'
+      'Found unexpected detached subtree when traversing.',
     );
     range.setStartBefore(bestContainer);
     if (bestContainer.nodeType === 1 &&

--- a/src/component/selection/getDraftEditorSelection.js
+++ b/src/component/selection/getDraftEditorSelection.js
@@ -24,7 +24,7 @@ import type EditorState from 'EditorState';
  */
 function getDraftEditorSelection(
   editorState: EditorState,
-  root: HTMLElement
+  root: HTMLElement,
 ): DOMDerivedSelection {
   var selection = global.getSelection();
 
@@ -42,7 +42,7 @@ function getDraftEditorSelection(
     selection.anchorNode,
     selection.anchorOffset,
     selection.focusNode,
-    selection.focusOffset
+    selection.focusOffset,
   );
 }
 

--- a/src/component/selection/getDraftEditorSelectionWithNodes.js
+++ b/src/component/selection/getDraftEditorSelectionWithNodes.js
@@ -37,7 +37,7 @@ function getDraftEditorSelectionWithNodes(
   anchorNode: Node,
   anchorOffset: number,
   focusNode: Node,
-  focusOffset: number
+  focusOffset: number,
 ): DOMDerivedSelection {
   var anchorIsTextNode = anchorNode.nodeType === Node.TEXT_NODE;
   var focusIsTextNode = focusNode.nodeType === Node.TEXT_NODE;
@@ -52,7 +52,7 @@ function getDraftEditorSelectionWithNodes(
         nullthrows(findAncestorOffsetKey(anchorNode)),
         anchorOffset,
         nullthrows(findAncestorOffsetKey(focusNode)),
-        focusOffset
+        focusOffset,
       ),
       needsRecovery: false,
     };
@@ -111,7 +111,7 @@ function getDraftEditorSelectionWithNodes(
       anchorPoint.key,
       anchorPoint.offset,
       focusPoint.key,
-      focusPoint.offset
+      focusPoint.offset,
     ),
     needsRecovery,
   };
@@ -140,7 +140,7 @@ function getLastLeaf(node: Node): Node {
 function getPointForNonTextNode(
   editorRoot: ?HTMLElement,
   startNode: Node,
-  childOffset: number
+  childOffset: number,
 ): SelectionPoint {
   let node = startNode;
   var offsetKey: ?string = findAncestorOffsetKey(node);
@@ -148,7 +148,7 @@ function getPointForNonTextNode(
   invariant(
     offsetKey != null ||
     editorRoot && (editorRoot === node || editorRoot.firstChild === node),
-    'Unknown node in selection range.'
+    'Unknown node in selection range.',
   );
 
   // If the editorRoot is the selection, step downward into the content
@@ -157,7 +157,7 @@ function getPointForNonTextNode(
     node = node.firstChild;
     invariant(
       node instanceof Element && node.getAttribute('data-contents') === 'true',
-      'Invalid DraftEditorContents structure.'
+      'Invalid DraftEditorContents structure.',
     );
     if (childOffset > 0) {
       childOffset = node.childNodes.length;

--- a/src/component/selection/getRangeClientRects.js
+++ b/src/component/selection/getRangeClientRects.js
@@ -53,7 +53,7 @@ function getRangeClientRectsChrome(range: Range): Array<ClientRect> {
 
   invariant(
     false,
-    'Found an unexpected detached subtree when getting range client rects.'
+    'Found an unexpected detached subtree when getting range client rects.',
   );
 }
 /* eslint-enable consistent-return */

--- a/src/component/selection/getUpdatedSelectionState.js
+++ b/src/component/selection/getUpdatedSelectionState.js
@@ -24,7 +24,7 @@ function getUpdatedSelectionState(
   anchorKey: string,
   anchorOffset: number,
   focusKey: string,
-  focusOffset: number
+  focusOffset: number,
 ): SelectionState {
   var selection: SelectionState = nullthrows(editorState.getSelection());
   if (__DEV__) {
@@ -33,7 +33,7 @@ function getUpdatedSelectionState(
       console.warn(
         'Invalid selection state.',
         arguments,
-        editorState.toJS()
+        editorState.toJS(),
       );
       /*eslint-enable no-console */
       return selection;

--- a/src/component/selection/setDraftEditorSelection.js
+++ b/src/component/selection/setDraftEditorSelection.js
@@ -32,7 +32,7 @@ function setDraftEditorSelection(
   node: Node,
   blockKey: string,
   nodeStart: number,
-  nodeEnd: number
+  nodeEnd: number,
 ): void {
   // It's possible that the editor has been removed from the DOM but
   // our selection code doesn't know it yet. Forcing selection in
@@ -123,7 +123,7 @@ function setDraftEditorSelection(
 function addFocusToSelection(
   selection: Object,
   node: Node,
-  offset: number
+  offset: number,
 ): void {
   if (selection.extend && containsNode(getActiveElement(), node)) {
     // If `extend` is called while another element has focus, an error is
@@ -147,7 +147,7 @@ function addFocusToSelection(
 function addPointToSelection(
   selection: Object,
   node: Node,
-  offset: number
+  offset: number,
 ): void {
   var range = document.createRange();
   range.setStart(node, offset);

--- a/src/component/utils/getDefaultKeyBinding.js
+++ b/src/component/utils/getDefaultKeyBinding.js
@@ -40,7 +40,7 @@ function shouldRemoveWord(e: SyntheticKeyboardEvent): boolean {
  * Get the appropriate undo/redo command for a Z key command.
  */
 function getZCommand(
-  e: SyntheticKeyboardEvent
+  e: SyntheticKeyboardEvent,
 ): ?DraftEditorCommand {
   if (!hasCommandModifier(e)) {
     return null;
@@ -49,7 +49,7 @@ function getZCommand(
 }
 
 function getDeleteCommand(
-  e: SyntheticKeyboardEvent
+  e: SyntheticKeyboardEvent,
 ): ?DraftEditorCommand {
   // Allow default "cut" behavior for Windows on Shift + Delete.
   if (isWindows && e.shiftKey) {
@@ -59,7 +59,7 @@ function getDeleteCommand(
 }
 
 function getBackspaceCommand(
-  e: SyntheticKeyboardEvent
+  e: SyntheticKeyboardEvent,
 ): ?DraftEditorCommand {
   if (hasCommandModifier(e) && isOSX) {
     return 'backspace-to-start-of-line';
@@ -71,7 +71,7 @@ function getBackspaceCommand(
  * Retrieve a bound key command for the given event.
  */
 function getDefaultKeyBinding(
-  e: SyntheticKeyboardEvent
+  e: SyntheticKeyboardEvent,
 ): ?DraftEditorCommand {
   switch (e.keyCode) {
     case 66: // B

--- a/src/component/utils/getTextContentFromFiles.js
+++ b/src/component/utils/getTextContentFromFiles.js
@@ -28,7 +28,7 @@ var TEXT_SIZE_UPPER_BOUND = 5000;
  */
 function getTextContentFromFiles(
   files: Array<File>,
-  callback: (contents: string) => void
+  callback: (contents: string) => void,
 ): void {
   var readCount = 0;
   var results = [];
@@ -48,7 +48,7 @@ function getTextContentFromFiles(
  */
 function readFile(
   file: File,
-  callback: (contents: string) => void
+  callback: (contents: string) => void,
 ): void {
   if (!global.FileReader || (file.type && !(file.type in TEXT_TYPES))) {
     callback('');

--- a/src/model/decorators/CompositeDraftDecorator.js
+++ b/src/model/decorators/CompositeDraftDecorator.js
@@ -69,7 +69,7 @@ class CompositeDraftDecorator {
           }
         };
         strategy(block, callback, contentState);
-      }
+      },
     );
 
     return List(decorations);
@@ -93,7 +93,7 @@ class CompositeDraftDecorator {
 function canOccupySlice(
   decorations: Array<?string>,
   start: number,
-  end: number
+  end: number,
 ): boolean {
   for (var ii = start; ii < end; ii++) {
     if (decorations[ii] != null) {
@@ -111,7 +111,7 @@ function occupySlice(
   targetArr: Array<?string>,
   start: number,
   end: number,
-  componentKey: string
+  componentKey: string,
 ): void {
   for (var ii = start; ii < end; ii++) {
     targetArr[ii] = componentKey;

--- a/src/model/decorators/__tests__/CompositeDraftDecorator-test.js
+++ b/src/model/decorators/__tests__/CompositeDraftDecorator-test.js
@@ -32,7 +32,7 @@ describe('CompositeDraftDecorator', () => {
         regex,
         function(/*string*/ match, /*number*/ offset) {
           callback(offset, offset + match.length);
-        }
+        },
       );
     };
   }

--- a/src/model/encoding/__tests__/decodeEntityRanges-test.js
+++ b/src/model/encoding/__tests__/decodeEntityRanges-test.js
@@ -47,7 +47,7 @@ describe('decodeEntityRanges', () => {
           length: 2,
           key: '8',
         },
-      ]
+      ],
     );
     expect(decoded).toEqual([null, null, '6', '6', null, '8', '8', null]);
   });
@@ -66,7 +66,7 @@ describe('decodeEntityRanges', () => {
           length: 2,
           key: '6',
         },
-      ]
+      ],
     );
     expect(decoded).toEqual([null, null, '6', '6', null, '6', '6', null]);
   });
@@ -85,7 +85,7 @@ describe('decodeEntityRanges', () => {
           length: 2,
           key: '8',
         },
-      ]
+      ],
     );
 
     var entities = [

--- a/src/model/encoding/__tests__/decodeInlineStyleRanges-test.js
+++ b/src/model/encoding/__tests__/decodeInlineStyleRanges-test.js
@@ -46,7 +46,7 @@ describe('decodeInlineStyleRanges', function() {
     };
     var decoded = decodeInlineStyleRanges(
       block.text,
-      block.inlineStyleRanges
+      block.inlineStyleRanges,
     );
     areEqual(decoded, Array(block.text.length).fill(BOLD));
   });
@@ -63,7 +63,7 @@ describe('decodeInlineStyleRanges', function() {
     };
     var decoded = decodeInlineStyleRanges(
       block.text,
-      block.inlineStyleRanges
+      block.inlineStyleRanges,
     );
     areEqual(decoded, [
       BOLD_UNDERLINE,
@@ -85,7 +85,7 @@ describe('decodeInlineStyleRanges', function() {
 
     var decoded = decodeInlineStyleRanges(
       block.text,
-      block.inlineStyleRanges
+      block.inlineStyleRanges,
     );
 
     areEqual(decoded, [

--- a/src/model/encoding/__tests__/encodeInlineStyleRanges-test.js
+++ b/src/model/encoding/__tests__/encodeInlineStyleRanges-test.js
@@ -54,22 +54,22 @@ describe('encodeInlineStyleRanges', () => {
 
   it('must encode for an unstyled document', () => {
     expect(
-      encodeInlineStyleRanges(createBlock(' '.repeat(2), Repeat(NONE, 2)))
+      encodeInlineStyleRanges(createBlock(' '.repeat(2), Repeat(NONE, 2))),
     ).toEqual([]);
     expect(
-      encodeInlineStyleRanges(createBlock(' '.repeat(20), Repeat(NONE, 20)))
+      encodeInlineStyleRanges(createBlock(' '.repeat(20), Repeat(NONE, 20))),
     ).toEqual([]);
     expect(
-      encodeInlineStyleRanges(createBlock(' '.repeat(200), Repeat(NONE, 200)))
+      encodeInlineStyleRanges(createBlock(' '.repeat(200), Repeat(NONE, 200))),
     ).toEqual([]);
     expect(
-      encodeInlineStyleRanges(createBlock(' '.repeat(2000), Repeat(NONE, 2000)))
+      encodeInlineStyleRanges(createBlock(' '.repeat(2000), Repeat(NONE, 2000))),
     ).toEqual([]);
   });
 
   it('must encode for a flat styled document', () => {
     expect(
-      encodeInlineStyleRanges(createBlock(' '.repeat(20), Repeat(BOLD, 20)))
+      encodeInlineStyleRanges(createBlock(' '.repeat(20), Repeat(BOLD, 20))),
     ).toEqual([
       {offset: 0, length: 20, style: 'BOLD'},
     ]);
@@ -77,9 +77,9 @@ describe('encodeInlineStyleRanges', () => {
       encodeInlineStyleRanges(
         createBlock(
           ' '.repeat(20),
-          Repeat(BOLD_ITALIC, 20)
-        )
-      )
+          Repeat(BOLD_ITALIC, 20),
+        ),
+      ),
     ).toEqual([
       {offset: 0, length: 20, style: 'BOLD'},
       {offset: 0, length: 20, style: 'ITALIC'},
@@ -87,7 +87,7 @@ describe('encodeInlineStyleRanges', () => {
 
     var all = BOLD_ITALIC_UNDERLINE;
     expect(
-      encodeInlineStyleRanges(createBlock(' '.repeat(20), Repeat(all, 20)))
+      encodeInlineStyleRanges(createBlock(' '.repeat(20), Repeat(all, 20))),
     ).toEqual([
       {offset: 0, length: 20, style: 'BOLD'},
       {offset: 0, length: 20, style: 'ITALIC'},
@@ -98,7 +98,7 @@ describe('encodeInlineStyleRanges', () => {
   it('must encode custom styles', () => {
     const custom = List([FOO, FOO, FOO_BAR, FOO_BAR, BOLD, BOLD]);
     expect(
-      encodeInlineStyleRanges(createBlock(' '.repeat(6), custom))
+      encodeInlineStyleRanges(createBlock(' '.repeat(6), custom)),
     ).toEqual([
       {offset: 0, length: 4, style: 'foo'},
       {offset: 2, length: 2, style: 'bar'},
@@ -115,7 +115,7 @@ describe('encodeInlineStyleRanges', () => {
     ]);
 
     expect(
-      encodeInlineStyleRanges(createBlock(' '.repeat(10), complex))
+      encodeInlineStyleRanges(createBlock(' '.repeat(10), complex)),
     ).toEqual([
       {offset: 0, length: 4, style: 'BOLD'},
       {offset: 5, length: 2, style: 'BOLD'},
@@ -136,7 +136,7 @@ describe('encodeInlineStyleRanges', () => {
     ]);
 
     expect(
-      encodeInlineStyleRanges(createBlock(str, styles))
+      encodeInlineStyleRanges(createBlock(str, styles)),
     ).toEqual([
       {offset: 4, length: 4, style: 'BOLD'},
       {offset: 6, length: 8, style: 'ITALIC'},

--- a/src/model/encoding/convertFromDraftStateToRaw.js
+++ b/src/model/encoding/convertFromDraftStateToRaw.js
@@ -21,7 +21,7 @@ import type ContentState from 'ContentState';
 import type {RawDraftContentState} from 'RawDraftContentState';
 
 function convertFromDraftStateToRaw(
-  contentState: ContentState
+  contentState: ContentState,
 ): RawDraftContentState {
   var entityStorageKey = 0;
   var entityStorageMap = {};
@@ -33,12 +33,12 @@ function convertFromDraftStateToRaw(
       start => {
         // Stringify to maintain order of otherwise numeric keys.
         var stringifiedEntityKey = DraftStringKey.stringify(
-          block.getEntityAt(start)
+          block.getEntityAt(start),
         );
         if (!entityStorageMap.hasOwnProperty(stringifiedEntityKey)) {
           entityStorageMap[stringifiedEntityKey] = '' + (entityStorageKey++);
         }
-      }
+      },
     );
 
     rawBlocks.push({

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -145,7 +145,7 @@ function getBlockDividerChunk(block: DraftBlockType, depth: number): Chunk {
 
 function getListBlockType(
   tag: string,
-  lastList: ?string
+  lastList: ?string,
 ): ?DraftBlockType {
   if (tag === 'li') {
     return lastList === 'ol' ? 'ordered-list-item' : 'unordered-list-item';
@@ -154,7 +154,7 @@ function getListBlockType(
 }
 
 function getBlockMapSupportedTags(
-  blockRenderMap: DraftBlockRenderMap
+  blockRenderMap: DraftBlockRenderMap,
 ): Array<string> {
   const unstyledElement = blockRenderMap.get('unstyled').element;
   let tags = new Set([]);
@@ -179,7 +179,7 @@ function getBlockMapSupportedTags(
 function getMultiMatchedType(
   tag: string,
   lastList: ?string,
-  multiMatchExtractor: Array<Function>
+  multiMatchExtractor: Array<Function>,
 ): ?DraftBlockType {
   for (let ii = 0; ii < multiMatchExtractor.length; ii++) {
     const matchType = multiMatchExtractor[ii](tag, lastList);
@@ -193,7 +193,7 @@ function getMultiMatchedType(
 function getBlockTypeForTag(
   tag: string,
   lastList: ?string,
-  blockRenderMap: DraftBlockRenderMap
+  blockRenderMap: DraftBlockRenderMap,
 ): DraftBlockType {
   const matchedTypes = blockRenderMap
     .filter((draftBlock: DraftBlockRenderConfig) => (
@@ -228,7 +228,7 @@ function getBlockTypeForTag(
 function processInlineTag(
   tag: string,
   node: Node,
-  currentStyle: DraftInlineStyle
+  currentStyle: DraftInlineStyle,
 ): DraftInlineStyle {
   var styleToCheck = inlineTags[tag];
   if (styleToCheck) {
@@ -311,7 +311,7 @@ function joinChunks(A: Chunk, B: Chunk): Chunk {
  */
 function containsSemanticBlockMarkup(
   html: string,
-  blockTags: Array<string>
+  blockTags: Array<string>,
 ): boolean {
   return blockTags.some(tag => html.indexOf('<' + tag) !== -1);
 }
@@ -319,7 +319,7 @@ function containsSemanticBlockMarkup(
 function hasValidLinkText(link: Node): boolean {
   invariant(
     link instanceof HTMLAnchorElement,
-    'Link must be an HTMLAnchorElement.'
+    'Link must be an HTMLAnchorElement.',
   );
   var protocol = link.protocol;
   return (
@@ -338,7 +338,7 @@ function genFragment(
   blockTags: Array<string>,
   depth: number,
   blockRenderMap: DraftBlockRenderMap,
-  inEntity?: string
+  inEntity?: string,
 ): {chunk: Chunk, entityMap: EntityMap} {
   var nodeName = node.nodeName.toLowerCase();
   var newBlock = false;
@@ -433,14 +433,14 @@ function genFragment(
   if (!inBlock && blockTags.indexOf(nodeName) !== -1) {
     chunk = getBlockDividerChunk(
       getBlockTypeForTag(nodeName, lastList, blockRenderMap),
-      depth
+      depth,
     );
     inBlock = nodeName;
     newBlock = true;
   } else if (lastList && inBlock === 'li' && nodeName === 'li') {
     chunk = getBlockDividerChunk(
       getBlockTypeForTag(nodeName, lastList, blockRenderMap),
-      depth
+      depth,
     );
     inBlock = nodeName;
     newBlock = true;
@@ -493,7 +493,7 @@ function genFragment(
       blockTags,
       depth,
       blockRenderMap,
-      entityId || inEntity
+      entityId || inEntity,
     );
 
     newChunk = generatedChunk;
@@ -519,7 +519,7 @@ function genFragment(
   if (newBlock) {
     chunk = joinChunks(
       chunk,
-      getBlockDividerChunk(nextBlockType, depth)
+      getBlockDividerChunk(nextBlockType, depth),
     );
   }
 
@@ -567,7 +567,7 @@ function getChunkForHTML(
     null,
     workingBlocks,
     -1,
-    blockRenderMap
+    blockRenderMap,
   );
 
 

--- a/src/model/encoding/convertFromRawToDraftState.js
+++ b/src/model/encoding/convertFromRawToDraftState.js
@@ -27,7 +27,7 @@ import type {RawDraftContentState} from 'RawDraftContentState';
 var {Map} = Immutable;
 
 function convertFromRawToDraftState(
-  rawState: RawDraftContentState
+  rawState: RawDraftContentState,
 ): ContentState {
   var {blocks, entityMap} = rawState;
 
@@ -40,7 +40,7 @@ function convertFromRawToDraftState(
       var {type, mutability, data} = encodedEntity;
       var newKey = DraftEntity.__create(type, mutability, data || {});
       fromStorageToLocal[storageKey] = newKey;
-    }
+    },
   );
 
   var contentBlocks = blocks.map(
@@ -74,7 +74,7 @@ function convertFromRawToDraftState(
       var characterList = createCharacterList(inlineStyles, entities);
 
       return new ContentBlock({key, type, text, depth, characterList, data});
-    }
+    },
   );
 
   return ContentState.createFromBlockArray(contentBlocks);

--- a/src/model/encoding/createCharacterList.js
+++ b/src/model/encoding/createCharacterList.js
@@ -22,7 +22,7 @@ var {List} = Immutable;
 
 function createCharacterList(
   inlineStyles: Array<DraftInlineStyle>,
-  entities: Array<?string>
+  entities: Array<?string>,
 ): List<CharacterMetadata> {
   var characterArray = inlineStyles.map((style, ii) => {
     var entity = entities[ii];

--- a/src/model/encoding/decodeEntityRanges.js
+++ b/src/model/encoding/decodeEntityRanges.js
@@ -22,7 +22,7 @@ var {substr} = UnicodeUtils;
  */
 function decodeEntityRanges(
   text: string,
-  ranges: Array<Object>
+  ranges: Array<Object>,
 ): Array<?string> {
   var entities = Array(text.length).fill(null);
   if (ranges) {
@@ -35,7 +35,7 @@ function decodeEntityRanges(
         for (var ii = start; ii < end; ii++) {
           entities[ii] = range.key;
         }
-      }
+      },
     );
   }
   return entities;

--- a/src/model/encoding/decodeInlineStyleRanges.js
+++ b/src/model/encoding/decodeInlineStyleRanges.js
@@ -28,7 +28,7 @@ const EMPTY_SET = OrderedSet();
  */
 function decodeInlineStyleRanges(
   text: string,
-  ranges?: Array<Object>
+  ranges?: Array<Object>,
 ): Array<DraftInlineStyle> {
   var styles = Array(text.length).fill(EMPTY_SET);
   if (ranges) {

--- a/src/model/encoding/encodeEntityRanges.js
+++ b/src/model/encoding/encodeEntityRanges.js
@@ -26,7 +26,7 @@ var {strlen} = UnicodeUtils;
  */
 function encodeEntityRanges(
   block: ContentBlock,
-  storageMap: Object
+  storageMap: Object,
 ): Array<EntityRange> {
   var encoded = [];
   block.findEntityRanges(
@@ -40,7 +40,7 @@ function encodeEntityRanges(
         // Encode the key as a number for range storage.
         key: Number(storageMap[DraftStringKey.stringify(key)]),
       });
-    }
+    },
   );
   return encoded;
 }

--- a/src/model/encoding/encodeInlineStyleRanges.js
+++ b/src/model/encoding/encodeInlineStyleRanges.js
@@ -32,7 +32,7 @@ var EMPTY_ARRAY = [];
 function getEncodedInlinesForType(
   block: ContentBlock,
   styleList: List<DraftInlineStyle>,
-  styleToEncode: string
+  styleToEncode: string,
 ): Array<InlineStyleRange> {
   var ranges = [];
 
@@ -53,7 +53,7 @@ function getEncodedInlinesForType(
         length: UnicodeUtils.strlen(text.slice(start, end)),
         style: styleToEncode,
       });
-    }
+    },
   );
 
   return ranges;
@@ -64,7 +64,7 @@ function getEncodedInlinesForType(
  * treated separately.
  */
 function encodeInlineStyleRanges(
-  block: ContentBlock
+  block: ContentBlock,
 ): Array<InlineStyleRange> {
   var styleList = block.getCharacterList().map(c => c.getStyle()).toList();
   var ranges = styleList

--- a/src/model/entity/DraftEntity.js
+++ b/src/model/entity/DraftEntity.js
@@ -226,7 +226,7 @@ var DraftEntity:DraftEntityMapObject = {
     data?: Object,
   ): string {
     return DraftEntity.__add(
-      new DraftEntityInstance({type, mutability, data: data || {}})
+      new DraftEntityInstance({type, mutability, data: data || {}}),
     );
   },
 
@@ -256,7 +256,7 @@ var DraftEntity:DraftEntityMapObject = {
    */
   __mergeData: function(
     key: string,
-    toMerge: {[key: string]: any}
+    toMerge: {[key: string]: any},
   ): DraftEntityInstance {
     var instance = DraftEntity.__get(key);
     var newData = {...instance.getData(), ...toMerge};
@@ -270,7 +270,7 @@ var DraftEntity:DraftEntityMapObject = {
    */
   __replaceData: function(
     key: string,
-    newData: {[key: string]: any}
+    newData: {[key: string]: any},
   ): DraftEntityInstance {
     const instance = DraftEntity.__get(key);
     const newInstance = instance.set('data', newData);

--- a/src/model/entity/getEntityKeyForSelection.js
+++ b/src/model/entity/getEntityKeyForSelection.js
@@ -24,7 +24,7 @@ import type {EntityMap} from 'EntityMap';
  */
 function getEntityKeyForSelection(
   contentState: ContentState,
-  targetSelection: SelectionState
+  targetSelection: SelectionState,
 ): ?string {
   var entityKey;
 
@@ -55,7 +55,7 @@ function getEntityKeyForSelection(
  */
 function filterKey(
   entityMap: EntityMap,
-  entityKey: ?string
+  entityKey: ?string,
 ): ?string {
   if (entityKey) {
     var entity = entityMap.__get(entityKey);

--- a/src/model/entity/getTextAfterNearestEntity.js
+++ b/src/model/entity/getTextAfterNearestEntity.js
@@ -21,7 +21,7 @@ import type ContentBlock from 'ContentBlock';
  */
 function getTextAfterNearestEntity(
   block: ContentBlock,
-  offset: number
+  offset: number,
 ): string {
   var start = offset;
 

--- a/src/model/immutable/BlockMapBuilder.js
+++ b/src/model/immutable/BlockMapBuilder.js
@@ -21,12 +21,12 @@ var {OrderedMap} = Immutable;
 
 var BlockMapBuilder = {
   createFromArray: function(
-    blocks: Array<ContentBlock>
+    blocks: Array<ContentBlock>,
   ): BlockMap {
     return OrderedMap(
       blocks.map(
-        block => [block.getKey(), block]
-      )
+        block => [block.getKey(), block],
+      ),
     );
   },
 };

--- a/src/model/immutable/BlockTree.js
+++ b/src/model/immutable/BlockTree.js
@@ -63,7 +63,7 @@ var BlockTree = {
   generate: function(
     contentState: ContentState,
     block: ContentBlock,
-    decorator: ?DraftDecoratorType
+    decorator: ?DraftDecoratorType,
   ): List<DecoratorRange> {
     var textLength = block.getLength();
     if (!textLength) {
@@ -73,9 +73,9 @@ var BlockTree = {
           end: 0,
           decoratorKey: null,
           leaves: List.of(
-            new LeafRange({start: 0, end: 0})
+            new LeafRange({start: 0, end: 0}),
           ),
-        })
+        }),
       );
     }
 
@@ -98,11 +98,11 @@ var BlockTree = {
             decoratorKey: decorations.get(start),
             leaves: generateLeaves(
               chars.slice(start, end).toList(),
-              start
+              start,
             ),
-          })
+          }),
         );
-      }
+      },
     );
 
     return List(leafSets);
@@ -121,7 +121,7 @@ var BlockTree = {
           decoratorKey + '.' + (leafSet.get('end') - leafSet.get('start')) :
           '';
         return '' + fingerprintString + '.' + leafSet.get('leaves').size;
-      }
+      },
     ).join(FINGERPRINT_DELIMITER);
   },
 };
@@ -131,7 +131,7 @@ var BlockTree = {
  */
 function generateLeaves(
   characters: List<CharacterMetadata>,
-  offset: number
+  offset: number,
 ): List<LeafRange> {
   var leaves = [];
   var inlineStyles = characters.map(c => c.getStyle()).toList();
@@ -144,9 +144,9 @@ function generateLeaves(
         new LeafRange({
           start: start + offset,
           end: end + offset,
-        })
+        }),
       );
-    }
+    },
   );
   return List(leaves);
 }

--- a/src/model/immutable/ContentBlock.js
+++ b/src/model/immutable/ContentBlock.js
@@ -91,13 +91,13 @@ class ContentBlock extends ContentBlockRecord {
    */
   findStyleRanges(
     filterFn: (value: CharacterMetadata) => boolean,
-    callback: (start: number, end: number) => void
+    callback: (start: number, end: number) => void,
   ): void {
     findRangesImmutable(
       this.getCharacterList(),
       haveEqualStyle,
       filterFn,
-      callback
+      callback,
     );
   }
 
@@ -106,27 +106,27 @@ class ContentBlock extends ContentBlockRecord {
    */
   findEntityRanges(
     filterFn: (value: CharacterMetadata) => boolean,
-    callback: (start: number, end: number) => void
+    callback: (start: number, end: number) => void,
   ): void {
     findRangesImmutable(
       this.getCharacterList(),
       haveEqualEntity,
       filterFn,
-      callback
+      callback,
     );
   }
 }
 
 function haveEqualStyle(
   charA: CharacterMetadata,
-  charB: CharacterMetadata
+  charB: CharacterMetadata,
 ): boolean {
   return charA.getStyle() === charB.getStyle();
 }
 
 function haveEqualEntity(
   charA: CharacterMetadata,
-  charB: CharacterMetadata
+  charB: CharacterMetadata,
 ): boolean {
   return charA.getEntity() === charB.getEntity();
 }

--- a/src/model/immutable/ContentState.js
+++ b/src/model/immutable/ContentState.js
@@ -209,7 +209,7 @@ class ContentState extends ContentStateRecord {
           type: 'unstyled',
           characterList: List(Repeat(CharacterMetadata.EMPTY, block.length)),
         });
-      }
+      },
     );
     return ContentState.createFromBlockArray(blocks);
   }

--- a/src/model/immutable/EditorBidiService.js
+++ b/src/model/immutable/EditorBidiService.js
@@ -27,7 +27,7 @@ var bidiService;
 var EditorBidiService = {
   getDirectionMap: function(
     content: ContentState,
-    prevBidiMap: ?OrderedMap<any, any>
+    prevBidiMap: ?OrderedMap<any, any>,
   ): OrderedMap<any, any> {
     if (!bidiService) {
       bidiService = new UnicodeBidiService();

--- a/src/model/immutable/EditorState.js
+++ b/src/model/immutable/EditorState.js
@@ -69,17 +69,17 @@ class EditorState {
   _immutable: EditorStateRecord;
 
   static createEmpty(
-    decorator?: ?DraftDecoratorType
+    decorator?: ?DraftDecoratorType,
   ): EditorState {
     return EditorState.createWithContent(
       ContentState.createFromText(''),
-      decorator
+      decorator,
     );
   }
 
   static createWithContent(
     contentState: ContentState,
-    decorator?: ?DraftDecoratorType
+    decorator?: ?DraftDecoratorType,
   ): EditorState {
     var firstKey = contentState.getBlockMap().first().getKey();
     return EditorState.create({
@@ -99,7 +99,7 @@ class EditorState {
       directionMap: EditorBidiService.getDirectionMap(currentContent),
     };
     return new EditorState(
-      new EditorStateRecord(recordConfig)
+      new EditorStateRecord(recordConfig),
     );
   }
 
@@ -124,7 +124,7 @@ class EditorState {
             newContent.getBlockMap(),
             treeMap,
             decorator,
-            existingDecorator
+            existingDecorator,
           );
         } else {
           newTreeMap = generateNewTreeMap(newContent, decorator);
@@ -146,8 +146,8 @@ class EditorState {
             editorState,
             newContent.getBlockMap(),
             newContent.getEntityMap(),
-            decorator
-          )
+            decorator,
+          ),
         );
       }
 
@@ -215,7 +215,7 @@ class EditorState {
 
   static setInlineStyleOverride(
     editorState: EditorState,
-    inlineStyleOverride: DraftInlineStyle
+    inlineStyleOverride: DraftInlineStyle,
   ): EditorState {
     return EditorState.set(editorState, {inlineStyleOverride});
   }
@@ -272,7 +272,7 @@ class EditorState {
    */
   static acceptSelection(
     editorState: EditorState,
-    selection: SelectionState
+    selection: SelectionState,
   ): EditorState {
     return updateSelection(editorState, selection, false);
   }
@@ -291,7 +291,7 @@ class EditorState {
    */
   static forceSelection(
     editorState: EditorState,
-    selection: SelectionState
+    selection: SelectionState,
   ): EditorState {
     if (!selection.getHasFocus()) {
       selection = selection.set('hasFocus', true);
@@ -316,7 +316,7 @@ class EditorState {
         focusKey: lastKey,
         focusOffset: length,
         isBackward: false,
-      })
+      }),
     );
   }
 
@@ -329,7 +329,7 @@ class EditorState {
     var afterSelectionMove = EditorState.moveSelectionToEnd(editorState);
     return EditorState.forceSelection(
       afterSelectionMove,
-      afterSelectionMove.getSelection()
+      afterSelectionMove.getSelection(),
     );
   }
 
@@ -341,7 +341,7 @@ class EditorState {
   static push(
     editorState: EditorState,
     contentState: ContentState,
-    changeType: EditorChangeType
+    changeType: EditorChangeType,
   ): EditorState {
     if (editorState.getCurrentContent() === contentState) {
       return editorState;
@@ -350,7 +350,7 @@ class EditorState {
     var forceSelection = changeType !== 'insert-characters';
     var directionMap = EditorBidiService.getDirectionMap(
       contentState,
-      editorState.getDirectionMap()
+      editorState.getDirectionMap(),
     );
 
     if (!editorState.getAllowUndo()) {
@@ -383,7 +383,7 @@ class EditorState {
       // Preserve the previous selection.
       newContent = newContent.set(
         'selectionBefore',
-        currentContent.getSelectionBefore()
+        currentContent.getSelectionBefore(),
       );
     }
 
@@ -428,7 +428,7 @@ class EditorState {
     var currentContent = editorState.getCurrentContent();
     var directionMap = EditorBidiService.getDirectionMap(
       newCurrentContent,
-      editorState.getDirectionMap()
+      editorState.getDirectionMap(),
     );
 
     return EditorState.set(editorState, {
@@ -462,7 +462,7 @@ class EditorState {
     var currentContent = editorState.getCurrentContent();
     var directionMap = EditorBidiService.getDirectionMap(
       newCurrentContent,
-      editorState.getDirectionMap()
+      editorState.getDirectionMap(),
     );
 
     return EditorState.set(editorState, {
@@ -500,7 +500,7 @@ class EditorState {
 function updateSelection(
   editorState: EditorState,
   selection: SelectionState,
-  forceSelection: boolean
+  forceSelection: boolean,
 ): EditorState {
   return EditorState.set(editorState, {
     selection,
@@ -516,7 +516,7 @@ function updateSelection(
  */
 function generateNewTreeMap(
   contentState: ContentState,
-  decorator?: ?DraftDecoratorType
+  decorator?: ?DraftDecoratorType,
 ): OrderedMap<string, List<any>> {
   return contentState
     .getBlockMap()
@@ -533,7 +533,7 @@ function regenerateTreeForNewBlocks(
   editorState: EditorState,
   newBlockMap: BlockMap,
   newEntityMap: EntityMap,
-  decorator?: ?DraftDecoratorType
+  decorator?: ?DraftDecoratorType,
 ): OrderedMap<string, List<any>> {
   const contentState = editorState.getCurrentContent().set('entityMap', newEntityMap);
   var prevBlockMap = contentState.getBlockMap();
@@ -559,7 +559,7 @@ function regenerateTreeForNewDecorator(
   blockMap: BlockMap,
   previousTreeMap: OrderedMap<string, List<any>>,
   decorator: DraftDecoratorType,
-  existingDecorator: DraftDecoratorType
+  existingDecorator: DraftDecoratorType,
 ): OrderedMap<string, List<any>> {
   return previousTreeMap.merge(
     blockMap
@@ -581,7 +581,7 @@ function regenerateTreeForNewDecorator(
  */
 function mustBecomeBoundary(
   editorState: EditorState,
-  changeType: EditorChangeType
+  changeType: EditorChangeType,
 ): boolean {
   var lastChangeType = editorState.getLastChangeType();
   return (
@@ -596,7 +596,7 @@ function mustBecomeBoundary(
 
 function getInlineStyleForCollapsedSelection(
   content: ContentState,
-  selection: SelectionState
+  selection: SelectionState,
 ): DraftInlineStyle {
   var startKey = selection.getStartKey();
   var startOffset = selection.getStartOffset();
@@ -620,7 +620,7 @@ function getInlineStyleForCollapsedSelection(
 
 function getInlineStyleForNonCollapsedSelection(
   content: ContentState,
-  selection: SelectionState
+  selection: SelectionState,
 ): DraftInlineStyle {
   var startKey = selection.getStartKey();
   var startOffset = selection.getStartOffset();
@@ -643,7 +643,7 @@ function getInlineStyleForNonCollapsedSelection(
 
 function lookUpwardForInlineStyle(
   content: ContentState,
-  fromKey: string
+  fromKey: string,
 ): DraftInlineStyle {
   var previousBlock = content.getBlockBefore(fromKey);
   var previousLength;

--- a/src/model/immutable/SelectionState.js
+++ b/src/model/immutable/SelectionState.js
@@ -76,7 +76,7 @@ class SelectionState extends SelectionStateRecord {
   hasEdgeWithin(
     blockKey: string,
     start: number,
-    end: number
+    end: number,
   ): boolean {
     var anchorKey = this.getAnchorKey();
     var focusKey = this.getFocusKey();
@@ -130,7 +130,7 @@ class SelectionState extends SelectionStateRecord {
   }
 
   static createEmpty(
-    key: string
+    key: string,
   ): SelectionState {
     return new SelectionState({
       anchorKey: key,

--- a/src/model/immutable/__tests__/BlockTree-test.js
+++ b/src/model/immutable/__tests__/BlockTree-test.js
@@ -35,7 +35,7 @@ var PLAIN_BLOCK = {
 var boldChar = CharacterMetadata.create({style: BOLD});
 var styledChars = Repeat(EMPTY, 4).concat(
   Repeat(boldChar, 4),
-  Repeat(EMPTY, 2)
+  Repeat(EMPTY, 2),
 );
 
 var STYLED_BLOCK = {
@@ -66,7 +66,7 @@ describe('BlockTree', () => {
   describe('generate tree with zero decorations', () => {
     function getDecorator(length) {
       Decorator.prototype.getDecorations.mockImplementation(
-        () => Repeat(null, length).toList()
+        () => Repeat(null, length).toList(),
       );
       return new Decorator();
     }
@@ -133,9 +133,9 @@ describe('BlockTree', () => {
         () => {
           return Repeat(null, RANGE_LENGTH).concat(
             Repeat(DECORATOR_KEY, RANGE_LENGTH),
-            Repeat(null, (length - (2 * RANGE_LENGTH)))
+            Repeat(null, (length - (2 * RANGE_LENGTH))),
           ).toList();
-        }
+        },
       );
       return new Decorator();
     }
@@ -220,9 +220,9 @@ describe('BlockTree', () => {
         () => {
           return Repeat(DECORATOR_KEY_A, RANGE_LENGTH).concat(
             Repeat(null, RANGE_LENGTH),
-            Repeat(DECORATOR_KEY_B, (length - (2 * RANGE_LENGTH)))
+            Repeat(DECORATOR_KEY_B, (length - (2 * RANGE_LENGTH))),
           ).toList();
-        }
+        },
       );
       return new Decorator();
     }

--- a/src/model/immutable/__tests__/CharacterMetadata-test.js
+++ b/src/model/immutable/__tests__/CharacterMetadata-test.js
@@ -94,28 +94,28 @@ describe('CharacterMetadata', () => {
       expect(CharacterMetadata.create()).toBe(empty);
       expect(CharacterMetadata.create({style: BOLD})).toBe(withStyle);
       expect(
-        CharacterMetadata.create({style: BOLD_ITALIC})
+        CharacterMetadata.create({style: BOLD_ITALIC}),
       ).toBe(
-        withTwoStyles
+        withTwoStyles,
       );
       expect(CharacterMetadata.create({entity: '1234'})).toBe(withEntity);
       expect(
-        CharacterMetadata.create({entity: '1234', style: BOLD})
+        CharacterMetadata.create({entity: '1234', style: BOLD}),
       ).toBe(
-        withStyleAndEntity
+        withStyleAndEntity,
       );
     });
 
     it('must reuse objects by defaulting config properties', () => {
       expect(
-        CharacterMetadata.create({style: BOLD, entity: null})
+        CharacterMetadata.create({style: BOLD, entity: null}),
       ).toBe(
-        withStyle
+        withStyle,
       );
       expect(
-        CharacterMetadata.create({style: NONE, entity: '1234'})
+        CharacterMetadata.create({style: NONE, entity: '1234'}),
       ).toBe(
-        withEntity
+        withEntity,
       );
 
       var underlined = CharacterMetadata.create({
@@ -124,9 +124,9 @@ describe('CharacterMetadata', () => {
       });
 
       expect(
-        CharacterMetadata.create({style: UNDERLINE})
+        CharacterMetadata.create({style: UNDERLINE}),
       ).toBe(
-        underlined
+        underlined,
       );
     });
   });

--- a/src/model/immutable/__tests__/ContentBlock-test.js
+++ b/src/model/immutable/__tests__/ContentBlock-test.js
@@ -35,7 +35,7 @@ describe('ContentBlock', () => {
         CharacterMetadata.EMPTY,
         CharacterMetadata.EMPTY,
         CharacterMetadata.create({style: BOLD}),
-        CharacterMetadata.create({entity: ENTITY_KEY})
+        CharacterMetadata.create({entity: ENTITY_KEY}),
       ),
     });
   }
@@ -46,7 +46,7 @@ describe('ContentBlock', () => {
       expect(block.getType()).toBe('unstyled');
       expect(block.getText()).toBe('');
       expect(
-        Immutable.is(block.getCharacterList(), Immutable.List())
+        Immutable.is(block.getCharacterList(), Immutable.List()),
       ).toBe(true);
     });
 

--- a/src/model/immutable/__tests__/ContentState-test.js
+++ b/src/model/immutable/__tests__/ContentState-test.js
@@ -50,7 +50,7 @@ describe('ContentState', () => {
 
   function getSample(textBlocks) {
     return getSampleFromConfig(
-      getConfigForText(textBlocks)
+      getConfigForText(textBlocks),
     );
   }
 

--- a/src/model/immutable/__tests__/EditorBidiService-test.js
+++ b/src/model/immutable/__tests__/EditorBidiService-test.js
@@ -54,14 +54,14 @@ describe('EditorBidiService', () => {
     var state = getContentState([ltr]);
     var directions = EditorBidiService.getDirectionMap(state);
     expect(
-      directions.keySeq().toArray()
+      directions.keySeq().toArray(),
     ).toEqual(
-      ['a']
+      ['a'],
     );
     expect(
-      directions.valueSeq().toArray()
+      directions.valueSeq().toArray(),
     ).toEqual(
-      [LTR]
+      [LTR],
     );
   });
 
@@ -72,7 +72,7 @@ describe('EditorBidiService', () => {
     var nextState = getContentState([ltr]);
     var nextDirections = EditorBidiService.getDirectionMap(
       nextState,
-      directions
+      directions,
     );
 
     expect(state).not.toBe(nextState);
@@ -92,7 +92,7 @@ describe('EditorBidiService', () => {
     var nextState = getContentState([newLTR]);
     var nextDirections = EditorBidiService.getDirectionMap(
       nextState,
-      directions
+      directions,
     );
 
     expect(state).not.toBe(nextState);
@@ -112,7 +112,7 @@ describe('EditorBidiService', () => {
     var nextState = getContentState([newLTR]);
     var nextDirections = EditorBidiService.getDirectionMap(
       nextState,
-      directions
+      directions,
     );
 
     expect(state).not.toBe(nextState);
@@ -131,21 +131,21 @@ describe('EditorBidiService', () => {
     var nextState = getContentState([newLTR]);
     var nextDirections = EditorBidiService.getDirectionMap(
       nextState,
-      directions
+      directions,
     );
 
     expect(state).not.toBe(nextState);
     expect(directions).not.toBe(nextDirections);
 
     expect(
-      nextDirections.keySeq().toArray()
+      nextDirections.keySeq().toArray(),
     ).toEqual(
-      ['asdf']
+      ['asdf'],
     );
     expect(
-      nextDirections.valueSeq().toArray()
+      nextDirections.valueSeq().toArray(),
     ).toEqual(
-      [LTR]
+      [LTR],
     );
   });
 
@@ -154,23 +154,23 @@ describe('EditorBidiService', () => {
     var directions = EditorBidiService.getDirectionMap(state);
 
     expect(
-      directions.valueSeq().toArray()
+      directions.valueSeq().toArray(),
     ).toEqual(
-      [LTR, LTR]
+      [LTR, LTR],
     );
 
     var nextState = getContentState([ltr, rtl]);
     var nextDirections = EditorBidiService.getDirectionMap(
       nextState,
-      directions
+      directions,
     );
 
     expect(state).not.toBe(nextState);
     expect(directions).not.toBe(nextDirections);
     expect(
-      nextDirections.valueSeq().toArray()
+      nextDirections.valueSeq().toArray(),
     ).toEqual(
-      [LTR, RTL]
+      [LTR, RTL],
     );
   });
 });

--- a/src/model/immutable/__tests__/EditorState-test.js
+++ b/src/model/immutable/__tests__/EditorState-test.js
@@ -178,7 +178,7 @@ describe('EditorState', () => {
 
         var contentState = DraftModifier.splitBlock(
           editor.getCurrentContent(),
-          editor.getSelection()
+          editor.getSelection(),
         );
 
         editor = EditorState.push(editor, contentState, 'split-block');
@@ -233,7 +233,7 @@ describe('EditorState', () => {
             focusKey: 'c',
             focusOffset: 3,
             isBackward: false,
-          })
+          }),
         );
         expect(editor.getCurrentInlineStyle()).toBe(NONE);
       });
@@ -287,15 +287,15 @@ describe('EditorState', () => {
 
       // Preserve block trees that had the same decorator list.
       expect(
-        editorState.getBlockTree(boldBlock.getKey())
+        editorState.getBlockTree(boldBlock.getKey()),
       ).toBe(
-        withNewDecorator.getBlockTree(boldBlock.getKey())
+        withNewDecorator.getBlockTree(boldBlock.getKey()),
       );
 
       expect(
-        editorState.getBlockTree(italicBlock.getKey())
+        editorState.getBlockTree(italicBlock.getKey()),
       ).not.toBe(
-        withNewDecorator.getBlockTree(italicBlock.getKey())
+        withNewDecorator.getBlockTree(italicBlock.getKey()),
       );
     });
 

--- a/src/model/immutable/__tests__/SelectionState-test.js
+++ b/src/model/immutable/__tests__/SelectionState-test.js
@@ -101,7 +101,7 @@ describe('SelectionState', () => {
     it('is true if selection range is entirely within test range', () => {
       expect(
         getSample({...COLLAPSED, anchorOffset: 5, focusOffset: 5})
-          .hasEdgeWithin('a', 0, 10)
+          .hasEdgeWithin('a', 0, 10),
       ).toBe(true);
       expect(getSample(WITHIN_BLOCK).hasEdgeWithin('a', 0, 40)).toBe(true);
     });

--- a/src/model/immutable/__tests__/findRangesImmutable-test.js
+++ b/src/model/immutable/__tests__/findRangesImmutable-test.js
@@ -25,7 +25,7 @@ describe('findRangesImmutable', () => {
       Immutable.List(),
       returnTrue,
       returnTrue,
-      cb
+      cb,
     );
     expect(cb.mock.calls.length).toBe(0);
   });
@@ -48,7 +48,7 @@ describe('findRangesImmutable', () => {
         list,
         areEqual, // never equal
         returnTrue,
-        cb
+        cb,
       );
       var calls = cb.mock.calls;
       expect(calls.length).toBe(5);
@@ -65,7 +65,7 @@ describe('findRangesImmutable', () => {
         list,
         returnTrue,
         () => false, // never an accepted filter result
-        cb
+        cb,
       );
       var calls = cb.mock.calls;
       expect(calls.length).toBe(0);
@@ -81,7 +81,7 @@ describe('findRangesImmutable', () => {
         list,
         (a, b) => a === b,
         returnTrue,
-        cb
+        cb,
       );
       var calls = cb.mock.calls;
       expect(calls.length).toBe(4);

--- a/src/model/immutable/findRangesImmutable.js
+++ b/src/model/immutable/findRangesImmutable.js
@@ -25,7 +25,7 @@ function findRangesImmutable<T>(
   haystack: List<T>,
   areEqualFn: (a: T, b: T) => boolean,
   filterFn: (value: T) => boolean,
-  foundFn: (start: number, end: number) => void
+  foundFn: (start: number, end: number) => void,
 ): void {
   if (!haystack.size) {
     return;

--- a/src/model/modifier/AtomicBlockUtils.js
+++ b/src/model/modifier/AtomicBlockUtils.js
@@ -35,7 +35,7 @@ const AtomicBlockUtils = {
   insertAtomicBlock: function(
     editorState: EditorState,
     entityKey: string,
-    character: string
+    character: string,
   ): EditorState {
     const contentState = editorState.getCurrentContent();
     const selectionState = editorState.getSelection();
@@ -43,7 +43,7 @@ const AtomicBlockUtils = {
     const afterRemoval = DraftModifier.removeRange(
       contentState,
       selectionState,
-      'backward'
+      'backward',
     );
 
     const targetSelection = afterRemoval.getSelectionAfter();
@@ -53,7 +53,7 @@ const AtomicBlockUtils = {
     const asAtomicBlock = DraftModifier.setBlockType(
       afterSplit,
       insertionTarget,
-      'atomic'
+      'atomic',
     );
 
     const charData = CharacterMetadata.create({entity: entityKey});
@@ -78,7 +78,7 @@ const AtomicBlockUtils = {
     const withAtomicBlock = DraftModifier.replaceWithFragment(
       asAtomicBlock,
       insertionTarget,
-      fragment
+      fragment,
     );
 
     const newContent = withAtomicBlock.merge({
@@ -93,7 +93,7 @@ const AtomicBlockUtils = {
     editorState: EditorState,
     atomicBlock: ContentBlock,
     targetRange: SelectionState,
-    insertionMode?: DraftInsertionType
+    insertionMode?: DraftInsertionType,
   ): EditorState {
     const contentState = editorState.getCurrentContent();
     const selectionState = editorState.getSelection();
@@ -104,25 +104,25 @@ const AtomicBlockUtils = {
       const targetBlock = contentState.getBlockForKey(
         insertionMode === 'before' ?
           targetRange.getStartKey() :
-          targetRange.getEndKey()
+          targetRange.getEndKey(),
       );
 
       withMovedAtomicBlock = moveBlockInContentState(
         contentState,
         atomicBlock,
         targetBlock,
-        insertionMode
+        insertionMode,
       );
     } else {
       const afterRemoval = DraftModifier.removeRange(
         contentState,
         targetRange,
-        'backward'
+        'backward',
       );
 
       const selectionAfterRemoval = afterRemoval.getSelectionAfter();
       const targetBlock = afterRemoval.getBlockForKey(
-        selectionAfterRemoval.getFocusKey()
+        selectionAfterRemoval.getFocusKey(),
       );
 
       if (selectionAfterRemoval.getStartOffset() === 0) {
@@ -130,31 +130,31 @@ const AtomicBlockUtils = {
           afterRemoval,
           atomicBlock,
           targetBlock,
-          'before'
+          'before',
         );
       } else if (selectionAfterRemoval.getEndOffset() === targetBlock.getLength()) {
         withMovedAtomicBlock = moveBlockInContentState(
           afterRemoval,
           atomicBlock,
           targetBlock,
-          'after'
+          'after',
         );
       } else {
         const afterSplit = DraftModifier.splitBlock(
           afterRemoval,
-          selectionAfterRemoval
+          selectionAfterRemoval,
         );
 
         const selectionAfterSplit = afterSplit.getSelectionAfter();
         const targetBlock = afterSplit.getBlockForKey(
-          selectionAfterSplit.getFocusKey()
+          selectionAfterSplit.getFocusKey(),
         );
 
         withMovedAtomicBlock = moveBlockInContentState(
           afterSplit,
           atomicBlock,
           targetBlock,
-          'before'
+          'before',
         );
       }
     }

--- a/src/model/modifier/DraftEntitySegments.js
+++ b/src/model/modifier/DraftEntitySegments.js
@@ -45,7 +45,7 @@ var DraftEntitySegments = {
     selectionEnd: number,
     text: string,
     entityStart: number,
-    direction: DraftRemovalDirection
+    direction: DraftRemovalDirection,
   ): DraftRange {
     var segments = text.split(' ');
     segments = segments.map((/*string*/ segment, /*number*/ ii) => {

--- a/src/model/modifier/DraftModifier.js
+++ b/src/model/modifier/DraftModifier.js
@@ -55,12 +55,12 @@ var DraftModifier = {
     rangeToReplace: SelectionState,
     text: string,
     inlineStyle?: DraftInlineStyle,
-    entityKey?: ?string
+    entityKey?: ?string,
   ): ContentState {
     var withoutEntities = removeEntitiesAtEdges(contentState, rangeToReplace);
     var withoutText = removeRangeFromContentState(
       withoutEntities,
-      rangeToReplace
+      rangeToReplace,
     );
 
     var character = CharacterMetadata.create({
@@ -72,7 +72,7 @@ var DraftModifier = {
       withoutText,
       withoutText.getSelectionAfter(),
       text,
-      character
+      character,
     );
   },
 
@@ -81,63 +81,63 @@ var DraftModifier = {
     targetRange: SelectionState,
     text: string,
     inlineStyle?: DraftInlineStyle,
-    entityKey?: ?string
+    entityKey?: ?string,
   ): ContentState {
     invariant(
       targetRange.isCollapsed(),
-      'Target range must be collapsed for `insertText`.'
+      'Target range must be collapsed for `insertText`.',
     );
     return DraftModifier.replaceText(
       contentState,
       targetRange,
       text,
       inlineStyle,
-      entityKey
+      entityKey,
     );
   },
 
   moveText: function(
     contentState: ContentState,
     removalRange: SelectionState,
-    targetRange: SelectionState
+    targetRange: SelectionState,
   ): ContentState {
     var movedFragment = getContentStateFragment(contentState, removalRange);
 
     var afterRemoval = DraftModifier.removeRange(
       contentState,
       removalRange,
-      'backward'
+      'backward',
     );
 
     return DraftModifier.replaceWithFragment(
       afterRemoval,
       targetRange,
-      movedFragment
+      movedFragment,
     );
   },
 
   replaceWithFragment: function(
     contentState: ContentState,
     targetRange: SelectionState,
-    fragment: BlockMap
+    fragment: BlockMap,
   ): ContentState {
     var withoutEntities = removeEntitiesAtEdges(contentState, targetRange);
     var withoutText = removeRangeFromContentState(
       withoutEntities,
-      targetRange
+      targetRange,
     );
 
     return insertFragmentIntoContentState(
       withoutText,
       withoutText.getSelectionAfter(),
-      fragment
+      fragment,
     );
   },
 
   removeRange: function(
     contentState: ContentState,
     rangeToRemove: SelectionState,
-    removalDirection: DraftRemovalDirection
+    removalDirection: DraftRemovalDirection,
   ): ContentState {
     let startKey, endKey, startBlock, endBlock;
     startKey = removalDirection === 'forward'
@@ -190,53 +190,53 @@ var DraftModifier = {
 
   splitBlock: function(
     contentState: ContentState,
-    selectionState: SelectionState
+    selectionState: SelectionState,
   ): ContentState {
     var withoutEntities = removeEntitiesAtEdges(contentState, selectionState);
     var withoutText = removeRangeFromContentState(
       withoutEntities,
-      selectionState
+      selectionState,
     );
 
     return splitBlockInContentState(
       withoutText,
-      withoutText.getSelectionAfter()
+      withoutText.getSelectionAfter(),
     );
   },
 
   applyInlineStyle: function(
     contentState: ContentState,
     selectionState: SelectionState,
-    inlineStyle: string
+    inlineStyle: string,
   ): ContentState {
     return ContentStateInlineStyle.add(
       contentState,
       selectionState,
-      inlineStyle
+      inlineStyle,
     );
   },
 
   removeInlineStyle: function(
     contentState: ContentState,
     selectionState: SelectionState,
-    inlineStyle: string
+    inlineStyle: string,
   ): ContentState {
     return ContentStateInlineStyle.remove(
       contentState,
       selectionState,
-      inlineStyle
+      inlineStyle,
     );
   },
 
   setBlockType: function(
     contentState: ContentState,
     selectionState: SelectionState,
-    blockType: DraftBlockType
+    blockType: DraftBlockType,
   ): ContentState {
     return modifyBlockForContentState(
       contentState,
       selectionState,
-      (block) => block.merge({type: blockType, depth: 0})
+      (block) => block.merge({type: blockType, depth: 0}),
     );
   },
 
@@ -248,7 +248,7 @@ var DraftModifier = {
     return modifyBlockForContentState(
       contentState,
       selectionState,
-      (block) => block.merge({data: blockData})
+      (block) => block.merge({data: blockData}),
     );
   },
 
@@ -260,7 +260,7 @@ var DraftModifier = {
     return modifyBlockForContentState(
       contentState,
       selectionState,
-      (block) => block.merge({data: block.getData().merge(blockData)})
+      (block) => block.merge({data: block.getData().merge(blockData)}),
     );
   },
 
@@ -268,13 +268,13 @@ var DraftModifier = {
   applyEntity: function(
     contentState: ContentState,
     selectionState: SelectionState,
-    entityKey: ?string
+    entityKey: ?string,
   ): ContentState {
     var withoutEntities = removeEntitiesAtEdges(contentState, selectionState);
     return applyEntityToContentState(
       withoutEntities,
       selectionState,
-      entityKey
+      entityKey,
     );
   },
 };

--- a/src/model/modifier/DraftRemovableWord.js
+++ b/src/model/modifier/DraftRemovableWord.js
@@ -43,7 +43,7 @@ var BACKSPACE_REGEX = new RegExp(BACKSPACE_STRING);
 
 function getRemovableWord(
   text: string,
-  isBackward: boolean
+  isBackward: boolean,
 ): string {
   var matches = isBackward ?
     BACKSPACE_REGEX.exec(text) :

--- a/src/model/modifier/RichTextEditorUtil.js
+++ b/src/model/modifier/RichTextEditorUtil.js
@@ -27,7 +27,7 @@ import type URI from 'URI';
 
 const RichTextEditorUtil = {
   currentBlockContainsLink: function(
-    editorState: EditorState
+    editorState: EditorState,
   ): boolean {
     var selection = editorState.getSelection();
     const contentState = editorState.getCurrentContent();
@@ -85,18 +85,18 @@ const RichTextEditorUtil = {
       editorState.getSelection(),
       '\n',
       editorState.getCurrentInlineStyle(),
-      null
+      null,
     );
 
     var newEditorState = EditorState.push(
       editorState,
       contentState,
-      'insert-characters'
+      'insert-characters',
     );
 
     return EditorState.forceSelection(
       newEditorState,
-      contentState.getSelectionAfter()
+      contentState.getSelectionAfter(),
     );
   },
 
@@ -129,14 +129,14 @@ const RichTextEditorUtil = {
 
     // If that doesn't succeed, try to remove the current block style.
     var withoutBlockStyle = RichTextEditorUtil.tryToRemoveBlockStyle(
-      editorState
+      editorState,
     );
 
     if (withoutBlockStyle) {
       return EditorState.push(
         editorState,
         withoutBlockStyle,
-        'change-block-type'
+        'change-block-type',
       );
     }
 
@@ -173,14 +173,14 @@ const RichTextEditorUtil = {
     const withoutAtomicBlock = DraftModifier.removeRange(
       content,
       atomicBlockTarget,
-      'forward'
+      'forward',
     );
 
     if (withoutAtomicBlock !== content) {
       return EditorState.push(
         editorState,
         withoutAtomicBlock,
-        'remove-range'
+        'remove-range',
       );
     }
 
@@ -190,7 +190,7 @@ const RichTextEditorUtil = {
   onTab: function(
     event: SyntheticKeyboardEvent,
     editorState: EditorState,
-    maxDepth: number
+    maxDepth: number,
   ): EditorState {
     var selection = editorState.getSelection();
     var key = selection.getAnchorKey();
@@ -233,19 +233,19 @@ const RichTextEditorUtil = {
       content,
       selection,
       event.shiftKey ? -1 : 1,
-      maxDepth
+      maxDepth,
     );
 
     return EditorState.push(
       editorState,
       withAdjustment,
-      'adjust-depth'
+      'adjust-depth',
     );
   },
 
   toggleBlockType: function(
     editorState: EditorState,
-    blockType: DraftBlockType
+    blockType: DraftBlockType,
   ): EditorState {
     var selection = editorState.getSelection();
     var startKey = selection.getStartKey();
@@ -286,7 +286,7 @@ const RichTextEditorUtil = {
     return EditorState.push(
       editorState,
       DraftModifier.setBlockType(content, target, typeToSet),
-      'change-block-type'
+      'change-block-type',
     );
   },
 
@@ -310,7 +310,7 @@ const RichTextEditorUtil = {
    */
   toggleInlineStyle: function(
     editorState: EditorState,
-    inlineStyle: string
+    inlineStyle: string,
   ): EditorState {
     var selection = editorState.getSelection();
     var currentStyle = editorState.getCurrentInlineStyle();
@@ -351,25 +351,25 @@ const RichTextEditorUtil = {
     return EditorState.push(
       editorState,
       newContent,
-      'change-inline-style'
+      'change-inline-style',
     );
   },
 
   toggleLink: function(
     editorState: EditorState,
     targetSelection: SelectionState,
-    entityKey: ?string
+    entityKey: ?string,
   ): EditorState {
     var withoutLink = DraftModifier.applyEntity(
       editorState.getCurrentContent(),
       targetSelection,
-      entityKey
+      entityKey,
     );
 
     return EditorState.push(
       editorState,
       withoutLink,
-      'apply-entity'
+      'apply-entity',
     );
   },
 

--- a/src/model/modifier/__tests__/AtomicBlockUtils-test.js
+++ b/src/model/modifier/__tests__/AtomicBlockUtils-test.js
@@ -41,7 +41,7 @@ describe('AtomicBlockUtils', () => {
       const resultEditor = insertAtomicBlock(
         editorState,
         entityKey,
-        character
+        character,
       );
       const resultContent = resultEditor.getCurrentContent();
 
@@ -64,22 +64,22 @@ describe('AtomicBlockUtils', () => {
       });
       const targetEditor = EditorState.forceSelection(
         editorState,
-        targetSelection
+        targetSelection,
       );
 
       const resultEditor = insertAtomicBlock(
         targetEditor,
         entityKey,
-        character
+        character,
       );
       const resultContent = resultEditor.getCurrentContent();
 
       const firstBlock = resultContent.getBlockMap().first();
       expect(firstBlock.getType()).toBe(originalFirstBlock.getType());
       expect(
-        firstBlock.getText()
+        firstBlock.getText(),
       ).toBe(
-        originalFirstBlock.getText().slice(0, 2)
+        originalFirstBlock.getText().slice(0, 2),
       );
 
       const secondBlock = resultContent.getBlockMap().skip(1).first();
@@ -97,13 +97,13 @@ describe('AtomicBlockUtils', () => {
       });
       const targetEditor = EditorState.forceSelection(
         editorState,
-        targetSelection
+        targetSelection,
       );
 
       const resultEditor = insertAtomicBlock(
         targetEditor,
         entityKey,
-        character
+        character,
       );
       const resultContent = resultEditor.getCurrentContent();
 
@@ -124,7 +124,7 @@ describe('AtomicBlockUtils', () => {
       const resultEditor = insertAtomicBlock(
         editorState,
         entityKey,
-        character
+        character,
       );
       const resultContent = resultEditor.getCurrentContent();
 
@@ -140,7 +140,7 @@ describe('AtomicBlockUtils', () => {
         new SelectionState({
           anchorKey: firstBlock.getKey(),
           focusKey: firstBlock.getKey(),
-        })
+        }),
       );
       const atomicResultContent = atomicResultEditor.getCurrentContent();
 
@@ -156,7 +156,7 @@ describe('AtomicBlockUtils', () => {
       const resultEditor = insertAtomicBlock(
         editorState,
         entityKey,
-        character
+        character,
       );
       const resultContent = resultEditor.getCurrentContent();
 
@@ -174,7 +174,7 @@ describe('AtomicBlockUtils', () => {
           anchorOffset: lastBlock.getLength(),
           focusKey: lastBlock.getKey(),
           focusOffset: lastBlock.getLength(),
-        })
+        }),
       );
       const atomicResultContent = atomicResultEditor.getCurrentContent();
 
@@ -190,7 +190,7 @@ describe('AtomicBlockUtils', () => {
       const resultEditor = insertAtomicBlock(
         editorState,
         entityKey,
-        character
+        character,
       );
       const resultContent = resultEditor.getCurrentContent();
 
@@ -208,7 +208,7 @@ describe('AtomicBlockUtils', () => {
           anchorOffset: 2,
           focusKey: thirdBlock.getKey(),
           focusOffset: 2,
-        })
+        }),
       );
       const atomicResultContent = atomicResultEditor.getCurrentContent();
 
@@ -229,7 +229,7 @@ describe('AtomicBlockUtils', () => {
       const resultEditor = insertAtomicBlock(
         editorState,
         entityKey,
-        character
+        character,
       );
       const resultContent = resultEditor.getCurrentContent();
 
@@ -245,7 +245,7 @@ describe('AtomicBlockUtils', () => {
         new SelectionState({
           anchorKey: firstBlock.getKey(),
         }),
-        'before'
+        'before',
       );
       const atomicResultContent = atomicResultEditor.getCurrentContent();
 
@@ -261,7 +261,7 @@ describe('AtomicBlockUtils', () => {
       const resultEditor = insertAtomicBlock(
         editorState,
         entityKey,
-        character
+        character,
       );
       const resultContent = resultEditor.getCurrentContent();
 
@@ -277,7 +277,7 @@ describe('AtomicBlockUtils', () => {
         new SelectionState({
           focusKey: lastBlock.getKey(),
         }),
-        'after'
+        'after',
       );
       const atomicResultContent = atomicResultEditor.getCurrentContent();
 
@@ -295,14 +295,14 @@ describe('AtomicBlockUtils', () => {
       });
       const targetEditor = EditorState.forceSelection(
         editorState,
-        targetSelection
+        targetSelection,
       );
 
       // Insert atomic block at the second position
       const resultEditor = insertAtomicBlock(
         targetEditor,
         entityKey,
-        character
+        character,
       );
       const resultContent = resultEditor.getCurrentContent();
 
@@ -323,9 +323,9 @@ describe('AtomicBlockUtils', () => {
               anchorOffset: beforeAtomicBlock.getLength(),
               focusKey: beforeAtomicBlock.getKey(),
               focusOffset: beforeAtomicBlock.getLength(),
-            })
+            }),
           );
-        }
+        },
       ).toThrow(new Error('Block cannot be moved next to itself.'));
 
       // Move atomic block above itself by moving it after preceeding block
@@ -338,9 +338,9 @@ describe('AtomicBlockUtils', () => {
               anchorKey: beforeAtomicBlock.getKey(),
               focusKey: beforeAtomicBlock.getKey(),
             }),
-            'after'
+            'after',
           );
-        }
+        },
       ).toThrow(new Error('Block cannot be moved next to itself.'));
 
       // Move atomic block above itself by replacement
@@ -352,9 +352,9 @@ describe('AtomicBlockUtils', () => {
             new SelectionState({
               anchorKey: atomicBlock.getKey(),
               focusKey: atomicBlock.getKey(),
-            })
+            }),
           );
-        }
+        },
       ).toThrow(new Error('Block cannot be moved next to itself.'));
 
       // Move atomic block above itself
@@ -366,9 +366,9 @@ describe('AtomicBlockUtils', () => {
             new SelectionState({
               anchorKey: atomicBlock.getKey(),
             }),
-            'before'
+            'before',
           );
-        }
+        },
       ).toThrow(new Error('Block cannot be moved next to itself.'));
 
       // Move atomic block below itself by moving it before following block by replacement
@@ -380,9 +380,9 @@ describe('AtomicBlockUtils', () => {
             new SelectionState({
               anchorKey: afterAtomicBlock.getKey(),
               focusKey: afterAtomicBlock.getKey(),
-            })
+            }),
           );
-        }
+        },
       ).toThrow(new Error('Block cannot be moved next to itself.'));
 
       // Move atomic block below itself by moving it before following block
@@ -395,9 +395,9 @@ describe('AtomicBlockUtils', () => {
               anchorKey: afterAtomicBlock.getKey(),
               focusKey: afterAtomicBlock.getKey(),
             }),
-            'before'
+            'before',
           );
-        }
+        },
       ).toThrow(new Error('Block cannot be moved next to itself.'));
 
       // Move atomic block below itself by replacement
@@ -411,9 +411,9 @@ describe('AtomicBlockUtils', () => {
               anchorOffset: atomicBlock.getLength(),
               focusKey: atomicBlock.getKey(),
               focusOffset: atomicBlock.getLength(),
-            })
+            }),
           );
-        }
+        },
       ).toThrow(new Error('Block cannot be moved next to itself.'));
 
       // Move atomic block below itself
@@ -425,9 +425,9 @@ describe('AtomicBlockUtils', () => {
             new SelectionState({
               focusKey: atomicBlock.getKey(),
             }),
-            'after'
+            'after',
           );
-        }
+        },
       ).toThrow(new Error('Block cannot be moved next to itself.'));
     });
   });
@@ -440,13 +440,13 @@ describe('AtomicBlockUtils', () => {
       });
       const targetEditor = EditorState.forceSelection(
         editorState,
-        targetSelection
+        targetSelection,
       );
 
       const resultEditor = insertAtomicBlock(
         targetEditor,
         entityKey,
-        character
+        character,
       );
       const resultContent = resultEditor.getCurrentContent();
 
@@ -469,22 +469,22 @@ describe('AtomicBlockUtils', () => {
       });
       const targetEditor = EditorState.forceSelection(
         editorState,
-        targetSelection
+        targetSelection,
       );
 
       const resultEditor = insertAtomicBlock(
         targetEditor,
         entityKey,
-        character
+        character,
       );
       const resultContent = resultEditor.getCurrentContent();
 
       const firstBlock = resultContent.getBlockMap().first();
       expect(firstBlock.getType()).toBe(originalFirstBlock.getType());
       expect(
-        firstBlock.getText()
+        firstBlock.getText(),
       ).toBe(
-        originalFirstBlock.getText().slice(0, 1)
+        originalFirstBlock.getText().slice(0, 1),
       );
 
       const secondBlock = resultContent.getBlockMap().skip(1).first();
@@ -503,22 +503,22 @@ describe('AtomicBlockUtils', () => {
       });
       const targetEditor = EditorState.forceSelection(
         editorState,
-        targetSelection
+        targetSelection,
       );
 
       const resultEditor = insertAtomicBlock(
         targetEditor,
         entityKey,
-        character
+        character,
       );
       const resultContent = resultEditor.getCurrentContent();
 
       const firstBlock = resultContent.getBlockMap().first();
       expect(firstBlock.getType()).toBe(originalFirstBlock.getType());
       expect(
-        firstBlock.getText()
+        firstBlock.getText(),
       ).toBe(
-        originalFirstBlock.getText().slice(0, origLength - 2)
+        originalFirstBlock.getText().slice(0, origLength - 2),
       );
 
       const secondBlock = resultContent.getBlockMap().skip(1).first();
@@ -539,22 +539,22 @@ describe('AtomicBlockUtils', () => {
       });
       const targetEditor = EditorState.forceSelection(
         editorState,
-        targetSelection
+        targetSelection,
       );
 
       const resultEditor = insertAtomicBlock(
         targetEditor,
         entityKey,
-        character
+        character,
       );
       const resultContent = resultEditor.getCurrentContent();
 
       const firstBlock = resultContent.getBlockMap().first();
       expect(firstBlock.getType()).toBe(originalFirstBlock.getType());
       expect(
-        firstBlock.getText()
+        firstBlock.getText(),
       ).toBe(
-        originalFirstBlock.getText().slice(0, 2)
+        originalFirstBlock.getText().slice(0, 2),
       );
 
       const secondBlock = resultContent.getBlockMap().skip(1).first();
@@ -572,7 +572,7 @@ describe('AtomicBlockUtils', () => {
       const resultEditor = insertAtomicBlock(
         editorState,
         entityKey,
-        character
+        character,
       );
       const resultContent = resultEditor.getCurrentContent();
 
@@ -590,7 +590,7 @@ describe('AtomicBlockUtils', () => {
           anchorOffset: 0,
           focusKey: lastBlock.getKey(),
           focusOffset: 2,
-        })
+        }),
       );
       const atomicResultContent = atomicResultEditor.getCurrentContent();
 
@@ -609,7 +609,7 @@ describe('AtomicBlockUtils', () => {
       const resultEditor = insertAtomicBlock(
         editorState,
         entityKey,
-        character
+        character,
       );
       const resultContent = resultEditor.getCurrentContent();
 
@@ -627,7 +627,7 @@ describe('AtomicBlockUtils', () => {
           anchorOffset: lastBlock.getLength() - 2,
           focusKey: lastBlock.getKey(),
           focusOffset: lastBlock.getLength(),
-        })
+        }),
       );
       const atomicResultContent = atomicResultEditor.getCurrentContent();
 
@@ -646,7 +646,7 @@ describe('AtomicBlockUtils', () => {
       const resultEditor = insertAtomicBlock(
         editorState,
         entityKey,
-        character
+        character,
       );
       const resultContent = resultEditor.getCurrentContent();
 
@@ -664,7 +664,7 @@ describe('AtomicBlockUtils', () => {
           anchorOffset: 1,
           focusKey: thirdBlock.getKey(),
           focusOffset: 2,
-        })
+        }),
       );
       const atomicResultContent = atomicResultEditor.getCurrentContent();
 
@@ -685,7 +685,7 @@ describe('AtomicBlockUtils', () => {
       const resultEditor = insertAtomicBlock(
         editorState,
         entityKey,
-        character
+        character,
       );
       const resultContent = resultEditor.getCurrentContent();
 
@@ -705,7 +705,7 @@ describe('AtomicBlockUtils', () => {
           focusKey: lastBlock.getKey(),
           focusOffset: 2,
         }),
-        'before'
+        'before',
       );
       const atomicResultContent = atomicResultEditor.getCurrentContent();
 
@@ -721,7 +721,7 @@ describe('AtomicBlockUtils', () => {
       const resultEditor = insertAtomicBlock(
         editorState,
         entityKey,
-        character
+        character,
       );
       const resultContent = resultEditor.getCurrentContent();
 
@@ -741,7 +741,7 @@ describe('AtomicBlockUtils', () => {
           focusKey: lastBlock.getKey(),
           focusOffset: 2,
         }),
-        'after'
+        'after',
       );
       const atomicResultContent = atomicResultEditor.getCurrentContent();
 
@@ -759,14 +759,14 @@ describe('AtomicBlockUtils', () => {
       });
       const targetEditor = EditorState.forceSelection(
         editorState,
-        targetSelection
+        targetSelection,
       );
 
       // Insert atomic block at the second position
       const resultEditor = insertAtomicBlock(
         targetEditor,
         entityKey,
-        character
+        character,
       );
       const resultContent = resultEditor.getCurrentContent();
 
@@ -787,9 +787,9 @@ describe('AtomicBlockUtils', () => {
               anchorOffset: beforeAtomicBlock.getLength() - 2,
               focusKey: beforeAtomicBlock.getKey(),
               focusOffset: beforeAtomicBlock.getLength(),
-            })
+            }),
           );
-        }
+        },
       ).toThrow(new Error('Block cannot be moved next to itself.'));
 
       // Move atomic block below itself by moving it before following block by replacement
@@ -803,9 +803,9 @@ describe('AtomicBlockUtils', () => {
               anchorOffset: 0,
               focusKey: afterAtomicBlock.getKey(),
               focusOffset: 2,
-            })
+            }),
           );
-        }
+        },
       ).toThrow(new Error('Block cannot be moved next to itself.'));
     });
   });

--- a/src/model/modifier/__tests__/DraftRemovableWord-test.js
+++ b/src/model/modifier/__tests__/DraftRemovableWord-test.js
@@ -82,7 +82,7 @@ describe('DraftRemovableWord', function() {
     expect(forward('|' + english)).toBe('|' + match);
     expect(forward('^' + english)).toBe('^' + match);
     expect(forward('\u060d\uFD3e\uFD3F' + english)).toBe(
-      '\u060d\uFD3e\uFD3F' + match
+      '\u060d\uFD3e\uFD3F' + match,
     );
     expect(forward('.. .. ..' + english)).toBe('.. .. ..' + match);
   });
@@ -121,7 +121,7 @@ describe('DraftRemovableWord', function() {
     expect(backward(english + '|')).toBe(match + '|');
     expect(backward(english + '^')).toBe(match + '^');
     expect(backward(english + '\u060d\uFD3e\uFD3F')).toBe(
-      match + '\u060d\uFD3e\uFD3F'
+      match + '\u060d\uFD3e\uFD3F',
     );
     expect(backward(english + '.. .. ..')).toBe(match + '.. .. ..');
   });

--- a/src/model/modifier/__tests__/RichTextEditorUtil-test.js
+++ b/src/model/modifier/__tests__/RichTextEditorUtil-test.js
@@ -39,16 +39,16 @@ describe('RichTextEditorUtil', () => {
     it('does not handle non-zero-offset or non-collapsed selections', () => {
       const nonZero = selectionState.merge({anchorOffset: 2, focusOffset: 2});
       expect(
-        onBackspace(EditorState.forceSelection(editorState, nonZero))
+        onBackspace(EditorState.forceSelection(editorState, nonZero)),
       ).toBe(
-        null
+        null,
       );
 
       const nonCollapsed = nonZero.merge({anchorOffset: 0});
       expect(
-        onBackspace(EditorState.forceSelection(editorState, nonCollapsed))
+        onBackspace(EditorState.forceSelection(editorState, nonCollapsed)),
       ).toBe(
-        null
+        null,
       );
     });
 
@@ -89,9 +89,9 @@ describe('RichTextEditorUtil', () => {
       const blockMap = contentState.getBlockMap();
       expect(blockMap.size).toBe(4);
       expect(
-        blockMap.some((block) => block.getType() === 'atomic')
+        blockMap.some((block) => block.getType() === 'atomic'),
       ).toBe(
-        false
+        false,
       );
     });
   });
@@ -102,16 +102,16 @@ describe('RichTextEditorUtil', () => {
     it('does not handle non-block-end or non-collapsed selections', () => {
       const nonZero = selectionState.merge({anchorOffset: 2, focusOffset: 2});
       expect(
-        onDelete(EditorState.forceSelection(editorState, nonZero))
+        onDelete(EditorState.forceSelection(editorState, nonZero)),
       ).toBe(
-        null
+        null,
       );
 
       const nonCollapsed = nonZero.merge({anchorOffset: 0});
       expect(
-        onDelete(EditorState.forceSelection(editorState, nonCollapsed))
+        onDelete(EditorState.forceSelection(editorState, nonCollapsed)),
       ).toBe(
-        null
+        null,
       );
     });
 
@@ -134,16 +134,16 @@ describe('RichTextEditorUtil', () => {
           anchorOffset: lengthBefore,
           focusKey: keyBefore,
           focusOffset: lengthBefore,
-        })
+        }),
       );
 
       const afterDelete = onDelete(withSelectionAboveAtomic);
       const blockMapAfterDelete = afterDelete.getCurrentContent().getBlockMap();
 
       expect(
-        blockMapAfterDelete.some((block) => block.getType() === 'atomic')
+        blockMapAfterDelete.some((block) => block.getType() === 'atomic'),
       ).toBe(
-        false
+        false,
       );
 
       expect(blockMapAfterDelete.size).toBe(4);

--- a/src/model/modifier/getRangesForDraftEntity.js
+++ b/src/model/modifier/getRangesForDraftEntity.js
@@ -28,19 +28,19 @@ import type {DraftRange} from 'DraftRange';
  */
 function getRangesForDraftEntity(
   block: ContentBlock,
-  key: string
+  key: string,
 ): Array<DraftRange> {
   var ranges = [];
   block.findEntityRanges(
     c => c.getEntity() === key,
     (start, end) => {
       ranges.push({start, end});
-    }
+    },
   );
 
   invariant(
     !!ranges.length,
-    'Entity key not found in this range.'
+    'Entity key not found in this range.',
   );
 
   return ranges;

--- a/src/model/paste/DraftPasteProcessor.js
+++ b/src/model/paste/DraftPasteProcessor.js
@@ -34,12 +34,12 @@ const {
 const DraftPasteProcessor = {
   processHTML(
     html: string,
-    blockRenderMap?: DraftBlockRenderMap
+    blockRenderMap?: DraftBlockRenderMap,
   ): ?{contentBlocks: ?Array<ContentBlock>, entityMap: EntityMap} {
     return convertFromHTMLtoContentBlocks(
       html,
       getSafeBodyFromHTML,
-      blockRenderMap
+      blockRenderMap,
     );
   },
 
@@ -56,7 +56,7 @@ const DraftPasteProcessor = {
           text: textLine,
           characterList: List(Repeat(character, textLine.length)),
         });
-      }
+      },
     );
   },
 };

--- a/src/model/paste/__tests__/DraftPasteProcessor-test.js
+++ b/src/model/paste/__tests__/DraftPasteProcessor-test.js
@@ -64,17 +64,17 @@ describe('DraftPasteProcessor', function() {
 
   function assertDepths(blocks, comparison) {
     expect(
-      blocks.map(b => b.getDepth())
+      blocks.map(b => b.getDepth()),
     ).toEqual(
-      comparison
+      comparison,
     );
   }
 
   function assertBlockTypes(blocks, comparison) {
     expect(
-      blocks.map(b => b.getType())
+      blocks.map(b => b.getType()),
     ).toEqual(
-      comparison
+      comparison,
     );
   }
 
@@ -297,7 +297,7 @@ describe('DraftPasteProcessor', function() {
     assertBlockTypes(output, ['unstyled']);
     assertEntities(
       output[0],
-      Array(10).fill(false).concat(Array(4).fill(true), Array(6).fill(false))
+      Array(10).fill(false).concat(Array(4).fill(true), Array(6).fill(false)),
     );
     expect(output[0].getText()).toBe('This is a link, yep.');
     var entityId = output[0].getCharacterList().get(12).getEntity();
@@ -311,11 +311,11 @@ describe('DraftPasteProcessor', function() {
     assertBlockTypes(output, ['unstyled']);
     assertInlineStyles(
       output[0],
-      Array(2).fill([]).concat(Array(4).fill(['ITALIC']), Array(11).fill([]))
+      Array(2).fill([]).concat(Array(4).fill(['ITALIC']), Array(11).fill([])),
     );
     assertEntities(
       output[0],
-      Array(2).fill(false).concat(Array(9).fill(true), Array(6).fill(false))
+      Array(2).fill(false).concat(Array(9).fill(true), Array(6).fill(false)),
     );
     expect(output[0].getText()).toBe('A cool link, yep.');
   });
@@ -345,7 +345,7 @@ describe('DraftPasteProcessor', function() {
     assertBlockTypes(output, ['unstyled']);
     assertEntities(
       output[0],
-      Array(10).fill(false).concat(Array(4).fill(true), Array(6).fill(false))
+      Array(10).fill(false).concat(Array(4).fill(true), Array(6).fill(false)),
     );
     expect(output[0].getText()).toBe('This is a link, yep.');
     var entityId = output[0].getCharacterList().get(12).getEntity();

--- a/src/model/transaction/ContentStateInlineStyle.js
+++ b/src/model/transaction/ContentStateInlineStyle.js
@@ -23,7 +23,7 @@ var ContentStateInlineStyle = {
   add: function(
     contentState: ContentState,
     selectionState: SelectionState,
-    inlineStyle: string
+    inlineStyle: string,
   ): ContentState {
     return modifyInlineStyle(contentState, selectionState, inlineStyle, true);
   },
@@ -31,7 +31,7 @@ var ContentStateInlineStyle = {
   remove: function(
     contentState: ContentState,
     selectionState: SelectionState,
-    inlineStyle: string
+    inlineStyle: string,
   ): ContentState {
     return modifyInlineStyle(contentState, selectionState, inlineStyle, false);
   },
@@ -41,7 +41,7 @@ function modifyInlineStyle(
   contentState: ContentState,
   selectionState: SelectionState,
   inlineStyle: string,
-  addOrRemove: boolean
+  addOrRemove: boolean,
 ): ContentState {
   var blockMap = contentState.getBlockMap();
   var startKey = selectionState.getStartKey();
@@ -73,7 +73,7 @@ function modifyInlineStyle(
           sliceStart,
           addOrRemove ?
             CharacterMetadata.applyStyle(current, inlineStyle) :
-            CharacterMetadata.removeStyle(current, inlineStyle)
+            CharacterMetadata.removeStyle(current, inlineStyle),
         );
         sliceStart++;
       }

--- a/src/model/transaction/__tests__/ContentStateInlineStyle-test.js
+++ b/src/model/transaction/__tests__/ContentStateInlineStyle-test.js
@@ -40,18 +40,18 @@ describe('ContentStateInlineStyle', () => {
     it('must add styles', () => {
       let modified = ContentStateInlineStyle.add(contentState, target, 'BOLD');
       expect(
-        getStyles(modified.getBlockForKey(blockKey))
+        getStyles(modified.getBlockForKey(blockKey)),
       ).toEqual(
-        Repeat('BOLD', length).toJS()
+        Repeat('BOLD', length).toJS(),
       );
 
       const nextTarget = target.set('focusOffset', 2);
       modified = ContentStateInlineStyle.add(modified, nextTarget, 'ITALIC');
       expect(
-        getStyles(modified.getBlockForKey(blockKey))
+        getStyles(modified.getBlockForKey(blockKey)),
       ).toEqual(
         List(['BOLD', 'ITALIC', 'BOLD', 'ITALIC'])
-          .concat(List(Repeat('BOLD', 3))).toJS()
+          .concat(List(Repeat('BOLD', 3))).toJS(),
       );
     });
 
@@ -60,22 +60,22 @@ describe('ContentStateInlineStyle', () => {
       let modified = ContentStateInlineStyle.add(
         contentState,
         target,
-        'BOLD'
+        'BOLD',
       );
       modified = ContentStateInlineStyle.add(modified, target, 'ITALIC');
       modified = ContentStateInlineStyle.remove(modified, target, 'BOLD');
       expect(
-        getStyles(modified.getBlockForKey(blockKey))
+        getStyles(modified.getBlockForKey(blockKey)),
       ).toEqual(
-        Repeat('ITALIC', length).toJS()
+        Repeat('ITALIC', length).toJS(),
       );
 
       const nextTarget = target.set('focusOffset', 2);
       modified = ContentStateInlineStyle.remove(modified, nextTarget, 'ITALIC');
       expect(
-        getStyles(modified.getBlockForKey(blockKey))
+        getStyles(modified.getBlockForKey(blockKey)),
       ).toEqual(
-        List(Repeat('ITALIC', 3)).toJS()
+        List(Repeat('ITALIC', 3)).toJS(),
       );
     });
   });
@@ -92,25 +92,25 @@ describe('ContentStateInlineStyle', () => {
       const start = contentState.getBlockForKey(target.getStartKey());
 
       expect(
-        getStyles(modified.getBlockForKey(target.getStartKey()))
+        getStyles(modified.getBlockForKey(target.getStartKey())),
       ).toEqual(
-        Repeat('BOLD', start.getLength()).toJS()
+        Repeat('BOLD', start.getLength()).toJS(),
       );
 
       expect(
-        getStyles(modified.getBlockForKey(nextBlock.getKey()))
+        getStyles(modified.getBlockForKey(nextBlock.getKey())),
       ).toEqual(
-        Repeat('BOLD', nextBlock.getLength()).toJS()
+        Repeat('BOLD', nextBlock.getLength()).toJS(),
       );
 
       modified = ContentStateInlineStyle.remove(contentState, target, 'BOLD');
 
       expect(
-        getStyles(modified.getBlockForKey(target.getStartKey())).length
+        getStyles(modified.getBlockForKey(target.getStartKey())).length,
       ).toEqual(0);
 
       expect(
-        getStyles(modified.getBlockForKey(nextBlock.getKey())).length
+        getStyles(modified.getBlockForKey(nextBlock.getKey())).length,
       ).toEqual(0);
     });
   });

--- a/src/model/transaction/__tests__/applyEntityToContentState-test.js
+++ b/src/model/transaction/__tests__/applyEntityToContentState-test.js
@@ -44,13 +44,13 @@ describe('applyEntityToContentState', () => {
       var withNewEntity = applyEntityToContentState(
         contentState,
         targetSelection,
-        entityKey
+        entityKey,
       );
       var first = withNewEntity.getBlockMap().first();
 
       checkForCharacterList(first);
       expect(getEntities(first)).toEqual(
-        Immutable.Repeat(entityKey, first.getLength()).toArray()
+        Immutable.Repeat(entityKey, first.getLength()).toArray(),
       );
     }
 
@@ -79,18 +79,18 @@ describe('applyEntityToContentState', () => {
       var withNewEntity = applyEntityToContentState(
         contentState,
         targetSelection,
-        entityKey
+        entityKey,
       );
       var first = withNewEntity.getBlockMap().first();
       var last = withNewEntity.getBlockAfter(first.getKey());
 
       checkForCharacterList(first);
       expect(getEntities(first)).toEqual(
-        Immutable.Repeat(entityKey, first.getLength()).toArray()
+        Immutable.Repeat(entityKey, first.getLength()).toArray(),
       );
       checkForCharacterList(last);
       expect(getEntities(last)).toEqual(
-        Immutable.Repeat(entityKey, last.getLength()).toArray()
+        Immutable.Repeat(entityKey, last.getLength()).toArray(),
       );
     }
 

--- a/src/model/transaction/__tests__/insertFragmentIntoContentState-test.js
+++ b/src/model/transaction/__tests__/insertFragmentIntoContentState-test.js
@@ -72,7 +72,7 @@ describe('insertFragmentIntoContentState', () => {
       insertFragmentIntoContentState(
         content,
         selection,
-        fragment
+        fragment,
       );
     }).toThrow();
   });
@@ -82,7 +82,7 @@ describe('insertFragmentIntoContentState', () => {
     var modified = insertFragmentIntoContentState(
       content,
       selection,
-      fragment
+      fragment,
     );
 
     var newBlock = modified.getBlockMap().first();
@@ -103,7 +103,7 @@ describe('insertFragmentIntoContentState', () => {
     var modified = insertFragmentIntoContentState(
       content,
       target,
-      fragment
+      fragment,
     );
 
     var newBlock = modified.getBlockMap().first();
@@ -124,7 +124,7 @@ describe('insertFragmentIntoContentState', () => {
     var modified = insertFragmentIntoContentState(
       content,
       target,
-      fragment
+      fragment,
     );
 
     var newBlock = modified.getBlockMap().first();
@@ -138,7 +138,7 @@ describe('insertFragmentIntoContentState', () => {
     var modified = insertFragmentIntoContentState(
       content,
       selection,
-      fragment
+      fragment,
     );
 
     var newBlock = modified.getBlockMap().first();

--- a/src/model/transaction/__tests__/insertIntoList-test.js
+++ b/src/model/transaction/__tests__/insertIntoList-test.js
@@ -23,7 +23,7 @@ describe('insertIntoList', () => {
     var result = insertIntoList(
       list,
       Immutable.List.of(100, 101, 102),
-      list.size
+      list.size,
     );
     expect(result.size).toBe(8);
     expect(result.toJS()).toEqual([0, 1, 2, 3, 4, 100, 101, 102]);
@@ -33,7 +33,7 @@ describe('insertIntoList', () => {
     var result = insertIntoList(
       list,
       Immutable.List.of(100, 101, 102),
-      0
+      0,
     );
     expect(result.size).toBe(8);
     expect(result.toJS()).toEqual([100, 101, 102, 0, 1, 2, 3, 4]);
@@ -43,7 +43,7 @@ describe('insertIntoList', () => {
     var result = insertIntoList(
       list,
       Immutable.List.of(100, 101, 102),
-      3
+      3,
     );
     expect(result.size).toBe(8);
     expect(result.toJS()).toEqual([0, 1, 2, 100, 101, 102, 3, 4]);

--- a/src/model/transaction/__tests__/insertTextIntoContentState-test.js
+++ b/src/model/transaction/__tests__/insertTextIntoContentState-test.js
@@ -46,7 +46,7 @@ describe('insertTextIntoContentState', () => {
       content,
       selection,
       'xx',
-      character
+      character,
     );
 
     var newBlock = modified.getBlockMap().first();
@@ -56,10 +56,10 @@ describe('insertTextIntoContentState', () => {
     expect(
       Immutable.is(
         Immutable.List.of(
-          character, character, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY
+          character, character, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY,
         ),
-        newBlock.getCharacterList()
-      )
+        newBlock.getCharacterList(),
+      ),
     ).toBe(true);
   });
 
@@ -82,8 +82,8 @@ describe('insertTextIntoContentState', () => {
         newBlock.getCharacterList(),
         Immutable.List([
           EMPTY, EMPTY, character, character, EMPTY, EMPTY, EMPTY,
-        ])
-      )
+        ]),
+      ),
     ).toBe(true);
   });
 
@@ -106,8 +106,8 @@ describe('insertTextIntoContentState', () => {
         newBlock.getCharacterList(),
         Immutable.List([
           EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, character, character,
-        ])
-      )
+        ]),
+      ),
     ).toBe(true);
   });
 });

--- a/src/model/transaction/__tests__/removeEntitiesAtEdges-test.js
+++ b/src/model/transaction/__tests__/removeEntitiesAtEdges-test.js
@@ -47,9 +47,9 @@ describe('removeEntitiesAtEdges', () => {
 
   function expectNullEntities(block) {
     expect(
-      getEntities(block)
+      getEntities(block),
     ).toEqual(
-      List(Repeat(null, block.getLength())).toJS()
+      List(Repeat(null, block.getLength())).toJS(),
     );
   }
 

--- a/src/model/transaction/__tests__/removeRangeFromContentState-test.js
+++ b/src/model/transaction/__tests__/removeRangeFromContentState-test.js
@@ -40,21 +40,21 @@ describe('removeRangeFromContentState', () => {
     expect(block.getType()).toBe(comparison.getType());
     expect(block.getText()).toBe(comparison.getText().slice(start, end));
     expect(
-      getInlineStyles(block)
+      getInlineStyles(block),
     ).toEqual(
-      getInlineStyles(comparison).slice(start, end)
+      getInlineStyles(comparison).slice(start, end),
     );
     expect(
-      getEntities(block)
+      getEntities(block),
     ).toEqual(
-      getEntities(comparison).slice(start, end)
+      getEntities(comparison).slice(start, end),
     );
     checkForCharacterList(block);
   }
 
   it('must return the input ContentState if selection is collapsed', () => {
     expect(
-      removeRangeFromContentState(contentState, selectionState)
+      removeRangeFromContentState(contentState, selectionState),
     ).toBe(contentState);
   });
 
@@ -85,16 +85,16 @@ describe('removeRangeFromContentState', () => {
       expect(alteredBlock.getType()).toBe(originalBlock.getType());
       expect(alteredBlock.getText()).toBe(
         originalBlock.getText().slice(0, 2) +
-        originalBlock.getText().slice(4)
+        originalBlock.getText().slice(4),
       );
 
       var stylesToJS = getInlineStyles(originalBlock);
       expect(getInlineStyles(alteredBlock)).toEqual(
-        stylesToJS.slice(0, 2).concat(stylesToJS.slice(4))
+        stylesToJS.slice(0, 2).concat(stylesToJS.slice(4)),
       );
       var entitiesToJS = getEntities(originalBlock);
       expect(getEntities(alteredBlock)).toEqual(
-        entitiesToJS.slice(0, 2).concat(entitiesToJS.slice(4))
+        entitiesToJS.slice(0, 2).concat(entitiesToJS.slice(4)),
       );
     });
 
@@ -127,7 +127,7 @@ describe('removeRangeFromContentState', () => {
         var blockB = contentState.getBlockMap().skip(1).first();
         var sameContentDifferentType = blockB.set(
           'type',
-          contentState.getBlockMap().first().getType()
+          contentState.getBlockMap().first().getType(),
         );
 
         expectBlockToBeSlice(alteredBlock, sameContentDifferentType, 0);
@@ -149,7 +149,7 @@ describe('removeRangeFromContentState', () => {
         var blockB = contentState.getBlockMap().skip(1).first();
         var sameContentDifferentType = blockB.set(
           'type',
-          contentState.getBlockMap().first().getType()
+          contentState.getBlockMap().first().getType(),
         );
 
         expectBlockToBeSlice(alteredBlock, sameContentDifferentType, 3);
@@ -196,16 +196,16 @@ describe('removeRangeFromContentState', () => {
         expect(alteredBlock.getType()).toBe(originalBlockA.getType());
         expect(alteredBlock.getText()).toBe(
           originalBlockA.getText().slice(0, 3) +
-          originalBlockB.getText()
+          originalBlockB.getText(),
         );
 
         var stylesToJS = getInlineStyles(originalBlockA);
         expect(getInlineStyles(alteredBlock)).toEqual(
-          stylesToJS.slice(0, 3).concat(getInlineStyles(originalBlockB))
+          stylesToJS.slice(0, 3).concat(getInlineStyles(originalBlockB)),
         );
         var entitiesToJS = getEntities(originalBlockA);
         expect(getEntities(alteredBlock)).toEqual(
-          entitiesToJS.slice(0, 3).concat(getEntities(originalBlockB))
+          entitiesToJS.slice(0, 3).concat(getEntities(originalBlockB)),
         );
 
         checkForCharacterList(alteredBlock);
@@ -229,20 +229,20 @@ describe('removeRangeFromContentState', () => {
         expect(alteredBlock.getType()).toBe(originalBlockA.getType());
         expect(alteredBlock.getText()).toBe(
           originalBlockA.getText().slice(0, 3) +
-          originalBlockB.getText().slice(3)
+          originalBlockB.getText().slice(3),
         );
 
         var stylesToJS = getInlineStyles(originalBlockA);
         expect(getInlineStyles(alteredBlock)).toEqual(
           stylesToJS.slice(0, 3).concat(
-            getInlineStyles(originalBlockB).slice(3)
-          )
+            getInlineStyles(originalBlockB).slice(3),
+          ),
         );
         var entitiesToJS = getEntities(originalBlockA);
         expect(getEntities(alteredBlock)).toEqual(
           entitiesToJS.slice(0, 3).concat(
-            getEntities(originalBlockB).slice(3)
-          )
+            getEntities(originalBlockB).slice(3),
+          ),
         );
 
         checkForCharacterList(alteredBlock);
@@ -266,16 +266,16 @@ describe('removeRangeFromContentState', () => {
         expect(alteredBlock).not.toBe(originalBlockB);
         expect(alteredBlock.getType()).toBe(originalBlockA.getType());
         expect(alteredBlock.getText()).toBe(
-          originalBlockA.getText().slice(0, 3)
+          originalBlockA.getText().slice(0, 3),
         );
 
         var stylesToJS = getInlineStyles(originalBlockA);
         expect(getInlineStyles(alteredBlock)).toEqual(
-          stylesToJS.slice(0, 3)
+          stylesToJS.slice(0, 3),
         );
         var entitiesToJS = getEntities(originalBlockA);
         expect(getEntities(alteredBlock)).toEqual(
-          entitiesToJS.slice(0, 3)
+          entitiesToJS.slice(0, 3),
         );
 
         checkForCharacterList(alteredBlock);
@@ -307,16 +307,16 @@ describe('removeRangeFromContentState', () => {
         expect(alteredBlock.getType()).toBe(originalBlockA.getType());
         expect(alteredBlock.getText()).toBe(
           originalBlockA.getText() +
-          originalBlockB.getText()
+          originalBlockB.getText(),
         );
 
         var stylesToJS = getInlineStyles(originalBlockA);
         expect(getInlineStyles(alteredBlock)).toEqual(
-          stylesToJS.concat(getInlineStyles(originalBlockB))
+          stylesToJS.concat(getInlineStyles(originalBlockB)),
         );
         var entitiesToJS = getEntities(originalBlockA);
         expect(getEntities(alteredBlock)).toEqual(
-          entitiesToJS.concat(getEntities(originalBlockB))
+          entitiesToJS.concat(getEntities(originalBlockB)),
         );
 
         checkForCharacterList(alteredBlock);
@@ -340,20 +340,20 @@ describe('removeRangeFromContentState', () => {
         expect(alteredBlock.getType()).toBe(originalBlockA.getType());
         expect(alteredBlock.getText()).toBe(
           originalBlockA.getText() +
-          originalBlockB.getText().slice(3)
+          originalBlockB.getText().slice(3),
         );
 
         var stylesToJS = getInlineStyles(originalBlockA);
         expect(getInlineStyles(alteredBlock)).toEqual(
           stylesToJS.concat(
-            getInlineStyles(originalBlockB).slice(3)
-          )
+            getInlineStyles(originalBlockB).slice(3),
+          ),
         );
         var entitiesToJS = getEntities(originalBlockA);
         expect(getEntities(alteredBlock)).toEqual(
           entitiesToJS.concat(
-            getEntities(originalBlockB).slice(3)
-          )
+            getEntities(originalBlockB).slice(3),
+          ),
         );
         checkForCharacterList(alteredBlock);
       });
@@ -406,20 +406,20 @@ describe('removeRangeFromContentState', () => {
       expect(alteredBlock.getType()).toBe(originalBlockA.getType());
       expect(alteredBlock.getText()).toBe(
         originalBlockA.getText().slice(0, 3) +
-        originalBlockC.getText().slice(3)
+        originalBlockC.getText().slice(3),
       );
 
       var stylesToJS = getInlineStyles(originalBlockA);
       expect(getInlineStyles(alteredBlock)).toEqual(
         stylesToJS.slice(0, 3).concat(
-          getInlineStyles(originalBlockC).slice(3)
-        )
+          getInlineStyles(originalBlockC).slice(3),
+        ),
       );
       var entitiesToJS = getEntities(originalBlockA);
       expect(getEntities(alteredBlock)).toEqual(
         entitiesToJS.slice(0, 3).concat(
-          getEntities(originalBlockC).slice(3)
-        )
+          getEntities(originalBlockC).slice(3),
+        ),
       );
 
       checkForCharacterList(alteredBlock);

--- a/src/model/transaction/__tests__/splitBlockInContentState-test.js
+++ b/src/model/transaction/__tests__/splitBlockInContentState-test.js
@@ -69,14 +69,14 @@ describe('splitBlockInContentState', () => {
     expect(postSplitBlock.getType()).toBe(initialBlock.getType());
     expect(postSplitBlock.getText()).toBe(initialBlock.getText());
     expect(
-      getInlineStyles(initialBlock)
+      getInlineStyles(initialBlock),
     ).toEqual(
-      getInlineStyles(postSplitBlock)
+      getInlineStyles(postSplitBlock),
     );
     expect(
-      getEntities(postSplitBlock)
+      getEntities(postSplitBlock),
     ).toEqual(
-      getEntities(initialBlock)
+      getEntities(initialBlock),
     );
 
     checkForCharacterList(preSplitBlock);
@@ -100,13 +100,13 @@ describe('splitBlockInContentState', () => {
 
     expect(preSplitBlock.getKey()).toBe(initialBlock.getKey());
     expect(preSplitBlock.getText()).toBe(
-      initialBlock.getText().slice(0, SPLIT_OFFSET)
+      initialBlock.getText().slice(0, SPLIT_OFFSET),
     );
     expect(getInlineStyles(preSplitBlock)).toEqual(
-      getInlineStyles(initialBlock).slice(0, SPLIT_OFFSET)
+      getInlineStyles(initialBlock).slice(0, SPLIT_OFFSET),
     );
     expect(getEntities(preSplitBlock)).toEqual(
-      getEntities(initialBlock).slice(0, SPLIT_OFFSET)
+      getEntities(initialBlock).slice(0, SPLIT_OFFSET),
     );
 
     expect(preSplitBlock.getKey()).not.toBe(postSplitBlock.getKey());
@@ -115,13 +115,13 @@ describe('splitBlockInContentState', () => {
     expect(postSplitBlock.getKey()).not.toBe(initialBlock.getKey());
     expect(postSplitBlock.getType()).toBe(initialBlock.getType());
     expect(postSplitBlock.getText()).toBe(
-      initialBlock.getText().slice(SPLIT_OFFSET)
+      initialBlock.getText().slice(SPLIT_OFFSET),
     );
     expect(getInlineStyles(postSplitBlock)).toEqual(
-      getInlineStyles(initialBlock).slice(SPLIT_OFFSET)
+      getInlineStyles(initialBlock).slice(SPLIT_OFFSET),
     );
     expect(getEntities(postSplitBlock)).toEqual(
-      getEntities(initialBlock).slice(SPLIT_OFFSET)
+      getEntities(initialBlock).slice(SPLIT_OFFSET),
     );
 
     checkForCharacterList(preSplitBlock);
@@ -149,14 +149,14 @@ describe('splitBlockInContentState', () => {
     expect(preSplitBlock.getType()).toBe(postSplitBlock.getType());
     expect(preSplitBlock.getText()).toBe(initialBlock.getText());
     expect(
-      getInlineStyles(preSplitBlock)
+      getInlineStyles(preSplitBlock),
     ).toEqual(
-      getInlineStyles(initialBlock)
+      getInlineStyles(initialBlock),
     );
     expect(
-      getEntities(preSplitBlock)
+      getEntities(preSplitBlock),
     ).toEqual(
-      getEntities(initialBlock)
+      getEntities(initialBlock),
     );
 
     expect(postSplitBlock.getKey()).not.toBe(initialBlock.getKey());

--- a/src/model/transaction/addEntityToContentState.js
+++ b/src/model/transaction/addEntityToContentState.js
@@ -20,7 +20,7 @@ import type DraftEntityInstance from 'DraftEntityInstance';
 
 function addEntityToContentState(
   contentState: ContentState,
-  instance: DraftEntityInstance
+  instance: DraftEntityInstance,
 ): ContentState {
   return contentState.set(
     'entityMap',

--- a/src/model/transaction/adjustBlockDepthForContentState.js
+++ b/src/model/transaction/adjustBlockDepthForContentState.js
@@ -20,7 +20,7 @@ function adjustBlockDepthForContentState(
   contentState: ContentState,
   selectionState: SelectionState,
   adjustment: number,
-  maxDepth: number
+  maxDepth: number,
 ): ContentState {
   var startKey = selectionState.getStartKey();
   var endKey = selectionState.getEndKey();

--- a/src/model/transaction/applyEntityToContentBlock.js
+++ b/src/model/transaction/applyEntityToContentBlock.js
@@ -21,13 +21,13 @@ function applyEntityToContentBlock(
   contentBlock: ContentBlock,
   start: number,
   end: number,
-  entityKey: ?string
+  entityKey: ?string,
 ): ContentBlock {
   var characterList = contentBlock.getCharacterList();
   while (start < end) {
     characterList = characterList.set(
       start,
-      CharacterMetadata.applyEntity(characterList.get(start), entityKey)
+      CharacterMetadata.applyEntity(characterList.get(start), entityKey),
     );
     start++;
   }

--- a/src/model/transaction/applyEntityToContentState.js
+++ b/src/model/transaction/applyEntityToContentState.js
@@ -23,7 +23,7 @@ import type SelectionState from 'SelectionState';
 function applyEntityToContentState(
   contentState: ContentState,
   selectionState: SelectionState,
-  entityKey: ?string
+  entityKey: ?string,
 ): ContentState {
   const blockMap = contentState.getBlockMap();
   const startKey = selectionState.getStartKey();
@@ -43,7 +43,7 @@ function applyEntityToContentState(
         block,
         sliceStart,
         sliceEnd,
-        entityKey
+        entityKey,
       );
     });
 

--- a/src/model/transaction/getContentStateFragment.js
+++ b/src/model/transaction/getContentStateFragment.js
@@ -22,7 +22,7 @@ import type SelectionState from 'SelectionState';
 
 function getContentStateFragment(
   contentState: ContentState,
-  selectionState: SelectionState
+  selectionState: SelectionState,
 ): BlockMap {
   var startKey = selectionState.getStartKey();
   var startOffset = selectionState.getStartOffset();
@@ -34,7 +34,7 @@ function getContentStateFragment(
   // preserve entities that are entirely within the selection range.
   var contentWithoutEdgeEntities = removeEntitiesAtEdges(
     contentState,
-    selectionState
+    selectionState,
   );
 
   var blockMap = contentWithoutEdgeEntities.getBlockMap();

--- a/src/model/transaction/getSampleStateForTesting.js
+++ b/src/model/transaction/getSampleStateForTesting.js
@@ -31,7 +31,7 @@ var BLOCKS = [
     type: 'unstyled',
     text: 'Alpha',
     characterList: Immutable.List(
-      Immutable.Repeat(CharacterMetadata.EMPTY, 5)
+      Immutable.Repeat(CharacterMetadata.EMPTY, 5),
     ),
   }),
   new ContentBlock({
@@ -41,8 +41,8 @@ var BLOCKS = [
     characterList: Immutable.List(
       Immutable.Repeat(
         CharacterMetadata.create({style: BOLD, entity: ENTITY_KEY}),
-        5
-      )
+        5,
+      ),
     ),
   }),
   new ContentBlock({
@@ -52,8 +52,8 @@ var BLOCKS = [
     characterList: Immutable.List(
       Immutable.Repeat(
         CharacterMetadata.create({style: ITALIC, entity: null}),
-        7
-      )
+        7,
+      ),
     ),
   }),
 ];

--- a/src/model/transaction/insertFragmentIntoContentState.js
+++ b/src/model/transaction/insertFragmentIntoContentState.js
@@ -26,11 +26,11 @@ import type SelectionState from 'SelectionState';
 function insertFragmentIntoContentState(
   contentState: ContentState,
   selectionState: SelectionState,
-  fragment: BlockMap
+  fragment: BlockMap,
 ): ContentState {
   invariant(
     selectionState.isCollapsed(),
-    '`insertFragment` should only be called with a collapsed selection state.'
+    '`insertFragment` should only be called with a collapsed selection state.',
   );
 
   var targetKey = selectionState.getStartKey();
@@ -57,7 +57,7 @@ function insertFragmentIntoContentState(
       characterList: insertIntoList(
         chars,
         pastedBlock.getCharacterList(),
-        targetOffset
+        targetOffset,
       ),
       data: pastedBlock.getData(),
     });
@@ -111,7 +111,7 @@ function insertFragmentIntoContentState(
       fragment.slice(1, fragmentSize - 1).forEach(
         fragmentBlock => {
           newBlockArr.push(fragmentBlock.set('key', generateRandomKey()));
-        }
+        },
       );
 
       // Modify tail portion of block.
@@ -130,7 +130,7 @@ function insertFragmentIntoContentState(
       });
 
       newBlockArr.push(modifiedTail);
-    }
+    },
   );
 
   finalOffset = fragment.last().getLength();

--- a/src/model/transaction/insertIntoList.js
+++ b/src/model/transaction/insertIntoList.js
@@ -20,7 +20,7 @@ import type {List} from 'immutable';
 function insertIntoList<T>(
   targetList: List<T>,
   toInsert: List<T>,
-  offset: number
+  offset: number,
 ): List<T> {
   if (offset === targetList.count()) {
     toInsert.forEach(c => {

--- a/src/model/transaction/insertTextIntoContentState.js
+++ b/src/model/transaction/insertTextIntoContentState.js
@@ -28,11 +28,11 @@ function insertTextIntoContentState(
   contentState: ContentState,
   selectionState: SelectionState,
   text: string,
-  characterMetadata: CharacterMetadata
+  characterMetadata: CharacterMetadata,
 ): ContentState {
   invariant(
     selectionState.isCollapsed(),
-    '`insertText` should only be called with a collapsed range.'
+    '`insertText` should only be called with a collapsed range.',
   );
 
   var len = text.length;
@@ -55,7 +55,7 @@ function insertTextIntoContentState(
     characterList: insertIntoList(
       block.getCharacterList(),
       Repeat(characterMetadata, len).toList(),
-      offset
+      offset,
     ),
   });
 

--- a/src/model/transaction/moveBlockInContentState.js
+++ b/src/model/transaction/moveBlockInContentState.js
@@ -23,16 +23,16 @@ function moveBlockInContentState(
   contentState: ContentState,
   blockToBeMoved: ContentBlock,
   targetBlock: ContentBlock,
-  insertionMode: DraftInsertionType
+  insertionMode: DraftInsertionType,
 ): ContentState {
   invariant(
     blockToBeMoved.getKey() !== targetBlock.getKey(),
-    'Block cannot be moved next to itself.'
+    'Block cannot be moved next to itself.',
   );
 
   invariant(
     insertionMode !== 'replace',
-    'Replacing blocks is not supported.'
+    'Replacing blocks is not supported.',
   );
 
   const targetKey = targetBlock.getKey();
@@ -49,22 +49,22 @@ function moveBlockInContentState(
   if (insertionMode === 'before') {
     invariant(
       (!blockBefore) || blockBefore.getKey() !== blockToBeMoved.getKey(),
-      'Block cannot be moved next to itself.'
+      'Block cannot be moved next to itself.',
     );
 
     newBlocks = blocksBefore.concat(
       [[blockToBeMoved.getKey(), blockToBeMoved], [targetBlock.getKey(), targetBlock]],
-      blocksAfter
+      blocksAfter,
     ).toOrderedMap();
   } else if (insertionMode === 'after') {
     invariant(
       (!blockAfter) || blockAfter.getKey() !== blockToBeMoved.getKey(),
-      'Block cannot be moved next to itself.'
+      'Block cannot be moved next to itself.',
     );
 
     newBlocks = blocksBefore.concat(
       [[targetBlock.getKey(), targetBlock], [blockToBeMoved.getKey(), blockToBeMoved]],
-      blocksAfter
+      blocksAfter,
     ).toOrderedMap();
   }
 

--- a/src/model/transaction/removeEntitiesAtEdges.js
+++ b/src/model/transaction/removeEntitiesAtEdges.js
@@ -25,7 +25,7 @@ import type SelectionState from 'SelectionState';
 
 function removeEntitiesAtEdges(
   contentState: ContentState,
-  selectionState: SelectionState
+  selectionState: SelectionState,
 ): ContentState {
   var blockMap = contentState.getBlockMap();
   var entityMap = contentState.getEntityMap();
@@ -67,7 +67,7 @@ function removeEntitiesAtEdges(
 function getRemovalRange(
   characters: List<CharacterMetadata>,
   key: ?string,
-  offset: number
+  offset: number,
 ): Object {
   var removalRange;
   findRangesImmutable(
@@ -78,11 +78,11 @@ function getRemovalRange(
       if (start <= offset && end >= offset) {
         removalRange = {start, end};
       }
-    }
+    },
   );
   invariant(
     typeof removalRange === 'object',
-    'Removal range must exist within character list.'
+    'Removal range must exist within character list.',
   );
   return removalRange;
 }
@@ -90,7 +90,7 @@ function getRemovalRange(
 function removeForBlock(
   entityMap: EntityMap,
   block: ContentBlock,
-  offset: number
+  offset: number,
 ): ContentBlock {
   var chars = block.getCharacterList();
   var charBefore = offset > 0 ? chars.get(offset - 1) : undefined;

--- a/src/model/transaction/removeRangeFromContentState.js
+++ b/src/model/transaction/removeRangeFromContentState.js
@@ -21,7 +21,7 @@ import type SelectionState from 'SelectionState';
 
 function removeRangeFromContentState(
   contentState: ContentState,
-  selectionState: SelectionState
+  selectionState: SelectionState,
 ): ContentState {
   if (selectionState.isCollapsed()) {
     return contentState;
@@ -41,7 +41,7 @@ function removeRangeFromContentState(
     characterList = removeFromList(
       startBlock.getCharacterList(),
       startOffset,
-      endOffset
+      endOffset,
     );
   } else {
     characterList = startBlock
@@ -87,7 +87,7 @@ function removeRangeFromContentState(
 function removeFromList(
   targetList: List<CharacterMetadata>,
   startOffset: number,
-  endOffset: number
+  endOffset: number,
 ): List<CharacterMetadata> {
   if (startOffset === 0) {
     while (startOffset < endOffset) {

--- a/src/model/transaction/splitBlockInContentState.js
+++ b/src/model/transaction/splitBlockInContentState.js
@@ -25,11 +25,11 @@ const {Map} = Immutable;
 
 function splitBlockInContentState(
   contentState: ContentState,
-  selectionState: SelectionState
+  selectionState: SelectionState,
 ): ContentState {
   invariant(
     selectionState.isCollapsed(),
-    'Selection range must be collapsed.'
+    'Selection range must be collapsed.',
   );
 
   var key = selectionState.getAnchorKey();
@@ -57,7 +57,7 @@ function splitBlockInContentState(
   var blocksAfter = blockMap.toSeq().skipUntil(v => v === blockToSplit).rest();
   var newBlocks = blocksBefore.concat(
     [[blockAbove.getKey(), blockAbove], [blockBelow.getKey(), blockBelow]],
-    blocksAfter
+    blocksAfter,
   ).toOrderedMap();
 
   return contentState.merge({


### PR DESCRIPTION
Updated lint rules to catch missing dangling commas in multiline function syntax. This brings the open-source project closer to being in line with Facebook's internal copy, making syncing them easier. This partially addresses #862.