### PR TITLE
Exploration - Feature tree / Setting up BlockNode interface

### DIFF
--- a/src/model/immutable/BlockNode.js
+++ b/src/model/immutable/BlockNode.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule BlockNode
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+import type CharacterMetadata from 'CharacterMetadata';
+import type {DraftBlockType} from 'DraftBlockType';
+import type {DraftInlineStyle} from 'DraftInlineStyle';
+import type {List, Map} from 'immutable';
+
+export type BlockNodeKey = string;
+
+export type BlockNodeConfig = {
+  characterList?: List<CharacterMetadata>,
+  data?: Map<any, any>,
+  depth?: number,
+  key?: BlockNodeKey,
+  text?: string,
+  type?: DraftBlockType,
+};
+
+export interface BlockNode {
+  findEntityRanges(
+    filterFn: (value: CharacterMetadata) => boolean,
+    callback: (start: number, end: number) => void,
+  ): void;
+
+  findStyleRanges(
+    filterFn: (value: CharacterMetadata) => boolean,
+    callback: (start: number, end: number) => void,
+  ): void;
+
+  getCharacterList(): List<CharacterMetadata>;
+
+  getData(): Map<any, any>;
+
+  getDepth(): number;
+
+  getEntityAt(offset: number): ?string;
+
+  getInlineStyleAt(offset: number): DraftInlineStyle;
+
+  getKey(): BlockNodeKey;
+
+  getLength(): number;
+
+  getText(): string;
+
+  getType(): DraftBlockType;
+}

--- a/src/model/immutable/ContentBlockNode.js
+++ b/src/model/immutable/ContentBlockNode.js
@@ -6,38 +6,60 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @providesModule ContentBlock
+ * @providesModule ContentBlockNode
  * @format
  * @flow
+ *
+ * This is unstable and not part of the public API and should not be used by
+ * production systems. This file may be update/removed without notice.
  */
 
 'use strict';
+
+const CharacterMetadata = require('CharacterMetadata');
+const findRangesImmutable = require('findRangesImmutable');
 
 import type {BlockNode, BlockNodeConfig, BlockNodeKey} from 'BlockNode';
 import type {DraftBlockType} from 'DraftBlockType';
 import type {DraftInlineStyle} from 'DraftInlineStyle';
 
-const CharacterMetadata = require('CharacterMetadata');
-const Immutable = require('immutable');
+import {List, Map, OrderedSet, Record, Repeat} from 'immutable';
 
-const findRangesImmutable = require('findRangesImmutable');
-
-const {List, Map, OrderedSet, Record, Repeat} = Immutable;
+type ContentBlockNodeConfig = BlockNodeConfig & {
+  children?: List<BlockNodeKey>,
+  parent?: ?BlockNodeKey,
+  prevSibling?: ?BlockNodeKey,
+  nextSibling?: ?BlockNodeKey,
+};
 
 const EMPTY_SET = OrderedSet();
 
-const defaultRecord: BlockNodeConfig = {
-  key: '',
-  type: 'unstyled',
-  text: '',
+const defaultRecord: ContentBlockNodeConfig = {
+  parent: null,
   characterList: List(),
-  depth: 0,
   data: Map(),
+  depth: 0,
+  key: '',
+  text: '',
+  type: 'unstyled',
+  children: List(),
+  prevSibling: null,
+  nextSibling: null,
 };
 
-const ContentBlockRecord = Record(defaultRecord);
+const haveEqualStyle = (
+  charA: CharacterMetadata,
+  charB: CharacterMetadata,
+): boolean => charA.getStyle() === charB.getStyle();
 
-const decorateCharacterList = (config: BlockNodeConfig): BlockNodeConfig => {
+const haveEqualEntity = (
+  charA: CharacterMetadata,
+  charB: CharacterMetadata,
+): boolean => charA.getEntity() === charB.getEntity();
+
+const decorateCharacterList = (
+  config: ContentBlockNodeConfig,
+): ContentBlockNodeConfig => {
   if (!config) {
     return config;
   }
@@ -51,9 +73,9 @@ const decorateCharacterList = (config: BlockNodeConfig): BlockNodeConfig => {
   return config;
 };
 
-class ContentBlock extends ContentBlockRecord implements BlockNode {
-  constructor(config: BlockNodeConfig) {
-    super(decorateCharacterList(config));
+class ContentBlockNode extends Record(defaultRecord) implements BlockNode {
+  constructor(props: ContentBlockNodeConfig) {
+    super(decorateCharacterList(props));
   }
 
   getKey(): BlockNodeKey {
@@ -94,9 +116,22 @@ class ContentBlock extends ContentBlockRecord implements BlockNode {
     return character ? character.getEntity() : null;
   }
 
-  /**
-   * Execute a callback for every contiguous range of styles within the block.
-   */
+  getChildKeys(): List<BlockNodeKey> {
+    return this.get('children');
+  }
+
+  getParentKey(): ?BlockNodeKey {
+    return this.get('parent');
+  }
+
+  getPrevSiblingKey(): ?BlockNodeKey {
+    return this.get('prevSibling');
+  }
+
+  getNextSiblingKey(): ?BlockNodeKey {
+    return this.get('nextSibling');
+  }
+
   findStyleRanges(
     filterFn: (value: CharacterMetadata) => boolean,
     callback: (start: number, end: number) => void,
@@ -109,9 +144,6 @@ class ContentBlock extends ContentBlockRecord implements BlockNode {
     );
   }
 
-  /**
-   * Execute a callback for every contiguous range of entities within the block.
-   */
   findEntityRanges(
     filterFn: (value: CharacterMetadata) => boolean,
     callback: (start: number, end: number) => void,
@@ -125,18 +157,4 @@ class ContentBlock extends ContentBlockRecord implements BlockNode {
   }
 }
 
-function haveEqualStyle(
-  charA: CharacterMetadata,
-  charB: CharacterMetadata,
-): boolean {
-  return charA.getStyle() === charB.getStyle();
-}
-
-function haveEqualEntity(
-  charA: CharacterMetadata,
-  charB: CharacterMetadata,
-): boolean {
-  return charA.getEntity() === charB.getEntity();
-}
-
-module.exports = ContentBlock;
+module.exports = ContentBlockNode;

--- a/src/model/immutable/__tests__/ContentBlockNode-test.js
+++ b/src/model/immutable/__tests__/ContentBlockNode-test.js
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An addtestional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+ui_infra
+ * @format
+ */
+
+'use strict';
+
+jest.disableAutomock();
+
+const CharacterMetadata = require('CharacterMetadata');
+const ContentBlockNode = require('ContentBlockNode');
+const Immutable = require('immutable');
+const {NONE, BOLD} = require('SampleDraftInlineStyle');
+
+const entity_KEY = 'x';
+
+const DEFAUL_BLOCK_CONFIG = {
+  key: 'a',
+  type: 'unstyled',
+  text: 'Alpha',
+  characterList: Immutable.List.of(
+    CharacterMetadata.create({style: BOLD, entity: entity_KEY}),
+    CharacterMetadata.EMPTY,
+    CharacterMetadata.EMPTY,
+    CharacterMetadata.create({style: BOLD}),
+    CharacterMetadata.create({entity: entity_KEY}),
+  ),
+};
+
+const getSampleBlock = props => {
+  return new ContentBlockNode({
+    ...DEFAUL_BLOCK_CONFIG,
+    ...props,
+  });
+};
+
+test('must have appropriate default values', () => {
+  const text = 'Alpha';
+  const block = new ContentBlockNode({
+    key: 'a',
+    type: 'unstyled',
+    text,
+  });
+
+  const characterList = Immutable.List(
+    Immutable.Repeat(CharacterMetadata.EMPTY, text.length),
+  );
+
+  expect(block.getKey()).toBe('a');
+  expect(block.getText()).toBe('Alpha');
+  expect(block.getType()).toBe('unstyled');
+  expect(block.getLength()).toBe(5);
+  expect(block.getCharacterList().count()).toBe(5);
+  expect(block.getCharacterList()).toEqual(characterList);
+});
+
+test('must provide default values', () => {
+  const block = new ContentBlockNode();
+  expect(block.getType()).toBe('unstyled');
+  expect(block.getText()).toBe('');
+  expect(Immutable.is(block.getCharacterList(), Immutable.List())).toBe(true);
+});
+
+test('must retrieve properties', () => {
+  const block = getSampleBlock();
+  expect(block.getKey()).toBe('a');
+  expect(block.getText()).toBe('Alpha');
+  expect(block.getType()).toBe('unstyled');
+  expect(block.getLength()).toBe(5);
+  expect(block.getCharacterList().count()).toBe(5);
+});
+
+test('must properly retrieve style at offset', () => {
+  const block = getSampleBlock();
+  expect(block.getInlineStyleAt(0)).toBe(BOLD);
+  expect(block.getInlineStyleAt(1)).toBe(NONE);
+  expect(block.getInlineStyleAt(2)).toBe(NONE);
+  expect(block.getInlineStyleAt(3)).toBe(BOLD);
+  expect(block.getInlineStyleAt(4)).toBe(NONE);
+});
+
+test('must correctly identify ranges of styles', () => {
+  const block = getSampleBlock();
+  const cb = jest.fn();
+  block.findStyleRanges(() => true, cb);
+
+  const calls = cb.mock.calls;
+  expect(calls.length).toBe(4);
+  expect(calls[0]).toEqual([0, 1]);
+  expect(calls[1]).toEqual([1, 3]);
+  expect(calls[2]).toEqual([3, 4]);
+  expect(calls[3]).toEqual([4, 5]);
+});
+
+test('must properly retrieve entity at offset', () => {
+  const block = getSampleBlock();
+  expect(block.getEntityAt(0)).toBe(entity_KEY);
+  expect(block.getEntityAt(1)).toBe(null);
+  expect(block.getEntityAt(2)).toBe(null);
+  expect(block.getEntityAt(3)).toBe(null);
+  expect(block.getEntityAt(4)).toBe(entity_KEY);
+});
+
+test('must correctly identify ranges of entities', () => {
+  const block = getSampleBlock();
+  const cb = jest.fn();
+  block.findEntityRanges(() => true, cb);
+
+  const calls = cb.mock.calls;
+  expect(calls.length).toBe(3);
+  expect(calls[0]).toEqual([0, 1]);
+  expect(calls[1]).toEqual([1, 4]);
+  expect(calls[2]).toEqual([4, 5]);
+});
+
+test('must retrieve null when has no parent', () => {
+  const block = getSampleBlock();
+  expect(block.getParentKey()).toBe(null);
+});
+
+test('must retrieve empty List when has no children', () => {
+  const block = getSampleBlock();
+  expect(block.getChildKeys()).toEqual(Immutable.List());
+});
+
+test('must retrieve null when has no next sibbling', () => {
+  const block = getSampleBlock();
+  expect(block.getNextSiblingKey()).toBe(null);
+});
+
+test('must retrieve null when has no previous sibbling', () => {
+  const block = getSampleBlock();
+  expect(block.getPrevSiblingKey()).toBe(null);
+});


### PR DESCRIPTION
### Context

This PR is part of a series of PR's that will be exploring **tree data block support** in Draft.

**Setting up BlockNode interface**

This PR will be laying down the foundations by creating a tree block compatible node.

In order to avoiding including conditional logic as much as possible to existing draft library while exploring we will use interfaces to guarantee that the new tree block structure is some what compatible with the existing ContentBlock

***

**Note:**
This is unstable and not part of the public API and should not be used by
production systems.
