### PR TITLE
Allow DraftJS to work in iframes

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -355,7 +355,8 @@ class DraftEditor extends React.Component {
     const {x, y} = scrollPosition || getScrollPosition(scrollParent);
 
     invariant(
-      editorNode instanceof HTMLElement,
+      editorNode &&
+        editorNode instanceof editorNode.ownerDocument.defaultView.HTMLElement,
       'editorNode is not an HTMLElement',
     );
     editorNode.focus();
@@ -382,7 +383,8 @@ class DraftEditor extends React.Component {
   _blur(): void {
     const editorNode = ReactDOM.findDOMNode(this.refs.editor);
     invariant(
-      editorNode instanceof HTMLElement,
+      editorNode &&
+        editorNode instanceof editorNode.ownerDocument.defaultView.HTMLElement,
       'editorNode is not an HTMLElement',
     );
     editorNode.blur();

--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -335,6 +335,10 @@ class DraftEditor extends React.Component {
     this._blockSelectEvents = false;
   }
 
+  getNode(): ?Element {
+    return ReactDOM.findDOMNode(this.refs.editor)
+  }
+
   /**
    * Used via `this.focus()`.
    *

--- a/src/component/contents/DraftEditorBlock.react.js
+++ b/src/component/contents/DraftEditorBlock.react.js
@@ -113,7 +113,8 @@ class DraftEditorBlock extends React.Component {
       }
     } else {
       invariant(
-        blockNode instanceof HTMLElement,
+        blockNode &&
+          blockNode instanceof blockNode.ownerDocument.defaultView.HTMLElement,
         'blockNode is not an HTMLElement',
       );
       var blockBottom = blockNode.offsetHeight + blockNode.offsetTop;

--- a/src/component/contents/DraftEditorTextNode.react.js
+++ b/src/component/contents/DraftEditorTextNode.react.js
@@ -71,7 +71,10 @@ class DraftEditorTextNode extends React.Component {
   shouldComponentUpdate(nextProps: Props): boolean {
     const node = ReactDOM.findDOMNode(this);
     const shouldBeNewline = nextProps.children === '';
-    invariant(node instanceof Element, 'node is not an Element');
+    invariant(
+      node && node instanceof node.ownerDocument.defaultView.Element,
+      'node is not an Element',
+    );
     if (shouldBeNewline) {
       return !isNewline(node);
     }

--- a/src/component/handlers/edit/commands/keyCommandBackspaceToStartOfLine.js
+++ b/src/component/handlers/edit/commands/keyCommandBackspaceToStartOfLine.js
@@ -30,7 +30,8 @@ function keyCommandBackspaceToStartOfLine(
         return moveSelectionBackward(strategyState, 1);
       }
 
-      var domSelection = global.getSelection();
+      var domSelection = editor.getNode().ownerDocument.defaultView
+        .getSelection();
       var range = domSelection.getRangeAt(0);
       range = expandRangeToStartOfLine(range);
 

--- a/src/component/handlers/edit/editOnBlur.js
+++ b/src/component/handlers/edit/editOnBlur.js
@@ -29,7 +29,7 @@ function editOnBlur(editor: DraftEditor, e: SyntheticEvent): void {
   // to force it when blurring occurs within the window (as opposed to
   // clicking to another tab or window).
   if (isWebKit && getActiveElement() === document.body) {
-    global.getSelection().removeAllRanges();
+    editor.getNode().ownerDocument.defaultView.getSelection().removeAllRanges();
   }
 
   var editorState = editor._latestEditorState;

--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -45,7 +45,7 @@ function editOnInput(editor: DraftEditor): void {
     editor._pendingStateFromBeforeInput = undefined;
   }
 
-  var domSelection = global.getSelection();
+  var domSelection = editor.getNode().ownerDocument.defaultView.getSelection();
 
   var {anchorNode, isCollapsed} = domSelection;
   const isNotTextNode =

--- a/src/component/handlers/edit/editOnSelect.js
+++ b/src/component/handlers/edit/editOnSelect.js
@@ -30,7 +30,9 @@ function editOnSelect(editor: DraftEditor): void {
   const editorNode = ReactDOM.findDOMNode(editor.refs.editorContainer);
   invariant(editorNode, 'Missing editorNode');
   invariant(
-    editorNode.firstChild instanceof HTMLElement,
+    editorNode.firstChild &&
+      editorNode.firstChild instanceof
+        editorNode.firstChild.ownerDocument.defaultView.HTMLElement,
     'editorNode.firstChild is not an HTMLElement',
   );
   var documentSelection = getDraftEditorSelection(

--- a/src/component/selection/getDraftEditorSelection.js
+++ b/src/component/selection/getDraftEditorSelection.js
@@ -26,7 +26,7 @@ function getDraftEditorSelection(
   editorState: EditorState,
   root: HTMLElement,
 ): DOMDerivedSelection {
-  var selection = global.getSelection();
+  var selection = editor.getNode().ownerDocument.defaultView.getSelection();
 
   // No active selection.
   if (selection.rangeCount === 0) {

--- a/src/component/selection/getDraftEditorSelectionWithNodes.js
+++ b/src/component/selection/getDraftEditorSelectionWithNodes.js
@@ -157,7 +157,9 @@ function getPointForNonTextNode(
   if (editorRoot === node) {
     node = node.firstChild;
     invariant(
-      node instanceof Element && node.getAttribute('data-contents') === 'true',
+      node &&
+        node instanceof node.ownerDocument.defaultView.Element &&
+          node.getAttribute('data-contents') === 'true',
       'Invalid DraftEditorContents structure.',
     );
     if (childOffset > 0) {

--- a/src/component/selection/getSelectionOffsetKeyForNode.js
+++ b/src/component/selection/getSelectionOffsetKeyForNode.js
@@ -18,7 +18,7 @@
  * found on the DOM tree of given node.
  */
 function getSelectionOffsetKeyForNode(node: Node): ?string {
-  if (node instanceof Element) {
+  if (node instanceof node.ownerDocument.defaultView.Element) {
     var offsetKey = node.getAttribute('data-offset-key');
     if (offsetKey) {
       return offsetKey;

--- a/src/component/selection/setDraftEditorSelection.js
+++ b/src/component/selection/setDraftEditorSelection.js
@@ -94,11 +94,11 @@ function setDraftEditorSelection(
   // It's possible that the editor has been removed from the DOM but
   // our selection code doesn't know it yet. Forcing selection in
   // this case may lead to errors, so just bail now.
-  if (!containsNode(document.documentElement, node)) {
+  if (!containsNode(node.ownerDocument.documentElement, node)) {
     return;
   }
 
-  var selection = global.getSelection();
+  var selection = node.ownerDocument.defaultView.getSelection();
   var anchorKey = selectionState.getAnchorKey();
   var anchorOffset = selectionState.getAnchorOffset();
   var focusKey = selectionState.getFocusKey();

--- a/src/component/selection/setDraftEditorSelection.js
+++ b/src/component/selection/setDraftEditorSelection.js
@@ -31,7 +31,7 @@ function getAnonymizedDOM(node: Node): string {
   }
 
   invariant(
-    anonymized instanceof Element,
+    anonymized instanceof anonymized.ownerDocument.defaultView.Element,
     'Node must be an Element if it is not a text node.',
   );
   return anonymized.innerHTML;
@@ -57,7 +57,7 @@ function getAnonymizedEditorDOM(node: Node): string {
   let currentNode = node;
   while (currentNode) {
     if (
-      currentNode instanceof Element
+      currentNode instanceof currentNode.ownerDocument.defaultView.Element
       && currentNode.hasAttribute('contenteditable')
     ) {
       // found the Draft editor container

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -233,7 +233,10 @@ function processInlineTag(
   var styleToCheck = inlineTags[tag];
   if (styleToCheck) {
     currentStyle = currentStyle.add(styleToCheck).toOrderedSet();
-  } else if (node instanceof HTMLElement) {
+  } else if (
+    node &&
+    node instanceof node.ownerDocument.defaultView.HTMLElement
+  ) {
     const htmlElement = node;
     currentStyle = currentStyle.withMutations(style => {
       const fontWeight = htmlElement.style.fontWeight;
@@ -318,7 +321,7 @@ function containsSemanticBlockMarkup(
 
 function hasValidLinkText(link: Node): boolean {
   invariant(
-    link instanceof HTMLAnchorElement,
+    link instanceof link.ownerDocument.defaultView.HTMLAnchorElement,
     'Link must be an HTMLAnchorElement.',
   );
   var protocol = link.protocol;
@@ -391,7 +394,7 @@ function genFragment(
   // IMG tags
   if (
     nodeName === 'img' &&
-    node instanceof HTMLImageElement &&
+    node instanceof node.ownerDocument.defaultView.HTMLImageElement &&
     node.attributes.getNamedItem('src') &&
     node.attributes.getNamedItem('src').value
   ) {
@@ -459,7 +462,7 @@ function genFragment(
 
   while (child) {
     if (
-      child instanceof HTMLAnchorElement &&
+      child instanceof child.ownerDocument.defaultView.HTMLAnchorElement &&
       child.href &&
       hasValidLinkText(child)
     ) {


### PR DESCRIPTION
**Summary**

This allows DraftJS to render within an iframe that is controlled by a script in an ancestor window.

The `instanceof` checks on `HTMLElement`, `Element` and friends triggered an invariant error because they don't necessarily inherit from the same one that is available as a global variable to the `draft-js` script.

**Test Plan**

Tests currently fail, and it seems to fail because of a jsdom or jest bug. 
