### PR TITLE
Fix-up diff for enabling 'ship-it' and 'import-it'

### DIFF
--- a/docs/APIReference-Editor.md
+++ b/docs/APIReference-Editor.md
@@ -249,7 +249,6 @@ onUpArrow?: (e: SyntheticKeyboardEvent) => void
 ```
 onDownArrow?: (e: SyntheticKeyboardEvent) => void
 ```
-
 ### Mouse events
 
 ### onFocus

--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -15,8 +15,8 @@
 'use strict';
 
 import type {BlockMap} from 'BlockMap';
-import type {DraftEditorDefaultProps, DraftEditorProps} from 'DraftEditorProps';
 import type {DraftEditorModes} from 'DraftEditorModes';
+import type {DraftEditorDefaultProps, DraftEditorProps} from 'DraftEditorProps';
 import type {DraftScrollPosition} from 'DraftScrollPosition';
 
 const DefaultDraftBlockRenderMap = require('DefaultDraftBlockRenderMap');
@@ -26,7 +26,6 @@ const DraftEditorContents = require('DraftEditorContents.react');
 const DraftEditorDragHandler = require('DraftEditorDragHandler');
 const DraftEditorEditHandler = require('DraftEditorEditHandler');
 const DraftEditorPlaceholder = require('DraftEditorPlaceholder.react');
-
 const EditorState = require('EditorState');
 const React = require('React');
 const ReactDOM = require('ReactDOM');
@@ -38,7 +37,6 @@ const cx = require('cx');
 const emptyFunction = require('emptyFunction');
 const generateRandomKey = require('generateRandomKey');
 const getDefaultKeyBinding = require('getDefaultKeyBinding');
-
 const getScrollPosition = require('getScrollPosition');
 const invariant = require('invariant');
 const nullthrows = require('nullthrows');

--- a/src/component/base/DraftEditorPlaceholder.css
+++ b/src/component/base/DraftEditorPlaceholder.css
@@ -6,7 +6,7 @@
 .public/DraftEditorPlaceholder/root {
   color: var(fig-secondary-text);
   position: absolute;
-  z-index: 0;
+  z-index: 1;
 }
 
 .public/DraftEditorPlaceholder/hasFocus {

--- a/src/component/base/DraftEditorPlaceholder.react.js
+++ b/src/component/base/DraftEditorPlaceholder.react.js
@@ -13,12 +13,12 @@
 
 'use strict';
 
+import type {DraftTextAlignment} from 'DraftTextAlignment';
+import type EditorState from 'EditorState';
+
 const React = require('React');
 
 const cx = require('cx');
-
-import type {DraftTextAlignment} from 'DraftTextAlignment';
-import type EditorState from 'EditorState';
 
 type Props = {
   accessibilityID: string,

--- a/src/component/base/DraftEditorProps.js
+++ b/src/component/base/DraftEditorProps.js
@@ -12,16 +12,16 @@
 
 'use strict';
 
-import type {BidiDirection} from 'UnicodeBidiDirection';
 import type ContentBlock from 'ContentBlock';
 import type {DraftBlockRenderMap} from 'DraftBlockRenderMap';
 import type {DraftDragType} from 'DraftDragType';
 import type {DraftEditorCommand} from 'DraftEditorCommand';
-import type {DraftTextAlignment} from 'DraftTextAlignment';
-import type {DraftInlineStyle} from 'DraftInlineStyle';
 import type {DraftHandleValue} from 'DraftHandleValue';
+import type {DraftInlineStyle} from 'DraftInlineStyle';
+import type {DraftTextAlignment} from 'DraftTextAlignment';
 import type EditorState from 'EditorState';
 import type SelectionState from 'SelectionState';
+import type {BidiDirection} from 'UnicodeBidiDirection';
 
 export type DraftEditorProps = {
   /**

--- a/src/component/base/__tests__/DraftEditor.react-test.js
+++ b/src/component/base/__tests__/DraftEditor.react-test.js
@@ -17,10 +17,10 @@ jest
   .unmock('react-test-renderer/shallow')
   .unmock('generateRandomKey');
 
-var React = require('React');
-var ReactShallowRenderer = require('react-test-renderer/shallow');
-
 var DraftEditor = require('DraftEditor.react');
+var React = require('React');
+
+var ReactShallowRenderer = require('react-test-renderer/shallow');
 
 describe('DraftEditor.react', () => {
   var shallow;

--- a/src/component/contents/DraftEditorBlock.react.js
+++ b/src/component/contents/DraftEditorBlock.react.js
@@ -13,19 +13,18 @@
 
 'use strict';
 
-import type {BidiDirection} from 'UnicodeBidiDirection';
 import type ContentBlock from 'ContentBlock';
 import type ContentState from 'ContentState';
 import type {DraftDecoratorType} from 'DraftDecoratorType';
-import type {List} from 'immutable';
 import type SelectionState from 'SelectionState';
+import type {BidiDirection} from 'UnicodeBidiDirection';
+import type {List} from 'immutable';
 
 const DraftEditorLeaf = require('DraftEditorLeaf.react');
 const DraftOffsetKey = require('DraftOffsetKey');
 const React = require('React');
 const ReactDOM = require('ReactDOM');
 const Scroll = require('Scroll');
-
 const Style = require('Style');
 const UnicodeBidi = require('UnicodeBidi');
 const UnicodeBidiDirection = require('UnicodeBidiDirection');

--- a/src/component/contents/DraftEditorContents.react.js
+++ b/src/component/contents/DraftEditorContents.react.js
@@ -13,6 +13,9 @@
 
 'use strict';
 
+import type ContentBlock from 'ContentBlock';
+import type {BidiDirection} from 'UnicodeBidiDirection';
+
 const DraftEditorBlock = require('DraftEditorBlock.react');
 const DraftOffsetKey = require('DraftOffsetKey');
 const EditorState = require('EditorState');
@@ -21,9 +24,6 @@ const React = require('React');
 const cx = require('cx');
 const joinClasses = require('joinClasses');
 const nullthrows = require('nullthrows');
-
-import type {BidiDirection} from 'UnicodeBidiDirection';
-import type ContentBlock from 'ContentBlock';
 
 type Props = {
   blockRendererFn: Function,

--- a/src/component/contents/__tests__/DraftEditorBlock.react-test.js
+++ b/src/component/contents/__tests__/DraftEditorBlock.react-test.js
@@ -18,10 +18,10 @@ jest.disableAutomock()
   .mock('getScrollPosition')
   .mock('getViewportDimensions');
 
-var ContentState = require('ContentState');
 var BlockTree = require('BlockTree');
 var CharacterMetadata = require('CharacterMetadata');
 var ContentBlock = require('ContentBlock');
+var ContentState = require('ContentState');
 var Immutable = require('immutable');
 var React = require('React');
 var ReactDOM = require('ReactDOM');

--- a/src/component/contents/__tests__/DraftEditorTextNode-test.js
+++ b/src/component/contents/__tests__/DraftEditorTextNode-test.js
@@ -11,7 +11,8 @@
 
 'use strict';
 
-jest.disableAutomock().mock('UserAgent');
+jest.disableAutomock().mock('UserAgent')
+  .mock('UserAgent');
 
 var BLOCK_DELIMITER_CHAR = '\n';
 var TEST_A = 'Hello';

--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -12,14 +12,14 @@
 
 'use strict';
 
+import type DraftEditor from 'DraftEditor.react';
+
 const DraftModifier = require('DraftModifier');
 const EditorState = require('EditorState');
 const Keys = require('Keys');
 
 const getEntityKeyForSelection = require('getEntityKeyForSelection');
 const isSelectionAtLeafStart = require('isSelectionAtLeafStart');
-
-import type DraftEditor from 'DraftEditor.react';
 
 /**
  * Millisecond delay to allow `compositionstart` to fire again upon

--- a/src/component/handlers/drag/DraftEditorDragHandler.js
+++ b/src/component/handlers/drag/DraftEditorDragHandler.js
@@ -13,6 +13,9 @@
 
 'use strict';
 
+import type DraftEditor from 'DraftEditor.react';
+import type SelectionState from 'SelectionState';
+
 const DataTransfer = require('DataTransfer');
 const DraftModifier = require('DraftModifier');
 const EditorState = require('EditorState');
@@ -20,11 +23,8 @@ const EditorState = require('EditorState');
 const findAncestorOffsetKey = require('findAncestorOffsetKey');
 const getTextContentFromFiles = require('getTextContentFromFiles');
 const getUpdatedSelectionState = require('getUpdatedSelectionState');
-const nullthrows = require('nullthrows');
-
-import type DraftEditor from 'DraftEditor.react';
-import type SelectionState from 'SelectionState';
 const isEventHandled = require('isEventHandled');
+const nullthrows = require('nullthrows');
 
 /**
  * Get a SelectionState for the supplied mouse event.

--- a/src/component/handlers/edit/commands/SecondaryClipboard.js
+++ b/src/component/handlers/edit/commands/SecondaryClipboard.js
@@ -12,14 +12,14 @@
 
 'use strict';
 
+import type {BlockMap} from 'BlockMap';
+import type SelectionState from 'SelectionState';
+
 var DraftModifier = require('DraftModifier');
 var EditorState = require('EditorState');
 
 var getContentStateFragment = require('getContentStateFragment');
 var nullthrows = require('nullthrows');
-
-import type {BlockMap} from 'BlockMap';
-import type SelectionState from 'SelectionState';
 
 var clipboard: ?BlockMap = null;
 

--- a/src/component/handlers/edit/commands/removeTextWithStrategy.js
+++ b/src/component/handlers/edit/commands/removeTextWithStrategy.js
@@ -12,12 +12,12 @@
 
 'use strict';
 
-var DraftModifier = require('DraftModifier');
-
 import type ContentState from 'ContentState';
 import type {DraftRemovalDirection} from 'DraftRemovalDirection';
 import type EditorState from 'EditorState';
 import type SelectionState from 'SelectionState';
+
+var DraftModifier = require('DraftModifier');
 
 /**
  * For a collapsed selection state, remove text based on the specified strategy.

--- a/src/component/handlers/edit/editOnBeforeInput.js
+++ b/src/component/handlers/edit/editOnBeforeInput.js
@@ -12,19 +12,19 @@
 
 'use strict';
 
+import type DraftEditor from 'DraftEditor.react';
+import type {DraftInlineStyle} from 'DraftInlineStyle';
+
 var BlockTree = require('BlockTree');
 var DraftModifier = require('DraftModifier');
 var EditorState = require('EditorState');
 var UserAgent = require('UserAgent');
 
 var getEntityKeyForSelection = require('getEntityKeyForSelection');
+const isEventHandled = require('isEventHandled');
 var isSelectionAtLeafStart = require('isSelectionAtLeafStart');
 var nullthrows = require('nullthrows');
 var setImmediate = require('setImmediate');
-
-import type DraftEditor from 'DraftEditor.react';
-import type {DraftInlineStyle} from 'DraftInlineStyle';
-const isEventHandled = require('isEventHandled');
 
 // When nothing is focused, Firefox regards two characters, `'` and `/`, as
 // commands that should open and focus the "quickfind" search bar. This should

--- a/src/component/handlers/edit/editOnBlur.js
+++ b/src/component/handlers/edit/editOnBlur.js
@@ -12,12 +12,12 @@
 
 'use strict';
 
+import type DraftEditor from 'DraftEditor.react';
+
 var EditorState = require('EditorState');
 var UserAgent = require('UserAgent');
 
 var getActiveElement = require('getActiveElement');
-
-import type DraftEditor from 'DraftEditor.react';
 
 var isWebKit = UserAgent.isEngine('WebKit');
 

--- a/src/component/handlers/edit/editOnCompositionStart.js
+++ b/src/component/handlers/edit/editOnCompositionStart.js
@@ -12,9 +12,9 @@
 
 'use strict';
 
-var EditorState = require('EditorState');
-
 import type DraftEditor from 'DraftEditor.react';
+
+var EditorState = require('EditorState');
 
 /**
  * The user has begun using an IME input system. Switching to `composite` mode

--- a/src/component/handlers/edit/editOnCopy.js
+++ b/src/component/handlers/edit/editOnCopy.js
@@ -12,9 +12,9 @@
 
 'use strict';
 
-var getFragmentFromSelection = require('getFragmentFromSelection');
-
 import type DraftEditor from 'DraftEditor.react';
+
+var getFragmentFromSelection = require('getFragmentFromSelection');
 
 /**
  * If we have a selection, create a ContentState fragment and store

--- a/src/component/handlers/edit/editOnCut.js
+++ b/src/component/handlers/edit/editOnCut.js
@@ -12,14 +12,14 @@
 
 'use strict';
 
+import type DraftEditor from 'DraftEditor.react';
+
 const DraftModifier = require('DraftModifier');
 const EditorState = require('EditorState');
 const Style = require('Style');
 
 const getFragmentFromSelection = require('getFragmentFromSelection');
 const getScrollPosition = require('getScrollPosition');
-
-import type DraftEditor from 'DraftEditor.react';
 
 /**
  * On `cut` events, native behavior is allowed to occur so that the system

--- a/src/component/handlers/edit/editOnFocus.js
+++ b/src/component/handlers/edit/editOnFocus.js
@@ -12,9 +12,10 @@
 
 'use strict';
 
-var EditorState = require('EditorState');
-
 import type DraftEditor from 'DraftEditor.react';
+
+var DraftFeatureFlags = require('DraftFeatureFlags');
+var EditorState = require('EditorState');
 
 function editOnFocus(editor: DraftEditor, e: SyntheticFocusEvent): void {
   var editorState = editor._latestEditorState;
@@ -32,7 +33,12 @@ function editOnFocus(editor: DraftEditor, e: SyntheticFocusEvent): void {
   // moves the cursor back to the beginning of the editor, so we force the
   // selection here instead of simply accepting it in order to preserve the
   // old cursor position. See https://crbug.com/540004.
-  editor.update(EditorState.forceSelection(editorState, selection));
+  // But it looks like this is fixed in Chrome 60.0.3081.0.
+  if (DraftFeatureFlags.draft_accept_selection_after_refocus) {
+    editor.update(EditorState.acceptSelection(editorState, selection));
+  } else {
+    editor.update(EditorState.forceSelection(editorState, selection));
+  }
 }
 
 module.exports = editOnFocus;

--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -12,6 +12,8 @@
 
 'use strict';
 
+import type DraftEditor from 'DraftEditor.react';
+
 const DraftFeatureFlags = require('DraftFeatureFlags');
 var DraftModifier = require('DraftModifier');
 var DraftOffsetKey = require('DraftOffsetKey');
@@ -20,8 +22,6 @@ var UserAgent = require('UserAgent');
 
 var findAncestorOffsetKey = require('findAncestorOffsetKey');
 var nullthrows = require('nullthrows');
-
-import type DraftEditor from 'DraftEditor.react';
 
 var isGecko = UserAgent.isEngine('Gecko');
 

--- a/src/component/handlers/edit/editOnKeyDown.js
+++ b/src/component/handlers/edit/editOnKeyDown.js
@@ -12,6 +12,9 @@
 
 'use strict';
 
+import type DraftEditor from 'DraftEditor.react';
+import type {DraftEditorCommand} from 'DraftEditorCommand';
+
 var DraftModifier = require('DraftModifier');
 var EditorState = require('EditorState');
 var KeyBindingUtil = require('KeyBindingUtil');
@@ -19,20 +22,17 @@ var Keys = require('Keys');
 var SecondaryClipboard = require('SecondaryClipboard');
 var UserAgent = require('UserAgent');
 
+const isEventHandled = require('isEventHandled');
 var keyCommandBackspaceToStartOfLine = require('keyCommandBackspaceToStartOfLine');
 var keyCommandBackspaceWord = require('keyCommandBackspaceWord');
 var keyCommandDeleteWord = require('keyCommandDeleteWord');
 var keyCommandInsertNewline = require('keyCommandInsertNewline');
-var keyCommandPlainBackspace = require('keyCommandPlainBackspace');
-var keyCommandPlainDelete = require('keyCommandPlainDelete');
 var keyCommandMoveSelectionToEndOfBlock = require('keyCommandMoveSelectionToEndOfBlock');
 var keyCommandMoveSelectionToStartOfBlock = require('keyCommandMoveSelectionToStartOfBlock');
+var keyCommandPlainBackspace = require('keyCommandPlainBackspace');
+var keyCommandPlainDelete = require('keyCommandPlainDelete');
 var keyCommandTransposeCharacters = require('keyCommandTransposeCharacters');
 var keyCommandUndo = require('keyCommandUndo');
-
-import type DraftEditor from 'DraftEditor.react';
-import type {DraftEditorCommand} from 'DraftEditorCommand';
-const isEventHandled = require('isEventHandled');
 
 var {isOptionKeyCommand} = KeyBindingUtil;
 var isChrome = UserAgent.isBrowser('Chrome');

--- a/src/component/handlers/edit/editOnPaste.js
+++ b/src/component/handlers/edit/editOnPaste.js
@@ -12,6 +12,10 @@
 
 'use strict';
 
+import type {BlockMap} from 'BlockMap';
+import type DraftEditor from 'DraftEditor.react';
+import type {EntityMap} from 'EntityMap';
+
 var BlockMapBuilder = require('BlockMapBuilder');
 var CharacterMetadata = require('CharacterMetadata');
 var DataTransfer = require('DataTransfer');
@@ -23,10 +27,6 @@ var getEntityKeyForSelection = require('getEntityKeyForSelection');
 var getTextContentFromFiles = require('getTextContentFromFiles');
 const isEventHandled = require('isEventHandled');
 var splitTextIntoTextBlocks = require('splitTextIntoTextBlocks');
-
-import type DraftEditor from 'DraftEditor.react';
-import type {BlockMap} from 'BlockMap';
-import type {EntityMap} from 'EntityMap';
 
 /**
  * Paste content.

--- a/src/component/handlers/edit/getFragmentFromSelection.js
+++ b/src/component/handlers/edit/getFragmentFromSelection.js
@@ -12,10 +12,10 @@
 
 'use strict';
 
-var getContentStateFragment = require('getContentStateFragment');
-
 import type {BlockMap} from 'BlockMap';
 import type EditorState from 'EditorState';
+
+var getContentStateFragment = require('getContentStateFragment');
 
 function getFragmentFromSelection(editorState: EditorState): ?BlockMap {
   var selectionState = editorState.getSelection();

--- a/src/component/selection/__tests__/getDraftEditorSelection-test.js
+++ b/src/component/selection/__tests__/getDraftEditorSelection-test.js
@@ -18,9 +18,8 @@ var ContentBlock = require('ContentBlock');
 var ContentState = require('ContentState');
 var EditorState = require('EditorState');
 var Immutable = require('immutable');
-var SelectionState = require('SelectionState');
-
 var {BOLD} = require('SampleDraftInlineStyle');
+var SelectionState = require('SelectionState');
 var {EMPTY} = CharacterMetadata;
 
 var getDraftEditorSelection = require('getDraftEditorSelection');

--- a/src/component/selection/getDraftEditorSelection.js
+++ b/src/component/selection/getDraftEditorSelection.js
@@ -13,10 +13,10 @@
 
 'use strict';
 
-var getDraftEditorSelectionWithNodes = require('getDraftEditorSelectionWithNodes');
-
 import type {DOMDerivedSelection} from 'DOMDerivedSelection';
 import type EditorState from 'EditorState';
+
+var getDraftEditorSelectionWithNodes = require('getDraftEditorSelectionWithNodes');
 
 /**
  * Convert the current selection range to an anchor/focus pair of offset keys

--- a/src/component/selection/getDraftEditorSelectionWithNodes.js
+++ b/src/component/selection/getDraftEditorSelectionWithNodes.js
@@ -13,14 +13,14 @@
 
 'use strict';
 
+import type {DOMDerivedSelection} from 'DOMDerivedSelection';
+import type EditorState from 'EditorState';
+
 var findAncestorOffsetKey = require('findAncestorOffsetKey');
 var getSelectionOffsetKeyForNode = require('getSelectionOffsetKeyForNode');
 var getUpdatedSelectionState = require('getUpdatedSelectionState');
 var invariant = require('invariant');
 var nullthrows = require('nullthrows');
-
-import type {DOMDerivedSelection} from 'DOMDerivedSelection';
-import type EditorState from 'EditorState';
 
 type SelectionPoint = {
   key: string,

--- a/src/component/selection/getUpdatedSelectionState.js
+++ b/src/component/selection/getUpdatedSelectionState.js
@@ -12,12 +12,12 @@
 
 'use strict';
 
+import type EditorState from 'EditorState';
+import type SelectionState from 'SelectionState';
+
 var DraftOffsetKey = require('DraftOffsetKey');
 
 var nullthrows = require('nullthrows');
-
-import type EditorState from 'EditorState';
-import type SelectionState from 'SelectionState';
 
 function getUpdatedSelectionState(
   editorState: EditorState,

--- a/src/component/selection/getVisibleSelectionRect.js
+++ b/src/component/selection/getVisibleSelectionRect.js
@@ -13,9 +13,9 @@
 
 'use strict';
 
-const getRangeBoundingClientRect = require('getRangeBoundingClientRect');
-
 import type {FakeClientRect} from 'getRangeBoundingClientRect';
+
+const getRangeBoundingClientRect = require('getRangeBoundingClientRect');
 
 /**
  * Return the bounding ClientRect for the visible DOM selection, if any.

--- a/src/component/selection/setDraftEditorSelection.js
+++ b/src/component/selection/setDraftEditorSelection.js
@@ -13,12 +13,13 @@
 
 'use strict';
 
+import type SelectionState from 'SelectionState';
+
 const DraftJsDebugLogging = require('DraftJsDebugLogging');
+
 const containsNode = require('containsNode');
 const getActiveElement = require('getActiveElement');
 const invariant = require('invariant');
-
-import type SelectionState from 'SelectionState';
 
 function getAnonymizedDOM(node: Node): string {
   if (!node) {

--- a/src/component/utils/getDefaultKeyBinding.js
+++ b/src/component/utils/getDefaultKeyBinding.js
@@ -13,11 +13,11 @@
 
 'use strict';
 
+import type {DraftEditorCommand} from 'DraftEditorCommand';
+
 var KeyBindingUtil = require('KeyBindingUtil');
 var Keys = require('Keys');
 var UserAgent = require('UserAgent');
-
-import type {DraftEditorCommand} from 'DraftEditorCommand';
 
 var isOSX = UserAgent.isPlatform('Mac OS X');
 var isWindows = UserAgent.isPlatform('Windows');

--- a/src/component/utils/getTextContentFromFiles.js
+++ b/src/component/utils/getTextContentFromFiles.js
@@ -12,6 +12,8 @@
 
 'use strict';
 
+const invariant = require('invariant');
+
 var TEXT_CLIPPING_REGEX = /\.textClipping$/;
 
 var TEXT_TYPES = {
@@ -70,7 +72,12 @@ function readFile(
 
   var reader = new FileReader();
   reader.onload = function() {
-    callback(reader.result);
+    const result = reader.result;
+    invariant(
+      typeof result === 'string',
+      'We should be calling "FileReader.readAsText" which returns a string',
+    );
+    callback(result);
   };
   reader.onerror = function() {
     callback('');

--- a/src/model/decorators/CompositeDraftDecorator.js
+++ b/src/model/decorators/CompositeDraftDecorator.js
@@ -13,11 +13,11 @@
 
 'use strict';
 
-var Immutable = require('immutable');
-
 import type ContentBlock from 'ContentBlock';
-import type {DraftDecorator} from 'DraftDecorator';
 import type ContentState from 'ContentState';
+import type {DraftDecorator} from 'DraftDecorator';
+
+var Immutable = require('immutable');
 
 var {List} = Immutable;
 

--- a/src/model/encoding/__tests__/decodeInlineStyleRanges-test.js
+++ b/src/model/encoding/__tests__/decodeInlineStyleRanges-test.js
@@ -13,8 +13,7 @@
 
 jest.disableAutomock();
 
-var decodeInlineStyleRanges = require('decodeInlineStyleRanges');
-
+var {List} = require('immutable');
 var {
   BOLD,
   BOLD_ITALIC,
@@ -24,7 +23,7 @@ var {
   NONE,
 } = require('SampleDraftInlineStyle');
 
-var {List} = require('immutable');
+var decodeInlineStyleRanges = require('decodeInlineStyleRanges');
 
 function areEqual(a, b) {
   expect(List(a).equals(List(b))).toBeTruthy();

--- a/src/model/encoding/convertFromDraftStateToRaw.js
+++ b/src/model/encoding/convertFromDraftStateToRaw.js
@@ -12,13 +12,13 @@
 
 'use strict';
 
+import type ContentState from 'ContentState';
+import type {RawDraftContentState} from 'RawDraftContentState';
+
 var DraftStringKey = require('DraftStringKey');
 
 var encodeEntityRanges = require('encodeEntityRanges');
 var encodeInlineStyleRanges = require('encodeInlineStyleRanges');
-
-import type ContentState from 'ContentState';
-import type {RawDraftContentState} from 'RawDraftContentState';
 
 function convertFromDraftStateToRaw(
   contentState: ContentState,

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -13,11 +13,18 @@
 
 'use strict';
 
+import type {DraftBlockRenderConfig} from 'DraftBlockRenderConfig';
+import type {DraftBlockRenderMap} from 'DraftBlockRenderMap';
+import type {DraftBlockType} from 'DraftBlockType';
+import type {DraftInlineStyle} from 'DraftInlineStyle';
+import type {EntityMap} from 'EntityMap';
+
 const CharacterMetadata = require('CharacterMetadata');
 const ContentBlock = require('ContentBlock');
 const DefaultDraftBlockRenderMap = require('DefaultDraftBlockRenderMap');
 const DraftEntity = require('DraftEntity');
 const Immutable = require('immutable');
+const {Set} = require('immutable');
 const URI = require('URI');
 
 const generateRandomKey = require('generateRandomKey');
@@ -25,14 +32,6 @@ const getSafeBodyFromHTML = require('getSafeBodyFromHTML');
 const invariant = require('invariant');
 const nullthrows = require('nullthrows');
 const sanitizeDraftText = require('sanitizeDraftText');
-
-const {Set} = require('immutable');
-
-import type {DraftBlockRenderMap} from 'DraftBlockRenderMap';
-import type {DraftBlockRenderConfig} from 'DraftBlockRenderConfig';
-import type {DraftBlockType} from 'DraftBlockType';
-import type {DraftInlineStyle} from 'DraftInlineStyle';
-import type {EntityMap} from 'EntityMap';
 
 var {
   List,

--- a/src/model/encoding/convertFromRawToDraftState.js
+++ b/src/model/encoding/convertFromRawToDraftState.js
@@ -12,17 +12,17 @@
 
 'use strict';
 
+import type {RawDraftContentState} from 'RawDraftContentState';
+
 var ContentBlock = require('ContentBlock');
 var ContentState = require('ContentState');
 var DraftEntity = require('DraftEntity');
+var Immutable = require('immutable');
 
 var createCharacterList = require('createCharacterList');
 var decodeEntityRanges = require('decodeEntityRanges');
 var decodeInlineStyleRanges = require('decodeInlineStyleRanges');
 var generateRandomKey = require('generateRandomKey');
-var Immutable = require('immutable');
-
-import type {RawDraftContentState} from 'RawDraftContentState';
 
 var {Map} = Immutable;
 

--- a/src/model/encoding/createCharacterList.js
+++ b/src/model/encoding/createCharacterList.js
@@ -13,10 +13,10 @@
 
 'use strict';
 
+import type {DraftInlineStyle} from 'DraftInlineStyle';
+
 var CharacterMetadata = require('CharacterMetadata');
 var Immutable = require('immutable');
-
-import type {DraftInlineStyle} from 'DraftInlineStyle';
 
 var {List} = Immutable;
 

--- a/src/model/encoding/decodeInlineStyleRanges.js
+++ b/src/model/encoding/decodeInlineStyleRanges.js
@@ -13,9 +13,8 @@
 
 'use strict';
 
-var UnicodeUtils = require('UnicodeUtils');
-
 var {OrderedSet} = require('immutable');
+var UnicodeUtils = require('UnicodeUtils');
 
 var {substr} = UnicodeUtils;
 

--- a/src/model/encoding/encodeEntityRanges.js
+++ b/src/model/encoding/encodeEntityRanges.js
@@ -13,11 +13,11 @@
 
 'use strict';
 
-var DraftStringKey = require('DraftStringKey');
-var UnicodeUtils = require('UnicodeUtils');
-
 import type ContentBlock from 'ContentBlock';
 import type {EntityRange} from 'EntityRange';
+
+var DraftStringKey = require('DraftStringKey');
+var UnicodeUtils = require('UnicodeUtils');
 
 var {strlen} = UnicodeUtils;
 

--- a/src/model/encoding/encodeInlineStyleRanges.js
+++ b/src/model/encoding/encodeInlineStyleRanges.js
@@ -12,14 +12,14 @@
 
 'use strict';
 
-var UnicodeUtils = require('UnicodeUtils');
-
-var findRangesImmutable = require('findRangesImmutable');
-
 import type ContentBlock from 'ContentBlock';
 import type {DraftInlineStyle} from 'DraftInlineStyle';
 import type {InlineStyleRange} from 'InlineStyleRange';
 import type {List} from 'immutable';
+
+var UnicodeUtils = require('UnicodeUtils');
+
+var findRangesImmutable = require('findRangesImmutable');
 
 var areEqual = (a, b) => a === b;
 var isTruthy = a => !!a;

--- a/src/model/entity/DraftEntity.js
+++ b/src/model/entity/DraftEntity.js
@@ -11,13 +11,13 @@
  * @flow
  */
 
+import type {DraftEntityMutability} from 'DraftEntityMutability';
+import type {DraftEntityType} from 'DraftEntityType';
+
 var DraftEntityInstance = require('DraftEntityInstance');
 var Immutable = require('immutable');
 
 var invariant = require('invariant');
-
-import type {DraftEntityMutability} from 'DraftEntityMutability';
-import type {DraftEntityType} from 'DraftEntityType';
 
 var {Map} = Immutable;
 
@@ -245,7 +245,7 @@ var DraftEntity:DraftEntityMapObject = {
    */
   __get: function(key: string): DraftEntityInstance {
     var instance = instances.get(key);
-    invariant(!!instance, 'Unknown DraftEntity key.');
+    invariant(!!instance, 'Unknown DraftEntity key: %s.', key);
     return instance;
   },
 

--- a/src/model/entity/DraftEntityInstance.js
+++ b/src/model/entity/DraftEntityInstance.js
@@ -12,10 +12,10 @@
 
 'use strict';
 
-var Immutable = require('immutable');
-
-import type {DraftEntityType} from 'DraftEntityType';
 import type {DraftEntityMutability} from 'DraftEntityMutability';
+import type {DraftEntityType} from 'DraftEntityType';
+
+var Immutable = require('immutable');
 
 var {Record} = Immutable;
 

--- a/src/model/entity/getEntityKeyForSelection.js
+++ b/src/model/entity/getEntityKeyForSelection.js
@@ -14,8 +14,8 @@
 'use strict';
 
 import type ContentState from 'ContentState';
-import type SelectionState from 'SelectionState';
 import type {EntityMap} from 'EntityMap';
+import type SelectionState from 'SelectionState';
 
 /**
  * Return the entity key that should be used when inserting text for the

--- a/src/model/immutable/BlockMapBuilder.js
+++ b/src/model/immutable/BlockMapBuilder.js
@@ -12,10 +12,10 @@
 
 'use strict';
 
-var Immutable = require('immutable');
-
 import type {BlockMap} from 'BlockMap';
 import type ContentBlock from 'ContentBlock';
+
+var Immutable = require('immutable');
 
 var {OrderedMap} = Immutable;
 

--- a/src/model/immutable/BlockTree.js
+++ b/src/model/immutable/BlockTree.js
@@ -12,15 +12,15 @@
 
 'use strict';
 
+import type CharacterMetadata from 'CharacterMetadata';
+import type ContentBlock from 'ContentBlock';
+import type ContentState from 'ContentState';
+import type {DraftDecoratorType} from 'DraftDecoratorType';
+
 var Immutable = require('immutable');
 
 var emptyFunction = require('emptyFunction');
 var findRangesImmutable = require('findRangesImmutable');
-
-import type CharacterMetadata from 'CharacterMetadata';
-import type ContentState from 'ContentState';
-import type ContentBlock from 'ContentBlock';
-import type {DraftDecoratorType} from 'DraftDecoratorType';
 
 var {
   List,

--- a/src/model/immutable/CharacterMetadata.js
+++ b/src/model/immutable/CharacterMetadata.js
@@ -13,13 +13,13 @@
 
 'use strict';
 
+import type {DraftInlineStyle} from 'DraftInlineStyle';
+
 var {
   Map,
   OrderedSet,
   Record,
 } = require('immutable');
-
-import type {DraftInlineStyle} from 'DraftInlineStyle';
 
 // Immutable.map is typed such that the value for every key in the map
 // must be the same type

--- a/src/model/immutable/ContentBlock.js
+++ b/src/model/immutable/ContentBlock.js
@@ -12,13 +12,13 @@
 
 'use strict';
 
-var Immutable = require('immutable');
-
-var findRangesImmutable = require('findRangesImmutable');
-
 import type CharacterMetadata from 'CharacterMetadata';
 import type {DraftBlockType} from 'DraftBlockType';
 import type {DraftInlineStyle} from 'DraftInlineStyle';
+
+var Immutable = require('immutable');
+
+var findRangesImmutable = require('findRangesImmutable');
 
 var {
   List,

--- a/src/model/immutable/ContentState.js
+++ b/src/model/immutable/ContentState.js
@@ -13,6 +13,11 @@
 
 'use strict';
 
+import type {BlockMap} from 'BlockMap';
+import type DraftEntityInstance from 'DraftEntityInstance';
+import type {DraftEntityMutability} from 'DraftEntityMutability';
+import type {DraftEntityType} from 'DraftEntityType';
+
 const BlockMapBuilder = require('BlockMapBuilder');
 const CharacterMetadata = require('CharacterMetadata');
 const ContentBlock = require('ContentBlock');
@@ -22,11 +27,6 @@ const SelectionState = require('SelectionState');
 
 const generateRandomKey = require('generateRandomKey');
 const sanitizeDraftText = require('sanitizeDraftText');
-
-import type {BlockMap} from 'BlockMap';
-import type DraftEntityInstance from 'DraftEntityInstance';
-import type {DraftEntityMutability} from 'DraftEntityMutability';
-import type {DraftEntityType} from 'DraftEntityType';
 
 const {List, Record, Repeat} = Immutable;
 

--- a/src/model/immutable/EditorBidiService.js
+++ b/src/model/immutable/EditorBidiService.js
@@ -13,12 +13,12 @@
 
 'use strict';
 
+import type ContentState from 'ContentState';
+
 var Immutable = require('immutable');
 var UnicodeBidiService = require('UnicodeBidiService');
 
 var nullthrows = require('nullthrows');
-
-import type ContentState from 'ContentState';
 
 var {OrderedMap} = Immutable;
 

--- a/src/model/immutable/EditorState.js
+++ b/src/model/immutable/EditorState.js
@@ -12,18 +12,18 @@
 
 'use strict';
 
+import type {BlockMap} from 'BlockMap';
+import type {DraftDecoratorType} from 'DraftDecoratorType';
+import type {DraftInlineStyle} from 'DraftInlineStyle';
+import type {EditorChangeType} from 'EditorChangeType';
+import type {EntityMap} from 'EntityMap';
+import type {List, OrderedMap} from 'immutable';
+
 var BlockTree = require('BlockTree');
 var ContentState = require('ContentState');
 var EditorBidiService = require('EditorBidiService');
 var Immutable = require('immutable');
 var SelectionState = require('SelectionState');
-
-import type {BlockMap} from 'BlockMap';
-import type {DraftDecoratorType} from 'DraftDecoratorType';
-import type {DraftInlineStyle} from 'DraftInlineStyle';
-import type {EntityMap} from 'EntityMap';
-import type {List, OrderedMap} from 'immutable';
-import type {EditorChangeType} from 'EditorChangeType';
 
 var {
   OrderedSet,

--- a/src/model/immutable/__tests__/ContentBlock-test.js
+++ b/src/model/immutable/__tests__/ContentBlock-test.js
@@ -16,7 +16,6 @@ jest.disableAutomock();
 var CharacterMetadata = require('CharacterMetadata');
 var ContentBlock = require('ContentBlock');
 var Immutable = require('immutable');
-
 var {
   NONE,
   BOLD,

--- a/src/model/immutable/__tests__/EditorState-test.js
+++ b/src/model/immutable/__tests__/EditorState-test.js
@@ -19,14 +19,13 @@ var ContentState = require('ContentState');
 var DraftModifier = require('DraftModifier');
 var EditorState = require('EditorState');
 var Immutable = require('immutable');
-var SelectionState = require('SelectionState');
 var RichTextEditorUtil = require('RichTextEditorUtil');
-
 var {
   NONE,
   BOLD,
   ITALIC,
 } = require('SampleDraftInlineStyle');
+var SelectionState = require('SelectionState');
 
 var {EMPTY} = CharacterMetadata;
 

--- a/src/model/immutable/__tests__/findRangesImmutable-test.js
+++ b/src/model/immutable/__tests__/findRangesImmutable-test.js
@@ -14,6 +14,7 @@
 jest.disableAutomock();
 
 var Immutable = require('immutable');
+
 var findRangesImmutable = require('findRangesImmutable');
 
 describe('findRangesImmutable', () => {

--- a/src/model/modifier/AtomicBlockUtils.js
+++ b/src/model/modifier/AtomicBlockUtils.js
@@ -13,18 +13,18 @@
 
 'use strict';
 
+import type {DraftInsertionType} from 'DraftInsertionType';
+
 const BlockMapBuilder = require('BlockMapBuilder');
 const CharacterMetadata = require('CharacterMetadata');
 const ContentBlock = require('ContentBlock');
 const DraftModifier = require('DraftModifier');
 const EditorState = require('EditorState');
-const SelectionState = require('SelectionState');
 const Immutable = require('immutable');
+const SelectionState = require('SelectionState');
 
 const generateRandomKey = require('generateRandomKey');
 const moveBlockInContentState = require('moveBlockInContentState');
-
-import type {DraftInsertionType} from 'DraftInsertionType';
 
 const {
   List,

--- a/src/model/modifier/DraftEntitySegments.js
+++ b/src/model/modifier/DraftEntitySegments.js
@@ -13,8 +13,8 @@
 
 'use strict';
 
-import type {DraftRemovalDirection} from 'DraftRemovalDirection';
 import type {DraftRange} from 'DraftRange';
+import type {DraftRemovalDirection} from 'DraftRemovalDirection';
 
 /**
  * Identify the range to delete from a segmented entity.

--- a/src/model/modifier/DraftModifier.js
+++ b/src/model/modifier/DraftModifier.js
@@ -13,6 +13,14 @@
 
 'use strict';
 
+import type {BlockMap} from 'BlockMap';
+import type ContentState from 'ContentState';
+import type {DraftBlockType} from 'DraftBlockType';
+import type {DraftInlineStyle} from 'DraftInlineStyle';
+import type {DraftRemovalDirection} from 'DraftRemovalDirection';
+import type SelectionState from 'SelectionState';
+import type {Map} from 'immutable';
+
 var CharacterMetadata = require('CharacterMetadata');
 var ContentStateInlineStyle = require('ContentStateInlineStyle');
 const DraftFeatureFlags = require('DraftFeatureFlags');
@@ -28,14 +36,6 @@ var modifyBlockForContentState = require('modifyBlockForContentState');
 var removeEntitiesAtEdges = require('removeEntitiesAtEdges');
 var removeRangeFromContentState = require('removeRangeFromContentState');
 var splitBlockInContentState = require('splitBlockInContentState');
-
-import type {BlockMap} from 'BlockMap';
-import type ContentState from 'ContentState';
-import type {DraftBlockType} from 'DraftBlockType';
-import type {DraftInlineStyle} from 'DraftInlineStyle';
-import type {DraftRemovalDirection} from 'DraftRemovalDirection';
-import type {Map} from 'immutable';
-import type SelectionState from 'SelectionState';
 
 const {OrderedSet} = Immutable;
 

--- a/src/model/modifier/RichTextEditorUtil.js
+++ b/src/model/modifier/RichTextEditorUtil.js
@@ -13,17 +13,17 @@
 
 'use strict';
 
+import type ContentState from 'ContentState';
+import type {DraftBlockType} from 'DraftBlockType';
+import type {DraftEditorCommand} from 'DraftEditorCommand';
+import type URI from 'URI';
+
 const DraftModifier = require('DraftModifier');
 const EditorState = require('EditorState');
 const SelectionState = require('SelectionState');
 
 const adjustBlockDepthForContentState = require('adjustBlockDepthForContentState');
 const nullthrows = require('nullthrows');
-
-import type ContentState from 'ContentState';
-import type {DraftBlockType} from 'DraftBlockType';
-import type {DraftEditorCommand} from 'DraftEditorCommand';
-import type URI from 'URI';
 
 const RichTextEditorUtil = {
   currentBlockContainsLink: function(

--- a/src/model/modifier/__tests__/AtomicBlockUtils-test.js
+++ b/src/model/modifier/__tests__/AtomicBlockUtils-test.js
@@ -14,8 +14,8 @@
 jest.disableAutomock();
 
 const {insertAtomicBlock, moveAtomicBlock} = require('AtomicBlockUtils');
-const EditorState = require('EditorState');
 const Entity = require('DraftEntity');
+const EditorState = require('EditorState');
 const SelectionState = require('SelectionState');
 
 const getSampleStateForTesting = require('getSampleStateForTesting');

--- a/src/model/modifier/getCharacterRemovalRange.js
+++ b/src/model/modifier/getCharacterRemovalRange.js
@@ -13,15 +13,15 @@
 
 'use strict';
 
+import type ContentBlock from 'ContentBlock';
+import type {DraftRemovalDirection} from 'DraftRemovalDirection';
+import type {EntityMap} from 'EntityMap';
+import type SelectionState from 'SelectionState';
+
 var DraftEntitySegments = require('DraftEntitySegments');
 
 var getRangesForDraftEntity = require('getRangesForDraftEntity');
 var invariant = require('invariant');
-
-import type ContentBlock from 'ContentBlock';
-import type {DraftRemovalDirection} from 'DraftRemovalDirection';
-import type SelectionState from 'SelectionState';
-import type {EntityMap} from 'EntityMap';
 
 /**
  * Given a SelectionState and a removal direction, determine the entire range

--- a/src/model/modifier/getRangesForDraftEntity.js
+++ b/src/model/modifier/getRangesForDraftEntity.js
@@ -13,10 +13,10 @@
 
 'use strict';
 
-var invariant = require('invariant');
-
 import type ContentBlock from 'ContentBlock';
 import type {DraftRange} from 'DraftRange';
+
+var invariant = require('invariant');
 
 /**
  * Obtain the start and end positions of the range that has the

--- a/src/model/paste/DraftPasteProcessor.js
+++ b/src/model/paste/DraftPasteProcessor.js
@@ -13,6 +13,9 @@
 
 'use strict';
 
+import type {DraftBlockRenderMap} from 'DraftBlockRenderMap';
+import type {EntityMap} from 'EntityMap';
+
 const CharacterMetadata = require('CharacterMetadata');
 const ContentBlock = require('ContentBlock');
 const Immutable = require('immutable');
@@ -22,9 +25,6 @@ const convertFromHTMLtoContentBlocks
 const generateRandomKey = require('generateRandomKey');
 const getSafeBodyFromHTML = require('getSafeBodyFromHTML');
 const sanitizeDraftText = require('sanitizeDraftText');
-
-import type {DraftBlockRenderMap} from 'DraftBlockRenderMap';
-import type {EntityMap} from 'EntityMap';
 
 const {
   List,

--- a/src/model/paste/__tests__/DraftPasteProcessor-test.js
+++ b/src/model/paste/__tests__/DraftPasteProcessor-test.js
@@ -13,9 +13,8 @@
 
 jest.disableAutomock();
 
-var Immutable = require('immutable');
-
 var DraftPasteProcessor = require('DraftPasteProcessor');
+var Immutable = require('immutable');
 var CUSTOM_BLOCK_MAP = Immutable.Map({
   'header-one': {
     element: 'h1',

--- a/src/model/transaction/ContentStateInlineStyle.js
+++ b/src/model/transaction/ContentStateInlineStyle.js
@@ -13,11 +13,11 @@
 
 'use strict';
 
-var CharacterMetadata = require('CharacterMetadata');
-var {Map} = require('immutable');
-
 import type ContentState from 'ContentState';
 import type SelectionState from 'SelectionState';
+
+var CharacterMetadata = require('CharacterMetadata');
+var {Map} = require('immutable');
 
 var ContentStateInlineStyle = {
   add: function(

--- a/src/model/transaction/__tests__/ContentStateInlineStyle-test.js
+++ b/src/model/transaction/__tests__/ContentStateInlineStyle-test.js
@@ -14,7 +14,6 @@
 jest.disableAutomock();
 
 const ContentStateInlineStyle = require('ContentStateInlineStyle');
-
 const {
   List,
   Repeat,

--- a/src/model/transaction/__tests__/applyEntityToContentBlock-test.js
+++ b/src/model/transaction/__tests__/applyEntityToContentBlock-test.js
@@ -15,12 +15,12 @@ jest.disableAutomock();
 
 var CharacterMetadata = require('CharacterMetadata');
 var ContentBlock = require('ContentBlock');
-var applyEntityToContentBlock = require('applyEntityToContentBlock');
-
 var {
   List,
   Repeat,
 } = require('immutable');
+
+var applyEntityToContentBlock = require('applyEntityToContentBlock');
 
 describe('applyEntityToContentBlock', () => {
   var block = new ContentBlock({

--- a/src/model/transaction/__tests__/applyEntityToContentState-test.js
+++ b/src/model/transaction/__tests__/applyEntityToContentState-test.js
@@ -15,6 +15,7 @@ jest.disableAutomock();
 
 var Immutable = require('immutable');
 var SelectionState = require('SelectionState');
+
 var applyEntityToContentState = require('applyEntityToContentState');
 var getSampleStateForTesting = require('getSampleStateForTesting');
 

--- a/src/model/transaction/__tests__/insertIntoList-test.js
+++ b/src/model/transaction/__tests__/insertIntoList-test.js
@@ -14,6 +14,7 @@
 jest.disableAutomock();
 
 var Immutable = require('immutable');
+
 var insertIntoList = require('insertIntoList');
 
 describe('insertIntoList', () => {

--- a/src/model/transaction/__tests__/insertTextIntoContentState-test.js
+++ b/src/model/transaction/__tests__/insertTextIntoContentState-test.js
@@ -15,9 +15,10 @@ jest.disableAutomock();
 
 var CharacterMetadata = require('CharacterMetadata');
 var Immutable = require('immutable');
-var insertTextIntoContentState = require('insertTextIntoContentState');
-var getSampleStateForTesting = require('getSampleStateForTesting');
 var {BOLD} = require('SampleDraftInlineStyle');
+
+var getSampleStateForTesting = require('getSampleStateForTesting');
+var insertTextIntoContentState = require('insertTextIntoContentState');
 
 describe('insertTextIntoContentState', () => {
   var sample = getSampleStateForTesting();

--- a/src/model/transaction/__tests__/removeEntitiesAtEdges-test.js
+++ b/src/model/transaction/__tests__/removeEntitiesAtEdges-test.js
@@ -15,6 +15,7 @@ jest
   .disableAutomock();
 
 var Immutable = require('immutable');
+
 var applyEntityToContentBlock = require('applyEntityToContentBlock');
 var getSampleStateForTesting = require('getSampleStateForTesting');
 var removeEntitiesAtEdges = require('removeEntitiesAtEdges');

--- a/src/model/transaction/__tests__/removeRangeFromContentState-test.js
+++ b/src/model/transaction/__tests__/removeRangeFromContentState-test.js
@@ -13,10 +13,11 @@
 
 jest.disableAutomock();
 
+var ContentBlock = require('ContentBlock');
 var Immutable = require('immutable');
+
 var getSampleStateForTesting = require('getSampleStateForTesting');
 var removeRangeFromContentState = require('removeRangeFromContentState');
-var ContentBlock = require('ContentBlock');
 
 describe('removeRangeFromContentState', () => {
   var {

--- a/src/model/transaction/__tests__/splitBlockInContentState-test.js
+++ b/src/model/transaction/__tests__/splitBlockInContentState-test.js
@@ -14,6 +14,7 @@
 jest.disableAutomock();
 
 var Immutable = require('immutable');
+
 var getSampleStateForTesting = require('getSampleStateForTesting');
 var splitBlockInContentState = require('splitBlockInContentState');
 

--- a/src/model/transaction/addEntityToContentState.js
+++ b/src/model/transaction/addEntityToContentState.js
@@ -13,10 +13,10 @@
 
 'use strict';
 
-const addEntityToEntityMap = require('addEntityToEntityMap');
-
 import type ContentState from 'ContentState';
 import type DraftEntityInstance from 'DraftEntityInstance';
+
+const addEntityToEntityMap = require('addEntityToEntityMap');
 
 function addEntityToContentState(
   contentState: ContentState,

--- a/src/model/transaction/applyEntityToContentBlock.js
+++ b/src/model/transaction/applyEntityToContentBlock.js
@@ -13,9 +13,9 @@
 
 'use strict';
 
-var CharacterMetadata = require('CharacterMetadata');
-
 import type ContentBlock from 'ContentBlock';
+
+var CharacterMetadata = require('CharacterMetadata');
 
 function applyEntityToContentBlock(
   contentBlock: ContentBlock,

--- a/src/model/transaction/applyEntityToContentState.js
+++ b/src/model/transaction/applyEntityToContentState.js
@@ -13,12 +13,12 @@
 
 'use strict';
 
+import type ContentState from 'ContentState';
+import type SelectionState from 'SelectionState';
+
 var Immutable = require('immutable');
 
 var applyEntityToContentBlock = require('applyEntityToContentBlock');
-
-import type ContentState from 'ContentState';
-import type SelectionState from 'SelectionState';
 
 function applyEntityToContentState(
   contentState: ContentState,

--- a/src/model/transaction/createEntityInContentState.js
+++ b/src/model/transaction/createEntityInContentState.js
@@ -13,13 +13,13 @@
 
 'use strict';
 
-const DraftEntityInstance = require('DraftEntityInstance');
-
-const addEntityToContentState = require('addEntityToContentState');
-
 import type ContentState from 'ContentState';
 import type {DraftEntityMutability} from 'DraftEntityMutability';
 import type {DraftEntityType} from 'DraftEntityType';
+
+const DraftEntityInstance = require('DraftEntityInstance');
+
+const addEntityToContentState = require('addEntityToContentState');
 
 function createEntityInContentState(
   contentState: ContentState,

--- a/src/model/transaction/getContentStateFragment.js
+++ b/src/model/transaction/getContentStateFragment.js
@@ -13,12 +13,12 @@
 
 'use strict';
 
-var generateRandomKey = require('generateRandomKey');
-var removeEntitiesAtEdges = require('removeEntitiesAtEdges');
-
 import type {BlockMap} from 'BlockMap';
 import type ContentState from 'ContentState';
 import type SelectionState from 'SelectionState';
+
+var generateRandomKey = require('generateRandomKey');
+var removeEntitiesAtEdges = require('removeEntitiesAtEdges');
 
 function getContentStateFragment(
   contentState: ContentState,

--- a/src/model/transaction/insertFragmentIntoContentState.js
+++ b/src/model/transaction/insertFragmentIntoContentState.js
@@ -13,15 +13,15 @@
 
 'use strict';
 
+import type {BlockMap} from 'BlockMap';
+import type ContentState from 'ContentState';
+import type SelectionState from 'SelectionState';
+
 var BlockMapBuilder = require('BlockMapBuilder');
 
 var generateRandomKey = require('generateRandomKey');
 var insertIntoList = require('insertIntoList');
 var invariant = require('invariant');
-
-import type {BlockMap} from 'BlockMap';
-import type ContentState from 'ContentState';
-import type SelectionState from 'SelectionState';
 
 function insertFragmentIntoContentState(
   contentState: ContentState,

--- a/src/model/transaction/modifyBlockForContentState.js
+++ b/src/model/transaction/modifyBlockForContentState.js
@@ -13,11 +13,11 @@
 
 'use strict';
 
-const Immutable = require('immutable');
-
 import type ContentBlock from 'ContentBlock';
 import type ContentState from 'ContentState';
 import type SelectionState from 'SelectionState';
+
+const Immutable = require('immutable');
 
 const {Map} = Immutable;
 

--- a/src/model/transaction/moveBlockInContentState.js
+++ b/src/model/transaction/moveBlockInContentState.js
@@ -13,11 +13,11 @@
 
 'use strict';
 
-const invariant = require('invariant');
-
 import type ContentBlock from 'ContentBlock';
 import type ContentState from 'ContentState';
 import type {DraftInsertionType} from 'DraftInsertionType';
+
+const invariant = require('invariant');
 
 function moveBlockInContentState(
   contentState: ContentState,

--- a/src/model/transaction/removeEntitiesAtEdges.js
+++ b/src/model/transaction/removeEntitiesAtEdges.js
@@ -12,16 +12,16 @@
 
 'use strict';
 
+import type ContentBlock from 'ContentBlock';
+import type ContentState from 'ContentState';
+import type {EntityMap} from 'EntityMap';
+import type SelectionState from 'SelectionState';
+import type {List} from 'immutable';
+
 var CharacterMetadata = require('CharacterMetadata');
 
 var findRangesImmutable = require('findRangesImmutable');
 var invariant = require('invariant');
-
-import type ContentBlock from 'ContentBlock';
-import type {EntityMap} from 'EntityMap';
-import type ContentState from 'ContentState';
-import type {List} from 'immutable';
-import type SelectionState from 'SelectionState';
 
 function removeEntitiesAtEdges(
   contentState: ContentState,

--- a/src/model/transaction/removeRangeFromContentState.js
+++ b/src/model/transaction/removeRangeFromContentState.js
@@ -12,12 +12,12 @@
 
 'use strict';
 
-var Immutable = require('immutable');
-
 import type CharacterMetadata from 'CharacterMetadata';
 import type ContentState from 'ContentState';
-import type {List} from 'immutable';
 import type SelectionState from 'SelectionState';
+import type {List} from 'immutable';
+
+var Immutable = require('immutable');
 
 function removeRangeFromContentState(
   contentState: ContentState,

--- a/src/model/transaction/splitBlockInContentState.js
+++ b/src/model/transaction/splitBlockInContentState.js
@@ -13,13 +13,13 @@
 
 'use strict';
 
+import type ContentState from 'ContentState';
+import type SelectionState from 'SelectionState';
+
 var Immutable = require('immutable');
 
 var generateRandomKey = require('generateRandomKey');
 var invariant = require('invariant');
-
-import type ContentState from 'ContentState';
-import type SelectionState from 'SelectionState';
 
 const {Map} = Immutable;
 


### PR DESCRIPTION
Note: We are aware of the comma dangle lint failure and will fix after enabling the sync scripts.

**what is the change?:**
Development on Draft.js is causing Github and our internal version to
get out of sync.

This pulls various changes from our internal version into the Github
project, so that they will be basically the same.

Some of the included changes;

Reorder requires via a codemod, maintained by an ESLint rule
(D5117037)
Fix 'first character prevention' bug that is triggered by Fiber async
rendering (D5161053)
Add 'z-index' to placeholder (D4769133)
Add possible fix for issue #1020 (D5261172)
Add 'flowfixme' comment (D5337485)
Fix 'flowfixme' comment (D5389367)

For reference, this patch was generated by the commands listed in
D5273910.

**why make this change?**:
We want to keep them in sync going forward, and will be enabling scripts
to automate mirroring changes back and forth.

**test plan**:
yarn install && yarn build && yarn test and manually tested examples.

**issue**:
related to #1244

fbshipit-source-id:a5d95c34f709c6fabcf0ceec876d4edb93881f85
