### PR TITLE
Fix website's rich text editor example

### DIFF
--- a/website/src/index.js
+++ b/website/src/index.js
@@ -31,10 +31,10 @@ class RichEditorExample extends React.Component {
     this.focus = () => this.refs.editor.focus();
     this.onChange = (editorState) => this.setState({editorState});
 
-    this.handleKeyCommand = (command) => this._handleKeyCommand(command);
-    this.onTab = (e) => this._onTab(e);
-    this.toggleBlockType = (type) => this._toggleBlockType(type);
-    this.toggleInlineStyle = (style) => this._toggleInlineStyle(style);
+    this.handleKeyCommand = this._handleKeyCommand.bind(this);
+    this.onTab = this._onTab.bind(this);
+    this.toggleBlockType = this._toggleBlockType.bind(this);
+    this.toggleInlineStyle = this._toggleInlineStyle.bind(this);
   }
 
   _handleKeyCommand(command, editorState) {


### PR DESCRIPTION
**Summary**
PR #1346 broke the example as it didn't update all the code needed for handleKeyCommand to correctly pass the editorState.

This change mirrors the same change applied to rich.html.

**Test Plan**
Go to the website's main page `/index.html`, write text on the editor and try to delete it, it should work as expected.