### PR TITLE
Prevent dropping soft newline when leaf isn't last

### DIFF
--- a/src/component/handlers/edit/editOnBlur.js
+++ b/src/component/handlers/edit/editOnBlur.js
@@ -17,6 +17,7 @@ import type DraftEditor from 'DraftEditor.react';
 var EditorState = require('EditorState');
 var UserAgent = require('UserAgent');
 
+var containsNode = require('containsNode');
 var getActiveElement = require('getActiveElement');
 
 var isWebKit = UserAgent.isEngine('WebKit');
@@ -29,7 +30,15 @@ function editOnBlur(editor: DraftEditor, e: SyntheticEvent): void {
   // to force it when blurring occurs within the window (as opposed to
   // clicking to another tab or window).
   if (isWebKit && getActiveElement() === document.body) {
-    global.getSelection().removeAllRanges();
+    var selection = global.getSelection();
+    var editorNode = editor.refs.editor;
+    if (
+      selection.rangeCount === 1 &&
+      containsNode(editorNode, selection.anchorNode) &&
+      containsNode(editorNode, selection.focusNode)
+    ) {
+      selection.removeAllRanges();
+    }
   }
 
   var editorState = editor._latestEditorState;

--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -107,10 +107,7 @@ function editOnInput(editor: DraftEditor): void {
   // and this is the last chunk of text, we will have manually inserted an extra
   // soft newline in DraftEditorLeaf. We want to remove this extra newline for
   // the purpose of our comparison of DOM and model text.
-  // Gecko's spellchecker seems to add extra new lines when it kicks in, go
-  // through with the removal of double new lines when on Gecko and users are
-  // typing in the very last chunk of text in the block.
-  if (isGecko && isLastChunk && domText.endsWith(DOUBLE_NEWLINE)) {
+  if (isLastChunk && domText.endsWith(DOUBLE_NEWLINE)) {
     domText = domText.slice(0, -1);
   }
 

--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -90,19 +90,19 @@ function editOnInput(editor: DraftEditor): void {
   var offsetKey = nullthrows(findAncestorOffsetKey(anchorNode));
   var {blockKey, decoratorKey, leafKey} = DraftOffsetKey.decode(offsetKey);
 
-  var {start, end} = editorState
-    .getBlockTree(blockKey)
-    .getIn([decoratorKey, 'leaves', leafKey]);
+  var blockTree = editorState.getBlockTree(blockKey);
+  var {start, end} = blockTree.getIn([decoratorKey, 'leaves', leafKey]);
+  var isLastLeaf = leafKey === blockTree.size - 1;
 
   var content = editorState.getCurrentContent();
   var block = content.getBlockForKey(blockKey);
   var modelText = block.getText().slice(start, end);
 
   // Special-case soft newlines here. If the DOM text ends in a soft newline,
-  // we will have manually inserted an extra soft newline in DraftEditorLeaf.
-  // We want to remove this extra newline for the purpose of our comparison
-  // of DOM and model text.
-  if (domText.endsWith(DOUBLE_NEWLINE)) {
+  // and this is the last leaf, we will have manually inserted an extra soft
+  // newline in DraftEditorLeaf. We want to remove this extra newline for the
+  // purpose of our comparison of DOM and model text.
+  if (isLastLeaf && domText.endsWith(DOUBLE_NEWLINE)) {
     domText = domText.slice(0, -1);
   }
 


### PR DESCRIPTION
**Summary**

When using DraftJS with entities and soft new lines, this change prevents `text↵↵entity` from being transformed to `text↵entity` because no extra soft new line was inserted.

This tweak makes the soft new line logic in editOnInput.js follow the same conditions as the one in DraftEditorLeaf.react.js.

*Note: I couldn't run `npm test` because of a dependency mismatch, and won't spend too much time on this given the scope of that tweak. I'd appreciate if you let me know if there's anything noteworthy in the output of that command :)*