### PR TITLE
Add docs on the lack of support for mobile web

### DIFF
--- a/docs/Advanced-Topics-Issues-and-Pitfalls.md
+++ b/docs/Advanced-Topics-Issues-and-Pitfalls.md
@@ -75,6 +75,12 @@ interaction.
 As of IE11, Internet Explorer demonstrates notable issues with certain international
 input methods, most significantly Korean input.
 
+### Mobile Support
+
+At this time Draft does not fully support mobile browsers. There are some known
+issues with certain Android keyboards and with international input methods. Full
+mobile support is a goal that the framework is moving towards for the future.
+
 ### Polyfills
 
 Some of Draft's code and that of its dependencies make use of ES2015 language


### PR DESCRIPTION
**what is the change?:**
Improvind docs by mentioning the lack of mobile web support

**why make this change?:**
For certain Android keyboards, and with IME in particular, Draft.js has
some known issues. We should document this so that folks are aware.

**test plan:**
Ran the website and manually tested.
![screen shot 2017-05-30 at 5 47 22 am](https://cloud.githubusercontent.com/assets/1114467/26583973/0bb462c2-44fc-11e7-89d8-f8bb02a07dda.png)

**issue:**
https://github.com/facebook/draft-js/issues/1224