### PR TITLE
Add docs about lack of support for mobile browsers

### DIFF
--- a/docs/Advanced-Topics-Issues-and-Pitfalls.md
+++ b/docs/Advanced-Topics-Issues-and-Pitfalls.md
@@ -110,3 +110,11 @@ ReactDOM.render(
   document.getElementById('root')
 );
 ```
+
+### Mobile Not Yet Supported
+
+Draft.js is moving towards full mobile support, but does not officially support
+mobile browsers at this point. There are some known issues affecting Android and
+iOS - see issues tagged
+['android'](https://github.com/facebook/draft-js/labels/android) or
+['ios'](https://github.com/facebook/draft-js/labels/ios) for the current status.


### PR DESCRIPTION
**what is the change?:**
Based on issues from the community and internal experiments, we know
that there are severe bugs affecting some mobile web uses of Draft.js.
In particular, Android with certain keyboards and IME/rtl on Android.

**why make this change?:**
This information is important for folks when deciding whether Draft.js
is the best choice for their use case. It may also get more interest in
improving Draft.js for mobile web use cases.

**test plan:**
Opened the docs and visually inspected. 
![screen shot 2017-06-28 at 9 52 10 am](https://user-images.githubusercontent.com/1114467/27649773-a2d5db8e-5be7-11e7-855b-3128c600c0a9.png)


**issue:**
Related to https://github.com/facebook/draft-js/issues/1224