### PR TITLE
allow for React 16 as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "object-assign": "^4.1.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0-rc",
-    "react-dom": "^0.14.0 || ^15.0.0-rc"
+    "react": "^0.14.0 || ^15.0.0-rc || ^16.0.0-rc",
+    "react-dom": "^0.14.0 || ^15.0.0-rc || ^16.0.0-rc"
   },
   "devDependencies": {
     "babel-core": "^6.8.0",


### PR DESCRIPTION
**Summary**

As Sophie suggested adding React 16 RC helps to avoid peerDep warnings. see https://twitter.com/sophiebits/status/906661088472813568