### PR TITLE
Add support for mark (highlight) inline tag when converting from HTML.

### DIFF
--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -68,6 +68,7 @@ var inlineTags = {
   strike: 'STRIKETHROUGH',
   strong: 'BOLD',
   u: 'UNDERLINE',
+  mark: 'HIGHLIGHT',
 };
 
 var anchorAttr = [


### PR DESCRIPTION
**Summary**
Support for mark (highlight) HTML inline tag style when converting from HTML.
