### PR TITLE
Fix minor typo in docs

### DIFF
--- a/docs/Advanced-Topics-Custom-Block-Render.md
+++ b/docs/Advanced-Topics-Custom-Block-Render.md
@@ -34,7 +34,7 @@ by matching the Draft block render map with the matched tag.
 
 \*\* - Block type will be based on the parent `<ul/>` or `<ol/>`
 
-\*\*\* -  Any block that is not recognized by the block redering mapping will be treated as unstyled
+\*\*\* -  Any block that is not recognized by the block rendering mapping will be treated as unstyled
 
 ## Configuring block render map
 


### PR DESCRIPTION
Noticed a missing character in "redering" on "Custom Block Rendering" docs page.