### PR TITLE
Can't type normal text after link creating

### DIFF
--- a/src/model/entity/__tests__/getEntityKeyForSelection-test.js
+++ b/src/model/entity/__tests__/getEntityKeyForSelection-test.js
@@ -24,11 +24,13 @@ selectionState = selectionState.merge({
   focusKey: 'b',
 });
 
-function setEntityMutability(mutability) {
+function setEntity(type, mutability) {
   contentState.getEntityMap().__get = () => ({
     getMutability: () => mutability,
+    getType: () => type,
   });
 }
+
 describe('getEntityKeyForSelection', () => {
   describe('collapsed selection', () => {
     var collapsed = selectionState.merge({
@@ -43,19 +45,19 @@ describe('getEntityKeyForSelection', () => {
     });
 
     it('must return key if mutable', () => {
-      setEntityMutability('MUTABLE');
+      setEntity('', 'MUTABLE');
       var key = getEntityKeyForSelection(contentState, collapsed);
       expect(key).toBe('123');
     });
 
     it('must not return key if immutable', () => {
-      setEntityMutability('IMMUTABLE');
+      setEntity('', 'IMMUTABLE');
       var key = getEntityKeyForSelection(contentState, collapsed);
       expect(key).toBe(null);
     });
 
     it('must not return key if segmented', () => {
-      setEntityMutability('SEGMENTED');
+      setEntity('', 'SEGMENTED');
       var key = getEntityKeyForSelection(contentState, collapsed);
       expect(key).toBe(null);
     });
@@ -77,19 +79,19 @@ describe('getEntityKeyForSelection', () => {
     });
 
     it('must return key if mutable', () => {
-      setEntityMutability('MUTABLE');
+      setEntity('', 'MUTABLE');
       var key = getEntityKeyForSelection(contentState, nonCollapsed);
       expect(key).toBe('123');
     });
 
     it('must not return key if immutable', () => {
-      setEntityMutability('IMMUTABLE');
+      setEntity('', 'IMMUTABLE');
       var key = getEntityKeyForSelection(contentState, nonCollapsed);
       expect(key).toBe(null);
     });
 
     it('must not return key if segmented', () => {
-      setEntityMutability('SEGMENTED');
+      setEntity('', 'SEGMENTED');
       var key = getEntityKeyForSelection(contentState, nonCollapsed);
       expect(key).toBe(null);
     });

--- a/src/model/entity/getEntityKeyForSelection.js
+++ b/src/model/entity/getEntityKeyForSelection.js
@@ -26,14 +26,25 @@ function getEntityKeyForSelection(
   contentState: ContentState,
   targetSelection: SelectionState,
 ): ?string {
-  var entityKey;
-
   if (targetSelection.isCollapsed()) {
     var key = targetSelection.getAnchorKey();
     var offset = targetSelection.getAnchorOffset();
     if (offset > 0) {
-      entityKey = contentState.getBlockForKey(key).getEntityAt(offset - 1);
-      return filterKey(contentState.getEntityMap(), entityKey);
+      var currentBlock = contentState.getBlockForKey(key);
+      var currentEntityKey = currentBlock.getEntityAt(offset);
+      var entityKeyBefore = currentBlock.getEntityAt(offset - 1);
+
+      if (entityKeyBefore) {
+        var entityBefore = contentState.getEntity(entityKeyBefore);
+
+        if (entityBefore.getType() === 'LINK') {
+          if (entityKeyBefore === currentEntityKey) {
+            return filterKey(contentState.getEntityMap(), entityKeyBefore);
+          }
+          return null;
+        }
+      }
+      return filterKey(contentState.getEntityMap(), entityKeyBefore);
     }
     return null;
   }
@@ -42,7 +53,7 @@ function getEntityKeyForSelection(
   var startOffset = targetSelection.getStartOffset();
   var startBlock = contentState.getBlockForKey(startKey);
 
-  entityKey = startOffset === startBlock.getLength() ?
+  var entityKey = startOffset === startBlock.getLength() ?
     null :
     startBlock.getEntityAt(startOffset);
 


### PR DESCRIPTION
**SUMMARY**
In examples of link after creating link user can't type normal text or put a space, because link will be continued. User can type a character after link and remove link from it, but it's not convenient.

**TEST PLAN**
I think, for entities with type 'LINK' it should be checked current character and character before, and if entity keys are equal continue link, otherwise don't.

Such behavior will be similar with link from gmail editor.