### PR TITLE
Fixed incorrect entity documentation

### DIFF
--- a/docs/Advanced-Topics-Entities.md
+++ b/docs/Advanced-Topics-Entities.md
@@ -56,7 +56,7 @@ add rich rendering to your editor based on entity metadata.
 ## Creating and Retrieving Entities
 
 Entities should be created using `contentState.createEntity`, which accepts the
-three properties above as arguments. This method returns a new `ContentState` record updated to include the newly created entity, then you can call `contentState.getLastCreatedEntityKey` to get the key of the newly created entity record.
+three properties above as arguments. This method returns a `ContentState` record updated to include the newly created entity, then you can call `contentState.getLastCreatedEntityKey` to get the key of the newly created entity record.
 
 This key is the value that should be used when applying entities to your
 content. For instance, the `Modifier` module contains an `applyEntity` method:


### PR DESCRIPTION
I made a mistake in merging in #1141. The `ContentState` returned by `ContentState.createEntity` is not a new `ContentState`. Instead of reverting #1141 I'm just opening a new PR with the small fix since it's documentation.