### PR TITLE
Update callbacks reference to include the EditorState

### DIFF
--- a/docs/APIReference-Editor.md
+++ b/docs/APIReference-Editor.md
@@ -175,14 +175,14 @@ the event is handled and the Draft core should do nothing more with it. By retur
 
 #### handleReturn
 ```
-handleReturn?: (e: SyntheticKeyboardEvent) => DraftHandleValue
+handleReturn?: (e: SyntheticKeyboardEvent, editorState: EditorState) => DraftHandleValue
 ```
 Handle a `RETURN` keydown event. Example usage: Choosing a mention tag from a
 rendered list of results to trigger applying the mention entity to your content.
 
 #### handleKeyCommand
 ```
-handleKeyCommand?: (command: string) => DraftHandleValue
+handleKeyCommand?: (command: string, editorState: EditorState) => DraftHandleValue
 ```
 Handle the named editor command. See
 [Advanced Topics: Key Bindings](/docs/advanced-topics-key-bindings.html)
@@ -190,7 +190,7 @@ for details on usage.
 
 #### handleBeforeInput
 ```
-handleBeforeInput?: (chars: string) => DraftHandleValue
+handleBeforeInput?: (chars: string, editorState: EditorState) => DraftHandleValue
 ```
 Handle the characters to be inserted from a `beforeInput` event. Returning `'handled'`
 causes the default behavior of the `beforeInput` event to be prevented (i.e. it is
@@ -203,7 +203,7 @@ and to convert typed emoticons into images.
 
 #### handlePastedText
 ```
-handlePastedText?: (text: string, html?: string) => DraftHandleValue
+handlePastedText?: (text: string, html?: string, editorState: EditorState) => DraftHandleValue
 ```
 Handle text and html(for rich text) that has been pasted directly into the editor. Returning true will prevent the default paste behavior.
 


### PR DESCRIPTION
**Summary**
These 4 `Editor`'s properties: `handleReturn`, `handleKeyCommand`, `handleBeforeInput` and `handlePastedText` now also pass the latest editor state.

This is a follow up on #1371.

**Test Plan**
Go to `/docs/api-reference-editor.html#cancelable-handlers-optional` and check the method's signatures include the editorState.
Screenshot:
<img width="677" alt="screen shot 2017-09-08 at 11 07 23 am" src="https://user-images.githubusercontent.com/78122/30225168-55aab596-9486-11e7-82e6-ee3d6ce9c79d.png">
