### PR TITLE
Docs tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ class MyEditor extends React.Component {
   }
   render() {
     return (
-        <Editor editorState={this.state.editorState} onChange={this.onChange} />
+      <Editor editorState={this.state.editorState} onChange={this.onChange} />
     );
   }
 }

--- a/docs/Advanced-Topics-Entities.md
+++ b/docs/Advanced-Topics-Entities.md
@@ -86,7 +86,7 @@ const blockWithLinkAtBeginning = contentState.getBlockForKey('...');
 const linkKey = blockWithLinkAtBeginning.getEntityAt(0);
 const contentState = editorState.getCurrentContent();
 const linkInstance = contentState.getEntity(linkKey);
-const {href} = linkInstance.getData();
+const {url} = linkInstance.getData();
 ```
 ## "Mutability"
 

--- a/docs/Advanced-Topics-Entities.md
+++ b/docs/Advanced-Topics-Entities.md
@@ -67,11 +67,11 @@ const contentState = editorState.getCurrentContent();
 const contentStateWithEntity = contentState.createEntity(
   'LINK',
   'MUTABLE',
-  {href: 'http://www.zombo.com'}
+  {url: 'http://www.zombo.com'}
 );
 const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
 const contentStateWithLink = Modifier.applyEntity(
-  contentState,
+  contentStateWithEntity,
   selectionState,
   entityKey
 );


### PR DESCRIPTION
- Fix reference to older contentState
- Change `href` to `url` for consistency with "link" example in case people copy-paste between both (which I did today)
- Fix indentation in README