### PR TITLE
dedupe explanation of mobile support in documentation

### DIFF
--- a/docs/Advanced-Topics-Issues-and-Pitfalls.md
+++ b/docs/Advanced-Topics-Issues-and-Pitfalls.md
@@ -75,12 +75,6 @@ interaction.
 As of IE11, Internet Explorer demonstrates notable issues with certain international
 input methods, most significantly Korean input.
 
-### Mobile Support
-
-At this time Draft does not fully support mobile browsers. There are some known
-issues with certain Android keyboards and with international input methods. Full
-mobile support is a goal that the framework is moving towards for the future.
-
 ### Polyfills
 
 Some of Draft's code and that of its dependencies make use of ES2015 language


### PR DESCRIPTION
Mobile support is mentioned twice in the 'Issues and Pitfalls' section of the documentation:
* first, in the section removed in the PR
* second, beginning line 114 on the same page
