### PR TITLE
Move DraftFeatureFlags to stubs

### DIFF
--- a/src/component/utils/DraftFeatureFlags-core.js
+++ b/src/component/utils/DraftFeatureFlags-core.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule DraftFeatureFlags-core
+ * @flow
+ */
+
+'use strict';
+
+var DraftFeatureFlags = {
+  draft_accept_selection_after_refocus: false,
+  draft_killswitch_allow_nontextnodes: false,
+  draft_segmented_entities_behavior: false,
+};
+
+module.exports = DraftFeatureFlags;

--- a/src/stubs/DraftFeatureFlags.js
+++ b/src/stubs/DraftFeatureFlags.js
@@ -12,9 +12,6 @@
 
 'use strict';
 
-var DraftFeatureFlags = {
-  draft_killswitch_allow_nontextnodes: false,
-  draft_segmented_entities_behavior: false,
-};
+var DraftFeatureFlags = require('DraftFeatureFlags-core');
 
 module.exports = DraftFeatureFlags;


### PR DESCRIPTION
Credit to @spicyj for this approach. Planning to merge fast to unblock the sync script activation, but would love a review after-the-fact.

**what is the change?:**
Moved 'DraftFeatureFlags' to 'stubs' directory, and make it export
'DraftFeatureFlags-core'.

**why make this change?:**
The 'DraftFeatureFlags' file is, *I think*, the last file which is out
of sync with our internal FB version of Draft. That is because we
actually use different flag configs within FB than the defaults for OS.

**test plan:**
`yarn install && yarn build && yarn test` and play with example files

**issue:**
issue #1244
