### PR TITLE
Modified composition mode event handlers to provide better support fo…

### DIFF
--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -41,11 +41,23 @@ const RESOLVE_DELAY = 20;
  */
 let resolved = false;
 let stillComposing = false;
-let textInputData = '';
+let beforeInputData = null;
+let compositionEndData = null;
 
 var DraftEditorCompositionHandler = {
-  onBeforeInput: function(editor: DraftEditor, e: SyntheticInputEvent): void {
-    textInputData = (textInputData || '') + e.data;
+  /**
+   * Some IMEs (Firefox Mobile, notably) fire multiple `beforeinput` events
+   * which include the text so far typed, in addition to (broken) 
+   * `compositionend` events. In these cases, we construct beforeInputData from 
+   * the `beforeinput` and cnsider that to be the definitive version of what
+   * was actually typed.
+   *
+   * Proper, compliant browsers will not do this and will instead include the
+   * entire resolved composition result in the `data` member of the 
+   * `compositionend` events that they fire.
+   */
+  onBeforeInput: function(editor: DraftEditor, e: SyntheticInputEvent) {
+    beforeInputData = (beforeInputData || '') + e.data;
   },
 
   /**
@@ -70,9 +82,12 @@ var DraftEditorCompositionHandler = {
    * twice could break the DOM, we only use the first event. Example: Arabic
    * Google Input Tools on Windows 8.1 fires `compositionend` three times.
    */
-  onCompositionEnd: function(editor: DraftEditor): void {
+  onCompositionEnd: function(editor: DraftEditor, 
+                             e: SyntheticCompositionEvent): void {
     resolved = false;
     stillComposing = false;
+    // Use e.data from the first compositionend event seen
+    compositionEndData = compositionEndData || e.data;
     setTimeout(() => {
       if (!resolved) {
         DraftEditorCompositionHandler.resolveComposition(editor);
@@ -133,8 +148,13 @@ var DraftEditorCompositionHandler = {
     }
 
     resolved = true;
-    const composedChars = textInputData;
-    textInputData = '';
+
+    // If we've built up a string from `beforeinput` events (e.g. Android 
+    // Firefox), use that as the definitive version of the composed characters
+    // Otherwise, use the data from the first `compositionend` event
+    const composedChars = beforeInputData || compositionEndData;
+    beforeInputData = null;
+    compositionEndData = null;
 
     const editorState = EditorState.set(editor._latestEditorState, {
       inCompositionMode: false,


### PR DESCRIPTION
Most browsers follow the spec for `compositionend` in a reasonable way that conforms to the spec, that is, the `data` field of the `compositionend` event contains the result of the composition. Firefox on Android, however, fires four events in sequence if you select a suggestion for a partially-typed word: `compositionend` (`data` is the partial the user typed), `beforeinput` (`data` is the partial the user typed), `compositionend` (`data` is the remaining letters in the complete word), and `beforeinput` (`data` is the remaining letters in the complete word). As a workaround for nonconforming behaviour like this, this patch changes the handling of events so that a variable textInputData is built from the concatenation of the `data` members of the `beforeinput` events fired during composition. During resolution, if this string has been built, it is used as the definitive source for the characters that have been typed. Otherwise, the `data` member from the first `compositionend` event fired during composition is used as the definitive source for the characters that have been typed.

I've tested this on Firefox and Chrome under Android 5.x, Safari on the iOS simulator, Chrome and Firefox under iOS, and IE11 under Windows 10. On desktop, I've tested it with both English and Japanese keyboard layouts. I'm reasonably confident that this change will improve support for mobile browser IMEs without breaking compatibility for any other existing supported IME, but I'm very interested in hearing any input that you have wrt these changes.

I acknowledge that I have received permission from Zugata Inc, the company for which I developed these changes under company time, to submit this pull request.