### PR TITLE
Correct spelling in DraftEntityMutability docs

### DIFF
--- a/src/model/entity/DraftEntityMutability.js
+++ b/src/model/entity/DraftEntityMutability.js
@@ -36,7 +36,7 @@ var ComposedEntityMutability = require('ComposedEntityMutability');
  *
  * `SEGMENTED`:
  *   Segmented entities allow the removal of partial ranges of text, as
- *   separated by a delimiter. Adding characters wihin the range will remove
+ *   separated by a delimiter. Adding characters within the range will remove
  *   the entity from the entire range. Deleting characters within a segmented
  *   entity will delete only the segments affected by the deletion. Example:
  *   Facebook User mentions.


### PR DESCRIPTION
**Summary**
Updated a small typo.

**Test Plan**
n/a
