### PR TITLE
Pass fresh editorState to edit handlers

### DIFF
--- a/src/component/base/DraftEditorProps.js
+++ b/src/component/base/DraftEditorProps.js
@@ -111,7 +111,10 @@ export type DraftEditorProps = {
 
   // Map a key command string provided by your key binding function to a
   // specified behavior.
-  handleKeyCommand?: (command: DraftEditorCommand | string) => DraftHandleValue,
+  handleKeyCommand?: (
+    command: DraftEditorCommand | string,
+    editorState: EditorState,
+  ) => DraftHandleValue,
 
   // Handle intended text insertion before the insertion occurs. This may be
   // useful in cases where the user has entered characters that you would like

--- a/src/component/handlers/edit/editOnBeforeInput.js
+++ b/src/component/handlers/edit/editOnBeforeInput.js
@@ -81,6 +81,8 @@ function editOnBeforeInput(editor: DraftEditor, e: SyntheticInputEvent): void {
     editor._pendingStateFromBeforeInput = undefined;
   }
 
+  var editorState = editor._latestEditorState;
+
   var chars = e.data;
 
   // In some cases (ex: IE ideographic space insertion) no character data
@@ -96,7 +98,7 @@ function editOnBeforeInput(editor: DraftEditor, e: SyntheticInputEvent): void {
   // start of the block.
   if (
     editor.props.handleBeforeInput &&
-    isEventHandled(editor.props.handleBeforeInput(chars))
+    isEventHandled(editor.props.handleBeforeInput(chars, editorState))
   ) {
     e.preventDefault();
     return;
@@ -105,7 +107,6 @@ function editOnBeforeInput(editor: DraftEditor, e: SyntheticInputEvent): void {
   // If selection is collapsed, conditionally allow native behavior. This
   // reduces re-renders and preserves spellcheck highlighting. If the selection
   // is not collapsed, we will re-render.
-  var editorState = editor._latestEditorState;
   var selection = editorState.getSelection();
 
   if (!selection.isCollapsed()) {

--- a/src/component/handlers/edit/editOnKeyDown.js
+++ b/src/component/handlers/edit/editOnKeyDown.js
@@ -154,7 +154,7 @@ function editOnKeyDown(editor: DraftEditor, e: SyntheticKeyboardEvent): void {
   // Allow components higher up the tree to handle the command first.
   if (
     editor.props.handleKeyCommand &&
-    isEventHandled(editor.props.handleKeyCommand(command))
+    isEventHandled(editor.props.handleKeyCommand(command, editorState))
   ) {
     return;
   }

--- a/src/component/handlers/edit/editOnPaste.js
+++ b/src/component/handlers/edit/editOnPaste.js
@@ -90,10 +90,11 @@ function editOnPaste(editor: DraftEditor, e: SyntheticClipboardEvent): void {
   let textBlocks: Array<string> = [];
   const text = data.getText();
   const html = data.getHTML();
+  const editorState = editor._latestEditorState;
 
   if (
     editor.props.handlePastedText &&
-    isEventHandled(editor.props.handlePastedText(text, html))
+    isEventHandled(editor.props.handlePastedText(text, html, editorState))
   ) {
     return;
   }
@@ -169,7 +170,6 @@ function editOnPaste(editor: DraftEditor, e: SyntheticClipboardEvent): void {
   }
 
   if (textBlocks.length) {
-    var editorState = editor._latestEditorState;
     var character = CharacterMetadata.create({
       style: editorState.getCurrentInlineStyle(),
       entity: getEntityKeyForSelection(


### PR DESCRIPTION
There have been bugs reported in cases where the users of Draft are
updating 'editorState' in their custom handlers for keyDown, paste, etc.
This can be a problem when they are using an 'editorState' that is in
the parent's props or state and is not in sync, at that moment, with the
editorState in Draft. This allows the parent to use the most updated
editorState in custom handlers.

This change was already reviewed by @spicyj and credit for this fix goes
to @alanouri for making this change.