### PR TITLE
Added support for the `compositionupdate` event

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -100,6 +100,7 @@ class DraftEditor extends React.Component {
   _onCharacterData: Function;
   _onCompositionEnd: Function;
   _onCompositionStart: Function;
+  _onCompositionUpdate: Function;
   _onCopy: Function;
   _onCut: Function;
   _onDragEnd: Function;
@@ -144,6 +145,7 @@ class DraftEditor extends React.Component {
     this._onCharacterData = this._buildHandler('onCharacterData');
     this._onCompositionEnd = this._buildHandler('onCompositionEnd');
     this._onCompositionStart = this._buildHandler('onCompositionStart');
+    this._onCompositionUpdate = this._buildHandler('onCompositionUpdate');
     this._onCopy = this._buildHandler('onCopy');
     this._onCut = this._buildHandler('onCut');
     this._onDragEnd = this._buildHandler('onDragEnd');
@@ -263,6 +265,7 @@ class DraftEditor extends React.Component {
             onBlur={this._onBlur}
             onCompositionEnd={this._onCompositionEnd}
             onCompositionStart={this._onCompositionStart}
+            onCompositionUpdate={this._onCompositionUpdate}
             onCopy={this._onCopy}
             onCut={this._onCut}
             onDragEnd={this._onDragEnd}

--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -68,7 +68,10 @@ var DraftEditorCompositionHandler = {
    * A `compositionupdate` event has fired. Update the current composition
    * session.
    */
-  onCompositionUpdate: function(editor: DraftEditor, e: SyntheticInputEvent): void {
+  onCompositionUpdate: function(
+    editor: DraftEditor,
+    e: SyntheticInputEvent,
+  ): void {
     compositionUpdates = true;
     textInputData = e.data;
   },

--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -41,10 +41,18 @@ const RESOLVE_DELAY = 20;
  */
 let resolved = false;
 let stillComposing = false;
+let compositionUpdates = false;
 let textInputData = '';
 
 var DraftEditorCompositionHandler = {
   onBeforeInput: function(editor: DraftEditor, e: SyntheticInputEvent): void {
+    if (compositionUpdates) {
+      // We only want to use the `beforeinput` event if the `compositionupdate`
+      // one isn't supported. We know that if it is, it fires before
+      // `beforeinput`.
+      return;
+    }
+
     textInputData = (textInputData || '') + e.data;
   },
 
@@ -54,6 +62,15 @@ var DraftEditorCompositionHandler = {
    */
   onCompositionStart: function(editor: DraftEditor): void {
     stillComposing = true;
+  },
+
+  /**
+   * A `compositionupdate` event has fired. Update the current composition
+   * session.
+   */
+  onCompositionUpdate: function(editor: DraftEditor, e: SyntheticInputEvent): void {
+    compositionUpdates = true;
+    textInputData = e.data;
   },
 
   /**


### PR DESCRIPTION
**Summary**

@flarnie As we discussed, this adds support for the [`compositionupdate`](https://developer.mozilla.org/en-US/docs/Web/Events/compositionupdate) event and ignores the `beforeinput` event if it were to be fired in that scenario too.  I imagine a slightly cleaner way of doing this would be to remove the listener on `beforeinput` altogether when we realize `compositionupdate` fires. Should I squash my changes?

**Test Plan**

I didn't add new tests, should I add tests that fail without this fix?
