### PR TITLE
Update Advanced-Topics-Issues-and-Pitfalls.md

### DIFF
--- a/docs/Advanced-Topics-Issues-and-Pitfalls.md
+++ b/docs/Advanced-Topics-Issues-and-Pitfalls.md
@@ -77,20 +77,21 @@ input methods, most significantly Korean input.
 
 ### Polyfills
 
-Some of Draft's code and that of its dependencies make use of ES2015 language
-features. Syntax features like `class` are compiled away via Babel when Draft is
-built, but it does not include polyfills for APIs now included in many modern
-browsers (for instance: `String.prototype.startsWith`). We expect your browser
-supports these APIs natively or with the assistance of a polyfill. One such
-polyfill is [es6-shim](https://github.com/es-shims/es6-shim), which we use in
-many examples but you are free to use [babel-
-polyfill](https://babeljs.io/docs/usage/polyfill/) if that's more your scene.
+Some of Draft's code and that of its dependencies make use of ES2015
+language features. Syntax features like `class` are compiled away via
+Babel when Draft is built, but it does not include polyfills for APIs
+now included in many modern browsers (for instance:
+`String.prototype.startsWith`). We expect your browser supports these
+APIs natively or with the assistance of a polyfill. One such polyfill
+is [es6-shim][es6-shim], which we use in many examples but you are
+free to use [babel- polyfill][babel-polyfill] if that's more your
+scene.
 
-When using either polyfill/shim, you should include it as early as possibly in
-your application's entrypoint (at the very minimum, before you import Draft).
-For instance, using [create-react-app](https://github.com/facebookincubator
-/create-react-app) and targeting ie11, `src/index.js` is probably a good spot to
-import your polyfill:
+When using either polyfill/shim, you should include it as early as
+possibly in your application's entrypoint (at the very minimum, before
+you import Draft).  For instance, using
+[create-react-app][create-react-app] and targeting ie11,
+`src/index.js` is probably a good spot to import your polyfill:
 
 **src/index.js**
 
@@ -109,3 +110,7 @@ ReactDOM.render(
   document.getElementById('root')
 );
 ```
+
+[es6-shim]: https://github.com/es-shims/es6-shim
+[babel-polyfill]: https://babeljs.io/docs/usage/polyfill/
+[create-react-app]: https://github.com/facebookincubator/create-react-app


### PR DESCRIPTION
**Summary**

The link to `create-react-app` is currently broken on the [live version of this page](https://draftjs.org/docs/advanced-topics-issues-and-pitfalls.html#ime-and-internet-explorer) due to the formatting of the markdown document breaking the link syntax.

In order to maintain the source line width in this file, and also the links, transition all links to the end of the file, rather than inline.

**Test Plan**

No test plan, just a documentation formatting fix
