### PR TITLE
Copy over misc. changes from Facebook

### DIFF
--- a/src/component/contents/__tests__/DraftEditorTextNode-test.js
+++ b/src/component/contents/__tests__/DraftEditorTextNode-test.js
@@ -11,8 +11,7 @@
 
 'use strict';
 
-jest.unmock('DraftEditorTextNode.react')
-  .mock('UserAgent');
+jest.disableAutomock().mock('UserAgent');
 
 var BLOCK_DELIMITER_CHAR = '\n';
 var TEST_A = 'Hello';

--- a/src/component/handlers/edit/editOnCut.js
+++ b/src/component/handlers/edit/editOnCut.js
@@ -42,6 +42,7 @@ function editOnCut(editor: DraftEditor, e: SyntheticClipboardEvent): void {
 
   // Track the current scroll position so that it can be forced back in place
   // after the editor regains control of the DOM.
+  // $FlowFixMe e.target should be an instanceof Node
   const scrollParent = Style.getScrollParent(e.target);
   const {x, y} = getScrollPosition(scrollParent);
 

--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -108,6 +108,10 @@ function editOnInput(editor: DraftEditor): void {
 
   // No change -- the DOM is up to date. Nothing to do here.
   if (domText === modelText) {
+    // This can be buggy for some Android keyboards because they don't fire
+    // standard onkeydown/pressed events and only fired editOnInput
+    // so domText is already changed by the browser and ends up being equal
+    // to modelText unexpectedly
     return;
   }
 

--- a/src/component/selection/setDraftEditorSelection.js
+++ b/src/component/selection/setDraftEditorSelection.js
@@ -234,7 +234,20 @@ function addFocusToSelection(
         selectionState: JSON.stringify(selectionState.toJS()),
       });
     }
-    selection.extend(node, offset);
+
+    // logging to catch bug that is being reported in t18110632
+    try {
+      selection.extend(node, offset);
+    } catch (e) {
+      DraftJsDebugLogging.logSelectionStateFailure({
+        anonymizedDom: getAnonymizedEditorDOM(node),
+        extraParams: JSON.stringify({offset: offset}),
+        selectionState: JSON.stringify(selectionState.toJS()),
+      });
+      // allow the error to be thrown -
+      // better than continuing in a broken state
+      throw e;
+    }
   } else {
     // IE doesn't support extend. This will mean no backward selection.
     // Extract the existing selection range and add focus to it.

--- a/src/model/decorators/__tests__/CompositeDraftDecorator-test.js
+++ b/src/model/decorators/__tests__/CompositeDraftDecorator-test.js
@@ -10,7 +10,7 @@
  * @typechecks
  */
 
-jest.unmock('CompositeDraftDecorator');
+jest.disableAutomock().mock('ContentState');
 
 var CompositeDraftDecorator = require('CompositeDraftDecorator');
 const ContentState = require('ContentState');

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -157,7 +157,7 @@ function getBlockMapSupportedTags(
   blockRenderMap: DraftBlockRenderMap,
 ): Array<string> {
   const unstyledElement = blockRenderMap.get('unstyled').element;
-  let tags = new Set([]);
+  let tags = Set([]);
 
   blockRenderMap.forEach((draftBlock: DraftBlockRenderConfig) => {
     if (draftBlock.aliasedElements) {


### PR DESCRIPTION
**what is the change?:**
In order to enable auto-syncing between Github and www we need to get
both to a point were they are in sync.

This copies some misc. changes from the www version of Draft into the
Github version of Draft. We are pulling in some changes as well.

Includes changes from
D5070771 Fix errors with single new in context
  (Note about above: TIL "by design you're not supposed to use new with Immutable.js data structures (well, except Records).")
D5172412 [codemod] disable automock by default on as many remaining tests in www as possible @bypass-lint
D5070207 [www][flowify] Start adding Flow typechecks to Style
D4966517 [TF] Minor comments and nits for the DraftJs Composer
D5109581 Add logging to catch Firefox Draft.js error

**why make this change?:**
To enable auto-syncing, to speed up speed of development.

**test plan:**
`yarn test`
I'm pretty confident of these changes since they have all been present
in FB Draft for some time.

**issue:**
https://github.com/facebook/draft-js/issues/1244