### PR TITLE
IE11 setImmediate work around

### DIFF
--- a/src/component/handlers/edit/editOnBeforeInput.js
+++ b/src/component/handlers/edit/editOnBeforeInput.js
@@ -26,6 +26,11 @@ var isSelectionAtLeafStart = require('isSelectionAtLeafStart');
 var nullthrows = require('nullthrows');
 var setImmediate = require('setImmediate');
 
+if (window.setImmediate) {
+  // IE11 workaround. 'setImmediate' package doesn't work with IE10/11
+  setImmediate = window.setImmediate.bind(window);
+}
+
 // When nothing is focused, Firefox regards two characters, `'` and `/`, as
 // commands that should open and focus the "quickfind" search bar. This should
 // *never* happen while a contenteditable is focused, but as of v28, it

--- a/src/component/handlers/edit/editOnBeforeInput.js
+++ b/src/component/handlers/edit/editOnBeforeInput.js
@@ -24,12 +24,16 @@ var getEntityKeyForSelection = require('getEntityKeyForSelection');
 const isEventHandled = require('isEventHandled');
 var isSelectionAtLeafStart = require('isSelectionAtLeafStart');
 var nullthrows = require('nullthrows');
-var setImmediate = require('setImmediate');
 
-if (window.setImmediate) {
+var setImmediate;
+if (global.setImmediate) {
   // IE11 workaround. 'setImmediate' package doesn't work with IE10/11
   setImmediate = window.setImmediate.bind(window);
+} else {
+  setImmediate = require('setImmediate');
 }
+
+
 
 // When nothing is focused, Firefox regards two characters, `'` and `/`, as
 // commands that should open and focus the "quickfind" search bar. This should


### PR DESCRIPTION
The `setImmediate` NPM package won't do anything if there's a global `setImmediate` function. But the IE10/IE11 `setImmediate` can only be called as `window.setImmediate` unless it's been bound to window. 