### PR TITLE
add support for data object to insertAtomicBlock function

### DIFF
--- a/docs/APIReference-AtomicBlockUtils.md
+++ b/docs/APIReference-AtomicBlockUtils.md
@@ -20,8 +20,9 @@ parameters and return `EditorState` objects.
 ```
 insertAtomicBlock: function(
   editorState: EditorState,
-  entityKey: string,
-  character: string
+  entityKey: string | null,
+  character: string,
+  data?: object
 ): EditorState
 ```
 

--- a/src/component/handlers/edit/editOnBeforeInput.js
+++ b/src/component/handlers/edit/editOnBeforeInput.js
@@ -75,7 +75,10 @@ function replaceText(
  * preserve spellcheck highlighting, which disappears or flashes if re-render
  * occurs on the relevant text nodes.
  */
-function editOnBeforeInput(editor: DraftEditor, e: SyntheticInputEvent<>): void {
+function editOnBeforeInput(
+  editor: DraftEditor,
+  e: SyntheticInputEvent<>,
+): void {
   if (editor._pendingStateFromBeforeInput !== undefined) {
     editor.update(editor._pendingStateFromBeforeInput);
     editor._pendingStateFromBeforeInput = undefined;

--- a/src/component/handlers/edit/editOnCompositionStart.js
+++ b/src/component/handlers/edit/editOnCompositionStart.js
@@ -20,7 +20,10 @@ var EditorState = require('EditorState');
  * The user has begun using an IME input system. Switching to `composite` mode
  * allows handling composition input and disables other edit behavior.
  */
-function editOnCompositionStart(editor: DraftEditor, e: SyntheticEvent<>): void {
+function editOnCompositionStart(
+  editor: DraftEditor,
+  e: SyntheticEvent<>,
+): void {
   editor.setMode('composite');
   editor.update(
     EditorState.set(editor._latestEditorState, {inCompositionMode: true}),

--- a/src/model/modifier/AtomicBlockUtils.js
+++ b/src/model/modifier/AtomicBlockUtils.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-import type {DraftInsertionType} from 'DraftInsertionType';
+import type {DraftInsertionType } from 'DraftInsertionType';
 
 const BlockMapBuilder = require('BlockMapBuilder');
 const CharacterMetadata = require('CharacterMetadata');
@@ -32,11 +32,11 @@ const {
 } = Immutable;
 
 const AtomicBlockUtils = {
-  insertAtomicBlock: function (
+  insertAtomicBlock: function(
     editorState: EditorState,
     entityKey: string | null,
     character: string,
-    data: Object
+    data: Object,
   ): EditorState {
     const contentState = editorState.getCurrentContent();
     const selectionState = editorState.getSelection();
@@ -64,8 +64,10 @@ const AtomicBlockUtils = {
         key: generateRandomKey(),
         type: 'atomic',
         text: character,
-        characterList: entity ? List(Repeat(charData, character.length)) : List(),
-        data: Map(data)
+        characterList: entityKey
+          ? List(Repeat(charData, character.length))
+          : List(),
+        data: Map(data),
       }),
       new ContentBlock({
         key: generateRandomKey(),
@@ -91,7 +93,7 @@ const AtomicBlockUtils = {
     return EditorState.push(editorState, newContent, 'insert-fragment');
   },
 
-  moveAtomicBlock: function (
+  moveAtomicBlock: function(
     editorState: EditorState,
     atomicBlock: ContentBlock,
     targetRange: SelectionState,

--- a/src/model/modifier/AtomicBlockUtils.js
+++ b/src/model/modifier/AtomicBlockUtils.js
@@ -32,10 +32,11 @@ const {
 } = Immutable;
 
 const AtomicBlockUtils = {
-  insertAtomicBlock: function(
+  insertAtomicBlock: function (
     editorState: EditorState,
-    entityKey: string,
+    entityKey: string | null,
     character: string,
+    data: Object
   ): EditorState {
     const contentState = editorState.getCurrentContent();
     const selectionState = editorState.getSelection();
@@ -56,14 +57,15 @@ const AtomicBlockUtils = {
       'atomic',
     );
 
-    const charData = CharacterMetadata.create({entity: entityKey});
+    const charData = CharacterMetadata.create({ entity: entityKey });
 
     const fragmentArray = [
       new ContentBlock({
         key: generateRandomKey(),
         type: 'atomic',
         text: character,
-        characterList: List(Repeat(charData, character.length)),
+        characterList: entity ? List(Repeat(charData, character.length)) : List(),
+        data: Map(data)
       }),
       new ContentBlock({
         key: generateRandomKey(),
@@ -89,7 +91,7 @@ const AtomicBlockUtils = {
     return EditorState.push(editorState, newContent, 'insert-fragment');
   },
 
-  moveAtomicBlock: function(
+  moveAtomicBlock: function (
     editorState: EditorState,
     atomicBlock: ContentBlock,
     targetRange: SelectionState,

--- a/src/model/modifier/AtomicBlockUtils.js
+++ b/src/model/modifier/AtomicBlockUtils.js
@@ -28,6 +28,7 @@ const moveBlockInContentState = require('moveBlockInContentState');
 
 const {
   List,
+  Map,
   Repeat,
 } = Immutable;
 

--- a/src/model/modifier/__tests__/AtomicBlockUtils-test.js
+++ b/src/model/modifier/__tests__/AtomicBlockUtils-test.js
@@ -43,7 +43,7 @@ describe('AtomicBlockUtils', () => {
         editorState,
         entityKey,
         character,
-        data
+        data,
       );
       const resultContent = resultEditor.getCurrentContent();
 

--- a/src/model/modifier/__tests__/AtomicBlockUtils-test.js
+++ b/src/model/modifier/__tests__/AtomicBlockUtils-test.js
@@ -29,6 +29,7 @@ describe('AtomicBlockUtils', () => {
   const originalFirstBlock = contentState.getBlockMap().first();
   const entityKey = Entity.create('TOKEN', 'MUTABLE');
   const character = ' ';
+  const data = { id, 12345 };
 
   function assertAtomicBlock(block) {
     expect(block.getType()).toBe('atomic');
@@ -42,6 +43,7 @@ describe('AtomicBlockUtils', () => {
         editorState,
         entityKey,
         character,
+        data
       );
       const resultContent = resultEditor.getCurrentContent();
 
@@ -49,6 +51,7 @@ describe('AtomicBlockUtils', () => {
       const firstBlock = resultContent.getBlockMap().first();
       expect(firstBlock.getType()).toBe('unstyled');
       expect(firstBlock.getText()).toBe('');
+      expect(firstBlock.getData().get('id')).toBe(12345);
 
       const secondBlock = resultContent.getBlockMap().skip(1).first();
       assertAtomicBlock(secondBlock);

--- a/src/model/modifier/__tests__/AtomicBlockUtils-test.js
+++ b/src/model/modifier/__tests__/AtomicBlockUtils-test.js
@@ -51,10 +51,10 @@ describe('AtomicBlockUtils', () => {
       const firstBlock = resultContent.getBlockMap().first();
       expect(firstBlock.getType()).toBe('unstyled');
       expect(firstBlock.getText()).toBe('');
-      expect(firstBlock.getData().get('id')).toBe(12345);
 
       const secondBlock = resultContent.getBlockMap().skip(1).first();
       assertAtomicBlock(secondBlock);
+      expect(secondBlock.getData().get('id')).toBe(data.id);
 
       const thirdBlock = resultContent.getBlockMap().skip(2).first();
       expect(thirdBlock.getText()).toBe(originalFirstBlock.getText());

--- a/src/model/modifier/__tests__/AtomicBlockUtils-test.js
+++ b/src/model/modifier/__tests__/AtomicBlockUtils-test.js
@@ -29,7 +29,7 @@ describe('AtomicBlockUtils', () => {
   const originalFirstBlock = contentState.getBlockMap().first();
   const entityKey = Entity.create('TOKEN', 'MUTABLE');
   const character = ' ';
-  const data = { id, 12345 };
+  const data = { id: 12345 };
 
   function assertAtomicBlock(block) {
     expect(block.getType()).toBe('atomic');


### PR DESCRIPTION
**Summary**

Adds an optional data parameter to the `AtomicBlockUtils.insertAtomicBlock` function. This is helpful if you don't need an entity and simply want to associate some metadata with the block itself. This is also a request that I've seen come up in the slack a few times

https://draftjs.slack.com/archives/C0PBTNQGY/p1503009836000334

If I'm missing something about why it's better to associate the metadata with an entity than directly with the atomic block, I'm all ears to that as well :)
