### PR TITLE
Corrected documentation typo, example code throws an error.

### DIFF
--- a/docs/Advanced-Topics-Custom-Block-Render.md
+++ b/docs/Advanced-Topics-Custom-Block-Render.md
@@ -146,7 +146,7 @@ const blockRenderMap = Immutable.Map({
     // element is used during paste or html conversion to auto match your component;
     // it is also retained as part of this.props.children and not stripped out
     element: 'section',
-    wrapper: <MyCustomBlock {...this.props} />
+    wrapper: MyCustomBlock,
   }
 });
 


### PR DESCRIPTION
**Summary**

`this.props` throws an exception. Because we don't have component state available at that point. It's pretty obvious but still, it can be a little confusing.

**Test Plan**

- n/a
