### PR TITLE
Allow Option+Space to be handled on OSX Chrome

### DIFF
--- a/src/component/handlers/edit/editOnKeyDown.js
+++ b/src/component/handlers/edit/editOnKeyDown.js
@@ -148,19 +148,9 @@ function editOnKeyDown(editor: DraftEditor, e: SyntheticKeyboardEvent<>): void {
       }
       break;
     case Keys.SPACE:
-      // Handling for OSX where option + space scrolls.
+      // Prevent Chrome on OSX behavior where option + space scrolls.
       if (isChrome && isOptionKeyCommand(e)) {
         e.preventDefault();
-        // Insert a nbsp into the editor.
-        const contentState = DraftModifier.replaceText(
-          editorState.getCurrentContent(),
-          editorState.getSelection(),
-          '\u00a0',
-        );
-        editor.update(
-          EditorState.push(editorState, contentState, 'insert-characters'),
-        );
-        return;
       }
   }
 
@@ -168,6 +158,19 @@ function editOnKeyDown(editor: DraftEditor, e: SyntheticKeyboardEvent<>): void {
 
   // If no command is specified, allow keydown event to continue.
   if (!command) {
+    if (keyCode === Keys.SPACE && isChrome && isOptionKeyCommand(e)) {
+      // The default keydown event has already been prevented in order to stop
+      // Chrome from scrolling. Insert a nbsp into the editor as OSX would for
+      // other browsers.
+      const contentState = DraftModifier.replaceText(
+        editorState.getCurrentContent(),
+        editorState.getSelection(),
+        '\u00a0',
+      );
+      editor.update(
+        EditorState.push(editorState, contentState, 'insert-characters'),
+      );
+    }
     return;
   }
 


### PR DESCRIPTION
**Summary**

Currently pressing Option+Space in Chrome on OSX will cause a nonbreaking space to always be inserted into the editor. This behavior ignores any key bindings that the editor has set.

This change moves the logic which adds the non breaking space to after the point that the key binding function has been run in order to give editors a chance to handle this behavior on their own.

**Test Plan**

This has been tested manually since there are no current tests for the event handlers and no current framework for testing the handlers. We have been running [with this change in our fork of Draft](https://github.com/textioHQ/draft-js/commit/f4c3aebe6593e3ccdb1de4c15363e72faae0f236) for about seven months without issue.