### PR TITLE
Update docs to clarify return value for handlePastedText

### DIFF
--- a/docs/APIReference-Editor.md
+++ b/docs/APIReference-Editor.md
@@ -205,7 +205,7 @@ and to convert typed emoticons into images.
 ```
 handlePastedText?: (text: string, html?: string) => DraftHandleValue
 ```
-Handle text and html(for rich text) that has been pasted directly into the editor. Returning true will prevent the default paste behavior.
+Handle text and html(for rich text) that has been pasted directly into the editor. Returning `'handled'` will prevent the default paste behavior.
 
 #### handlePastedFiles
 ```


### PR DESCRIPTION
**Summary**

Docs for `handlePastedText` are a bit unclear about what it should be returning. According to the [Cancelable Handlers](https://draftjs.org/docs/api-reference-editor.html#cancelable-handlers-optional) section, all should return `'handled'` or `'not-handled'`, but the section for `handlePastedText` mentions returning a boolean. This has caused some confusion in draft-js-plugins-editor here: https://github.com/draft-js-plugins/draft-js-plugins/issues/806
