### PR TITLE
Add logging for hard-to-reproduce bug

### DIFF
--- a/src/stubs/DraftJsDebugLogging.js
+++ b/src/stubs/DraftJsDebugLogging.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule DraftJsDebugLogging
+ */
+
+'use strict';
+
+module.exports = {
+  logSelectionStateFailure: () => null,
+};


### PR DESCRIPTION
Since the main logging method is stubbed out, this should have no effect
on the open source Draft project. Adding this on Github in order to
continue syncing the internal and open source version of Draft, to
unblock releasing v0.10.1 of Draft.

Not waiting on review since this change was already reviewed internally at FB.

Context of this change:
We have gotten reports of an error thrown from `setDraftEditorSelection`
that completely breaks Draft functionality once it occurs. It happens
very inconsistently, across multiple browsers, and we have not yet been
able to find the root cause or reproduce it reliably. This logging may
help us get more information about the problem.