### PR TITLE
Add bundles from 'universal' example to eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,5 @@ node_modules/
 website/
 gulpfile.js
 scripts/module-map.js
+examples/draft-0-10-0/universal/static/bundle.js
+examples/draft-0-9-1/universal/static/bundle.js


### PR DESCRIPTION
After running the build step for the 'universal' example there is a bundle file which we don't want to lint. This fixes the issue.

Steps to reproduce the problem:
 - install dependencies and run `npm run demo` in the universal example directory.
 - then run `npm run lint` and see the errors from linting the `bundle.js` file