### PR TITLE
Making DraftBlockType less restrictive

### DIFF
--- a/src/model/constants/DraftBlockType.js
+++ b/src/model/constants/DraftBlockType.js
@@ -16,7 +16,7 @@
 /**
  * The list of default valid block types.
  */
-export type DraftBlockType =
+export type CoreDraftBlockType =
   | 'unstyled'
   | 'paragraph'
   | 'header-one'
@@ -30,3 +30,10 @@ export type DraftBlockType =
   | 'blockquote'
   | 'code-block'
   | 'atomic';
+
+/**
+ * User defined types can be of any valid string.
+ */
+export type CustomBlockType = string;
+
+export type DraftBlockType = CoreDraftBlockType | CustomBlockType;

--- a/src/model/immutable/ContentBlock.js
+++ b/src/model/immutable/ContentBlock.js
@@ -26,7 +26,7 @@ const {List, Map, OrderedSet, Record, Repeat} = Immutable;
 const EMPTY_SET = OrderedSet();
 
 type ContentBlockConfig = {
-  key?: string,
+  key?: DraftBlockType,
   type?: string,
   text?: string,
   characterList?: List<CharacterMetadata>,

--- a/src/model/immutable/DefaultDraftBlockRenderMap.js
+++ b/src/model/immutable/DefaultDraftBlockRenderMap.js
@@ -13,18 +13,23 @@
 
 'use strict';
 
-import type {DraftBlockRenderMap} from 'DraftBlockRenderMap';
-
 const {Map} = require('immutable');
 const React = require('React');
-
 const cx = require('cx');
+
+import type {CoreDraftBlockType} from 'DraftBlockType';
+import type {DraftBlockRenderConfig} from 'DraftBlockRenderConfig';
+
+type DefaultCoreDraftBlockRenderMap = Map<
+  CoreDraftBlockType,
+  DraftBlockRenderConfig,
+>;
 
 const UL_WRAP = <ul className={cx('public/DraftStyleDefault/ul')} />;
 const OL_WRAP = <ol className={cx('public/DraftStyleDefault/ol')} />;
 const PRE_WRAP = <pre className={cx('public/DraftStyleDefault/pre')} />;
 
-const DefaultDraftBlockRenderMap: DraftBlockRenderMap = Map({
+const DefaultDraftBlockRenderMap: DefaultCoreDraftBlockRenderMap = Map({
   'header-one': {
     element: 'h1',
   },


### PR DESCRIPTION
DraftBlockType needs to be less strict in order to allow user defined block types however we also want to retain a way to identify our core draft blocks.

fixes: https://github.com/facebook/draft-js/issues/1453