### PR TITLE
Add mention of draft css in overview doc

### DIFF
--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -75,4 +75,10 @@ Because Draft.js supports unicode, you must have the following meta tag in the `
 <meta charset="utf-8" />
 ```
 
+`Draft.css` should be included when rendering the editor. Learn more about [why](/docs/advanced-topics-issues-and-pitfalls.html#missing-draft-css).
+
+```js
+import from 'draft-js/dist/Draft.css';
+```
+
 Next, let's go into the basics of the API and learn what else you can do with Draft.js.

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -77,8 +77,4 @@ Because Draft.js supports unicode, you must have the following meta tag in the `
 
 `Draft.css` should be included when rendering the editor. Learn more about [why](/docs/advanced-topics-issues-and-pitfalls.html#missing-draft-css).
 
-```js
-import from 'draft-js/dist/Draft.css';
-```
-
 Next, let's go into the basics of the API and learn what else you can do with Draft.js.


### PR DESCRIPTION
**Summary**

Mention the need to include `Draft.css` when rendering the editor in the overview doc and reference the link, https://draftjs.org/docs/advanced-topics-issues-and-pitfalls.html#missing-draft-css, to learn more about why it is needed. 

This is related to https://github.com/facebook/draft-js/issues/1201.

**Test Plan**

This is a doc update. There is probably no need for additional tests.
