### PR TITLE
Force update of  `fbjs` to get fix for #14, #1381

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "enzyme": "^2.9.1",
-    "fbjs": ">=0.8.15",
+    "fbjs": "^0.8.15",
     "immutable": "~3.7.4",
     "object-assign": "^4.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "enzyme": "^2.9.1",
-    "fbjs": "^0.8.12",
+    "fbjs": ">=0.8.15",
     "immutable": "~3.7.4",
     "object-assign": "^4.1.0"
   },


### PR DESCRIPTION
**what is the change?:**
Pin the `fbjs` dependency version to 0.8.15 or later.

**why make this change?:**
We need to get everyone updated to use the fixed version, to avoid a
scroll issue in Chrome 61+
See https://github.com/facebook/fbjs/pull/229

**test plan:**
Didn't test because we already are using this fix internally at FB.

**issue:**
fixes #1381