### PR TITLE
1111 - move all .gitignores to toplevel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,12 @@
 /examples/tex/node_modules/
 /examples/draft-0-9-1/tex/node_modules/
 /examples/draft-0-10-0/tex/node_modules/
+/examples/draft-0-9-1/universal/static
+/examples/draft-0-9-1/universal/node_modules
+/examples/draft-0-9-1/universal/yarn.lock
+/examples/draft-0-10-0/universal/static
+/examples/draft-0-10-0/universal/yarn.lock
+/examples/draft-0-10-0/universal/node_modules
 /website/build/
 /website/node_modules/
 /website/src/lib/

--- a/examples/draft-0-10-0/universal/.gitignore
+++ b/examples/draft-0-10-0/universal/.gitignore
@@ -1,2 +1,0 @@
-static
-node_modules

--- a/examples/draft-0-9-1/universal/.gitignore
+++ b/examples/draft-0-9-1/universal/.gitignore
@@ -1,2 +1,0 @@
-static
-node_modules


### PR DESCRIPTION
**Summary**
Fixes #1111
- Moves all `.gitigores` to top level
- adds `yarn.lock` to gitignore
[...]

**Test Plan**
Verify using `git status` that the files continue to be ignored, and `yarn.lock` is now ignored
[...]
