### PR TITLE
Fixed bugs with deletion of entities between blocks and the atomic block deletion test case

### DIFF
--- a/src/model/modifier/DraftModifier.js
+++ b/src/model/modifier/DraftModifier.js
@@ -140,12 +140,17 @@ var DraftModifier = {
     removalDirection: DraftRemovalDirection,
   ): ContentState {
     let startKey, endKey, startBlock, endBlock;
-    startKey = removalDirection === 'forward'
-      ? rangeToRemove.getAnchorKey()
-      : rangeToRemove.getFocusKey();
-    endKey = removalDirection === 'forward'
-      ? rangeToRemove.getFocusKey()
-      : rangeToRemove.getAnchorKey();
+    if (rangeToRemove.getIsBackward()) {
+      rangeToRemove = rangeToRemove.merge({
+        anchorKey: rangeToRemove.getFocusKey(),
+        anchorOffset: rangeToRemove.getFocusOffset(),
+        focusKey: rangeToRemove.getAnchorKey(),
+        focusOffset: rangeToRemove.getAnchorOffset(),
+        isBackward: false,
+      });
+    }
+    startKey = rangeToRemove.getAnchorKey();
+    endKey = rangeToRemove.getFocusKey();
     startBlock = contentState.getBlockForKey(startKey);
     endBlock = contentState.getBlockForKey(endKey);
     const startOffset = rangeToRemove.getStartOffset();

--- a/src/model/modifier/__tests__/RichTextEditorUtil-test.js
+++ b/src/model/modifier/__tests__/RichTextEditorUtil-test.js
@@ -23,7 +23,11 @@ describe('RichTextEditorUtil', () => {
   const {editorState, selectionState} = getSampleStateForTesting();
 
   function insertAtomicBlock(targetEditorState) {
-    const entityKey = 'foo';
+    const entityKey = targetEditorState.getCurrentContent().createEntity(
+      'TEST',
+      'IMMUTABLE',
+      null,
+    ).getLastCreatedEntityKey();
     const character = ' ';
     const movedSelection = EditorState.moveSelectionToEnd(targetEditorState);
     return AtomicBlockUtils.insertAtomicBlock(


### PR DESCRIPTION
**Summary**

Fixed bugs with entity deletion when the start and end of the selection are not in the same block. Also fixed a bug with the atomic block deletion test case which was identified when PR #1094 was opened.

**Test Plan**

Ensured all unit tests pass with the draft_segmented_entities_behavior feature flag enabled and disabled. Also tested all deletion edge cases related to mutable, segmented, and immutable entities, along with atomic block deletion.
