### PR TITLE
Make default text content of img blocks a little camera emoji

### DIFF
--- a/src/model/encoding/__tests__/convertFromHTMLToContentBlocks-test.js
+++ b/src/model/encoding/__tests__/convertFromHTMLToContentBlocks-test.js
@@ -50,18 +50,18 @@ describe('convertFromHTMLToContentBlocks', () => {
   ].forEach(tag => testConvertingAdjacentHtmlElementsToContentBlocks(tag));
 
   describe('img tag', function() {
-    test('img with http protocol should have empty content', function() {
+    test('img with http protocol should have camera emoji content', function() {
       const blocks = convertFromHTMLToContentBlocks(
         '<img src="http://www.facebook.com">',
       );
-      expect(blocks.contentBlocks[0].text).toBe(' ');
+      expect(blocks.contentBlocks[0].text).toBe('\ud83d\udcf7');
     });
 
     test('img with data protocol should be correctly parsed', function() {
       const blocks = convertFromHTMLToContentBlocks(
         `<img src="${IMAGE_DATA_URL}">`,
       );
-      expect(blocks.contentBlocks[0].text).toBe(' ');
+      expect(blocks.contentBlocks[0].text).toBe('\ud83d\udcf7');
     });
   });
 });

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -405,7 +405,10 @@ function genFragment(
     });
     // Forcing this node to have children because otherwise no entity will be
     // created for this node.
-    node.textContent = ' ';
+    // The child text node cannot just have a space or return as content -
+    // we strip those out.
+    // See https://github.com/facebook/draft-js/issues/231 for some context.
+    node.textContent = '\ud83d\udcf7';
 
     // TODO: update this when we remove DraftEntity entirely
     inEntity = DraftEntity.__create(


### PR DESCRIPTION
**what is the change?:**
We don't allow pasting whitespace-only blocks - see https://github.com/facebook/draft-js/issues/231

In the past we set the 'src' as the text content of an 'img' block when
pasting/converting HTML, but sometimes the 'src' is really long and can
even crash the editor. Plus that's not really what users expect when
they paste an image.

An empty string as a default would be better but the code in
`convertFromHTML` needs refactored and for now I don't want to touch it.
The camera emoji is a cute and easy fix.

**why make this change?:**
Right now images are being dropped by `convertFromHTML

**test plan:**
Manual testing with examples/draft-0-10-0/convertFromHTML/convert.html

We should do a follow-up change to add a test that catches this.

**issue:**
https://github.com/facebook/draft-js/issues/1377

*Before* submitting a pull request, please make sure the following is done...

1. Fork the repo and create your branch from `master`.
2. If you've added code that should be tested, add tests!
3. If you've changed APIs, update the documentation.
4. Ensure that:
  * The test suite passes (`npm test`)
  * Your code lints (`npm run lint`) and passes Flow (`npm run flow`)
  * You have followed the [testing guidelines](https://github.com/facebook/draft-js/wiki/Testing-for-Pull-Requests)
5. If you haven't already, complete the [CLA](https://code.facebook.com/cla).

Please use the simple form below as a guideline for describing your pull request.

Thanks for contributing to Draft.js!

-

**Summary**

[...]

**Test Plan**

[...]
