### PR TITLE
Prepare Entities docs for v0.11 changes

### DIFF
--- a/docs/Advanced-Topics-Entities.md
+++ b/docs/Advanced-Topics-Entities.md
@@ -70,7 +70,7 @@ const contentStateWithEntity = contentState.createEntity(
 );
 const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
 const contentStateWithLink = Modifier.applyEntity(
-  contentState,
+  contentStateWithEntity,
   selectionState,
   entityKey
 );


### PR DESCRIPTION
As explained by @flarnie on https://github.com/facebook/draft-js/pull/1149#issuecomment-294659681, `ContentState.createEntity` will return a new `contentState` on `v0.11` instead of the same instance.

To prevent additional migration work, I've updated Entities docs to behave as if `ContentState.createEntity` already returns a new instance instead of the same instance.