### PR TITLE
use `event.target` in FileReader load handler

### DIFF
--- a/src/component/utils/getTextContentFromFiles.js
+++ b/src/component/utils/getTextContentFromFiles.js
@@ -69,8 +69,8 @@ function readFile(
   }
 
   var reader = new FileReader();
-  reader.onload = function() {
-    callback(reader.result);
+  reader.onload = function(event) {
+    callback(event.target.result);
   };
   reader.onerror = function() {
     callback('');


### PR DESCRIPTION
**Summary**

According to the spec (https://w3c.github.io/FileAPI/#events):

> The FileReader object must be the event target for all events in this specification.

Using `event.target` also avoids a Flow error when using Flow 0.49.0 or greater, since 0.49.0 changed FileReader's `result` property to be `string | ArrayBuffer`.

**Test Plan**

* Open `examples/draft-0-10-0/rich/rich.html` and drag and drop one or more text files from your operating system's file browser into the editor
* Contents of dropped file(s) should be added to the editor
