### PR TITLE
selection.extend is called on selection without ranges

### DIFF
--- a/src/component/selection/setDraftEditorSelection.js
+++ b/src/component/selection/setDraftEditorSelection.js
@@ -235,9 +235,7 @@ function addFocusToSelection(
       });
     }
     // Check for active selection before extending
-    if (selection.rangeCount !== 0) {
-      selection.extend(node, offset);
-    }
+    selection.extend(node, offset);
   } else {
     // IE doesn't support extend. This will mean no backward selection.
     // Extract the existing selection range and add focus to it.
@@ -268,6 +266,9 @@ function addPointToSelection(
   }
   range.setStart(node, offset);
   selection.addRange(range);
+  if (selection.rangeCount === 0) {
+    selection.addRange(range);
+  }
 }
 
 module.exports = setDraftEditorSelection;

--- a/src/component/selection/setDraftEditorSelection.js
+++ b/src/component/selection/setDraftEditorSelection.js
@@ -234,7 +234,10 @@ function addFocusToSelection(
         selectionState: JSON.stringify(selectionState.toJS()),
       });
     }
-    selection.extend(node, offset);
+
+    if (selection.rangeCount > 0) {
+      selection.extend(node, offset);
+    }
   } else {
     // IE doesn't support extend. This will mean no backward selection.
     // Extract the existing selection range and add focus to it.

--- a/src/component/selection/setDraftEditorSelection.js
+++ b/src/component/selection/setDraftEditorSelection.js
@@ -234,8 +234,8 @@ function addFocusToSelection(
         selectionState: JSON.stringify(selectionState.toJS()),
       });
     }
-
-    if (selection.rangeCount > 0) {
+    // Check for active selection before extending
+    if (selection.rangeCount !== 0) {
       selection.extend(node, offset);
     }
   } else {


### PR DESCRIPTION
**Summary**

In our application we have multiple draft-js instances. When users try to drag entities from one editor to the other, the selection state is temporarily lost and we end up with the following error:

*Failed to execute 'extend' on 'Selection': This Selection object doesn't have any Ranges.*

We were able to recreate the issue and the following PR fixes the issue by verifying that the selection has ranges.

**Test Plan**

This particular file does not appear to have any active spec files, but I did confirm that the solution works for both when there is a selection and when there is not an active selection.