### PR TITLE
safety handle empty block arrays in raw states

### DIFF
--- a/src/model/encoding/convertFromRawToDraftState.js
+++ b/src/model/encoding/convertFromRawToDraftState.js
@@ -31,6 +31,10 @@ function convertFromRawToDraftState(
 ): ContentState {
   var {blocks, entityMap} = rawState;
 
+  if (blocks.length === 0) {
+    return ContentState.createFromText('');
+  }
+    
   var fromStorageToLocal = {};
 
   // TODO: Update this once we completely remove DraftEntity


### PR DESCRIPTION
**Summary**

Currently, it is possible to make raw objects that have an empty block array.
These raw objects, when rehydrated, return undefined for methods like `getFirstBlock` since no blocks exist. A contentState without a single block is dangerous & can cause errors, so let's eliminate the possibility of that.

**Test Plan**

Happy to write tests, wanna get the general idea approved before doing so.
