### PR TITLE
Add flow pragma to 'Draft.js'

### DIFF
--- a/src/Draft.js
+++ b/src/Draft.js
@@ -7,6 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule Draft
+ * @flow
  */
 
 'use strict';


### PR DESCRIPTION
**what is the change?:**
Adds missing pragma.

**why make this change?:**
This was causing a problem for users in some build set-ups.
Fixes #982
Thanks @yuku-t for this solution. :)

**test plan:**
Ran `yarn build` and inspected `lib/Draft.js.flow` before and after this
fix. It has the `@flow` pragma after, and did not before.

**issue:**
https://github.com/facebook/draft-js/issues/982