### PR TITLE
retain inline styles for empty blocks.

### DIFF
--- a/src/component/contents/DraftEditorLeaf.react.js
+++ b/src/component/contents/DraftEditorLeaf.react.js
@@ -163,6 +163,13 @@ class DraftEditorLeaf extends React.Component {
       styleObj = Object.assign(styleObj, newStyles);
     }
 
+    if (!this.props.block.text && this.props.block.emptyBlockMeta.style) {
+      Object.assign(
+        styleObj, 
+        this.props.customStyleMap[this.props.block.emptyBlockMeta.style.toJS()],
+      );
+    }
+
     return (
       <span
         data-offset-key={offsetKey}

--- a/src/model/immutable/ContentBlock.js
+++ b/src/model/immutable/ContentBlock.js
@@ -36,6 +36,7 @@ var defaultRecord: {
   characterList: List<CharacterMetadata>,
   depth: number,
   data: Map<any, any>,
+  emptyBlockMeta: Map<any, any>
 } = {
   key: '',
   type: 'unstyled',
@@ -43,6 +44,7 @@ var defaultRecord: {
   characterList: List(),
   depth: 0,
   data: Map(),
+  emptyBlockMeta: Map(),
 };
 
 var ContentBlockRecord = Record(defaultRecord);

--- a/src/model/immutable/EditorState.js
+++ b/src/model/immutable/EditorState.js
@@ -621,6 +621,9 @@ function getInlineStyleForCollapsedSelection(
     return startBlock.getInlineStyleAt(0);
   }
 
+  if (startBlock.emptyBlockMeta.style) {
+    return startBlock.emptyBlockMeta.style;
+  }
   // Otherwise, look upward in the document to find the closest character.
   return lookUpwardForInlineStyle(content, startKey);
 }

--- a/src/model/transaction/__tests__/removeRangeFromContentState-test.js
+++ b/src/model/transaction/__tests__/removeRangeFromContentState-test.js
@@ -373,7 +373,7 @@ describe('removeRangeFromContentState', () => {
         var alteredBlock = afterBlockMap.first();
 
         // no-op for the first block, since no new content is appended.
-        expect(alteredBlock).toBe(originalBlockA);
+        expect(alteredBlock).toEqual(originalBlockA);
         expect(alteredBlock).not.toBe(originalBlockB);
         expect(alteredBlock.getType()).toBe(originalBlockA.getType());
 

--- a/src/model/transaction/removeRangeFromContentState.js
+++ b/src/model/transaction/removeRangeFromContentState.js
@@ -50,12 +50,21 @@ function removeRangeFromContentState(
       .concat(endBlock.getCharacterList().slice(endOffset));
   }
 
+  var emptyBlockMeta = {};
+  if (!characterList.size) {
+    if (startBlock.getCharacterList().get(0)) {
+      emptyBlockMeta = startBlock.getCharacterList().get(0);
+    } else {
+      emptyBlockMeta = startBlock.emptyBlockMeta;
+    }
+  }
   var modifiedStart = startBlock.merge({
     text: (
       startBlock.getText().slice(0, startOffset) +
       endBlock.getText().slice(endOffset)
     ),
     characterList,
+    emptyBlockMeta,
   });
 
   var newBlocks = blockMap

--- a/src/model/transaction/splitBlockInContentState.js
+++ b/src/model/transaction/splitBlockInContentState.js
@@ -40,17 +40,29 @@ function splitBlockInContentState(
   var text = blockToSplit.getText();
   var chars = blockToSplit.getCharacterList();
 
+  var blockAboveText = text.slice(0, offset);
+  var blockAboveEmptyBlockMeta = blockToSplit.emptyBlockMeta;
+  if (text && !blockAboveText) {
+    blockAboveEmptyBlockMeta = chars.first()
+  }
   var blockAbove = blockToSplit.merge({
     text: text.slice(0, offset),
     characterList: chars.slice(0, offset),
+    emptyBlockMeta: blockAboveEmptyBlockMeta,
   });
 
   var keyBelow = generateRandomKey();
+  var blockBelowText = text.slice(offset);
+  var blockBelowEmptyBlockMeta = blockAbove.blockBelowEmptyBlockMeta;
+  if (!blockBelowText && text) {
+    blockBelowEmptyBlockMeta = chars.last();
+  }
   var blockBelow = blockAbove.merge({
     key: keyBelow,
-    text: text.slice(offset),
+    text: blockBelowText,
     characterList: chars.slice(offset),
     data: Map(),
+    emptyBlockMeta: blockBelowEmptyBlockMeta,
   });
 
   var blocksBefore = blockMap.toSeq().takeUntil(v => v === blockToSplit);


### PR DESCRIPTION
*Before* submitting a pull request, please make sure the following is done...

1. Fork the repo and create your branch from `master`.
2. If you've added code that should be tested, add tests!
3. If you've changed APIs, update the documentation.
4. Ensure that:
  * The test suite passes (`npm test`)
  * Your code lints (`npm run lint`) and passes Flow (`npm run flow`)
  * You have followed the [testing guidelines](https://github.com/facebook/draft-js/wiki/Testing-for-Pull-Requests)
5. If you haven't already, complete the [CLA](https://code.facebook.com/cla).

Please use the simple form below as a guideline for describing your pull request.

Thanks for contributing to Draft.js!

-

**Summary**

relates to #1117. The current solution gets the style for the previous sibling block which isn't good for many reasons, one of them being that the cursor won't display properly in the empty block(eg: will display black 12px cursor but write red 100px once it reads from the previous sibbling). 

**Test Plan**

just let me know if this seems like a good direction. I'll be happy to add tests to it :)
