### PR TITLE
Fix video component style issues in media example

### DIFF
--- a/examples/draft-0-10-0/media/media.html
+++ b/examples/draft-0-10-0/media/media.html
@@ -267,6 +267,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         },
         media: {
           width: '100%',
+          whiteSpace: 'initial'
         },
       };
 

--- a/examples/draft-0-10-0/media/media.html
+++ b/examples/draft-0-10-0/media/media.html
@@ -267,6 +267,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         },
         media: {
           width: '100%',
+          // Fix an issue with Firefox rendering video controls
+          // with 'pre-wrap' white-space
           whiteSpace: 'initial'
         },
       };


### PR DESCRIPTION
# Summary

Fix two style issues on the `video` component in the media example on Firefox and maybe Safari(I could not reproduce it there) by setting its `white-space` css property to 'initial' from 'pre-wrap' inherited from the `.public-DraftEditor-content` div's inline styles. 

For more information on the style issues, see https://github.com/facebook/draft-js/issues/1310. 

# Test Plan

Open `media.html` in the `media` folder in Safari and Firefox and check if the above-mentioned issues still appear.

Let me know if there is anything else I can improve on this PR. Thanks!