### PR TITLE
Clarify comment above `tryToRemoveBlockStyle`

### DIFF
--- a/src/model/modifier/RichTextEditorUtil.js
+++ b/src/model/modifier/RichTextEditorUtil.js
@@ -374,9 +374,9 @@ const RichTextEditorUtil = {
   },
 
   /**
-   * When a collapsed cursor is at the start of an empty styled block, allow
-   * certain key commands (newline, backspace) to simply change the
-   * style of the block instead of the default behavior.
+   * When a collapsed cursor is at the start of an empty styled block, 
+   * changes block to 'unstyled'. Returns null if block or selection does not
+   * meet that criteria.
    */
   tryToRemoveBlockStyle: function(editorState: EditorState): ?ContentState {
     var selection = editorState.getSelection();


### PR DESCRIPTION
I found the comment above `RichUtils.tryToRemoveBlockStyle` a bit confusing while trying to understand the function's logic.

I would argue that the current comment's inclusion of information about where it is used is unnecessary, and makes it seem as if its interaction with those key commands was implemented inside the function itself.