### PR TITLE
Update handleKeyCommand examples and docs

### DIFF
--- a/docs/QuickStart-Rich-Styling.md
+++ b/docs/QuickStart-Rich-Styling.md
@@ -53,8 +53,8 @@ class MyEditor extends React.Component {
     this.onChange = (editorState) => this.setState({editorState});
     this.handleKeyCommand = this.handleKeyCommand.bind(this);
   }
-  handleKeyCommand(command) {
-    const newState = RichUtils.handleKeyCommand(this.state.editorState, command);
+  handleKeyCommand(command, editorState) {
+    const newState = RichUtils.handleKeyCommand(editorState, command);
     if (newState) {
       this.onChange(newState);
       return 'handled';
@@ -76,7 +76,10 @@ class MyEditor extends React.Component {
 > handleKeyCommand
 >
 > The `command` argument supplied to `handleKeyCommand` is a string value, the
-> name of the command to be executed. This is mapped from a DOM key event. See
+> name of the command to be executed. This is mapped from a DOM key event. The
+> `editorState` argument represents the latest editor state as it might be
+> changed internally by draft when handling the key. Use this instance of the
+> editor state inside `handleKeyCommand`. See
 > [Advanced Topics - Key Binding](/docs/advanced-topics-key-bindings.html) for more
 > on this, as well as details on why the function returns `handled` or `not-handled`.
 

--- a/examples/draft-0-10-0/media/media.html
+++ b/examples/draft-0-10-0/media/media.html
@@ -64,8 +64,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           this.onURLInputKeyDown = this._onURLInputKeyDown.bind(this);
         }
 
-        _handleKeyCommand(command) {
-          const {editorState} = this.state;
+        _handleKeyCommand(command, editorState) {
           const newState = RichUtils.handleKeyCommand(editorState, command);
           if (newState) {
             this.onChange(newState);

--- a/examples/draft-0-10-0/rich/rich.html
+++ b/examples/draft-0-10-0/rich/rich.html
@@ -43,14 +43,13 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           this.focus = () => this.refs.editor.focus();
           this.onChange = (editorState) => this.setState({editorState});
 
-          this.handleKeyCommand = (command) => this._handleKeyCommand(command);
-          this.onTab = (e) => this._onTab(e);
-          this.toggleBlockType = (type) => this._toggleBlockType(type);
-          this.toggleInlineStyle = (style) => this._toggleInlineStyle(style);
+          this.handleKeyCommand = this._handleKeyCommand.bind(this);
+          this.onTab = this._onTab.bind(this);
+          this.toggleBlockType = this._toggleBlockType.bind(this);
+          this.toggleInlineStyle = this._toggleInlineStyle.bind(this);
         }
 
-        _handleKeyCommand(command) {
-          const {editorState} = this.state;
+        _handleKeyCommand(command, editorState) {
           const newState = RichUtils.handleKeyCommand(editorState, command);
           if (newState) {
             this.onChange(newState);

--- a/examples/draft-0-10-0/tex/js/components/TeXEditorExample.js
+++ b/examples/draft-0-10-0/tex/js/components/TeXEditorExample.js
@@ -60,8 +60,7 @@ export default class TeXEditorExample extends React.Component {
     this._focus = () => this.refs.editor.focus();
     this._onChange = (editorState) => this.setState({editorState});
 
-    this._handleKeyCommand = command => {
-      var {editorState} = this.state;
+    this._handleKeyCommand = (command, editorState) => {
       var newState = RichUtils.handleKeyCommand(editorState, command);
       if (newState) {
         this._onChange(newState);

--- a/website/src/index.js
+++ b/website/src/index.js
@@ -37,8 +37,7 @@ class RichEditorExample extends React.Component {
     this.toggleInlineStyle = (style) => this._toggleInlineStyle(style);
   }
 
-  _handleKeyCommand(command) {
-    const {editorState} = this.state;
+  _handleKeyCommand(command, editorState) {
     const newState = RichUtils.handleKeyCommand(editorState, command);
     if (newState) {
       this.onChange(newState);


### PR DESCRIPTION
**Summary**
handleKeyCommand receives a second parameter with the latest instance of the editor state. When this function needs the editor state it should use this instance instead of any other reference.

This update reflects a change made to handleKeyCommand to also receive the editor state. Since it can be potentially changed by Draft during key handling any previous references might be of an old version of the state.

**Test Plan**
Loaded `examples/draft-0-10-0/{media/media.html, rich/rich.html, tex/}` in the browser and verified the text input worked as expected and in particular that we could delete deadkeys like `.