### PR TITLE
Support moving atomics

### DIFF
--- a/src/model/modifier/AtomicBlockUtils.js
+++ b/src/model/modifier/AtomicBlockUtils.js
@@ -13,6 +13,8 @@
 
 'use strict';
 
+const invariant = require('invariant');
+
 const BlockMapBuilder = require('BlockMapBuilder');
 const CharacterMetadata = require('CharacterMetadata');
 const ContentBlock = require('ContentBlock');
@@ -112,6 +114,15 @@ const AtomicBlockUtils = {
         insertionMode,
       );
     } else {
+
+      invariant(
+        !(
+          targetRange.isCollapsed() &&
+          atomicBlock.getKey() === targetRange.getStartKey()
+        ),
+        'Block cannot be moved next to itself.',
+      );
+
       const afterRemoval = DraftModifier.removeRange(
         contentState,
         targetRange,

--- a/src/model/modifier/AtomicBlockUtils.js
+++ b/src/model/modifier/AtomicBlockUtils.js
@@ -46,15 +46,7 @@ const AtomicBlockUtils = {
       'backward',
     );
 
-    const targetSelection = afterRemoval.getSelectionAfter();
-    const afterSplit = DraftModifier.splitBlock(afterRemoval, targetSelection);
-    const insertionTarget = afterSplit.getSelectionAfter();
-
-    const asAtomicBlock = DraftModifier.setBlockType(
-      afterSplit,
-      insertionTarget,
-      'atomic',
-    );
+    const insertionTarget = afterRemoval.getSelectionAfter();
 
     const charData = CharacterMetadata.create({entity: entityKey});
 
@@ -76,7 +68,7 @@ const AtomicBlockUtils = {
     const fragment = BlockMapBuilder.createFromArray(fragmentArray);
 
     const withAtomicBlock = DraftModifier.replaceWithFragment(
-      asAtomicBlock,
+      afterRemoval,
       insertionTarget,
       fragment,
     );

--- a/src/model/modifier/AtomicBlockUtils.js
+++ b/src/model/modifier/AtomicBlockUtils.js
@@ -53,6 +53,12 @@ const AtomicBlockUtils = {
     const fragmentArray = [
       new ContentBlock({
         key: generateRandomKey(),
+        type: 'unstyled',
+        text: '',
+        characterList: List(),
+      }),
+      new ContentBlock({
+        key: generateRandomKey(),
         type: 'atomic',
         text: character,
         characterList: List(Repeat(charData, character.length)),

--- a/src/model/transaction/__tests__/insertFragmentIntoContentState-test.js
+++ b/src/model/transaction/__tests__/insertFragmentIntoContentState-test.js
@@ -32,6 +32,7 @@ describe('insertFragmentIntoContentState', () => {
   var block = content.getBlockMap().first();
   var data = new Map({a: 1});
   var secondData = new Map({b: 2});
+  var thirdData = new Map({c: 2});
 
   function createFragment() {
     var fragmentArray = [
@@ -61,6 +62,53 @@ describe('insertFragmentIntoContentState', () => {
         text: 'yy',
         characterList: List.of(EMPTY, EMPTY),
         data: secondData,
+      }),
+    ];
+    return BlockMapBuilder.createFromArray(fragmentArray);
+  }
+
+  function createFragmentWithAtomicStart() {
+    var fragmentArray = [
+      new ContentBlock({
+        key: 'j',
+        type: 'atomic',
+        text: ' ',
+        characterList: List.of(EMPTY),
+        data: data,
+      }),
+      new ContentBlock({
+        key: 'k',
+        type: 'unstyled',
+        text: 'yy',
+        characterList: List.of(EMPTY, EMPTY),
+        data: secondData,
+      }),
+    ];
+    return BlockMapBuilder.createFromArray(fragmentArray);
+  }
+
+  function createFragmentWithAtomicBounds() {
+    var fragmentArray = [
+      new ContentBlock({
+        key: 'j',
+        type: 'atomic',
+        text: ' ',
+        characterList: List.of(EMPTY),
+        data: data,
+      }),
+      new ContentBlock({
+        key: 'k',
+        type: 'unstyled',
+        text: 'yy',
+        characterList: List.of(EMPTY, EMPTY),
+        data: secondData,
+      }),
+      new ContentBlock({
+        key: 'i',
+        type: 'atomic',
+        text: ' ',
+        characterList: List.of(EMPTY),
+        data: thirdData,
       }),
     ];
     return BlockMapBuilder.createFromArray(fragmentArray);
@@ -148,6 +196,130 @@ describe('insertFragmentIntoContentState', () => {
     expect(newBlock.getData()).toBe(data);
     expect(secondBlock.getText().slice(0, 2)).toBe('yy');
     expect(secondBlock.getData()).toBe(secondData);
+  });
+
+  it(
+    `must apply multiblock fragments starting with 'atomic'
+    to the start`,
+    () => {
+      var fragment = createFragmentWithAtomicStart();
+      var modified = insertFragmentIntoContentState(
+        content,
+        selection,
+        fragment,
+      );
+
+      var blocks = modified.getBlockMap().toArray();
+
+      expect(blocks.length).toBe(4);
+      expect(blocks[0].getType()).toBe('atomic');
+      expect(blocks[0].getData()).toBe(data);
+      expect(blocks[1].getType()).toBe('unstyled');
+      expect(blocks[1].getText().slice(0, 2)).toBe('yy');
+      expect(blocks[2].getType()).toBe(
+        content.getBlockMap().skip(1).first().getType(),
+      );
+      expect(blocks[2].getText()).toBe(
+        content.getBlockMap().skip(1).first().getText(),
+      );
+    },
+  );
+
+  it(
+    `must apply multiblock fragments starting with 'atomic'
+    at the end`,
+    () => {
+      var length = block.getLength();
+      var target = selection.merge({
+        focusOffset: length,
+        anchorOffset: length,
+        isBackward: false,
+      });
+
+      var fragment = createFragmentWithAtomicStart();
+      var modified = insertFragmentIntoContentState(
+        content,
+        target,
+        fragment,
+      );
+
+      var blocks = modified.getBlockMap().toArray();
+
+      expect(blocks.length).toBe(5);
+
+      expect(blocks[0].getText()).toBe(block.getText());
+      expect(blocks[0].getData()).toBe(block.getData());
+
+      expect(blocks[1].getType()).toBe('atomic');
+      expect(blocks[1].getData()).toBe(data);
+      expect(blocks[2].getType()).toBe('unstyled');
+      expect(blocks[2].getText()).toBe('yy');
+    },
+  );
+
+  it(
+    `must apply multiblock fragments starting with 'atomic'
+    to within block`,
+    () => {
+      var fragment = createFragmentWithAtomicStart();
+      var originalFirstBlock = content.getBlockMap().first();
+      var target = selection.merge({
+        focusOffset: 2,
+        anchorOffset: 2,
+        isBackward: false,
+      });
+      var modified = insertFragmentIntoContentState(
+        content,
+        target,
+        fragment,
+      );
+
+      var blocks = modified.getBlockMap().toArray();
+
+      expect(blocks.length).toBe(5);
+      expect(blocks[0].getType()).toBe('unstyled');
+      expect(blocks[0].getText()).toBe(
+        originalFirstBlock.getText().slice(0, 2),
+      );
+      expect(blocks[1].getType()).toBe('atomic');
+      expect(blocks[1].getData()).toBe(data);
+      expect(blocks[2].getType()).toBe('unstyled');
+      expect(blocks[2].getText().slice(0, 2)).toBe('yy');
+    },
+  );
+
+  it('must apply multiblock fragments with `atomic`s to within block', () => {
+    var fragment = createFragmentWithAtomicBounds();
+    var originalFirstBlock = content.getBlockMap().first();
+    var target = selection.merge({
+      focusOffset: 2,
+      anchorOffset: 2,
+      isBackward: false,
+    });
+    var modified = insertFragmentIntoContentState(
+      content,
+      target,
+      fragment,
+    );
+
+    var blocks = modified.getBlockMap().toArray();
+
+    expect(blocks.length).toBe(7);
+    expect(blocks[0].getType()).toBe('unstyled');
+    expect(blocks[0].getText()).toBe(
+      originalFirstBlock.getText().slice(0, 2),
+    );
+    expect(blocks[1].getType()).toBe('atomic');
+    expect(blocks[1].getData()).toBe(data);
+    expect(blocks[2].getType()).toBe('unstyled');
+    expect(blocks[2].getText()).toBe('yy');
+    expect(blocks[3].getType()).toBe('atomic');
+    expect(blocks[3].getData()).toBe(thirdData);
+
+    expect(blocks[4].getType()).toBe('unstyled');
+    expect(blocks[4].getText()).toBe(
+      originalFirstBlock.getText().slice(2),
+    );
   });
 
 });

--- a/src/model/transaction/__tests__/insertFragmentIntoContentState-test.js
+++ b/src/model/transaction/__tests__/insertFragmentIntoContentState-test.js
@@ -177,6 +177,7 @@ describe('insertFragmentIntoContentState', () => {
 
     var newBlock = modified.getBlockMap().first();
 
+    expect(modified.getBlockMap().size).toBe(3);
     expect(newBlock.getText().slice(length, length + 2)).toBe('xx');
     expect(newBlock.getData()).toBe(data);
   });

--- a/src/model/transaction/insertFragmentIntoContentState.js
+++ b/src/model/transaction/insertFragmentIntoContentState.js
@@ -61,11 +61,13 @@ function insertFragmentIntoContentState(
       var headCharacters = chars.slice(0, targetOffset);
       var modifiedHead;
       if (firstFragmentPartIsAtomic) {
-        modifiedHead = block.merge({
-          text: headText,
-          characterList: headCharacters,
-        });
-
+        if (headText) {
+          modifiedHead = block.merge({
+            text: headText,
+            characterList: headCharacters,
+          });
+          newBlockArr.push(modifiedHead);
+        }
       } else {
         var appendToHead = fragment.first();
 
@@ -75,8 +77,8 @@ function insertFragmentIntoContentState(
           type: headText ? block.getType() : appendToHead.getType(),
           data: appendToHead.getData(),
         });
+        newBlockArr.push(modifiedHead);
       }
-      newBlockArr.push(modifiedHead);
 
       // Insert fragment blocks after the head and before the tail.
       fragment.slice(

--- a/src/model/transaction/insertFragmentIntoContentState.js
+++ b/src/model/transaction/insertFragmentIntoContentState.js
@@ -81,6 +81,8 @@ function insertFragmentIntoContentState(
   }
 
   var newBlockArr = [];
+  var newSelectionKey;
+  var newSelectionOffset;
 
   contentState.getBlockMap().forEach(
     (block, blockKey) => {
@@ -89,6 +91,9 @@ function insertFragmentIntoContentState(
         return;
       }
 
+      var firstFragmentPartIsAtomic = fragment.first().getType() === 'atomic';
+      var lastFragmentPartIsAtomic = fragment.first().getType() === 'atomic';
+
       var text = block.getText();
       var chars = block.getCharacterList();
 
@@ -96,19 +101,30 @@ function insertFragmentIntoContentState(
       var blockSize = text.length;
       var headText = text.slice(0, targetOffset);
       var headCharacters = chars.slice(0, targetOffset);
-      var appendToHead = fragment.first();
+      var modifiedHead;
+      if (firstFragmentPartIsAtomic) {
+        modifiedHead = block.merge({
+          text: headText,
+          characterList: headCharacters,
+        });
 
-      var modifiedHead = block.merge({
-        text: headText + appendToHead.getText(),
-        characterList: headCharacters.concat(appendToHead.getCharacterList()),
-        type: headText ? block.getType() : appendToHead.getType(),
-        data: appendToHead.getData(),
-      });
+      } else {
+        var appendToHead = fragment.first();
 
+        modifiedHead = block.merge({
+          text: headText + appendToHead.getText(),
+          characterList: headCharacters.concat(appendToHead.getCharacterList()),
+          type: headText ? block.getType() : appendToHead.getType(),
+          data: appendToHead.getData(),
+        });
+      }
       newBlockArr.push(modifiedHead);
 
       // Insert fragment blocks after the head and before the tail.
-      fragment.slice(1, fragmentSize - 1).forEach(
+      fragment.slice(
+        firstFragmentPartIsAtomic ? 0 : 1,
+        lastFragmentPartIsAtomic ? fragmentSize : fragmentSize - 1,
+      ).forEach(
         fragmentBlock => {
           newBlockArr.push(fragmentBlock.set('key', generateRandomKey()));
         },
@@ -120,29 +136,45 @@ function insertFragmentIntoContentState(
       var prependToTail = fragment.last();
       finalKey = generateRandomKey();
 
-      var modifiedTail = prependToTail.merge({
-        key: finalKey,
-        text: prependToTail.getText() + tailText,
-        characterList: prependToTail
-          .getCharacterList()
-          .concat(tailCharacters),
-        data: prependToTail.getData(),
-      });
-
-      newBlockArr.push(modifiedTail);
+      if (lastFragmentPartIsAtomic) {
+        if (tailText) {
+          var targetTail = block.merge({
+            key: finalKey,
+            text: tailText,
+            characterList: tailCharacters,
+          });
+          newBlockArr.push(targetTail);
+          newSelectionKey = finalKey;
+          newSelectionOffset = 0;
+        } else {
+          var lastFragmentPart = newBlockArr[newBlockArr.length - 1];
+          newSelectionKey = lastFragmentPart.getKey();
+          newSelectionOffset = lastFragmentPart.getLength();
+        }
+      } else {
+        var modifiedTail = prependToTail.merge({
+          key: finalKey,
+          text: prependToTail.getText() + tailText,
+          characterList: prependToTail
+            .getCharacterList()
+            .concat(tailCharacters),
+          data: prependToTail.getData(),
+        });
+        newBlockArr.push(modifiedTail);
+        newSelectionKey = finalKey;
+        newSelectionOffset = fragment.last().getLength();
+      }
     },
   );
-
-  finalOffset = fragment.last().getLength();
 
   return contentState.merge({
     blockMap: BlockMapBuilder.createFromArray(newBlockArr),
     selectionBefore: selectionState,
     selectionAfter: selectionState.merge({
-      anchorKey: finalKey,
-      anchorOffset: finalOffset,
-      focusKey: finalKey,
-      focusOffset: finalOffset,
+      anchorKey: newSelectionKey,
+      anchorOffset: newSelectionOffset,
+      focusKey: newSelectionKey,
+      focusOffset: newSelectionOffset,
       isBackward: false,
     }),
   });

--- a/src/model/transaction/insertFragmentIntoContentState.js
+++ b/src/model/transaction/insertFragmentIntoContentState.js
@@ -16,7 +16,6 @@
 var BlockMapBuilder = require('BlockMapBuilder');
 
 var generateRandomKey = require('generateRandomKey');
-var insertIntoList = require('insertIntoList');
 var invariant = require('invariant');
 
 import type {BlockMap} from 'BlockMap';
@@ -36,49 +35,8 @@ function insertFragmentIntoContentState(
   var targetKey = selectionState.getStartKey();
   var targetOffset = selectionState.getStartOffset();
 
-  var blockMap = contentState.getBlockMap();
-
   var fragmentSize = fragment.size;
   var finalKey;
-  var finalOffset;
-
-  if (fragmentSize === 1) {
-    var targetBlock = blockMap.get(targetKey);
-    var pastedBlock = fragment.first();
-    var text = targetBlock.getText();
-    var chars = targetBlock.getCharacterList();
-
-    var newBlock = targetBlock.merge({
-      text: (
-        text.slice(0, targetOffset) +
-        pastedBlock.getText() +
-        text.slice(targetOffset)
-      ),
-      characterList: insertIntoList(
-        chars,
-        pastedBlock.getCharacterList(),
-        targetOffset,
-      ),
-      data: pastedBlock.getData(),
-    });
-
-    blockMap = blockMap.set(targetKey, newBlock);
-
-    finalKey = targetKey;
-    finalOffset = targetOffset + pastedBlock.getText().length;
-
-    return contentState.merge({
-      blockMap: blockMap.set(targetKey, newBlock),
-      selectionBefore: selectionState,
-      selectionAfter: selectionState.merge({
-        anchorKey: finalKey,
-        anchorOffset: finalOffset,
-        focusKey: finalKey,
-        focusOffset: finalOffset,
-        isBackward: false,
-      }),
-    });
-  }
 
   var newBlockArr = [];
   var newSelectionKey;
@@ -92,7 +50,7 @@ function insertFragmentIntoContentState(
       }
 
       var firstFragmentPartIsAtomic = fragment.first().getType() === 'atomic';
-      var lastFragmentPartIsAtomic = fragment.first().getType() === 'atomic';
+      var lastFragmentPartIsAtomic = fragment.last().getType() === 'atomic';
 
       var text = block.getText();
       var chars = block.getCharacterList();

--- a/src/model/transaction/insertFragmentIntoContentState.js
+++ b/src/model/transaction/insertFragmentIntoContentState.js
@@ -48,6 +48,7 @@ function insertFragmentIntoContentState(
     var pastedBlock = fragment.first();
     var text = targetBlock.getText();
     var chars = targetBlock.getCharacterList();
+
     var newBlock = targetBlock.merge({
       text: (
         text.slice(0, targetOffset) +
@@ -61,9 +62,12 @@ function insertFragmentIntoContentState(
       ),
       data: pastedBlock.getData(),
     });
+
     blockMap = blockMap.set(targetKey, newBlock);
+
     finalKey = targetKey;
     finalOffset = targetOffset + pastedBlock.getText().length;
+
     return contentState.merge({
       blockMap: blockMap.set(targetKey, newBlock),
       selectionBefore: selectionState,

--- a/src/model/transaction/removeRangeFromContentState.js
+++ b/src/model/transaction/removeRangeFromContentState.js
@@ -23,9 +23,6 @@ function removeRangeFromContentState(
   contentState: ContentState,
   selectionState: SelectionState,
 ): ContentState {
-  if (selectionState.isCollapsed()) {
-    return contentState;
-  }
 
   var blockMap = contentState.getBlockMap();
   var startKey = selectionState.getStartKey();
@@ -34,6 +31,12 @@ function removeRangeFromContentState(
   var endOffset = selectionState.getEndOffset();
 
   var startBlock = blockMap.get(startKey);
+  var startIsAtomic = startBlock.getType() === 'atomic';
+  // Any kind of selection on `atomic`, including collapsed one,
+  // is treated as full selection of `atomic`
+  if (selectionState.isCollapsed() && !startIsAtomic) {
+    return contentState;
+  }
   var endBlock = blockMap.get(endKey);
   var characterList;
 
@@ -50,7 +53,6 @@ function removeRangeFromContentState(
       .concat(endBlock.getCharacterList().slice(endOffset));
   }
 
-  var startIsAtomic = startBlock.getType() === 'atomic';
   var modifiedStart = startIsAtomic ?
     null :
     startBlock.merge({


### PR DESCRIPTION
**Summary**

While testing `Editor`, my team has discovered that drag'n'drop doesn't work well with atomics (blocks of type `atomic`) selected. Delving deeper into the issue, it came out that core `removeRangeFromContentState` and `insertFragmentIntoContentState` functions don't fully support atomics.

`removeRangeFromContentState`, if given a fragment with a first block as atomic, only cuts text from that atomic without removing it, which effectively leaves the block unchanged. 

`insertFragmentIntoContentState`, if given a fragment with a first block as atomic, takes that atomic and merges its text (whitespace character) to a target block, leaving target's block type as it was (for example, `unstyled`). That effectively does not insert the atomic block.

This solution is generally to remove atomics in first case and to append them, not merge, in second case.

**Test Plan**

```
src/model/transaction/__tests__/removeRangeFromContentState-test.js
src/model/transaction/__tests__/insertFragmentIntoContentState-test.js
```