### PR TITLE
Mark editor element as notranslate

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -249,7 +249,14 @@ class DraftEditor extends React.Component {
             autoCapitalize={this.props.autoCapitalize}
             autoComplete={this.props.autoComplete}
             autoCorrect={this.props.autoCorrect}
-            className={cx('public/DraftEditor/content')}
+            className={cx({
+              // Chrome's built-in translation feature mutates the DOM in ways
+              // that Draft doesn't expect (ex: adding <font> tags inside
+              // DraftEditorLeaf spans) and causes problems. We add notranslate
+              // here which makes its autotranslation skip over this subtree.
+              'notranslate': !readOnly,
+              'public/DraftEditor/content': true,
+            })}
             contentEditable={!readOnly}
             data-testid={this.props.webDriverTestID}
             onBeforeInput={this._onBeforeInput}


### PR DESCRIPTION
This should help a lot with "Failed to execute 'setStart' on 'Range'" exceptions we've logged in production and seen in bug reports.

Test Plan:
Type in editor, right-click in Chrome then "Translate to English", editing no longer breaks.