### PR TITLE
[Part 2] Pass fresh editorState to edit handlers

### DIFF
--- a/src/component/base/DraftEditorProps.js
+++ b/src/component/base/DraftEditorProps.js
@@ -107,7 +107,10 @@ export type DraftEditorProps = {
 
   // Useful for managing special behavior for pressing the `Return` key. E.g.
   // removing the style from an empty list item.
-  handleReturn?: (e: SyntheticKeyboardEvent) => DraftHandleValue,
+  handleReturn?: (
+    e: SyntheticKeyboardEvent,
+    editorState: EditorState,
+  ) => DraftHandleValue,
 
   // Map a key command string provided by your key binding function to a
   // specified behavior.
@@ -121,9 +124,16 @@ export type DraftEditorProps = {
   // to trigger some special behavior. E.g. immediately converting `:)` to an
   // emoji Unicode character, or replacing ASCII quote characters with smart
   // quotes.
-  handleBeforeInput?: (chars: string) => DraftHandleValue,
+  handleBeforeInput?: (
+    chars: string,
+    editorState: EditorState,
+  ) => DraftHandleValue,
 
-  handlePastedText?: (text: string, html?: string) => DraftHandleValue,
+  handlePastedText?: (
+    text: string,
+    html?: string,
+    editorState: EditorState,
+  ) => DraftHandleValue,
 
   handlePastedFiles?: (files: Array<Blob>) => DraftHandleValue,
 

--- a/src/component/handlers/edit/editOnBeforeInput.js
+++ b/src/component/handlers/edit/editOnBeforeInput.js
@@ -81,7 +81,7 @@ function editOnBeforeInput(editor: DraftEditor, e: SyntheticInputEvent): void {
     editor._pendingStateFromBeforeInput = undefined;
   }
 
-  var editorState = editor._latestEditorState;
+  const editorState = editor._latestEditorState;
 
   var chars = e.data;
 

--- a/src/component/handlers/edit/editOnKeyDown.js
+++ b/src/component/handlers/edit/editOnKeyDown.js
@@ -94,7 +94,7 @@ function editOnKeyDown(editor: DraftEditor, e: SyntheticKeyboardEvent): void {
       // no special handling is performed, fall through to command handling.
       if (
         editor.props.handleReturn &&
-        isEventHandled(editor.props.handleReturn(e))
+        isEventHandled(editor.props.handleReturn(e, editorState))
       ) {
         return;
       }


### PR DESCRIPTION
I had mirrored parts of this change from FB to github but missed some
things. This is the second part of the same change - context below.
Earlier part merged as https://github.com/facebook/draft-js/pull/1112

---

There have been bugs reported in cases where the users of Draft are
updating 'editorState' in their custom handlers for keyDown, paste, etc.
This can be a problem when they are using an 'editorState' that is in
the parent's props or state and is not in sync, at that moment, with the
editorState in Draft. This allows the parent to use the most updated
editorState in custom handlers.

This change was already reviewed by @spicyj and credit for this fix goes
to @alanouri for making this change.