### PR TITLE
Add es6 polyfill to all examples

### DIFF
--- a/examples/draft-0-10-0/convertFromHTML/convert.html
+++ b/examples/draft-0-10-0/convertFromHTML/convert.html
@@ -24,6 +24,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     <script src="../../../node_modules/react-dom/dist/react-dom.js"></script>
     <script src="../../../node_modules/immutable/dist/immutable.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.34/browser.js"></script>
+    <script src="../../../node_modules/es6-shim/es6-shim.js"></script>
     <script src="../../../dist/Draft.js"></script>
     <script type="text/babel">
       'use strict';

--- a/examples/draft-0-10-0/media/media.html
+++ b/examples/draft-0-10-0/media/media.html
@@ -23,6 +23,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     <script src="../../../node_modules/react/dist/react.js"></script>
     <script src="../../../node_modules/react-dom/dist/react-dom.js"></script>
     <script src="../../../node_modules/immutable/dist/immutable.js"></script>
+    <script src="../../../node_modules/es6-shim/es6-shim.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.34/browser.js"></script>
     <script src="../../../dist/Draft.js"></script>
     <script type="text/babel">

--- a/examples/draft-0-9-1/convertFromHTML/convert.html
+++ b/examples/draft-0-9-1/convertFromHTML/convert.html
@@ -23,6 +23,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     <script src="../../../node_modules/react/dist/react.js"></script>
     <script src="../../../node_modules/react-dom/dist/react-dom.js"></script>
     <script src="../../../node_modules/immutable/dist/immutable.js"></script>
+    <script src="../../../node_modules/es6-shim/es6-shim.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.34/browser.js"></script>
     <script src="../../../dist/Draft.js"></script>
     <script type="text/babel">

--- a/examples/draft-0-9-1/media/media.html
+++ b/examples/draft-0-9-1/media/media.html
@@ -23,6 +23,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     <script src="../../../node_modules/react/dist/react.js"></script>
     <script src="../../../node_modules/react-dom/dist/react-dom.js"></script>
     <script src="../../../node_modules/immutable/dist/immutable.js"></script>
+    <script src="../../../node_modules/es6-shim/es6-shim.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.34/browser.js"></script>
     <script src="../../../dist/Draft.js"></script>
     <script type="text/babel">


### PR DESCRIPTION
**what is the change?:**
Draft uses some ES6 syntax and assumes users will pair it with an ES6
polyfill. See
https://github.com/facebook/draft-js/blob/c12640f05e8328f5c97902c0c5e94a02ba9f58be/docs/Advanced-Topics-Issues-and-Pitfalls.md#polyfills

**why make this change?:**
When testing some examples in IE they were not rendering, and threw an
error because we use `String.prototype.startsWith` in Draft.

**test plan:**
Open the 'convertFromHTML' and 'media' example files in IE, and they
will render.

**issue:**
https://github.com/facebook/draft-js/issues/1165