### PR TITLE
Add check for selection type of None

### DIFF
--- a/src/component/selection/setDraftEditorSelection.js
+++ b/src/component/selection/setDraftEditorSelection.js
@@ -234,7 +234,9 @@ function addFocusToSelection(
         selectionState: JSON.stringify(selectionState.toJS()),
       });
     }
-    selection.extend(node, offset);
+    if (selection.type !== 'None') {
+      selection.extend(node, offset);
+    }
   } else {
     // IE doesn't support extend. This will mean no backward selection.
     // Extract the existing selection range and add focus to it.


### PR DESCRIPTION
This fixes https://github.com/facebook/draft-js/issues/1188 which occurs when attempting to extend a Selection with type 'None'