### PR TITLE
Tweak syntax of accessing '_instance' in DraftEditor test

### DIFF
--- a/src/component/base/__tests__/DraftEditor.react-test.js
+++ b/src/component/base/__tests__/DraftEditor.react-test.js
@@ -34,8 +34,15 @@ describe('DraftEditor.react', () => {
       shallow.render(
         <DraftEditor />,
       );
-     
-      var key = shallow._instance._instance.getEditorKey();
+
+      // internally at Facebook we use a newer version of the shallowRenderer
+      // which has a different level of wrapping of the '_instance'
+      // long term we should rewrite this test to not depend on private
+      // properties
+      var getEditorKey =
+        shallow._instance.getEditorKey
+        || shallow._instance._instance.getEditorKey;
+      var key = getEditorKey();
       expect(typeof key).toBe('string');
       expect(key.length).toBeGreaterThanOrEqual(4);
     });
@@ -44,8 +51,15 @@ describe('DraftEditor.react', () => {
       shallow.render(
         <DraftEditor editorKey="hash" />,
       );
-      
-      var key = shallow._instance._instance.getEditorKey();
+
+      // internally at Facebook we use a newer version of the shallowRenderer
+      // which has a different level of wrapping of the '_instance'
+      // long term we should rewrite this test to not depend on private
+      // properties
+      var getEditorKey =
+        shallow._instance.getEditorKey
+        || shallow._instance._instance.getEditorKey;
+      var key = getEditorKey();
       expect(key).toBe('hash');
     });
   });


### PR DESCRIPTION
**what is the change?:**
We either check for the 'getEditorKey' method on the
'renderedComponent._instance' or the
'renderedComponent._instance._instance'

**why make this change?:**
Internally we are using a different variation of the 'shallowRenderer'
and this test needs to run internally at Facebook as well as on Github.

This is not an ideal solution, but we can continue improving this test
once cleaning up the inconsistencies between Facebook and Github.

**test plan:**
`jest src/component/base/__tests__/DraftEditor.react-test.js`

Since I have limited time to work on this I will probably merge if/when CI passes.

**issue:**
https://github.com/facebook/draft-js/issues/1244