### PR TITLE
Fix when anchorNode is undefined instead of null

### DIFF
--- a/src/component/handlers/edit/editOnBeforeInput.js
+++ b/src/component/handlers/edit/editOnBeforeInput.js
@@ -155,7 +155,7 @@ function editOnBeforeInput(
     const nativeSelection = global.getSelection();
     // Selection is necessarily collapsed at this point due to earlier check.
     if (
-      nativeSelection.anchorNode !== null &&
+      nativeSelection.anchorNode &&
       nativeSelection.anchorNode.nodeType === Node.TEXT_NODE
     ) {
       // See isTabHTMLSpanElement in chromium EditingUtilities.cpp.


### PR DESCRIPTION
Fixes #1399

`nativeSelection.anchorNode` can be undefined instead of null, so I'm changing the condition to handle this use case.