### PR TITLE
Support React v16 when editor is focused after removed from DOM

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -365,13 +365,13 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
     const alreadyHasFocus = editorState.getSelection().getHasFocus();
     const editorNode = ReactDOM.findDOMNode(this.refs.editor);
 
+    if (!(editorNode instanceof HTMLElement)) {
+      return;
+    }
+
     const scrollParent = Style.getScrollParent(editorNode);
     const {x, y} = scrollPosition || getScrollPosition(scrollParent);
 
-    invariant(
-      editorNode instanceof HTMLElement,
-      'editorNode is not an HTMLElement',
-    );
     editorNode.focus();
 
     // Restore scroll position

--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -368,13 +368,19 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
     const alreadyHasFocus = editorState.getSelection().getHasFocus();
     const editorNode = ReactDOM.findDOMNode(this.refs.editor);
 
-    if (!(editorNode instanceof HTMLElement)) {
+    if (!editorNode) {
+      // once in a while people call 'focus' in a setTimeout, and the node has
+      // been deleted, so it can be null in that case.
       return;
     }
 
     const scrollParent = Style.getScrollParent(editorNode);
     const {x, y} = scrollPosition || getScrollPosition(scrollParent);
 
+    invariant(
+      editorNode instanceof HTMLElement,
+      'editorNode is not an HTMLElement',
+    );
     editorNode.focus();
 
     // Restore scroll position


### PR DESCRIPTION

**Summary**
- calling `Style.getScrollParent(editorNode)` with `null` will result in an uncaught error
- `Ref#focus()` is often called within a `setTimeout` (even in some example IIRC). `Ref` doesn't get GCd, but the DOM node it points to may no longer exist. Since React v16 is so blazing fast, it's possible that we're trying to focus something that no longer exists.  
- Without this bit of code, we'd have to call `findDOMNode` on the ref before calling `focus`. That's not great since putting `findDOMNode` is discouraged in application code.