### PR TITLE
Change 'lookUpwardForInlineStyle' from O(n^2) to O(n).

### DIFF
--- a/src/model/immutable/EditorState.js
+++ b/src/model/immutable/EditorState.js
@@ -654,7 +654,9 @@ function lookUpwardForInlineStyle(
 ): DraftInlineStyle {
   var lastNonEmpty = content.getBlockMap()
     .reverse()
-    .skipUntil((block, k) => k === fromKey && block.getLength())
+    .skipUntil((_, k) => k === fromKey)
+    .skip(1)
+    .skipUntil((block, _) => block.getLength())
     .first();
 
   if (lastNonEmpty)

--- a/src/model/immutable/EditorState.js
+++ b/src/model/immutable/EditorState.js
@@ -652,17 +652,13 @@ function lookUpwardForInlineStyle(
   content: ContentState,
   fromKey: string,
 ): DraftInlineStyle {
-  var previousBlock = content.getBlockBefore(fromKey);
-  var previousLength;
+  var lastNonEmpty = content.getBlockMap()
+    .reverse()
+    .skipUntil((block, k) => k === fromKey && block.getLength())
+    .first();
 
-  while (previousBlock) {
-    previousLength = previousBlock.getLength();
-    if (previousLength) {
-      return previousBlock.getInlineStyleAt(previousLength - 1);
-    }
-    previousBlock = content.getBlockBefore(previousBlock.getKey());
-  }
-
+  if (lastNonEmpty)
+    return lastNonEmpty.getInlineStyleAt(lastNonEmpty.getLength() - 1);
   return OrderedSet();
 }
 


### PR DESCRIPTION
**Summary**

The function 'lookUpwardForInlineStyle' repeatedly called 'getPreviousBlock' which has the complexity O(n). This tanks performance when creating a document with lots of empty lines. Simply holding down the enter key will quickly cause the frame rate to drop below 1fps.

The fix is straightforward and, in my opinion, preferable to a while loop.

**Test Plan**

I did some manual testing. The code was able to correctly (and efficiently) find the correct style.