### PR TITLE
Add hook in travis to notify FB people when they break CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,3 +67,6 @@ script:
     fi
 
   fi
+
+notifications:
+  webhooks: https://code.facebook.com/travis/webhook/


### PR DESCRIPTION
**what is the change?:**
Add a hook similar to https://github.com/facebook/relay/commit/a1eff1a49aa511426c09c481e942256c751c9281

**why make this change?:**
We want people who sync commits out from FB to be notified (and maybe
stopped?) if their change breaks CI on Github.

**test plan:**
Do it live

**issue:**
Follow up of https://github.com/facebook/draft-js/issues/1364