### PR TITLE
Add list of supported types for ContentBlock for docs

### DIFF
--- a/docs/APIReference-ContentBlock.md
+++ b/docs/APIReference-ContentBlock.md
@@ -19,7 +19,21 @@ A `ContentState` object contains an `OrderedMap` of these `ContentBlock` objects
 which together comprise the full contents of the editor.
 
 `ContentBlock` objects are largely analogous to block-level HTML elements like
-paragraphs and list items.
+paragraphs and list items. The available types are:
+
+  - unstyled
+  - paragraph
+  - header-one
+  - header-two
+  - header-three
+  - header-four
+  - header-five
+  - header-six
+  - unordered-list-item
+  - ordered-list-item
+  - blockquote
+  - code-block
+  - atomic
 
 New `ContentBlock` objects may be created directly using the constructor.
 Expected Record values are detailed below.


### PR DESCRIPTION
This addresses the issue raised in #1051. I've just added a list of the types towards the top of documentation for ContentBlock.
