### PR TITLE
Expose path to Draft.css for usage by CSS pre-processors

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "PATENTS"
   ],
   "main": "lib/Draft.js",
+  "style": "dist/Draft.css",
   "repository": "facebook/draft-js",
   "license": "BSD-3-Clause",
   "scripts": {


### PR DESCRIPTION
**what is the change?:**
CREDIT TO @darobin for this change, originally made in
https://github.com/facebook/draft-js/pull/566

---

Some CSS pre-processors understand node_modules and are able to @import without requiring an absolute path. However, without assistance from the module all that they can resolve is its root directory. This leads to @import statements like the following:

```
@import "draft-js/dist/Draft.css";
```

While this works, it requires internal knowledge of the package's layout. This requires digging around and if the layout changes, this breaks.

These pre-processors also recognise a style field in package.json, which is the equivalent of main for CSS. This allows one to import thusly:

```
@import "draft-js";
```

It's a small change, but it helps!