### PR TITLE
This days it makes more sense to also have the "dev" task stated on the

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "prepublish": "npm run build",
     "pretest": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json",
     "build": "gulp",
+    "dev": "gulp dev",
     "postbuild": "node node_modules/fbjs-scripts/node/check-lib-requires.js lib",
     "lint": "eslint .",
     "flow": "flow src",


### PR DESCRIPTION
Its a common practice now for projects to have a devleopment run task, ours at the moment is living inside `gulp` adding a proxy to it on the `package.json` makes it easier to get started enabling:

`yarn run dev` or `npm run dev`