### PR TITLE
Added documentation for DraftEntityMutability

### DIFF
--- a/docs/APIReference-ContentState.md
+++ b/docs/APIReference-ContentState.md
@@ -336,7 +336,7 @@ Returns whether the contents contain any text at all.
 ```
 createEntity(
   type: DraftEntityType,
-  mutability: DraftEntityMutability,
+  mutability: [DraftEntityMutability](/docs/advanced-topics-entities.html#mutability),
   data?: Object
 ): ContentState
 ```

--- a/docs/APIReference-Entity.md
+++ b/docs/APIReference-Entity.md
@@ -62,7 +62,7 @@ be used only for retrieval.
 ```
 create(
   type: DraftEntityType,
-  mutability: DraftEntityMutability,
+  mutability: [DraftEntityMutability](/docs/advanced-topics-entities.html#mutability),
   data?: Object
 ): string
 ```

--- a/docs/Advanced-Topics-Entities.md
+++ b/docs/Advanced-Topics-Entities.md
@@ -96,7 +96,9 @@ property is meant only to indicate how the annotated text may be "mutated" withi
 the editor. _(Future changes may rename this property to ward off potential
 confusion around naming.)_
 
-### Immutable
+### Values
+
+#### `IMMUTABLE`
 
 This text cannot be altered without removing the entity annotation
 from the text. Entities with this mutability type are effectively atomic.
@@ -109,13 +111,13 @@ the entire entity is removed.
 This mutability value is useful in cases where the text absolutely must match
 its relevant metadata, and may not be altered.
 
-### Mutable
+#### `MUTABLE`
 
 This text may be altered freely. For instance, link text is
 generally intended to be "mutable" since the href and linkified text are not
 tightly coupled.
 
-### Segmented
+#### `SEGMENTED`
 
 Entities that are "segmented" are tightly coupled to their text in much the
 same way as "immutable" entities, but allow customization via deletion.


### PR DESCRIPTION
**Summary**
I often come across docs that show the raw types for a method signature (e.g., `Entity.create` has `DraftEntityMutability` as its second arg). Seeing this in raw text with no link to the true options that are available can be frustrating to a new user. They're essentially left to dive into the code on github to figure it out.

Would it be useful for me to start building some of these out like I've done in this PR? My apologies if there is some 'documentation guidelines' or decisions that have been made on what or what not to document. My primary goal here is a conversation rather than necessarily this specific PR's content.

**Test Plan**
n/a
