### PR TITLE
Link to Yarn package page in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Draft.js](http://draftjs.org/) [![Build Status](https://img.shields.io/travis/facebook/draft-js/master.svg?style=flat)](https://travis-ci.org/facebook/draft-js) [![npm version](https://img.shields.io/npm/v/draft-js.svg?style=flat)](https://www.npmjs.com/package/draft-js)
+# [Draft.js](http://draftjs.org/) [![Build Status](https://img.shields.io/travis/facebook/draft-js/master.svg?style=flat)](https://travis-ci.org/facebook/draft-js) [![npm version](https://img.shields.io/npm/v/draft-js.svg?style=flat)](https://yarn.pm/draft-js)
 
 Draft.js is a JavaScript rich text editor framework, built for React and
 backed by an immutable model.


### PR DESCRIPTION
In the README, link to the Yarn package page rather than the npm one. The Yarn site has a nice package listing page.