### PR TITLE
Add aria-multiline attr to DraftEditor

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -245,6 +245,7 @@ class DraftEditor extends React.Component {
             aria-expanded={readOnly ? null : this.props.ariaExpanded}
             aria-haspopup={readOnly ? null : this.props.ariaHasPopup}
             aria-label={this.props.ariaLabel}
+            aria-multiline={this.props.ariaMultiline}
             aria-owns={readOnly ? null : this.props.ariaOwneeID}
             autoCapitalize={this.props.autoCapitalize}
             autoComplete={this.props.autoComplete}

--- a/src/component/base/DraftEditorProps.js
+++ b/src/component/base/DraftEditorProps.js
@@ -96,6 +96,7 @@ export type DraftEditorProps = {
   ariaExpanded?: boolean,
   ariaHasPopup?: boolean,
   ariaLabel?: string,
+  ariaMultiline?: boolean,
   ariaOwneeID?: string,
 
   webDriverTestID?: string,


### PR DESCRIPTION
`aria-multiline` is used to indicate to assistive technology agents that a textbox is a multiline textbox. When `aria-multiline` is true, an AT should treat return key presses as carriage returns, not submit actions.

https://www.w3.org/TR/wai-aria-1.1/#aria-multiline

teeeeeeeested: `npm run test && npm run lint && npm run flow`