### PR TITLE
Fix mystery text deletion

### DIFF
--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -64,6 +64,27 @@ function editOnInput(editor: DraftEditor): void {
     }
   }
 
+  if (
+    anchorNode.nodeType === Node.TEXT_NODE &&
+    (anchorNode.previousSibling !== null || anchorNode.nextSibling !== null)
+  ) {
+    // When typing at the beginning of a visual line, Chrome splits the text
+    // nodes into two. Why? No one knows. This commit is suspicious:
+    // https://chromium.googlesource.com/chromium/src/+/a3b600981286b135632371477f902214c55a1724
+    // To work around, we'll merge the sibling text nodes back into this one.
+    const span = anchorNode.parentNode;
+    anchorNode.nodeValue = span.textContent;
+    for (
+      let child = span.firstChild;
+      child !== null;
+      child = child.nextSibling
+    ) {
+      if (child !== anchorNode) {
+        span.removeChild(child);
+      }
+    }
+  }
+
   var domText = anchorNode.textContent;
   var editorState = editor._latestEditorState;
   var offsetKey = nullthrows(findAncestorOffsetKey(anchorNode));


### PR DESCRIPTION
Type `wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww` in Chrome. Click at the beginning of the second line. Press space. It no longer deletes your text. That's a good thing.

T17377963