### PR TITLE
Use a random key instead of an autoincrement starting at 0

### DIFF
--- a/src/model/encoding/EntityRange.js
+++ b/src/model/encoding/EntityRange.js
@@ -14,12 +14,9 @@
 
 /**
  * A plain object representation of an entity attribution.
- *
- * The `key` value corresponds to the key of the entity in the `entityMap` of
- * a `ComposedText` object, not for use with `DraftEntity.get()`.
  */
 export type EntityRange = {
-  key: number,
+  key: string,
   offset: number,
   length: number,
 };

--- a/src/model/encoding/__tests__/encodeEntityRanges-test.js
+++ b/src/model/encoding/__tests__/encodeEntityRanges-test.js
@@ -37,22 +37,22 @@ describe('encodeEntityRanges', () => {
 
   it('must return an empty array if no entities present', () => {
     var block = createBlock(' '.repeat(20), Repeat(null, 20).toArray());
-    var encoded = encodeEntityRanges(block, {});
+    var encoded = encodeEntityRanges(block);
     expect(encoded).toEqual([]);
 
-    encoded = encodeEntityRanges(block, {'0': '0'});
+    encoded = encodeEntityRanges(block);
     expect(encoded).toEqual([]);
   });
 
   it('must return ranges with the storage-mapped key', () => {
     var entities = [null, null, '6', '6', null];
     var block = createBlock(' '.repeat(entities.length), entities);
-    var encoded = encodeEntityRanges(block, {'_6': '0'});
+    var encoded = encodeEntityRanges(block);
     expect(encoded).toEqual([
       {
         offset: 2,
         length: 2,
-        key: 0,
+        key: '6',
       },
     ]);
   });
@@ -60,17 +60,17 @@ describe('encodeEntityRanges', () => {
   it('must return ranges with multiple entities present', () => {
     var entities = [null, null, '6', '6', null, '8', '8', null];
     var block = createBlock(' '.repeat(entities.length), entities);
-    var encoded = encodeEntityRanges(block, {'_6': '0', '_8': '1'});
+    var encoded = encodeEntityRanges(block);
     expect(encoded).toEqual([
       {
         offset: 2,
         length: 2,
-        key: 0,
+        key: '6',
       },
       {
         offset: 5,
         length: 2,
-        key: 1,
+        key: '8',
       },
     ]);
   });
@@ -78,17 +78,17 @@ describe('encodeEntityRanges', () => {
   it('must return ranges with an entity present more than once', () => {
     var entities = [null, null, '6', '6', null, '6', '6', null];
     var block = createBlock(' '.repeat(entities.length), entities);
-    var encoded = encodeEntityRanges(block, {'_6': '0', '_8': '1'});
+    var encoded = encodeEntityRanges(block);
     expect(encoded).toEqual([
       {
         offset: 2,
         length: 2,
-        key: 0,
+        key: '6',
       },
       {
         offset: 5,
         length: 2,
-        key: 0,
+        key: '6',
       },
     ]);
   });
@@ -96,23 +96,37 @@ describe('encodeEntityRanges', () => {
   it('must handle ranges that include surrogate pairs', () => {
     var str = 'Take a \uD83D\uDCF7 #selfie';
     var entities = [
-      null, null, null, null, null, null, // `Take a`
-      '6', '6', '6', '6', '6', '6',       // ` [camera] #s`
-      null, null, '8', '8', null,         // `elfie`
+      null,
+      null,
+      null,
+      null,
+      null,
+      null, // `Take a`
+      '6',
+      '6',
+      '6',
+      '6',
+      '6',
+      '6', // ` [camera] #s`
+      null,
+      null,
+      '8',
+      '8',
+      null, // `elfie`
     ];
 
     var block = createBlock(str, entities);
-    var encoded = encodeEntityRanges(block, {'_6': '0', '_8': '1'});
+    var encoded = encodeEntityRanges(block);
     expect(encoded).toEqual([
       {
         offset: 6,
         length: 5,
-        key: 0,
+        key: '6',
       },
       {
         offset: 13,
         length: 2,
-        key: 1,
+        key: '8',
       },
     ]);
   });

--- a/src/model/encoding/convertFromDraftStateToRaw.js
+++ b/src/model/encoding/convertFromDraftStateToRaw.js
@@ -23,7 +23,6 @@ var encodeInlineStyleRanges = require('encodeInlineStyleRanges');
 function convertFromDraftStateToRaw(
   contentState: ContentState,
 ): RawDraftContentState {
-  var entityStorageKey = 0;
   var entityStorageMap = {};
   var rawBlocks = [];
 
@@ -36,7 +35,7 @@ function convertFromDraftStateToRaw(
           block.getEntityAt(start),
         );
         if (!entityStorageMap.hasOwnProperty(stringifiedEntityKey)) {
-          entityStorageMap[stringifiedEntityKey] = '' + (entityStorageKey++);
+          entityStorageMap[stringifiedEntityKey] = true;
         }
       },
     );
@@ -56,9 +55,9 @@ function convertFromDraftStateToRaw(
   // DraftEntity keys.
   var entityKeys = Object.keys(entityStorageMap);
   var flippedStorageMap = {};
-  entityKeys.forEach((key, jj) => {
+  entityKeys.forEach(key => {
     var entity = contentState.getEntity(DraftStringKey.unstringify(key));
-    flippedStorageMap[jj] = {
+    flippedStorageMap[key] = {
       type: entity.getType(),
       mutability: entity.getMutability(),
       data: entity.getData(),

--- a/src/model/encoding/convertFromDraftStateToRaw.js
+++ b/src/model/encoding/convertFromDraftStateToRaw.js
@@ -56,8 +56,10 @@ function convertFromDraftStateToRaw(
   var entityKeys = Object.keys(entityStorageMap);
   var flippedStorageMap = {};
   entityKeys.forEach(key => {
-    var entity = contentState.getEntity(DraftStringKey.unstringify(key));
-    flippedStorageMap[key] = {
+    var storageKey = DraftStringKey.unstringify(key);
+
+    var entity = contentState.getEntity(storageKey);
+    flippedStorageMap[storageKey] = {
       type: entity.getType(),
       mutability: entity.getMutability(),
       data: entity.getData(),

--- a/src/model/encoding/convertFromDraftStateToRaw.js
+++ b/src/model/encoding/convertFromDraftStateToRaw.js
@@ -46,7 +46,7 @@ function convertFromDraftStateToRaw(
       type: block.getType(),
       depth: block.getDepth(),
       inlineStyleRanges: encodeInlineStyleRanges(block),
-      entityRanges: encodeEntityRanges(block, entityStorageMap),
+      entityRanges: encodeEntityRanges(block),
       data: block.getData().toObject(),
     });
   });

--- a/src/model/encoding/encodeEntityRanges.js
+++ b/src/model/encoding/encodeEntityRanges.js
@@ -34,8 +34,7 @@ function encodeEntityRanges(block: ContentBlock): Array<EntityRange> {
       encoded.push({
         offset: strlen(text.slice(0, start)),
         length: strlen(text.slice(start, end)),
-        // Encode the key as a number for range storage.
-        key: DraftStringKey.stringify(key),
+        key,
       });
     },
   );

--- a/src/model/encoding/encodeEntityRanges.js
+++ b/src/model/encoding/encodeEntityRanges.js
@@ -29,7 +29,12 @@ function encodeEntityRanges(block: ContentBlock): Array<EntityRange> {
     character => !!character.getEntity(),
     (/*number*/ start, /*number*/ end) => {
       var text = block.getText();
+
       var key = block.getEntityAt(start);
+      if (key == null) {
+        return;
+      }
+
       encoded.push({
         offset: strlen(text.slice(0, start)),
         length: strlen(text.slice(start, end)),

--- a/src/model/encoding/encodeEntityRanges.js
+++ b/src/model/encoding/encodeEntityRanges.js
@@ -38,7 +38,7 @@ function encodeEntityRanges(
         offset: strlen(text.slice(0, start)),
         length: strlen(text.slice(start, end)),
         // Encode the key as a number for range storage.
-        key: Number(storageMap[DraftStringKey.stringify(key)]),
+        key: storageMap[DraftStringKey.stringify(key)],
       });
     },
   );

--- a/src/model/encoding/encodeEntityRanges.js
+++ b/src/model/encoding/encodeEntityRanges.js
@@ -24,10 +24,7 @@ var {strlen} = UnicodeUtils;
 /**
  * Convert to UTF-8 character counts for storage.
  */
-function encodeEntityRanges(
-  block: ContentBlock,
-  storageMap: Object,
-): Array<EntityRange> {
+function encodeEntityRanges(block: ContentBlock): Array<EntityRange> {
   var encoded = [];
   block.findEntityRanges(
     character => !!character.getEntity(),
@@ -38,7 +35,7 @@ function encodeEntityRanges(
         offset: strlen(text.slice(0, start)),
         length: strlen(text.slice(start, end)),
         // Encode the key as a number for range storage.
-        key: storageMap[DraftStringKey.stringify(key)],
+        key: DraftStringKey.stringify(key),
       });
     },
   );

--- a/src/model/encoding/encodeEntityRanges.js
+++ b/src/model/encoding/encodeEntityRanges.js
@@ -16,7 +16,6 @@
 import type ContentBlock from 'ContentBlock';
 import type {EntityRange} from 'EntityRange';
 
-var DraftStringKey = require('DraftStringKey');
 var UnicodeUtils = require('UnicodeUtils');
 
 var {strlen} = UnicodeUtils;

--- a/src/model/transaction/addEntityToEntityMap.js
+++ b/src/model/transaction/addEntityToEntityMap.js
@@ -20,7 +20,7 @@ import generateRandomKey from 'generateRandomKey';
 function addEntityToEntityMap(
   entityMap: EntityMap,
   instance: DraftEntityInstance,
-  key: string | undefined,
+  key: string | void,
 ): EntityMap {
   return entityMap.set(key || generateRandomKey(), instance);
 }

--- a/src/model/transaction/addEntityToEntityMap.js
+++ b/src/model/transaction/addEntityToEntityMap.js
@@ -20,8 +20,9 @@ import generateRandomKey from 'generateRandomKey';
 function addEntityToEntityMap(
   entityMap: EntityMap,
   instance: DraftEntityInstance,
+  key: string | undefined,
 ): EntityMap {
-  return entityMap.set(generateRandomKey(), instance);
+  return entityMap.set(key || generateRandomKey(), instance);
 }
 
 module.exports = addEntityToEntityMap;

--- a/src/model/transaction/addEntityToEntityMap.js
+++ b/src/model/transaction/addEntityToEntityMap.js
@@ -15,14 +15,13 @@
 
 import type DraftEntityInstance from 'DraftEntityInstance';
 import type {EntityMap} from 'EntityMap';
-
-let key = 0;
+import generateRandomKey from 'generateRandomKey';
 
 function addEntityToEntityMap(
   entityMap: EntityMap,
   instance: DraftEntityInstance,
 ): EntityMap {
-  return entityMap.set(`${++key}`, instance);
+  return entityMap.set(generateRandomKey(), instance);
 }
 
 module.exports = addEntityToEntityMap;


### PR DESCRIPTION
By always starting entityIDs at 0 a user would always get entityID reuse when serializing entity state between browser refreshes.

This should make it significantly less likely to have a collision.