### PR TITLE
Ensures that after an undo is done, the next selected block has focus

### DIFF
--- a/src/model/immutable/EditorState.js
+++ b/src/model/immutable/EditorState.js
@@ -440,7 +440,7 @@ class EditorState {
       inlineStyleOverride: null,
       lastChangeType: 'undo',
       nativelyRenderedContent: null,
-      selection: currentContent.getSelectionBefore(),
+      selection: currentContent.getSelectionBefore().set('hasFocus', true),
     });
   }
 


### PR DESCRIPTION
This addresses issue #1120 

This issue could be reproduced by adding any custom component and then doing an **undo**.  This will cause a glitch in the cursor position and will affect all text written after that. 

This issue occurs because if the last added element is a custom block, and then the user clicks undo. The next block doesn't automatically get focus. This commit ensures that the new block after the undo gets focus.

_Issue reproduced on facebook notes_:
![Issue](http://g.recordit.co/cVekMRWX4L.gif)
