### PR TITLE
Refactoring our test suite and introducing jest snapshots

### DIFF
--- a/src/__mocks__/generateRandomKey.js
+++ b/src/__mocks__/generateRandomKey.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @format
+ */
+
+'use strict';
+
+let count = 0;
+
+function generateRandomKey() {
+  return `key${count++}`;
+}
+
+module.exports = generateRandomKey;

--- a/src/component/base/__tests__/DraftEditor.react-test.js
+++ b/src/component/base/__tests__/DraftEditor.react-test.js
@@ -15,48 +15,39 @@
 jest
   .unmock('DraftEditor.react')
   .unmock('react-test-renderer/shallow')
-  .unmock('generateRandomKey');
+  .mock('generateRandomKey');
 
-var DraftEditor = require('DraftEditor.react');
-var React = require('React');
+const DraftEditor = require('DraftEditor.react');
+const React = require('React');
 
-var ReactShallowRenderer = require('react-test-renderer/shallow');
+const ReactShallowRenderer = require('react-test-renderer/shallow');
 
-describe('DraftEditor.react', () => {
-  var shallow;
+let shallow;
 
-  beforeEach(function() {
-    shallow = new ReactShallowRenderer();
-  });
+beforeEach(() => {
+  shallow = new ReactShallowRenderer();
+});
 
-  describe('Basic rendering', () => {
-    it('must has generated editorKey', () => {
-      shallow.render(<DraftEditor />);
+test('must has generated editorKey', () => {
+  shallow.render(<DraftEditor />);
 
-      // internally at Facebook we use a newer version of the shallowRenderer
-      // which has a different level of wrapping of the '_instance'
-      // long term we should rewrite this test to not depend on private
-      // properties
-      var getEditorKey =
-        shallow._instance.getEditorKey ||
-        shallow._instance._instance.getEditorKey;
-      var key = getEditorKey();
-      expect(typeof key).toBe('string');
-      expect(key.length).toBeGreaterThanOrEqual(4);
-    });
+  // internally at Facebook we use a newer version of the shallowRenderer
+  // which has a different level of wrapping of the '_instance'
+  // long term we should rewrite this test to not depend on private
+  // properties
+  const getEditorKey =
+    shallow._instance.getEditorKey || shallow._instance._instance.getEditorKey;
+  expect(getEditorKey()).toMatchSnapshot();
+});
 
-    it('must has editorKey same as props', () => {
-      shallow.render(<DraftEditor editorKey="hash" />);
+test('must has editorKey same as props', () => {
+  shallow.render(<DraftEditor editorKey="hash" />);
 
-      // internally at Facebook we use a newer version of the shallowRenderer
-      // which has a different level of wrapping of the '_instance'
-      // long term we should rewrite this test to not depend on private
-      // properties
-      var getEditorKey =
-        shallow._instance.getEditorKey ||
-        shallow._instance._instance.getEditorKey;
-      var key = getEditorKey();
-      expect(key).toBe('hash');
-    });
-  });
+  // internally at Facebook we use a newer version of the shallowRenderer
+  // which has a different level of wrapping of the '_instance'
+  // long term we should rewrite this test to not depend on private
+  // properties
+  const getEditorKey =
+    shallow._instance.getEditorKey || shallow._instance._instance.getEditorKey;
+  expect(getEditorKey()).toMatchSnapshot();
 });

--- a/src/component/base/__tests__/DraftEditor.react-test.js
+++ b/src/component/base/__tests__/DraftEditor.react-test.js
@@ -12,10 +12,9 @@
 
 'use strict';
 
-jest
-  .unmock('DraftEditor.react')
-  .unmock('react-test-renderer/shallow')
-  .mock('generateRandomKey');
+jest.disableAutomock();
+
+jest.mock('generateRandomKey');
 
 const DraftEditor = require('DraftEditor.react');
 const React = require('React');

--- a/src/component/base/__tests__/__snapshots__/DraftEditor.react-test.js.snap
+++ b/src/component/base/__tests__/__snapshots__/DraftEditor.react-test.js.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must has editorKey same as props 1`] = `"hash"`;
+
+exports[`must has generated editorKey 1`] = `"key0"`;

--- a/src/component/contents/__tests__/DraftEditorBlock.react-test.js
+++ b/src/component/contents/__tests__/DraftEditorBlock.react-test.js
@@ -19,34 +19,34 @@ jest
   .mock('getScrollPosition')
   .mock('getViewportDimensions');
 
-var BlockTree = require('BlockTree');
-var CharacterMetadata = require('CharacterMetadata');
-var ContentBlock = require('ContentBlock');
-var ContentState = require('ContentState');
-var Immutable = require('immutable');
-var React = require('React');
-var ReactDOM = require('ReactDOM');
-var ReactTestUtils = require('ReactTestUtils');
-var SampleDraftInlineStyle = require('SampleDraftInlineStyle');
-var SelectionState = require('SelectionState');
-var Style = require('Style');
-var UnicodeBidiDirection = require('UnicodeBidiDirection');
+const BlockTree = require('BlockTree');
+const CharacterMetadata = require('CharacterMetadata');
+const ContentBlock = require('ContentBlock');
+const ContentState = require('ContentState');
+const Immutable = require('immutable');
+const React = require('React');
+const ReactDOM = require('ReactDOM');
+const ReactTestUtils = require('ReactTestUtils');
+const SampleDraftInlineStyle = require('SampleDraftInlineStyle');
+const SelectionState = require('SelectionState');
+const Style = require('Style');
+const UnicodeBidiDirection = require('UnicodeBidiDirection');
 
-var getElementPosition = require('getElementPosition');
-var getScrollPosition = require('getScrollPosition');
-var getViewportDimensions = require('getViewportDimensions');
-var reactComponentExpect = require('reactComponentExpect');
-var {BOLD, NONE, ITALIC} = SampleDraftInlineStyle;
+const getElementPosition = require('getElementPosition');
+const getScrollPosition = require('getScrollPosition');
+const getViewportDimensions = require('getViewportDimensions');
+const reactComponentExpect = require('reactComponentExpect');
+const DraftEditorBlock = require('DraftEditorBlock.react');
 
-var mockGetDecorations = jest.fn();
+const {BOLD, NONE, ITALIC} = SampleDraftInlineStyle;
+
+const mockGetDecorations = jest.fn();
 
 class DecoratorSpan extends React.Component {
   render() {
     return <span>{this.props.children}</span>;
   }
 }
-
-var DraftEditorBlock = require('DraftEditorBlock.react');
 
 // Define a class to satisfy typechecks.
 class Decorator {
@@ -61,30 +61,40 @@ class Decorator {
   }
 }
 
-var mockLeafRender = jest.fn(() => <span />);
+const mockLeafRender = jest.fn(() => <span />);
 class MockEditorLeaf extends React.Component {
   render() {
     return mockLeafRender();
   }
 }
 jest.setMock('DraftEditorLeaf.react', MockEditorLeaf);
+Style.getScrollParent.mockReturnValue(window);
+window.scrollTo = jest.fn();
+getElementPosition.mockReturnValue({
+  x: 0,
+  y: 600,
+  width: 500,
+  height: 16,
+});
+getScrollPosition.mockReturnValue({x: 0, y: 0});
+getViewportDimensions.mockReturnValue({width: 1200, height: 800});
 
-var DraftEditorLeaf = require('DraftEditorLeaf.react');
+const DraftEditorLeaf = require('DraftEditorLeaf.react');
 
-function returnEmptyString() {
+const returnEmptyString = () => {
   return '';
-}
+};
 
-function getHelloBlock() {
+const getHelloBlock = () => {
   return new ContentBlock({
     key: 'a',
     type: 'unstyled',
     text: 'hello',
     characterList: Immutable.List(Immutable.Repeat(CharacterMetadata.EMPTY, 5)),
   });
-}
+};
 
-function getSelection() {
+const getSelection = () => {
   return new SelectionState({
     anchorKey: 'a',
     anchorOffset: 0,
@@ -93,9 +103,9 @@ function getSelection() {
     isBackward: false,
     hasFocus: true,
   });
-}
+};
 
-function getProps(block, decorator) {
+const getProps = (block, decorator) => {
   return {
     block,
     tree: BlockTree.generate(ContentState.createFromText(''), block, decorator),
@@ -106,401 +116,385 @@ function getProps(block, decorator) {
     blockStyleFn: returnEmptyString,
     styleSet: NONE,
   };
-}
+};
 
-function arePropsEqual(renderedChild, leafPropSet) {
+const arePropsEqual = (renderedChild, leafPropSet) => {
   Object.keys(leafPropSet).forEach(key => {
     expect(
       Immutable.is(leafPropSet[key], renderedChild.instance().props[key]),
-    ).toBeTruthy();
+    ).toMatchSnapshot();
   });
-}
+};
 
-function assertLeaves(renderedBlock, leafProps) {
+const assertLeaves = (renderedBlock, leafProps) => {
   leafProps.forEach((leafPropSet, ii) => {
     const child = renderedBlock.expectRenderedChildAt(ii);
     child.toBeComponentOfType(DraftEditorLeaf);
     arePropsEqual(child, leafPropSet);
   });
-}
+};
 
-describe('DraftEditorBlock.react', () => {
-  Style.getScrollParent.mockReturnValue(window);
-  window.scrollTo = jest.fn();
-  getElementPosition.mockReturnValue({
+beforeEach(() => {
+  window.scrollTo.mockClear();
+  mockGetDecorations.mockClear();
+  mockLeafRender.mockClear();
+});
+
+test('must render a leaf node', () => {
+  const props = getProps(getHelloBlock());
+  const block = ReactTestUtils.renderIntoDocument(
+    <DraftEditorBlock {...props} />,
+  );
+
+  const rendered = reactComponentExpect(block)
+    .expectRenderedChild()
+    .toBeComponentOfType('div');
+
+  assertLeaves(rendered, [
+    {
+      text: 'hello',
+      offsetKey: 'a-0-0',
+      start: 0,
+      styleSet: NONE,
+      isLast: true,
+    },
+  ]);
+
+  expect(ReactDOM.findDOMNode(block)).toMatchSnapshot();
+});
+
+test('must render multiple leaf nodes', () => {
+  const boldLength = 2;
+  let helloBlock = getHelloBlock();
+  let characters = helloBlock.getCharacterList();
+  characters = characters
+    .slice(0, boldLength)
+    .map(c => CharacterMetadata.applyStyle(c, 'BOLD'))
+    .concat(characters.slice(boldLength));
+
+  helloBlock = helloBlock.set('characterList', characters.toList());
+
+  const props = getProps(helloBlock);
+  const block = ReactTestUtils.renderIntoDocument(
+    <DraftEditorBlock {...props} />,
+  );
+
+  const rendered = reactComponentExpect(block)
+    .expectRenderedChild()
+    .toBeComponentOfType('div');
+
+  assertLeaves(rendered, [
+    {
+      text: 'he',
+      offsetKey: 'a-0-0',
+      start: 0,
+      styleSet: BOLD,
+      isLast: false,
+    },
+    {
+      text: 'llo',
+      offsetKey: 'a-0-1',
+      start: 2,
+      styleSet: NONE,
+      isLast: true,
+    },
+  ]);
+
+  expect(ReactDOM.findDOMNode(block)).toMatchSnapshot();
+});
+
+test('must allow update when `block` has changed', () => {
+  const helloBlock = getHelloBlock();
+  const props = getProps(helloBlock);
+
+  const container = document.createElement('div');
+  ReactDOM.render(<DraftEditorBlock {...props} />, container);
+
+  expect(mockLeafRender.mock.calls.length).toMatchSnapshot();
+
+  const updatedHelloBlock = helloBlock.set('text', 'hxllo');
+  const nextProps = getProps(updatedHelloBlock);
+
+  expect(updatedHelloBlock !== helloBlock).toMatchSnapshot();
+  expect(props.block !== nextProps.block).toMatchSnapshot();
+
+  ReactDOM.render(<DraftEditorBlock {...nextProps} />, container);
+
+  expect(mockLeafRender.mock.calls.length).toMatchSnapshot();
+});
+
+test('must allow update when `tree` has changed', () => {
+  const helloBlock = getHelloBlock();
+  const props = getProps(helloBlock);
+
+  const container = document.createElement('div');
+  ReactDOM.render(<DraftEditorBlock {...props} />, container);
+
+  expect(mockLeafRender.mock.calls.length).toMatchSnapshot();
+
+  mockGetDecorations.mockReturnValue(
+    Immutable.List.of('x', 'x', null, null, null),
+  );
+  const decorator = new Decorator();
+
+  const newTree = BlockTree.generate(
+    ContentState.createFromText(helloBlock.getText()),
+    helloBlock,
+    decorator,
+  );
+  const nextProps = {...props, tree: newTree, decorator};
+
+  expect(props.tree !== nextProps.tree).toMatchSnapshot();
+
+  ReactDOM.render(<DraftEditorBlock {...nextProps} />, container);
+
+  expect(mockLeafRender.mock.calls.length).toMatchSnapshot();
+});
+
+test('must allow update when `direction` has changed', () => {
+  const helloBlock = getHelloBlock();
+  const props = getProps(helloBlock);
+
+  const container = document.createElement('div');
+  ReactDOM.render(<DraftEditorBlock {...props} />, container);
+
+  expect(mockLeafRender.mock.calls.length).toMatchSnapshot();
+
+  const nextProps = {...props, direction: UnicodeBidiDirection.RTL};
+  expect(props.direction !== nextProps.direction).toMatchSnapshot();
+
+  ReactDOM.render(<DraftEditorBlock {...nextProps} />, container);
+
+  expect(mockLeafRender.mock.calls.length).toMatchSnapshot();
+});
+
+test('must allow update when forcing selection', () => {
+  const helloBlock = getHelloBlock();
+  const props = getProps(helloBlock);
+
+  const container = document.createElement('div');
+  ReactDOM.render(<DraftEditorBlock {...props} />, container);
+
+  expect(mockLeafRender.mock.calls.length).toMatchSnapshot();
+
+  // The default selection state in this test is on a selection edge.
+  const nextProps = {
+    ...props,
+    forceSelection: true,
+  };
+
+  ReactDOM.render(<DraftEditorBlock {...nextProps} />, container);
+
+  expect(mockLeafRender.mock.calls.length).toMatchSnapshot();
+});
+
+test('must reject update if conditions are not met', () => {
+  const helloBlock = getHelloBlock();
+  const props = getProps(helloBlock);
+
+  const container = document.createElement('div');
+  ReactDOM.render(<DraftEditorBlock {...props} />, container);
+
+  expect(mockLeafRender.mock.calls.length).toMatchSnapshot();
+
+  // Render again with the exact same props as before.
+  ReactDOM.render(<DraftEditorBlock {...props} />, container);
+
+  // No new leaf renders.
+  expect(mockLeafRender.mock.calls.length).toMatchSnapshot();
+});
+
+test('must reject update if selection is not on an edge', () => {
+  const helloBlock = getHelloBlock();
+  const props = getProps(helloBlock);
+
+  const container = document.createElement('div');
+  ReactDOM.render(<DraftEditorBlock {...props} />, container);
+
+  expect(mockLeafRender.mock.calls.length).toMatchSnapshot();
+
+  // Move selection state to some other block.
+  const nonEdgeSelection = props.selection.merge({
+    anchorKey: 'z',
+    focusKey: 'z',
+  });
+
+  const newProps = {...props, selection: nonEdgeSelection};
+
+  // Render again with selection now moved elsewhere and the contents
+  // unchanged.
+  ReactDOM.render(<DraftEditorBlock {...newProps} />, container);
+
+  // No new leaf renders.
+  expect(mockLeafRender.mock.calls.length).toMatchSnapshot();
+});
+
+test('must split apart two decorated and undecorated', () => {
+  const helloBlock = getHelloBlock();
+
+  mockGetDecorations.mockReturnValue(
+    Immutable.List.of('x', 'x', null, null, null),
+  );
+  const decorator = new Decorator();
+  const props = getProps(helloBlock, decorator);
+
+  const container = document.createElement('div');
+  const block = ReactDOM.render(<DraftEditorBlock {...props} />, container);
+
+  expect(mockLeafRender.mock.calls.length).toMatchSnapshot();
+
+  const rendered = reactComponentExpect(block)
+    .expectRenderedChild()
+    .toBeComponentOfType('div');
+
+  rendered
+    .expectRenderedChildAt(0)
+    .scalarPropsEqual({offsetKey: 'a-0-0'})
+    .toBeComponentOfType(DecoratorSpan)
+    .expectRenderedChild()
+    .toBeComponentOfType('span');
+
+  rendered
+    .expectRenderedChildAt(1)
+    .scalarPropsEqual({offsetKey: 'a-1-0'})
+    .toBeComponentOfType(DraftEditorLeaf);
+
+  expect(ReactDOM.findDOMNode(block)).toMatchSnapshot();
+});
+
+test('must split apart two decorators', () => {
+  const helloBlock = getHelloBlock();
+
+  mockGetDecorations.mockReturnValue(
+    Immutable.List.of('x', 'x', 'y', 'y', 'y'),
+  );
+
+  const decorator = new Decorator();
+  const props = getProps(helloBlock, decorator);
+
+  const container = document.createElement('div');
+  const block = ReactDOM.render(<DraftEditorBlock {...props} />, container);
+
+  expect(mockLeafRender.mock.calls.length).toMatchSnapshot();
+
+  const rendered = reactComponentExpect(block)
+    .expectRenderedChild()
+    .toBeComponentOfType('div');
+
+  rendered
+    .expectRenderedChildAt(0)
+    .scalarPropsEqual({offsetKey: 'a-0-0'})
+    .toBeComponentOfType(DecoratorSpan);
+
+  rendered
+    .expectRenderedChildAt(1)
+    .scalarPropsEqual({offsetKey: 'a-1-0'})
+    .toBeComponentOfType(DecoratorSpan);
+
+  expect(ReactDOM.findDOMNode(block)).toMatchSnapshot();
+});
+
+test('must split apart styled spans', () => {
+  let helloBlock = getHelloBlock();
+  const characters = helloBlock.getCharacterList();
+  const newChars = characters
+    .slice(0, 2)
+    .map(ch => {
+      return CharacterMetadata.applyStyle(ch, 'BOLD');
+    })
+    .concat(characters.slice(2));
+
+  helloBlock = helloBlock.set('characterList', Immutable.List(newChars));
+  const props = getProps(helloBlock);
+
+  const container = document.createElement('div');
+  const block = ReactDOM.render(<DraftEditorBlock {...props} />, container);
+
+  expect(mockLeafRender.mock.calls.length).toMatchSnapshot();
+
+  const rendered = reactComponentExpect(block)
+    .expectRenderedChild()
+    .toBeComponentOfType('div');
+
+  let child = rendered.expectRenderedChildAt(0);
+  child.toBeComponentOfType(DraftEditorLeaf);
+  arePropsEqual(child, {offsetKey: 'a-0-0', styleSet: BOLD});
+
+  child = rendered.expectRenderedChildAt(1);
+  child.toBeComponentOfType(DraftEditorLeaf);
+  arePropsEqual(child, {offsetKey: 'a-0-1', styleSet: NONE});
+
+  expect(ReactDOM.findDOMNode(block)).toMatchSnapshot();
+});
+
+test('must split styled spans apart within decorator', () => {
+  let helloBlock = getHelloBlock();
+  const characters = helloBlock.getCharacterList();
+  const newChars = Immutable.List([
+    CharacterMetadata.applyStyle(characters.get(0), 'BOLD'),
+    CharacterMetadata.applyStyle(characters.get(1), 'ITALIC'),
+  ]).concat(characters.slice(2));
+
+  helloBlock = helloBlock.set('characterList', Immutable.List(newChars));
+
+  mockGetDecorations.mockReturnValue(
+    Immutable.List.of('x', 'x', null, null, null),
+  );
+  const decorator = new Decorator();
+  const props = getProps(helloBlock, decorator);
+
+  const container = document.createElement('div');
+  const block = ReactDOM.render(<DraftEditorBlock {...props} />, container);
+
+  expect(mockLeafRender.mock.calls.length).toMatchSnapshot();
+
+  const rendered = reactComponentExpect(block)
+    .expectRenderedChild()
+    .toBeComponentOfType('div');
+
+  const decoratedSpan = rendered
+    .expectRenderedChildAt(0)
+    .scalarPropsEqual({offsetKey: 'a-0-0'})
+    .toBeComponentOfType(DecoratorSpan)
+    .expectRenderedChild();
+
+  let child = decoratedSpan.expectRenderedChildAt(0);
+  child.toBeComponentOfType(DraftEditorLeaf);
+  arePropsEqual(child, {offsetKey: 'a-0-0', styleSet: BOLD});
+
+  child = decoratedSpan.expectRenderedChildAt(1);
+  child.toBeComponentOfType(DraftEditorLeaf);
+  arePropsEqual(child, {offsetKey: 'a-0-1', styleSet: ITALIC});
+
+  child = rendered.expectRenderedChildAt(1);
+  child.toBeComponentOfType(DraftEditorLeaf);
+  arePropsEqual(child, {offsetKey: 'a-1-0', styleSet: NONE});
+
+  expect(ReactDOM.findDOMNode(block)).toMatchSnapshot();
+});
+
+test('must scroll the window if needed', () => {
+  const props = getProps(getHelloBlock());
+
+  getElementPosition.mockReturnValueOnce({
     x: 0,
-    y: 600,
+    y: 800,
     width: 500,
     height: 16,
   });
-  getScrollPosition.mockReturnValue({x: 0, y: 0});
-  getViewportDimensions.mockReturnValue({width: 1200, height: 800});
 
-  beforeEach(() => {
-    window.scrollTo.mockClear();
-    mockGetDecorations.mockClear();
-    mockLeafRender.mockClear();
-  });
+  const container = document.createElement('div');
+  ReactDOM.render(<DraftEditorBlock {...props} />, container);
 
-  describe('Basic rendering', () => {
-    it('must render a leaf node', () => {
-      var props = getProps(getHelloBlock());
-      var block = ReactTestUtils.renderIntoDocument(
-        <DraftEditorBlock {...props} />,
-      );
+  const scrollCalls = window.scrollTo.mock.calls;
+  expect(scrollCalls).toMatchSnapshot();
+});
 
-      var rendered = reactComponentExpect(block)
-        .expectRenderedChild()
-        .toBeComponentOfType('div');
+test('must not scroll the window if unnecessary', () => {
+  const props = getProps(getHelloBlock());
+  const container = document.createElement('div');
+  ReactDOM.render(<DraftEditorBlock {...props} />, container);
 
-      assertLeaves(rendered, [
-        {
-          text: 'hello',
-          offsetKey: 'a-0-0',
-          start: 0,
-          styleSet: NONE,
-          isLast: true,
-        },
-      ]);
-    });
-
-    it('must render multiple leaf nodes', () => {
-      var boldLength = 2;
-      var helloBlock = getHelloBlock();
-      var characters = helloBlock.getCharacterList();
-      characters = characters
-        .slice(0, boldLength)
-        .map(c => CharacterMetadata.applyStyle(c, 'BOLD'))
-        .concat(characters.slice(boldLength));
-
-      helloBlock = helloBlock.set('characterList', characters.toList());
-
-      var props = getProps(helloBlock);
-      var block = ReactTestUtils.renderIntoDocument(
-        <DraftEditorBlock {...props} />,
-      );
-
-      var rendered = reactComponentExpect(block)
-        .expectRenderedChild()
-        .toBeComponentOfType('div');
-
-      assertLeaves(rendered, [
-        {
-          text: 'he',
-          offsetKey: 'a-0-0',
-          start: 0,
-          styleSet: BOLD,
-          isLast: false,
-        },
-        {
-          text: 'llo',
-          offsetKey: 'a-0-1',
-          start: 2,
-          styleSet: NONE,
-          isLast: true,
-        },
-      ]);
-    });
-  });
-
-  describe('Allow/reject component updates', () => {
-    it('must allow update when `block` has changed', () => {
-      var helloBlock = getHelloBlock();
-      var props = getProps(helloBlock);
-
-      var container = document.createElement('div');
-      ReactDOM.render(<DraftEditorBlock {...props} />, container);
-
-      expect(mockLeafRender.mock.calls.length).toBe(1);
-
-      var updatedHelloBlock = helloBlock.set('text', 'hxllo');
-      var nextProps = getProps(updatedHelloBlock);
-
-      expect(updatedHelloBlock).not.toBe(helloBlock);
-      expect(props.block).not.toBe(nextProps.block);
-
-      ReactDOM.render(<DraftEditorBlock {...nextProps} />, container);
-
-      expect(mockLeafRender.mock.calls.length).toBe(2);
-    });
-
-    it('must allow update when `tree` has changed', () => {
-      var helloBlock = getHelloBlock();
-      var props = getProps(helloBlock);
-
-      var container = document.createElement('div');
-      ReactDOM.render(<DraftEditorBlock {...props} />, container);
-
-      expect(mockLeafRender.mock.calls.length).toBe(1);
-
-      mockGetDecorations.mockReturnValue(
-        Immutable.List.of('x', 'x', null, null, null),
-      );
-      var decorator = new Decorator();
-
-      var newTree = BlockTree.generate(
-        ContentState.createFromText(helloBlock.getText()),
-        helloBlock,
-        decorator,
-      );
-      var nextProps = {...props, tree: newTree, decorator};
-
-      expect(props.tree).not.toBe(nextProps.tree);
-
-      ReactDOM.render(<DraftEditorBlock {...nextProps} />, container);
-
-      expect(mockLeafRender.mock.calls.length).toBe(3);
-    });
-
-    it('must allow update when `direction` has changed', () => {
-      var helloBlock = getHelloBlock();
-      var props = getProps(helloBlock);
-
-      var container = document.createElement('div');
-      ReactDOM.render(<DraftEditorBlock {...props} />, container);
-
-      expect(mockLeafRender.mock.calls.length).toBe(1);
-
-      var nextProps = {...props, direction: UnicodeBidiDirection.RTL};
-      expect(props.direction).not.toBe(nextProps.direction);
-
-      ReactDOM.render(<DraftEditorBlock {...nextProps} />, container);
-
-      expect(mockLeafRender.mock.calls.length).toBe(2);
-    });
-
-    it('must allow update when forcing selection', () => {
-      var helloBlock = getHelloBlock();
-      var props = getProps(helloBlock);
-
-      var container = document.createElement('div');
-      ReactDOM.render(<DraftEditorBlock {...props} />, container);
-
-      expect(mockLeafRender.mock.calls.length).toBe(1);
-
-      // The default selection state in this test is on a selection edge.
-      var nextProps = {
-        ...props,
-        forceSelection: true,
-      };
-
-      ReactDOM.render(<DraftEditorBlock {...nextProps} />, container);
-
-      expect(mockLeafRender.mock.calls.length).toBe(2);
-    });
-
-    it('must reject update if conditions are not met', () => {
-      var helloBlock = getHelloBlock();
-      var props = getProps(helloBlock);
-
-      var container = document.createElement('div');
-      ReactDOM.render(<DraftEditorBlock {...props} />, container);
-
-      expect(mockLeafRender.mock.calls.length).toBe(1);
-
-      // Render again with the exact same props as before.
-      ReactDOM.render(<DraftEditorBlock {...props} />, container);
-
-      // No new leaf renders.
-      expect(mockLeafRender.mock.calls.length).toBe(1);
-    });
-
-    it('must reject update if selection is not on an edge', () => {
-      var helloBlock = getHelloBlock();
-      var props = getProps(helloBlock);
-
-      var container = document.createElement('div');
-      ReactDOM.render(<DraftEditorBlock {...props} />, container);
-
-      expect(mockLeafRender.mock.calls.length).toBe(1);
-
-      // Move selection state to some other block.
-      var nonEdgeSelection = props.selection.merge({
-        anchorKey: 'z',
-        focusKey: 'z',
-      });
-
-      var newProps = {...props, selection: nonEdgeSelection};
-
-      // Render again with selection now moved elsewhere and the contents
-      // unchanged.
-      ReactDOM.render(<DraftEditorBlock {...newProps} />, container);
-
-      // No new leaf renders.
-      expect(mockLeafRender.mock.calls.length).toBe(1);
-    });
-  });
-
-  describe('Complex rendering with a decorator', () => {
-    it('must split apart two decorated and undecorated', () => {
-      var helloBlock = getHelloBlock();
-
-      mockGetDecorations.mockReturnValue(
-        Immutable.List.of('x', 'x', null, null, null),
-      );
-      var decorator = new Decorator();
-      var props = getProps(helloBlock, decorator);
-
-      var container = document.createElement('div');
-      var block = ReactDOM.render(<DraftEditorBlock {...props} />, container);
-
-      expect(mockLeafRender.mock.calls.length).toBe(2);
-
-      var rendered = reactComponentExpect(block)
-        .expectRenderedChild()
-        .toBeComponentOfType('div');
-
-      rendered
-        .expectRenderedChildAt(0)
-        .scalarPropsEqual({offsetKey: 'a-0-0'})
-        .toBeComponentOfType(DecoratorSpan)
-        .expectRenderedChild()
-        .toBeComponentOfType('span');
-
-      rendered
-        .expectRenderedChildAt(1)
-        .scalarPropsEqual({offsetKey: 'a-1-0'})
-        .toBeComponentOfType(DraftEditorLeaf);
-    });
-
-    it('must split apart two decorators', () => {
-      var helloBlock = getHelloBlock();
-
-      mockGetDecorations.mockReturnValue(
-        Immutable.List.of('x', 'x', 'y', 'y', 'y'),
-      );
-
-      var decorator = new Decorator();
-      var props = getProps(helloBlock, decorator);
-
-      var container = document.createElement('div');
-      var block = ReactDOM.render(<DraftEditorBlock {...props} />, container);
-
-      expect(mockLeafRender.mock.calls.length).toBe(2);
-
-      var rendered = reactComponentExpect(block)
-        .expectRenderedChild()
-        .toBeComponentOfType('div');
-
-      rendered
-        .expectRenderedChildAt(0)
-        .scalarPropsEqual({offsetKey: 'a-0-0'})
-        .toBeComponentOfType(DecoratorSpan);
-
-      rendered
-        .expectRenderedChildAt(1)
-        .scalarPropsEqual({offsetKey: 'a-1-0'})
-        .toBeComponentOfType(DecoratorSpan);
-    });
-  });
-
-  describe('Complex rendering with inline styles', () => {
-    it('must split apart styled spans', () => {
-      var helloBlock = getHelloBlock();
-      var characters = helloBlock.getCharacterList();
-      var newChars = characters
-        .slice(0, 2)
-        .map(ch => {
-          return CharacterMetadata.applyStyle(ch, 'BOLD');
-        })
-        .concat(characters.slice(2));
-
-      helloBlock = helloBlock.set('characterList', Immutable.List(newChars));
-      var props = getProps(helloBlock);
-
-      var container = document.createElement('div');
-      var block = ReactDOM.render(<DraftEditorBlock {...props} />, container);
-
-      expect(mockLeafRender.mock.calls.length).toBe(2);
-
-      var rendered = reactComponentExpect(block)
-        .expectRenderedChild()
-        .toBeComponentOfType('div');
-
-      let child = rendered.expectRenderedChildAt(0);
-      child.toBeComponentOfType(DraftEditorLeaf);
-      arePropsEqual(child, {offsetKey: 'a-0-0', styleSet: BOLD});
-
-      child = rendered.expectRenderedChildAt(1);
-      child.toBeComponentOfType(DraftEditorLeaf);
-      arePropsEqual(child, {offsetKey: 'a-0-1', styleSet: NONE});
-    });
-
-    it('must split styled spans apart within decorator', () => {
-      var helloBlock = getHelloBlock();
-      var characters = helloBlock.getCharacterList();
-      var newChars = Immutable.List([
-        CharacterMetadata.applyStyle(characters.get(0), 'BOLD'),
-        CharacterMetadata.applyStyle(characters.get(1), 'ITALIC'),
-      ]).concat(characters.slice(2));
-
-      helloBlock = helloBlock.set('characterList', Immutable.List(newChars));
-
-      mockGetDecorations.mockReturnValue(
-        Immutable.List.of('x', 'x', null, null, null),
-      );
-      var decorator = new Decorator();
-      var props = getProps(helloBlock, decorator);
-
-      var container = document.createElement('div');
-      var block = ReactDOM.render(<DraftEditorBlock {...props} />, container);
-
-      expect(mockLeafRender.mock.calls.length).toBe(3);
-
-      var rendered = reactComponentExpect(block)
-        .expectRenderedChild()
-        .toBeComponentOfType('div');
-
-      var decoratedSpan = rendered
-        .expectRenderedChildAt(0)
-        .scalarPropsEqual({offsetKey: 'a-0-0'})
-        .toBeComponentOfType(DecoratorSpan)
-        .expectRenderedChild();
-
-      let child = decoratedSpan.expectRenderedChildAt(0);
-      child.toBeComponentOfType(DraftEditorLeaf);
-      arePropsEqual(child, {offsetKey: 'a-0-0', styleSet: BOLD});
-
-      child = decoratedSpan.expectRenderedChildAt(1);
-      child.toBeComponentOfType(DraftEditorLeaf);
-      arePropsEqual(child, {offsetKey: 'a-0-1', styleSet: ITALIC});
-
-      child = rendered.expectRenderedChildAt(1);
-      child.toBeComponentOfType(DraftEditorLeaf);
-      arePropsEqual(child, {offsetKey: 'a-1-0', styleSet: NONE});
-    });
-  });
-
-  describe('Scroll-to-cursor on mount', () => {
-    var props = getProps(getHelloBlock());
-
-    describe('Scroll parent is `window`', () => {
-      it('must scroll the window if needed', () => {
-        getElementPosition.mockReturnValueOnce({
-          x: 0,
-          y: 800,
-          width: 500,
-          height: 16,
-        });
-
-        var container = document.createElement('div');
-        ReactDOM.render(<DraftEditorBlock {...props} />, container);
-
-        var scrollCalls = window.scrollTo.mock.calls;
-        expect(scrollCalls.length).toBe(1);
-        expect(scrollCalls[0][0]).toBe(0);
-
-        // (current scroll position) + (block height) + (buffer)
-        expect(scrollCalls[0][1]).toBe(26);
-      });
-
-      it('must not scroll the window if unnecessary', () => {
-        var container = document.createElement('div');
-        ReactDOM.render(<DraftEditorBlock {...props} />, container);
-
-        var scrollCalls = window.scrollTo.mock.calls;
-        expect(scrollCalls.length).toBe(0);
-      });
-    });
-  });
+  const scrollCalls = window.scrollTo.mock.calls;
+  expect(scrollCalls.length).toMatchSnapshot();
 });

--- a/src/component/contents/__tests__/DraftEditorBlock.react-test.js
+++ b/src/component/contents/__tests__/DraftEditorBlock.react-test.js
@@ -496,5 +496,5 @@ test('must not scroll the window if unnecessary', () => {
   ReactDOM.render(<DraftEditorBlock {...props} />, container);
 
   const scrollCalls = window.scrollTo.mock.calls;
-  expect(scrollCalls.length).toMatchSnapshot();
+  expect(scrollCalls).toMatchSnapshot();
 });

--- a/src/component/contents/__tests__/DraftEditorContent.react-test.js
+++ b/src/component/contents/__tests__/DraftEditorContent.react-test.js
@@ -14,81 +14,84 @@
 
 jest.disableAutomock();
 
+jest.mock('generateRandomKey');
+
 const Editor = require('DraftEditor.react');
 const EditorState = require('EditorState');
 const RichUtils = require('RichTextEditorUtil');
 
 const {mount} = require('enzyme');
 const React = require('react');
+const ReactDOM = require('ReactDOM');
 
-describe('DraftEditor.react', () => {
-  describe('with a custom block type and the default blockRenderMap', () => {
-    it('defaults to "unstyled" block type for unknown block types', () => {
-      const CUSTOM_BLOCK_TYPE = 'CUSTOM_BLOCK_TYPE';
+test('defaults to "unstyled" block type for unknown block types', () => {
+  const CUSTOM_BLOCK_TYPE = 'CUSTOM_BLOCK_TYPE';
 
-      function CustomText(props) {
-        // contrived example
-        return (
-          <p>
-            <b>{props.children}</b>
-          </p>
-        );
-      }
+  function CustomText(props) {
+    // contrived example
+    return (
+      <p>
+        <b>{props.children}</b>
+      </p>
+    );
+  }
 
-      class Container extends React.Component {
-        constructor(props) {
-          super(props);
-          this.state = {
-            editorState: EditorState.createEmpty(),
-          };
-        }
-        toggleCustomBlock = () => {
-          this.setState(
-            {
-              editorState: RichUtils.toggleBlockType(
-                this.state.editorState,
-                CUSTOM_BLOCK_TYPE,
-              ),
-            },
-            () => {
-              setTimeout(() => this.focus(), 0);
-            },
-          );
-        };
-        blockRenderFn(block) {
-          if (block.getType() === CUSTOM_BLOCK_TYPE) {
-            return {
-              component: CustomText,
-              editable: true,
-            };
-          }
-          return null;
-        }
-        render() {
-          return (
-            <div className="container-root">
-              <div>
-                <button onClick={this.toggleCustomBlock}>CenterAlign</button>
-              </div>
-              <Editor
-                placeholder="Type away :)"
-                editorState={this.state.editorState}
-                blockRendererFn={this.blockRenderFn}
-                onChange={this._handleChange}
-              />
-            </div>
-          );
-        }
-        _handleChange = editorState => {
-          this.setState({editorState});
-        };
-      }
-
-      const mountedEditorContainer = mount(<Container />);
-      const triggerCustomBlockRender = () => {
-        mountedEditorContainer.find('button').simulate('click');
+  class Container extends React.Component {
+    constructor(props) {
+      super(props);
+      this.state = {
+        editorState: EditorState.createEmpty(),
       };
-      expect(triggerCustomBlockRender).not.toThrow();
-    });
-  });
+    }
+    toggleCustomBlock = () => {
+      this.setState(
+        {
+          editorState: RichUtils.toggleBlockType(
+            this.state.editorState,
+            CUSTOM_BLOCK_TYPE,
+          ),
+        },
+        () => {
+          setTimeout(() => this.focus(), 0);
+        },
+      );
+    };
+    blockRenderFn(block) {
+      if (block.getType() === CUSTOM_BLOCK_TYPE) {
+        return {
+          component: CustomText,
+          editable: true,
+        };
+      }
+      return null;
+    }
+    render() {
+      return (
+        <div className="container-root">
+          <div>
+            <button onClick={this.toggleCustomBlock}>CenterAlign</button>
+          </div>
+          <Editor
+            placeholder="Type away :)"
+            editorState={this.state.editorState}
+            blockRendererFn={this.blockRenderFn}
+            onChange={this._handleChange}
+          />
+        </div>
+      );
+    }
+    _handleChange = editorState => {
+      this.setState({editorState});
+    };
+  }
+
+  const mountedEditorContainer = mount(<Container />);
+  const triggerCustomBlockRender = () => {
+    mountedEditorContainer.find('button').simulate('click');
+  };
+
+  expect(triggerCustomBlockRender).not.toThrow();
+
+  const stub = ReactDOM.render(<Container />, document.createElement('div'));
+  expect(ReactDOM.findDOMNode(stub)).toMatchSnapshot();
 });

--- a/src/component/contents/__tests__/DraftEditorTextNode-test.js
+++ b/src/component/contents/__tests__/DraftEditorTextNode-test.js
@@ -14,202 +14,183 @@
 
 jest.disableAutomock().mock('UserAgent');
 
-var BLOCK_DELIMITER_CHAR = '\n';
-var TEST_A = 'Hello';
-var TEST_B = ' World!';
+const TEST_A = 'Hello';
+const TEST_B = ' World!';
 
-var DraftEditorTextNode = require('DraftEditorTextNode.react');
-var React = require('React');
-var ReactDOM = require('ReactDOM');
-var UserAgent = require('UserAgent');
+const DraftEditorTextNode = require('DraftEditorTextNode.react');
+const React = require('React');
+const ReactDOM = require('ReactDOM');
+const UserAgent = require('UserAgent');
 
-describe('DraftEditorTextNode', function() {
-  var container;
+let container;
 
-  beforeEach(function() {
-    jest.resetModules();
-    container = document.createElement('div');
-  });
+beforeEach(() => {
+  jest.resetModules();
+  container = document.createElement('div');
+});
 
-  function renderIntoContainer(element) {
-    return ReactDOM.render(element, container);
-  }
+const renderIntoContainer = element => {
+  return ReactDOM.render(element, container);
+};
 
-  function initializeAsIE() {
-    UserAgent.isBrowser.mockImplementation(() => true);
-  }
+const initializeAsIE = () => {
+  UserAgent.isBrowser.mockImplementation(() => true);
+};
 
-  function initializeAsNonIE() {
-    UserAgent.isBrowser.mockImplementation(() => false);
-  }
+const initializeAsNonIE = () => {
+  UserAgent.isBrowser.mockImplementation(() => false);
+};
 
-  function expectPopulatedSpan(stub, testString) {
-    var node = ReactDOM.findDOMNode(stub);
-    expect(node.tagName).toBe('SPAN');
-    expect(node.childNodes.length).toBe(1);
-    expect(node.firstChild.textContent).toBe(testString);
-  }
+test('must initialize correctly with an empty string, non-IE', () => {
+  initializeAsNonIE();
+  const stub = renderIntoContainer(
+    <DraftEditorTextNode>{''}</DraftEditorTextNode>,
+  );
+  expect(ReactDOM.findDOMNode(stub)).toMatchSnapshot();
+});
 
-  it('must initialize correctly with an empty string, non-IE', function() {
-    initializeAsNonIE();
-    var stub = renderIntoContainer(
-      <DraftEditorTextNode>{''}</DraftEditorTextNode>,
-    );
-    expect(ReactDOM.findDOMNode(stub).tagName).toBe('BR');
-  });
+test('must initialize correctly with an empty string, IE', () => {
+  initializeAsIE();
+  const stub = renderIntoContainer(
+    <DraftEditorTextNode>{''}</DraftEditorTextNode>,
+  );
+  expect(ReactDOM.findDOMNode(stub)).toMatchSnapshot();
+});
 
-  it('must initialize correctly with an empty string, IE', function() {
-    initializeAsIE();
-    var stub = renderIntoContainer(
-      <DraftEditorTextNode>{''}</DraftEditorTextNode>,
-    );
-    expectPopulatedSpan(stub, BLOCK_DELIMITER_CHAR);
-  });
+test('must initialize correctly with a string, non-IE', () => {
+  initializeAsNonIE();
+  const stub = renderIntoContainer(
+    <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>,
+  );
+  expect(ReactDOM.findDOMNode(stub)).toMatchSnapshot();
+});
 
-  it('must initialize correctly with a string, non-IE', function() {
-    initializeAsNonIE();
-    var stub = renderIntoContainer(
-      <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>,
-    );
-    expectPopulatedSpan(stub, TEST_A);
-  });
+test('must initialize correctly with a string, IE', () => {
+  initializeAsIE();
+  const stub = renderIntoContainer(
+    <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>,
+  );
+  expect(ReactDOM.findDOMNode(stub)).toMatchSnapshot();
+});
 
-  it('must initialize correctly with a string, IE', function() {
-    initializeAsIE();
-    var stub = renderIntoContainer(
-      <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>,
-    );
-    expectPopulatedSpan(stub, TEST_A);
-  });
+test('must update from empty to non-empty, non-IE', () => {
+  initializeAsNonIE();
+  const stub = renderIntoContainer(
+    <DraftEditorTextNode>{''}</DraftEditorTextNode>,
+  );
 
-  it('must update from empty to non-empty, non-IE', function() {
-    initializeAsNonIE();
-    var stub = renderIntoContainer(
-      <DraftEditorTextNode>{''}</DraftEditorTextNode>,
-    );
+  renderIntoContainer(<DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>);
 
-    renderIntoContainer(<DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>);
-    expectPopulatedSpan(stub, TEST_A);
-  });
+  expect(ReactDOM.findDOMNode(stub)).toMatchSnapshot();
+});
 
-  it('must update from empty to non-empty, IE', function() {
-    initializeAsIE();
-    var stub = renderIntoContainer(
-      <DraftEditorTextNode>{''}</DraftEditorTextNode>,
-    );
+test('must update from empty to non-empty, IE', () => {
+  initializeAsIE();
+  const stub = renderIntoContainer(
+    <DraftEditorTextNode>{''}</DraftEditorTextNode>,
+  );
 
-    renderIntoContainer(<DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>);
-    expectPopulatedSpan(stub, TEST_A);
-  });
+  renderIntoContainer(<DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>);
 
-  it('must update from non-empty to non-empty, non-IE', function() {
-    initializeAsNonIE();
-    var stub = renderIntoContainer(
-      <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>,
-    );
+  expect(ReactDOM.findDOMNode(stub)).toMatchSnapshot();
+});
 
-    renderIntoContainer(
-      <DraftEditorTextNode>{TEST_A + TEST_B}</DraftEditorTextNode>,
-    );
+test('must update from non-empty to non-empty, non-IE', () => {
+  initializeAsIE();
+  const stub = renderIntoContainer(
+    <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>,
+  );
 
-    expectPopulatedSpan(stub, TEST_A + TEST_B);
+  renderIntoContainer(
+    <DraftEditorTextNode>{TEST_A + TEST_B}</DraftEditorTextNode>,
+  );
 
-    renderIntoContainer(<DraftEditorTextNode>{TEST_B}</DraftEditorTextNode>);
-    expectPopulatedSpan(stub, TEST_B);
-  });
+  expect(ReactDOM.findDOMNode(stub)).toMatchSnapshot();
 
-  it('must update from non-empty to non-empty, non-IE', function() {
-    initializeAsIE();
-    var stub = renderIntoContainer(
-      <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>,
-    );
+  renderIntoContainer(<DraftEditorTextNode>{TEST_B}</DraftEditorTextNode>);
 
-    renderIntoContainer(
-      <DraftEditorTextNode>{TEST_A + TEST_B}</DraftEditorTextNode>,
-    );
-    expectPopulatedSpan(stub, TEST_A + TEST_B);
+  expect(ReactDOM.findDOMNode(stub)).toMatchSnapshot();
+});
 
-    renderIntoContainer(<DraftEditorTextNode>{TEST_B}</DraftEditorTextNode>);
-    expectPopulatedSpan(stub, TEST_B);
-  });
+test('must skip updates if text already matches DOM, non-IE', () => {
+  initializeAsNonIE();
+  const stub = renderIntoContainer(
+    <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>,
+  );
 
-  it('must skip updates if text already matches DOM, non-IE', function() {
-    initializeAsNonIE();
-    var stub = renderIntoContainer(
-      <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>,
-    );
+  spyOn(stub, 'render').and.callThrough();
 
-    spyOn(stub, 'render').and.callThrough();
+  renderIntoContainer(<DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>);
 
-    renderIntoContainer(<DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>);
+  expect(stub.render.calls.count()).toMatchSnapshot();
 
-    expect(stub.render.calls.count()).toBe(0);
+  // Sanity check that updating is performed when appropriate.
+  renderIntoContainer(<DraftEditorTextNode>{TEST_B}</DraftEditorTextNode>);
 
-    // Sanity check that updating is performed when appropriate.
-    renderIntoContainer(<DraftEditorTextNode>{TEST_B}</DraftEditorTextNode>);
+  expect(stub.render.calls.count()).toMatchSnapshot();
+});
 
-    expect(stub.render.calls.count()).toBe(1);
-  });
+test('must skip updates if text already matches DOM, IE', () => {
+  initializeAsIE();
+  const stub = renderIntoContainer(
+    <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>,
+  );
 
-  it('must skip updates if text already matches DOM, IE', function() {
-    initializeAsIE();
-    var stub = renderIntoContainer(
-      <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>,
-    );
+  spyOn(stub, 'render').and.callThrough();
 
-    spyOn(stub, 'render').and.callThrough();
+  renderIntoContainer(<DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>);
 
-    renderIntoContainer(<DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>);
+  expect(stub.render.calls.count()).toMatchSnapshot();
 
-    expect(stub.render.calls.count()).toBe(0);
+  // Sanity check that updating is performed when appropriate.
+  renderIntoContainer(<DraftEditorTextNode>{TEST_B}</DraftEditorTextNode>);
 
-    // Sanity check that updating is performed when appropriate.
-    renderIntoContainer(<DraftEditorTextNode>{TEST_B}</DraftEditorTextNode>);
+  expect(stub.render.calls.count()).toMatchSnapshot();
+});
 
-    expect(stub.render.calls.count()).toBe(1);
-  });
+test('must update from non-empty to empty, non-IE', () => {
+  initializeAsNonIE();
+  const stub = renderIntoContainer(
+    <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>,
+  );
 
-  it('must update from non-empty to empty, non-IE', function() {
-    initializeAsNonIE();
-    var stub = renderIntoContainer(
-      <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>,
-    );
+  renderIntoContainer(<DraftEditorTextNode>{''}</DraftEditorTextNode>);
 
-    renderIntoContainer(<DraftEditorTextNode>{''}</DraftEditorTextNode>);
+  expect(ReactDOM.findDOMNode(stub)).toMatchSnapshot();
+});
 
-    expect(ReactDOM.findDOMNode(stub).tagName).toBe('BR');
-  });
+test('must update from non-empty to empty, IE', () => {
+  initializeAsIE();
+  const stub = renderIntoContainer(
+    <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>,
+  );
 
-  it('must update from non-empty to empty, IE', function() {
-    initializeAsIE();
-    var stub = renderIntoContainer(
-      <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>,
-    );
+  renderIntoContainer(<DraftEditorTextNode>{''}</DraftEditorTextNode>);
 
-    renderIntoContainer(<DraftEditorTextNode>{''}</DraftEditorTextNode>);
+  expect(ReactDOM.findDOMNode(stub)).toMatchSnapshot();
+});
 
-    expectPopulatedSpan(stub, BLOCK_DELIMITER_CHAR);
-  });
+test('must render properly into a parent DOM node', () => {
+  initializeAsNonIE();
 
-  it('must render properly into a parent DOM node', function() {
-    initializeAsNonIE();
-    renderIntoContainer(
-      <div>
-        <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>
-      </div>,
-    );
-  });
+  const stub = renderIntoContainer(
+    <div>
+      <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>
+    </div>,
+  );
 
-  it('must force unchanged text back into the DOM', function() {
-    initializeAsNonIE();
-    var stub = renderIntoContainer(
-      <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>,
-    );
+  expect(ReactDOM.findDOMNode(stub)).toMatchSnapshot();
+});
 
-    ReactDOM.findDOMNode(stub).textContent = TEST_B;
+test('must force unchanged text back into the DOM', () => {
+  initializeAsNonIE();
+  const stub = renderIntoContainer(
+    <DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>,
+  );
 
-    renderIntoContainer(<DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>);
+  ReactDOM.findDOMNode(stub).textContent = TEST_B;
 
-    expect(ReactDOM.findDOMNode(stub).textContent).toBe(TEST_A);
-  });
+  renderIntoContainer(<DraftEditorTextNode>{TEST_A}</DraftEditorTextNode>);
+
+  expect(ReactDOM.findDOMNode(stub)).toMatchSnapshot();
 });

--- a/src/component/contents/__tests__/__snapshots__/DraftEditorBlock.react-test.js.snap
+++ b/src/component/contents/__tests__/__snapshots__/DraftEditorBlock.react-test.js.snap
@@ -1,0 +1,170 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must allow update when \`block\` has changed 1`] = `1`;
+
+exports[`must allow update when \`block\` has changed 2`] = `true`;
+
+exports[`must allow update when \`block\` has changed 3`] = `true`;
+
+exports[`must allow update when \`block\` has changed 4`] = `2`;
+
+exports[`must allow update when \`direction\` has changed 1`] = `1`;
+
+exports[`must allow update when \`direction\` has changed 2`] = `true`;
+
+exports[`must allow update when \`direction\` has changed 3`] = `2`;
+
+exports[`must allow update when \`tree\` has changed 1`] = `1`;
+
+exports[`must allow update when \`tree\` has changed 2`] = `true`;
+
+exports[`must allow update when \`tree\` has changed 3`] = `3`;
+
+exports[`must allow update when forcing selection 1`] = `1`;
+
+exports[`must allow update when forcing selection 2`] = `2`;
+
+exports[`must not scroll the window if unnecessary 1`] = `0`;
+
+exports[`must reject update if conditions are not met 1`] = `1`;
+
+exports[`must reject update if conditions are not met 2`] = `1`;
+
+exports[`must reject update if selection is not on an edge 1`] = `1`;
+
+exports[`must reject update if selection is not on an edge 2`] = `1`;
+
+exports[`must render a leaf node 1`] = `true`;
+
+exports[`must render a leaf node 2`] = `true`;
+
+exports[`must render a leaf node 3`] = `true`;
+
+exports[`must render a leaf node 4`] = `true`;
+
+exports[`must render a leaf node 5`] = `true`;
+
+exports[`must render a leaf node 6`] = `
+<div
+  class="public-DraftStyleDefault-block public-DraftStyleDefault-ltr"
+  data-reactroot=""
+>
+  <span />
+</div>
+`;
+
+exports[`must render multiple leaf nodes 1`] = `true`;
+
+exports[`must render multiple leaf nodes 2`] = `true`;
+
+exports[`must render multiple leaf nodes 3`] = `true`;
+
+exports[`must render multiple leaf nodes 4`] = `true`;
+
+exports[`must render multiple leaf nodes 5`] = `true`;
+
+exports[`must render multiple leaf nodes 6`] = `true`;
+
+exports[`must render multiple leaf nodes 7`] = `true`;
+
+exports[`must render multiple leaf nodes 8`] = `true`;
+
+exports[`must render multiple leaf nodes 9`] = `true`;
+
+exports[`must render multiple leaf nodes 10`] = `true`;
+
+exports[`must render multiple leaf nodes 11`] = `
+<div
+  class="public-DraftStyleDefault-block public-DraftStyleDefault-ltr"
+  data-reactroot=""
+>
+  <span />
+  <span />
+</div>
+`;
+
+exports[`must scroll the window if needed 1`] = `
+Array [
+  Array [
+    0,
+    26,
+  ],
+]
+`;
+
+exports[`must split apart styled spans 1`] = `2`;
+
+exports[`must split apart styled spans 2`] = `true`;
+
+exports[`must split apart styled spans 3`] = `true`;
+
+exports[`must split apart styled spans 4`] = `true`;
+
+exports[`must split apart styled spans 5`] = `true`;
+
+exports[`must split apart styled spans 6`] = `
+<div
+  class="public-DraftStyleDefault-block public-DraftStyleDefault-ltr"
+  data-reactroot=""
+>
+  <span />
+  <span />
+</div>
+`;
+
+exports[`must split apart two decorated and undecorated 1`] = `2`;
+
+exports[`must split apart two decorated and undecorated 2`] = `
+<div
+  class="public-DraftStyleDefault-block public-DraftStyleDefault-ltr"
+  data-reactroot=""
+>
+  <span>
+    <span />
+  </span>
+  <span />
+</div>
+`;
+
+exports[`must split apart two decorators 1`] = `2`;
+
+exports[`must split apart two decorators 2`] = `
+<div
+  class="public-DraftStyleDefault-block public-DraftStyleDefault-ltr"
+  data-reactroot=""
+>
+  <span>
+    <span />
+  </span>
+  <span>
+    <span />
+  </span>
+</div>
+`;
+
+exports[`must split styled spans apart within decorator 1`] = `3`;
+
+exports[`must split styled spans apart within decorator 2`] = `true`;
+
+exports[`must split styled spans apart within decorator 3`] = `true`;
+
+exports[`must split styled spans apart within decorator 4`] = `true`;
+
+exports[`must split styled spans apart within decorator 5`] = `true`;
+
+exports[`must split styled spans apart within decorator 6`] = `true`;
+
+exports[`must split styled spans apart within decorator 7`] = `true`;
+
+exports[`must split styled spans apart within decorator 8`] = `
+<div
+  class="public-DraftStyleDefault-block public-DraftStyleDefault-ltr"
+  data-reactroot=""
+>
+  <span>
+    <span />
+    <span />
+  </span>
+  <span />
+</div>
+`;

--- a/src/component/contents/__tests__/__snapshots__/DraftEditorBlock.react-test.js.snap
+++ b/src/component/contents/__tests__/__snapshots__/DraftEditorBlock.react-test.js.snap
@@ -24,7 +24,7 @@ exports[`must allow update when forcing selection 1`] = `1`;
 
 exports[`must allow update when forcing selection 2`] = `2`;
 
-exports[`must not scroll the window if unnecessary 1`] = `0`;
+exports[`must not scroll the window if unnecessary 1`] = `Array []`;
 
 exports[`must reject update if conditions are not met 1`] = `1`;
 

--- a/src/component/contents/__tests__/__snapshots__/DraftEditorContent.react-test.js.snap
+++ b/src/component/contents/__tests__/__snapshots__/DraftEditorContent.react-test.js.snap
@@ -1,0 +1,64 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`defaults to "unstyled" block type for unknown block types 1`] = `
+<div
+  class="container-root"
+  data-reactroot=""
+>
+  <div>
+    <button>
+      CenterAlign
+    </button>
+  </div>
+  <div
+    class="DraftEditor-root"
+  >
+    <div
+      class="public-DraftEditorPlaceholder-root"
+    >
+      <div
+        class="public-DraftEditorPlaceholder-inner"
+        id="placeholder-key3"
+      >
+        Type away :)
+      </div>
+    </div>
+    <div
+      class="DraftEditor-editorContainer"
+    >
+      <div
+        aria-describedby="placeholder-key3"
+        class="notranslate public-DraftEditor-content"
+        contenteditable="true"
+        role="textbox"
+        spellcheck="false"
+        style="outline: none; white-space: pre-wrap; word-wrap: break-word;"
+      >
+        <div
+          data-contents="true"
+        >
+          <div
+            class=""
+            data-block="true"
+            data-editor="key3"
+            data-offset-key="key2-0-0"
+          >
+            <div
+              class="public-DraftStyleDefault-block public-DraftStyleDefault-ltr"
+              data-offset-key="key2-0-0"
+            >
+              <span
+                data-offset-key="key2-0-0"
+              >
+                <br
+                  data-text="true"
+                />
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/component/contents/__tests__/__snapshots__/DraftEditorTextNode-test.js.snap
+++ b/src/component/contents/__tests__/__snapshots__/DraftEditorTextNode-test.js.snap
@@ -1,0 +1,118 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must force unchanged text back into the DOM 1`] = `
+<span
+  data-reactroot=""
+  data-text="true"
+>
+  Hello
+</span>
+`;
+
+exports[`must initialize correctly with a string, IE 1`] = `
+<span
+  data-reactroot=""
+  data-text="true"
+>
+  Hello
+</span>
+`;
+
+exports[`must initialize correctly with a string, non-IE 1`] = `
+<span
+  data-reactroot=""
+  data-text="true"
+>
+  Hello
+</span>
+`;
+
+exports[`must initialize correctly with an empty string, IE 1`] = `
+<span
+  data-reactroot=""
+  data-text="true"
+>
+  
+
+</span>
+`;
+
+exports[`must initialize correctly with an empty string, non-IE 1`] = `
+<br
+  data-reactroot=""
+  data-text="true"
+/>
+`;
+
+exports[`must render properly into a parent DOM node 1`] = `
+<div
+  data-reactroot=""
+>
+  <span
+    data-text="true"
+  >
+    Hello
+  </span>
+</div>
+`;
+
+exports[`must skip updates if text already matches DOM, IE 1`] = `0`;
+
+exports[`must skip updates if text already matches DOM, IE 2`] = `1`;
+
+exports[`must skip updates if text already matches DOM, non-IE 1`] = `0`;
+
+exports[`must skip updates if text already matches DOM, non-IE 2`] = `1`;
+
+exports[`must update from empty to non-empty, IE 1`] = `
+<span
+  data-reactroot=""
+  data-text="true"
+>
+  Hello
+</span>
+`;
+
+exports[`must update from empty to non-empty, non-IE 1`] = `
+<span
+  data-reactroot=""
+  data-text="true"
+>
+  Hello
+</span>
+`;
+
+exports[`must update from non-empty to empty, IE 1`] = `
+<span
+  data-reactroot=""
+  data-text="true"
+>
+  
+
+</span>
+`;
+
+exports[`must update from non-empty to empty, non-IE 1`] = `
+<br
+  data-reactroot=""
+  data-text="true"
+/>
+`;
+
+exports[`must update from non-empty to non-empty, non-IE 1`] = `
+<span
+  data-reactroot=""
+  data-text="true"
+>
+  Hello World!
+</span>
+`;
+
+exports[`must update from non-empty to non-empty, non-IE 2`] = `
+<span
+  data-reactroot=""
+  data-text="true"
+>
+   World!
+</span>
+`;

--- a/src/component/selection/__tests__/__snapshots__/getDraftEditorSelection-test.js.snap
+++ b/src/component/selection/__tests__/__snapshots__/getDraftEditorSelection-test.js.snap
@@ -70,7 +70,7 @@ Object {
 }
 `;
 
-exports[`from start of one to end of other 1`] = `
+exports[`from start of one block to end of other block 1`] = `
 Object {
   "needsRecovery": true,
   "selectionState": Immutable.Record {
@@ -84,7 +84,7 @@ Object {
 }
 `;
 
-exports[`from start of one to start of another 1`] = `
+exports[`from start of one block to start of another 1`] = `
 Object {
   "needsRecovery": true,
   "selectionState": Immutable.Record {
@@ -98,7 +98,7 @@ Object {
 }
 `;
 
-exports[`goes from end of one to end of other 1`] = `
+exports[`goes from end of one to end of other block 1`] = `
 Object {
   "needsRecovery": true,
   "selectionState": Immutable.Record {
@@ -112,7 +112,7 @@ Object {
 }
 `;
 
-exports[`goes from start of one to end of other 1`] = `
+exports[`goes from start of one block to end of other block 1`] = `
 Object {
   "needsRecovery": true,
   "selectionState": Immutable.Record {
@@ -126,7 +126,7 @@ Object {
 }
 `;
 
-exports[`goes from start of one to start of other 1`] = `
+exports[`goes from start of one block to start of other 1`] = `
 Object {
   "needsRecovery": true,
   "selectionState": Immutable.Record {
@@ -140,7 +140,7 @@ Object {
 }
 `;
 
-exports[`goes from within one to within another 1`] = `
+exports[`goes from within one block to within another block 1`] = `
 Object {
   "needsRecovery": true,
   "selectionState": Immutable.Record {
@@ -574,7 +574,7 @@ Object {
 }
 `;
 
-exports[`starts within one text node and ends within another 1`] = `
+exports[`starts within one text node and ends within another block 1`] = `
 Object {
   "needsRecovery": false,
   "selectionState": Immutable.Record {

--- a/src/component/selection/__tests__/__snapshots__/getDraftEditorSelection-test.js.snap
+++ b/src/component/selection/__tests__/__snapshots__/getDraftEditorSelection-test.js.snap
@@ -1,0 +1,645 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`begins at text node zero, ends at end of block 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 0,
+    "focusKey": "a",
+    "focusOffset": 19,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`begins within text node, ends at end of block 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 5,
+    "focusKey": "a",
+    "focusOffset": 19,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`contains an entire leaf 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "c",
+    "anchorOffset": 0,
+    "focusKey": "c",
+    "focusOffset": 7,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`does the crazy stuff described above 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 0,
+    "focusKey": "c",
+    "focusOffset": 12,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`extends from head of one node to end of another 1`] = `
+Object {
+  "needsRecovery": false,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 0,
+    "focusKey": "b",
+    "focusOffset": 7,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`from start of one to end of other 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 0,
+    "focusKey": "c",
+    "focusOffset": 7,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`from start of one to start of another 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 0,
+    "focusKey": "c",
+    "focusOffset": 0,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`goes from end of one to end of other 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 19,
+    "focusKey": "c",
+    "focusOffset": 12,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`goes from start of one to end of other 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 0,
+    "focusKey": "c",
+    "focusOffset": 12,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`goes from start of one to start of other 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 0,
+    "focusKey": "c",
+    "focusOffset": 0,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`goes from within one to within another 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 19,
+    "focusKey": "c",
+    "focusOffset": 7,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`is a reversed selection across multiple text nodes 1`] = `
+Object {
+  "needsRecovery": false,
+  "selectionState": Immutable.Record {
+    "anchorKey": "c",
+    "anchorOffset": 4,
+    "focusKey": "a",
+    "focusOffset": 6,
+    "isBackward": true,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`is a reversed text-to-leaf selection 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "c",
+    "anchorOffset": 0,
+    "focusKey": "a",
+    "focusOffset": 4,
+    "isBackward": true,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`is a reversed text-to-leaf-child selection 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "c",
+    "anchorOffset": 0,
+    "focusKey": "a",
+    "focusOffset": 4,
+    "isBackward": true,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`is collapsed at end at single block 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 19,
+    "focusKey": "a",
+    "focusOffset": 19,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`is collapsed at end of single span 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 10,
+    "focusKey": "a",
+    "focusOffset": 10,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`is collapsed at end with full selection 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "c",
+    "anchorOffset": 12,
+    "focusKey": "c",
+    "focusOffset": 12,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`is collapsed at start at single block 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 0,
+    "focusKey": "a",
+    "focusOffset": 0,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`is collapsed at start of single span 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 0,
+    "focusKey": "a",
+    "focusOffset": 0,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`is collapsed at start with full selection 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 0,
+    "focusKey": "a",
+    "focusOffset": 0,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`is collapsed at the end of a child 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 19,
+    "focusKey": "a",
+    "focusOffset": 19,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`is collapsed at the start of the contents 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 0,
+    "focusKey": "a",
+    "focusOffset": 0,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`is completely selected 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 0,
+    "focusKey": "c",
+    "focusOffset": 12,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`is contains multiple children 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 0,
+    "focusKey": "c",
+    "focusOffset": 12,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`is entirely selected 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 0,
+    "focusKey": "a",
+    "focusOffset": 19,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`is reversed from above 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "c",
+    "anchorOffset": 12,
+    "focusKey": "a",
+    "focusOffset": 0,
+    "isBackward": true,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`is reversed from the first case 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 19,
+    "focusKey": "a",
+    "focusOffset": 0,
+    "isBackward": true,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`is reversed on entire leaf 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "c",
+    "anchorOffset": 7,
+    "focusKey": "c",
+    "focusOffset": 0,
+    "isBackward": true,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`is the same as above but reversed 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "c",
+    "anchorOffset": 7,
+    "focusKey": "a",
+    "focusOffset": 19,
+    "isBackward": true,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`must find offsets for non-collapsed selection 1`] = `
+Object {
+  "needsRecovery": false,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 1,
+    "focusKey": "a",
+    "focusOffset": 6,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`must find offsets for reversed selection 1`] = `
+Object {
+  "needsRecovery": false,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 6,
+    "focusKey": "a",
+    "focusOffset": 1,
+    "isBackward": true,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`must find offsets for selection on entire text node 1`] = `
+Object {
+  "needsRecovery": false,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 0,
+    "focusKey": "a",
+    "focusOffset": 10,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`must find offsets when collapsed at end 1`] = `
+Object {
+  "needsRecovery": false,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 10,
+    "focusKey": "a",
+    "focusOffset": 10,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`must find offsets when collapsed at start 1`] = `
+Object {
+  "needsRecovery": false,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 0,
+    "focusKey": "a",
+    "focusOffset": 0,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`occupies a single child of the contents 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 0,
+    "focusKey": "a",
+    "focusOffset": 19,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`reversed leaf to leaf 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "c",
+    "anchorOffset": 7,
+    "focusKey": "a",
+    "focusOffset": 0,
+    "isBackward": true,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`starts at head of one node and ends at head of another 1`] = `
+Object {
+  "needsRecovery": false,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 0,
+    "focusKey": "c",
+    "focusOffset": 0,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`starts at head of text node, ends at end of leaf child 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 0,
+    "focusKey": "c",
+    "focusOffset": 7,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`starts at head of text node, ends at end of leaf span 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 0,
+    "focusKey": "c",
+    "focusOffset": 7,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`starts at head of text node, ends at head of leaf child 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 0,
+    "focusKey": "c",
+    "focusOffset": 0,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`starts at head of text node, ends at head of leaf span 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 0,
+    "focusKey": "c",
+    "focusOffset": 0,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`starts within one text node and ends within another 1`] = `
+Object {
+  "needsRecovery": false,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 4,
+    "focusKey": "c",
+    "focusOffset": 6,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`starts within text node, ends at end of leaf child 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 4,
+    "focusKey": "c",
+    "focusOffset": 7,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`starts within text node, ends at end of leaf span 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 4,
+    "focusKey": "c",
+    "focusOffset": 7,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`starts within text node, ends at start of leaf child 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 4,
+    "focusKey": "c",
+    "focusOffset": 0,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;
+
+exports[`starts within text node, ends at start of leaf span 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 4,
+    "focusKey": "c",
+    "focusOffset": 0,
+    "isBackward": false,
+    "hasFocus": false,
+  },
+}
+`;

--- a/src/component/selection/__tests__/getDraftEditorSelection-test.js
+++ b/src/component/selection/__tests__/getDraftEditorSelection-test.js
@@ -14,16 +14,129 @@
 
 jest.disableAutomock();
 
-var CharacterMetadata = require('CharacterMetadata');
-var ContentBlock = require('ContentBlock');
-var ContentState = require('ContentState');
-var EditorState = require('EditorState');
-var Immutable = require('immutable');
-var {BOLD} = require('SampleDraftInlineStyle');
-var SelectionState = require('SelectionState');
-var {EMPTY} = CharacterMetadata;
+const CharacterMetadata = require('CharacterMetadata');
+const ContentBlock = require('ContentBlock');
+const ContentState = require('ContentState');
+const EditorState = require('EditorState');
+const Immutable = require('immutable');
+const {BOLD} = require('SampleDraftInlineStyle');
+const {EMPTY} = CharacterMetadata;
 
-var getDraftEditorSelection = require('getDraftEditorSelection');
+const getDraftEditorSelection = require('getDraftEditorSelection');
+
+let editorState;
+let root;
+let contents;
+let blocks;
+let decorators;
+let leafs;
+let leafChildren;
+let textNodes;
+
+const assertGetDraftEditorSelection = getSelectionReturnValue => {
+  window.getSelection.mockReturnValueOnce(getSelectionReturnValue);
+  const selection = getDraftEditorSelection(editorState, root);
+  expect(selection).toMatchSnapshot();
+};
+
+beforeEach(() => {
+  window.getSelection = jest.fn();
+  root = document.createElement('div');
+  contents = document.createElement('div');
+  contents.setAttribute('data-contents', 'true');
+  root.appendChild(contents);
+
+  const text = [
+    'Washington',
+    'Jefferson',
+    'Lincoln',
+    'Roosevelt',
+    'Kennedy',
+    'Obama',
+  ];
+
+  const textA = text[0] + text[1];
+  const textB = text[2] + text[3];
+  const textC = text[4] + text[5];
+
+  const boldChar = CharacterMetadata.create({style: BOLD});
+  const aChars = Immutable.List(
+    Immutable.Repeat(EMPTY, text[0].length).concat(
+      Immutable.Repeat(boldChar, text[1].length),
+    ),
+  );
+  const bChars = Immutable.List(
+    Immutable.Repeat(EMPTY, text[2].length).concat(
+      Immutable.Repeat(boldChar, text[3].length),
+    ),
+  );
+  const cChars = Immutable.List(
+    Immutable.Repeat(EMPTY, text[4].length).concat(
+      Immutable.Repeat(boldChar, text[5].length),
+    ),
+  );
+
+  const contentBlocks = [
+    new ContentBlock({
+      key: 'a',
+      type: 'unstyled',
+      text: textA,
+      characterList: aChars,
+    }),
+    new ContentBlock({
+      key: 'b',
+      type: 'unstyled',
+      text: textB,
+      characterList: bChars,
+    }),
+    new ContentBlock({
+      key: 'c',
+      type: 'unstyled',
+      text: textC,
+      characterList: cChars,
+    }),
+  ];
+
+  const contentState = ContentState.createFromBlockArray(contentBlocks);
+  editorState = EditorState.createWithContent(contentState);
+
+  textNodes = text.map(function(text) {
+    return document.createTextNode(text);
+  });
+  leafChildren = textNodes.map(function(textNode) {
+    const span = document.createElement('span');
+    span.appendChild(textNode);
+    return span;
+  });
+  leafs = ['a-0-0', 'a-0-1', 'b-0-0', 'b-0-1', 'c-0-0', 'c-0-1'].map(function(
+    blockKey,
+    ii,
+  ) {
+    const span = document.createElement('span');
+    span.setAttribute('data-offset-key', '' + blockKey);
+    span.appendChild(leafChildren[ii]);
+    return span;
+  });
+  decorators = ['a-0-0', 'b-0-0', 'c-0-0'].map(function(decoratorKey, ii) {
+    const span = document.createElement('span');
+    // Decorators may not have `data-offset-key` attribute
+    span.setAttribute('decorator-key', '' + decoratorKey);
+    span.appendChild(leafs[ii * 2]);
+    span.appendChild(leafs[ii * 2 + 1]);
+    return span;
+  });
+  blocks = ['a-0-0', 'b-0-0', 'c-0-0'].map(function(blockKey, ii) {
+    const blockElement = document.createElement('div');
+    blockElement.setAttribute('data-offset-key', '' + blockKey);
+    blockElement.appendChild(decorators[ii]);
+    return blockElement;
+  });
+  blocks.forEach(function(blockElem) {
+    contents.appendChild(blockElem);
+  });
+
+  document.selection = null;
+});
 
 /**
  * Test possible selection states for the text editor. This is based on
@@ -33,1227 +146,506 @@ var getDraftEditorSelection = require('getDraftEditorSelection');
  *
  * Welcome to the jungle.
  */
-describe('getDraftEditorSelection', function() {
-  var editorState;
-  var root;
-  var contents;
-  var blocks;
-  var decorators;
-  var leafs;
-  var leafChildren;
-  var textNodes;
-
-  beforeEach(function() {
-    window.getSelection = jest.fn();
-    root = document.createElement('div');
-    contents = document.createElement('div');
-    contents.setAttribute('data-contents', 'true');
-    root.appendChild(contents);
-
-    var text = [
-      'Washington',
-      'Jefferson',
-      'Lincoln',
-      'Roosevelt',
-      'Kennedy',
-      'Obama',
-    ];
-
-    var textA = text[0] + text[1];
-    var textB = text[2] + text[3];
-    var textC = text[4] + text[5];
-
-    var boldChar = CharacterMetadata.create({style: BOLD});
-    var aChars = Immutable.List(
-      Immutable.Repeat(EMPTY, text[0].length).concat(
-        Immutable.Repeat(boldChar, text[1].length),
-      ),
-    );
-    var bChars = Immutable.List(
-      Immutable.Repeat(EMPTY, text[2].length).concat(
-        Immutable.Repeat(boldChar, text[3].length),
-      ),
-    );
-    var cChars = Immutable.List(
-      Immutable.Repeat(EMPTY, text[4].length).concat(
-        Immutable.Repeat(boldChar, text[5].length),
-      ),
-    );
-
-    var contentBlocks = [
-      new ContentBlock({
-        key: 'a',
-        type: 'unstyled',
-        text: textA,
-        characterList: aChars,
-      }),
-      new ContentBlock({
-        key: 'b',
-        type: 'unstyled',
-        text: textB,
-        characterList: bChars,
-      }),
-      new ContentBlock({
-        key: 'c',
-        type: 'unstyled',
-        text: textC,
-        characterList: cChars,
-      }),
-    ];
-
-    var contentState = ContentState.createFromBlockArray(contentBlocks);
-    editorState = EditorState.createWithContent(contentState);
-
-    textNodes = text.map(function(text) {
-      return document.createTextNode(text);
-    });
-    leafChildren = textNodes.map(function(textNode) {
-      var span = document.createElement('span');
-      span.appendChild(textNode);
-      return span;
-    });
-    leafs = ['a-0-0', 'a-0-1', 'b-0-0', 'b-0-1', 'c-0-0', 'c-0-1'].map(function(
-      blockKey,
-      ii,
-    ) {
-      var span = document.createElement('span');
-      span.setAttribute('data-offset-key', '' + blockKey);
-      span.appendChild(leafChildren[ii]);
-      return span;
-    });
-    decorators = ['a-0-0', 'b-0-0', 'c-0-0'].map(function(decoratorKey, ii) {
-      var span = document.createElement('span');
-      // Decorators may not have `data-offset-key` attribute
-      span.setAttribute('decorator-key', '' + decoratorKey);
-      span.appendChild(leafs[ii * 2]);
-      span.appendChild(leafs[ii * 2 + 1]);
-      return span;
-    });
-    blocks = ['a-0-0', 'b-0-0', 'c-0-0'].map(function(blockKey, ii) {
-      var blockElement = document.createElement('div');
-      blockElement.setAttribute('data-offset-key', '' + blockKey);
-      blockElement.appendChild(decorators[ii]);
-      return blockElement;
-    });
-    blocks.forEach(function(blockElem) {
-      contents.appendChild(blockElem);
-    });
+test('must find offsets when collapsed at start', () => {
+  const textNode = textNodes[0];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNode,
+    anchorOffset: 0,
+    focusNode: textNode,
+    focusOffset: 0,
   });
-
-  function assertEquals(result, assert) {
-    var resultSelection = result.selectionState;
-    var resultRecovery = result.needsRecovery;
-    var assertSelection = assert.selectionState;
-    var assertRecovery = assert.needsRecovery;
-    expect(resultSelection.getAnchorKey()).toBe(assertSelection.getAnchorKey());
-    expect(resultSelection.getAnchorOffset()).toBe(
-      assertSelection.getAnchorOffset(),
-    );
-    expect(resultSelection.getFocusKey()).toBe(assertSelection.getFocusKey());
-    expect(resultSelection.getFocusOffset()).toBe(
-      assertSelection.getFocusOffset(),
-    );
-    expect(resultSelection.getIsBackward()).toBe(
-      assertSelection.getIsBackward(),
-    );
-    expect(resultRecovery).toBe(assertRecovery);
-  }
-
-  describe('Modern Selection', function() {
-    beforeEach(function() {
-      document.selection = null;
-    });
-
-    describe('Selection is entirely within a single text node', function() {
-      it('must find offsets when collapsed at start', function() {
-        var textNode = textNodes[0];
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: textNode,
-          anchorOffset: 0,
-          focusNode: textNode,
-          focusOffset: 0,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: 0,
-            focusKey: 'a',
-            focusOffset: 0,
-            isBackward: false,
-          }),
-          needsRecovery: false,
-        });
-      });
-
-      it('must find offsets when collapsed at end', function() {
-        var textNode = textNodes[0];
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: textNode,
-          anchorOffset: textNode.length,
-          focusNode: textNode,
-          focusOffset: textNode.length,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: textNode.length,
-            focusKey: 'a',
-            focusOffset: textNode.length,
-            isBackward: false,
-          }),
-          needsRecovery: false,
-        });
-      });
-
-      it('must find offsets for non-collapsed selection', function() {
-        var textNode = textNodes[0];
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: textNode,
-          anchorOffset: 1,
-          focusNode: textNode,
-          focusOffset: 6,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: 1,
-            focusKey: 'a',
-            focusOffset: 6,
-            isBackward: false,
-          }),
-          needsRecovery: false,
-        });
-      });
-
-      it('must find offsets for reversed selection', function() {
-        var textNode = textNodes[0];
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: textNode,
-          anchorOffset: 6,
-          focusNode: textNode,
-          focusOffset: 1,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: 6,
-            focusKey: 'a',
-            focusOffset: 1,
-            isBackward: true,
-          }),
-          needsRecovery: false,
-        });
-      });
-
-      it('must find offsets for selection on entire text node', function() {
-        var textNode = textNodes[0];
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: textNode,
-          anchorOffset: 0,
-          focusNode: textNode,
-          focusOffset: textNode.length,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: 0,
-            focusKey: 'a',
-            focusOffset: textNode.length,
-            isBackward: false,
-          }),
-          needsRecovery: false,
-        });
-      });
-    });
-
-    describe('Selection spans multiple text nodes', function() {
-      it('starts at head of one node and ends at head of another', function() {
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: textNodes[0],
-          anchorOffset: 0,
-          focusNode: textNodes[4],
-          focusOffset: 0,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: 0,
-            focusKey: 'c',
-            focusOffset: 0,
-            isBackward: false,
-          }),
-          needsRecovery: false,
-        });
-      });
-
-      it('extends from head of one node to end of another', function() {
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: textNodes[0],
-          anchorOffset: 0,
-          focusNode: textNodes[2],
-          focusOffset: textNodes[2].textContent.length,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: 0,
-            focusKey: 'b',
-            focusOffset: textNodes[2].textContent.length,
-            isBackward: false,
-          }),
-          needsRecovery: false,
-        });
-      });
-
-      it('starts within one text node and ends within another', function() {
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: textNodes[0],
-          anchorOffset: 4,
-          focusNode: textNodes[4],
-          focusOffset: 6,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: 4,
-            focusKey: 'c',
-            focusOffset: 6,
-            isBackward: false,
-          }),
-          needsRecovery: false,
-        });
-      });
-
-      it('is a reversed selection across multiple text nodes', function() {
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: textNodes[4],
-          anchorOffset: 4,
-          focusNode: textNodes[0],
-          focusOffset: 6,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'c',
-            anchorOffset: 4,
-            focusKey: 'a',
-            focusOffset: 6,
-            isBackward: true,
-          }),
-          needsRecovery: false,
-        });
-      });
-    });
-
-    // I'm not even certain this is possible, but let's handle it anyway.
-    describe('One end is a text node, the other is a leaf child', function() {
-      it('starts at head of text node, ends at head of leaf child', function() {
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: textNodes[0],
-          anchorOffset: 0,
-          focusNode: leafChildren[4],
-          focusOffset: 0,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: 0,
-            focusKey: 'c',
-            focusOffset: 0,
-            isBackward: false,
-          }),
-          needsRecovery: true,
-        });
-      });
-
-      it('starts at head of text node, ends at end of leaf child', function() {
-        var leaf = leafChildren[4];
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: textNodes[0],
-          anchorOffset: 0,
-          focusNode: leaf,
-          focusOffset: leaf.childNodes.length,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: 0,
-            focusKey: 'c',
-            focusOffset: leaf.textContent.length,
-            isBackward: false,
-          }),
-          needsRecovery: true,
-        });
-      });
-
-      it('starts within text node, ends at start of leaf child', function() {
-        var leaf = leafChildren[4];
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: textNodes[0],
-          anchorOffset: 4,
-          focusNode: leaf,
-          focusOffset: 0,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: 4,
-            focusKey: 'c',
-            focusOffset: 0,
-            isBackward: false,
-          }),
-          needsRecovery: true,
-        });
-      });
-
-      it('starts within text node, ends at end of leaf child', function() {
-        var leaf = leafChildren[4];
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: textNodes[0],
-          anchorOffset: 4,
-          focusNode: leaf,
-          focusOffset: leaf.childNodes.length,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: 4,
-            focusKey: 'c',
-            focusOffset: leaf.textContent.length,
-            isBackward: false,
-          }),
-          needsRecovery: true,
-        });
-      });
-
-      it('is a reversed text-to-leaf-child selection', function() {
-        var leaf = leafChildren[4];
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: leaf,
-          anchorOffset: 0,
-          focusNode: textNodes[0],
-          focusOffset: 4,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'c',
-            anchorOffset: 0,
-            focusKey: 'a',
-            focusOffset: 4,
-            isBackward: true,
-          }),
-          needsRecovery: true,
-        });
-      });
-    });
-
-    describe('One end is a text node, the other is a leaf span', function() {
-      it('starts at head of text node, ends at head of leaf span', function() {
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: textNodes[0],
-          anchorOffset: 0,
-          focusNode: leafs[4],
-          focusOffset: 0,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: 0,
-            focusKey: 'c',
-            focusOffset: 0,
-            isBackward: false,
-          }),
-          needsRecovery: true,
-        });
-      });
-
-      it('starts at head of text node, ends at end of leaf span', function() {
-        var leaf = leafs[4];
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: textNodes[0],
-          anchorOffset: 0,
-          focusNode: leaf,
-          focusOffset: leaf.childNodes.length,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: 0,
-            focusKey: 'c',
-            focusOffset: leaf.textContent.length,
-            isBackward: false,
-          }),
-          needsRecovery: true,
-        });
-      });
-
-      it('starts within text node, ends at start of leaf span', function() {
-        var leaf = leafs[4];
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: textNodes[0],
-          anchorOffset: 4,
-          focusNode: leaf,
-          focusOffset: 0,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: 4,
-            focusKey: 'c',
-            focusOffset: 0,
-            isBackward: false,
-          }),
-          needsRecovery: true,
-        });
-      });
-
-      it('starts within text node, ends at end of leaf span', function() {
-        var leaf = leafs[4];
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: textNodes[0],
-          anchorOffset: 4,
-          focusNode: leaf,
-          focusOffset: leaf.childNodes.length,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: 4,
-            focusKey: 'c',
-            focusOffset: leaf.textContent.length,
-            isBackward: false,
-          }),
-          needsRecovery: true,
-        });
-      });
-
-      it('is a reversed text-to-leaf selection', function() {
-        var leaf = leafs[4];
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: leaf,
-          anchorOffset: 0,
-          focusNode: textNodes[0],
-          focusOffset: 4,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'c',
-            anchorOffset: 0,
-            focusKey: 'a',
-            focusOffset: 4,
-            isBackward: true,
-          }),
-          needsRecovery: true,
-        });
-      });
-    });
-
-    describe('A single leaf span is selected', function() {
-      it('is collapsed at start', function() {
-        var leaf = leafs[0];
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: leaf,
-          anchorOffset: 0,
-          focusNode: leaf,
-          focusOffset: 0,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: 0,
-            focusKey: 'a',
-            focusOffset: 0,
-            isBackward: false,
-          }),
-          needsRecovery: true,
-        });
-      });
-
-      it('is collapsed at end', function() {
-        var leaf = leafs[0];
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: leaf,
-          anchorOffset: leaf.childNodes.length,
-          focusNode: leaf,
-          focusOffset: leaf.childNodes.length,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: leaf.textContent.length,
-            focusKey: 'a',
-            focusOffset: leaf.textContent.length,
-            isBackward: false,
-          }),
-          needsRecovery: true,
-        });
-      });
-
-      it('contains an entire leaf', function() {
-        var leaf = leafs[4];
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: leaf,
-          anchorOffset: 0,
-          focusNode: leaf,
-          focusOffset: leaf.childNodes.length,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'c',
-            anchorOffset: 0,
-            focusKey: 'c',
-            focusOffset: leaf.textContent.length,
-            isBackward: false,
-          }),
-          needsRecovery: true,
-        });
-      });
-
-      it('is reversed on entire leaf', function() {
-        var leaf = leafs[4];
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: leaf,
-          anchorOffset: leaf.childNodes.length,
-          focusNode: leaf,
-          focusOffset: 0,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'c',
-            anchorOffset: leaf.textContent.length,
-            focusKey: 'c',
-            focusOffset: 0,
-            isBackward: true,
-          }),
-          needsRecovery: true,
-        });
-      });
-    });
-
-    describe('Multiple leaf spans are selected', function() {
-      it('from start of one to start of another', function() {
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: leafs[0],
-          anchorOffset: 0,
-          focusNode: leafs[4],
-          focusOffset: 0,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: 0,
-            focusKey: 'c',
-            focusOffset: 0,
-            isBackward: false,
-          }),
-          needsRecovery: true,
-        });
-      });
-
-      it('from start of one to end of other', function() {
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: leafs[0],
-          anchorOffset: 0,
-          focusNode: leafs[4],
-          focusOffset: leafs[4].childNodes.length,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: 0,
-            focusKey: 'c',
-            focusOffset: leafs[4].textContent.length,
-            isBackward: false,
-          }),
-          needsRecovery: true,
-        });
-      });
-
-      it('reversed leaf to leaf', function() {
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: leafs[4],
-          anchorOffset: leafs[4].childNodes.length,
-          focusNode: leafs[0],
-          focusOffset: 0,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'c',
-            anchorOffset: leafs[4].textContent.length,
-            focusKey: 'a',
-            focusOffset: 0,
-            isBackward: true,
-          }),
-          needsRecovery: true,
-        });
-      });
-    });
-
-    describe('A single block is selected', function() {
-      it('is collapsed at start', function() {
-        var block = blocks[0];
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: block,
-          anchorOffset: 0,
-          focusNode: block,
-          focusOffset: 0,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: 0,
-            focusKey: 'a',
-            focusOffset: 0,
-            isBackward: false,
-          }),
-          needsRecovery: true,
-        });
-      });
-
-      it('is collapsed at end', function() {
-        var block = blocks[0];
-        var decorators = block.childNodes;
-        var leafs = decorators[0].childNodes;
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: block,
-          anchorOffset: decorators.length,
-          focusNode: block,
-          focusOffset: decorators.length,
-        });
-
-        var textLength = 0;
-        for (var ii = 0; ii < leafs.length; ii++) {
-          textLength += leafs[ii].textContent.length;
-        }
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: textLength,
-            focusKey: 'a',
-            focusOffset: textLength,
-            isBackward: false,
-          }),
-          needsRecovery: true,
-        });
-      });
-
-      it('is entirely selected', function() {
-        var block = blocks[0];
-        var decorators = block.childNodes;
-        var leafs = decorators[0].childNodes;
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: block,
-          anchorOffset: 0,
-          focusNode: block,
-          focusOffset: decorators.length,
-        });
-
-        var textLength = 0;
-        for (var ii = 0; ii < leafs.length; ii++) {
-          textLength += leafs[ii].textContent.length;
-        }
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: 0,
-            focusKey: 'a',
-            focusOffset: textLength,
-            isBackward: false,
-          }),
-          needsRecovery: true,
-        });
-      });
-    });
-
-    /**
-     * FF: Triple-clicking a block leads to an entire block being selected,
-     * with the first text node as the anchor (0 offset) and the block element
-     * as the focus (childNodes.length offset)
-     */
-    describe('Selection with text node and block', function() {
-      it('begins at text node zero, ends at end of block', function() {
-        var textNode = textNodes[0];
-        var block = blocks[0];
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: textNode,
-          anchorOffset: 0,
-          focusNode: block,
-          focusOffset: block.childNodes.length,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: 0,
-            focusKey: 'a',
-            focusOffset: block.textContent.length,
-            isBackward: false,
-          }),
-          needsRecovery: true,
-        });
-      });
-
-      // No idea if this is possible.
-      it('begins within text node, ends at end of block', function() {
-        var textNode = textNodes[0];
-        var block = blocks[0];
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: textNode,
-          anchorOffset: 5,
-          focusNode: block,
-          focusOffset: block.childNodes.length,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: 5,
-            focusKey: 'a',
-            focusOffset: block.textContent.length,
-            isBackward: false,
-          }),
-          needsRecovery: true,
-        });
-      });
-
-      // No idea if this is possible.
-      it('is reversed from the first case', function() {
-        var textNode = textNodes[0];
-        var block = blocks[0];
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: block,
-          anchorOffset: block.childNodes.length,
-          focusNode: textNode,
-          focusOffset: 0,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: block.textContent.length,
-            focusKey: 'a',
-            focusOffset: 0,
-            isBackward: true,
-          }),
-          needsRecovery: true,
-        });
-      });
-    });
-
-    describe('Multiple blocks are selected', function() {
-      it('goes from start of one to end of other', function() {
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: blocks[0],
-          anchorOffset: 0,
-          focusNode: blocks[2],
-          focusOffset: blocks[2].childNodes.length,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: 0,
-            focusKey: 'c',
-            focusOffset: blocks[2].textContent.length,
-            isBackward: false,
-          }),
-          needsRecovery: true,
-        });
-      });
-
-      it('goes from start of one to start of other', function() {
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: blocks[0],
-          anchorOffset: 0,
-          focusNode: blocks[2],
-          focusOffset: 0,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: 0,
-            focusKey: 'c',
-            focusOffset: 0,
-            isBackward: false,
-          }),
-          needsRecovery: true,
-        });
-      });
-
-      it('goes from end of one to end of other', function() {
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: blocks[0],
-          anchorOffset: blocks[0].childNodes.length,
-          focusNode: blocks[2],
-          focusOffset: blocks[2].childNodes.length,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: blocks[0].textContent.length,
-            focusKey: 'c',
-            focusOffset: blocks[2].textContent.length,
-            isBackward: false,
-          }),
-          needsRecovery: true,
-        });
-      });
-
-      it('goes from within one to within another', function() {
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: blocks[0],
-          anchorOffset: 1,
-          focusNode: blocks[2].firstChild,
-          focusOffset: 1,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: blocks[0].textContent.length,
-            focusKey: 'c',
-            focusOffset: textNodes[4].textContent.length,
-            isBackward: false,
-          }),
-          needsRecovery: true,
-        });
-      });
-
-      it('is the same as above but reversed', function() {
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: blocks[2].firstChild,
-          anchorOffset: 1,
-          focusNode: blocks[0],
-          focusOffset: 1,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'c',
-            anchorOffset: textNodes[4].textContent.length,
-            focusKey: 'a',
-            focusOffset: blocks[0].textContent.length,
-            isBackward: true,
-          }),
-          needsRecovery: true,
-        });
-      });
-    });
-
-    describe('The content wrapper is selected', () => {
-      it('is collapsed at the start of the contents', () => {
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: contents,
-          anchorOffset: 0,
-          focusNode: contents,
-          focusOffset: 0,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: 0,
-            focusKey: 'a',
-            focusOffset: 0,
-            isBackward: false,
-          }),
-          needsRecovery: true,
-        });
-      });
-
-      it('occupies a single child of the contents', () => {
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: contents,
-          anchorOffset: 0,
-          focusNode: contents,
-          focusOffset: 1,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: 0,
-            focusKey: 'a',
-            focusOffset: blocks[0].textContent.length,
-            isBackward: false,
-          }),
-          needsRecovery: true,
-        });
-      });
-
-      it('is collapsed at the end of a child', () => {
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: contents,
-          anchorOffset: 1,
-          focusNode: contents,
-          focusOffset: 1,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: blocks[0].textContent.length,
-            focusKey: 'a',
-            focusOffset: blocks[0].textContent.length,
-            isBackward: false,
-          }),
-          needsRecovery: true,
-        });
-      });
-
-      it('is contains multiple children', () => {
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: contents,
-          anchorOffset: 0,
-          focusNode: contents,
-          focusOffset: 3,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: 0,
-            focusKey: 'c',
-            focusOffset: blocks[2].textContent.length,
-            isBackward: false,
-          }),
-          needsRecovery: true,
-        });
-      });
-    });
-
-    /**
-     * In some scenarios, the entire editor may be selected by command-A.
-     */
-    describe('The entire editor is selected.', function() {
-      it('is collapsed at start', function() {
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: root,
-          anchorOffset: 0,
-          focusNode: root,
-          focusOffset: 0,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: 0,
-            focusKey: 'a',
-            focusOffset: 0,
-            isBackward: false,
-          }),
-          needsRecovery: true,
-        });
-      });
-
-      it('is collapsed at end', function() {
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: root,
-          anchorOffset: root.childNodes.length,
-          focusNode: root,
-          focusOffset: root.childNodes.length,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'c',
-            anchorOffset: blocks[2].textContent.length,
-            focusKey: 'c',
-            focusOffset: blocks[2].textContent.length,
-            isBackward: false,
-          }),
-          needsRecovery: true,
-        });
-      });
-
-      it('is completely selected', function() {
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: root,
-          anchorOffset: 0,
-          focusNode: root,
-          focusOffset: root.childNodes.length,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: 0,
-            focusKey: 'c',
-            focusOffset: blocks[2].textContent.length,
-            isBackward: false,
-          }),
-          needsRecovery: true,
-        });
-      });
-
-      it('is reversed from above', function() {
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: root,
-          anchorOffset: root.childNodes.length,
-          focusNode: root,
-          focusOffset: 0,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'c',
-            anchorOffset: blocks[2].textContent.length,
-            focusKey: 'a',
-            focusOffset: 0,
-            isBackward: true,
-          }),
-          needsRecovery: true,
-        });
-      });
-    });
-
-    /**
-     * A selection possibility that defies logic. In IE11, triple clicking a
-     * block leads to the text node being selected as the anchor, and the
-     * **entire editor** being selected as the focus. Ludicrous.
-     */
-    describe('One end is text node, the other is the whole editor', function() {
-      it('does the crazy stuff described above', function() {
-        window.getSelection.mockReturnValueOnce({
-          rangeCount: 1,
-          anchorNode: textNodes[0],
-          anchorOffset: 0,
-          focusNode: root,
-          focusOffset: root.childNodes.length,
-        });
-
-        var selection = getDraftEditorSelection(editorState, root);
-        assertEquals(selection, {
-          selectionState: new SelectionState({
-            anchorKey: 'a',
-            anchorOffset: 0,
-            focusKey: 'c',
-            focusOffset: blocks[2].textContent.length,
-            isBackward: false,
-          }),
-          needsRecovery: true,
-        });
-      });
-    });
+});
+
+test('must find offsets when collapsed at end', () => {
+  const textNode = textNodes[0];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNode,
+    anchorOffset: textNode.length,
+    focusNode: textNode,
+    focusOffset: textNode.length,
+  });
+});
+
+test('must find offsets for non-collapsed selection', () => {
+  const textNode = textNodes[0];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNode,
+    anchorOffset: 1,
+    focusNode: textNode,
+    focusOffset: 6,
+  });
+});
+
+test('must find offsets for reversed selection', () => {
+  const textNode = textNodes[0];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNode,
+    anchorOffset: 6,
+    focusNode: textNode,
+    focusOffset: 1,
+  });
+});
+
+test('must find offsets for selection on entire text node', () => {
+  const textNode = textNodes[0];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNode,
+    anchorOffset: 0,
+    focusNode: textNode,
+    focusOffset: textNode.length,
+  });
+});
+
+test('starts at head of one node and ends at head of another', () => {
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNodes[0],
+    anchorOffset: 0,
+    focusNode: textNodes[4],
+    focusOffset: 0,
+  });
+});
+
+test('extends from head of one node to end of another', () => {
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNodes[0],
+    anchorOffset: 0,
+    focusNode: textNodes[2],
+    focusOffset: textNodes[2].textContent.length,
+  });
+});
+
+test('starts within one text node and ends within another', () => {
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNodes[0],
+    anchorOffset: 4,
+    focusNode: textNodes[4],
+    focusOffset: 6,
+  });
+});
+
+test('is a reversed selection across multiple text nodes', () => {
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNodes[4],
+    anchorOffset: 4,
+    focusNode: textNodes[0],
+    focusOffset: 6,
+  });
+});
+
+// I'm not even certain this is possible, but let's handle it anyway.
+test('starts at head of text node, ends at head of leaf child', () => {
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNodes[0],
+    anchorOffset: 0,
+    focusNode: leafChildren[4],
+    focusOffset: 0,
+  });
+});
+
+test('starts at head of text node, ends at end of leaf child', () => {
+  const leaf = leafChildren[4];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNodes[0],
+    anchorOffset: 0,
+    focusNode: leaf,
+    focusOffset: leaf.childNodes.length,
+  });
+});
+
+test('starts within text node, ends at start of leaf child', () => {
+  const leaf = leafChildren[4];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNodes[0],
+    anchorOffset: 4,
+    focusNode: leaf,
+    focusOffset: 0,
+  });
+});
+
+test('starts within text node, ends at end of leaf child', () => {
+  const leaf = leafChildren[4];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNodes[0],
+    anchorOffset: 4,
+    focusNode: leaf,
+    focusOffset: leaf.childNodes.length,
+  });
+});
+
+test('is a reversed text-to-leaf-child selection', () => {
+  const leaf = leafChildren[4];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: leaf,
+    anchorOffset: 0,
+    focusNode: textNodes[0],
+    focusOffset: 4,
+  });
+});
+
+test('starts at head of text node, ends at head of leaf span', () => {
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNodes[0],
+    anchorOffset: 0,
+    focusNode: leafs[4],
+    focusOffset: 0,
+  });
+});
+
+test('starts at head of text node, ends at end of leaf span', () => {
+  const leaf = leafs[4];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNodes[0],
+    anchorOffset: 0,
+    focusNode: leaf,
+    focusOffset: leaf.childNodes.length,
+  });
+});
+
+test('starts within text node, ends at start of leaf span', () => {
+  const leaf = leafs[4];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNodes[0],
+    anchorOffset: 4,
+    focusNode: leaf,
+    focusOffset: 0,
+  });
+});
+
+test('starts within text node, ends at end of leaf span', () => {
+  const leaf = leafs[4];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNodes[0],
+    anchorOffset: 4,
+    focusNode: leaf,
+    focusOffset: leaf.childNodes.length,
+  });
+});
+
+test('is a reversed text-to-leaf selection', () => {
+  const leaf = leafs[4];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: leaf,
+    anchorOffset: 0,
+    focusNode: textNodes[0],
+    focusOffset: 4,
+  });
+});
+
+test('is collapsed at start of single span', () => {
+  const leaf = leafs[0];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: leaf,
+    anchorOffset: 0,
+    focusNode: leaf,
+    focusOffset: 0,
+  });
+});
+
+test('is collapsed at end of single span', () => {
+  const leaf = leafs[0];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: leaf,
+    anchorOffset: leaf.childNodes.length,
+    focusNode: leaf,
+    focusOffset: leaf.childNodes.length,
+  });
+});
+
+test('contains an entire leaf', () => {
+  const leaf = leafs[4];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: leaf,
+    anchorOffset: 0,
+    focusNode: leaf,
+    focusOffset: leaf.childNodes.length,
+  });
+});
+
+test('is reversed on entire leaf', () => {
+  const leaf = leafs[4];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: leaf,
+    anchorOffset: leaf.childNodes.length,
+    focusNode: leaf,
+    focusOffset: 0,
+  });
+});
+
+test('from start of one to start of another', () => {
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: leafs[0],
+    anchorOffset: 0,
+    focusNode: leafs[4],
+    focusOffset: 0,
+  });
+});
+
+test('from start of one to end of other', () => {
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: leafs[0],
+    anchorOffset: 0,
+    focusNode: leafs[4],
+    focusOffset: leafs[4].childNodes.length,
+  });
+});
+
+test('reversed leaf to leaf', () => {
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: leafs[4],
+    anchorOffset: leafs[4].childNodes.length,
+    focusNode: leafs[0],
+    focusOffset: 0,
+  });
+});
+
+test('is collapsed at start at single block', () => {
+  const block = blocks[0];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: block,
+    anchorOffset: 0,
+    focusNode: block,
+    focusOffset: 0,
+  });
+});
+
+test('is collapsed at end at single block', () => {
+  const block = blocks[0];
+  const decorators = block.childNodes;
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: block,
+    anchorOffset: decorators.length,
+    focusNode: block,
+    focusOffset: decorators.length,
+  });
+});
+
+test('is entirely selected', () => {
+  const block = blocks[0];
+  const decorators = block.childNodes;
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: block,
+    anchorOffset: 0,
+    focusNode: block,
+    focusOffset: decorators.length,
+  });
+});
+
+/**
+ * FF: Triple-clicking a block leads to an entire block being selected,
+ * with the first text node as the anchor (0 offset) and the block element
+ * as the focus (childNodes.length offset)
+ */
+test('begins at text node zero, ends at end of block', () => {
+  const textNode = textNodes[0];
+  const block = blocks[0];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNode,
+    anchorOffset: 0,
+    focusNode: block,
+    focusOffset: block.childNodes.length,
+  });
+});
+
+// No idea if this is possible.
+test('begins within text node, ends at end of block', () => {
+  const textNode = textNodes[0];
+  const block = blocks[0];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNode,
+    anchorOffset: 5,
+    focusNode: block,
+    focusOffset: block.childNodes.length,
+  });
+});
+
+// No idea if this is possible.
+test('is reversed from the first case', () => {
+  const textNode = textNodes[0];
+  const block = blocks[0];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: block,
+    anchorOffset: block.childNodes.length,
+    focusNode: textNode,
+    focusOffset: 0,
+  });
+});
+
+test('goes from start of one to end of other', () => {
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: blocks[0],
+    anchorOffset: 0,
+    focusNode: blocks[2],
+    focusOffset: blocks[2].childNodes.length,
+  });
+});
+
+test('goes from start of one to start of other', () => {
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: blocks[0],
+    anchorOffset: 0,
+    focusNode: blocks[2],
+    focusOffset: 0,
+  });
+});
+
+test('goes from end of one to end of other', () => {
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: blocks[0],
+    anchorOffset: blocks[0].childNodes.length,
+    focusNode: blocks[2],
+    focusOffset: blocks[2].childNodes.length,
+  });
+});
+
+test('goes from within one to within another', () => {
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: blocks[0],
+    anchorOffset: 1,
+    focusNode: blocks[2].firstChild,
+    focusOffset: 1,
+  });
+});
+
+test('is the same as above but reversed', () => {
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: blocks[2].firstChild,
+    anchorOffset: 1,
+    focusNode: blocks[0],
+    focusOffset: 1,
+  });
+});
+
+test('is collapsed at the start of the contents', () => {
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: contents,
+    anchorOffset: 0,
+    focusNode: contents,
+    focusOffset: 0,
+  });
+});
+
+test('occupies a single child of the contents', () => {
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: contents,
+    anchorOffset: 0,
+    focusNode: contents,
+    focusOffset: 1,
+  });
+});
+
+test('is collapsed at the end of a child', () => {
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: contents,
+    anchorOffset: 1,
+    focusNode: contents,
+    focusOffset: 1,
+  });
+});
+
+test('is contains multiple children', () => {
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: contents,
+    anchorOffset: 0,
+    focusNode: contents,
+    focusOffset: 3,
+  });
+});
+
+/**
+ * In some scenarios, the entire editor may be selected by command-A.
+ */
+test('is collapsed at start with full selection', () => {
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: root,
+    anchorOffset: 0,
+    focusNode: root,
+    focusOffset: 0,
+  });
+});
+
+test('is collapsed at end with full selection', () => {
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: root,
+    anchorOffset: root.childNodes.length,
+    focusNode: root,
+    focusOffset: root.childNodes.length,
+  });
+});
+
+test('is completely selected', () => {
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: root,
+    anchorOffset: 0,
+    focusNode: root,
+    focusOffset: root.childNodes.length,
+  });
+});
+
+test('is reversed from above', () => {
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: root,
+    anchorOffset: root.childNodes.length,
+    focusNode: root,
+    focusOffset: 0,
+  });
+});
+
+/**
+ * A selection possibility that defies logic. In IE11, triple clicking a
+ * block leads to the text node being selected as the anchor, and the
+ * **entire editor** being selected as the focus. Ludicrous.
+ */
+test('does the crazy stuff described above', () => {
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNodes[0],
+    anchorOffset: 0,
+    focusNode: root,
+    focusOffset: root.childNodes.length,
   });
 });

--- a/src/component/selection/__tests__/getDraftEditorSelection-test.js
+++ b/src/component/selection/__tests__/getDraftEditorSelection-test.js
@@ -221,7 +221,7 @@ test('extends from head of one node to end of another', () => {
   });
 });
 
-test('starts within one text node and ends within another', () => {
+test('starts within one text node and ends within another block', () => {
   assertGetDraftEditorSelection({
     rangeCount: 1,
     anchorNode: textNodes[0],
@@ -394,7 +394,7 @@ test('is reversed on entire leaf', () => {
   });
 });
 
-test('from start of one to start of another', () => {
+test('from start of one block to start of another', () => {
   assertGetDraftEditorSelection({
     rangeCount: 1,
     anchorNode: leafs[0],
@@ -404,7 +404,7 @@ test('from start of one to start of another', () => {
   });
 });
 
-test('from start of one to end of other', () => {
+test('from start of one block to end of other block', () => {
   assertGetDraftEditorSelection({
     rangeCount: 1,
     anchorNode: leafs[0],
@@ -502,7 +502,7 @@ test('is reversed from the first case', () => {
   });
 });
 
-test('goes from start of one to end of other', () => {
+test('goes from start of one block to end of other block', () => {
   assertGetDraftEditorSelection({
     rangeCount: 1,
     anchorNode: blocks[0],
@@ -512,7 +512,7 @@ test('goes from start of one to end of other', () => {
   });
 });
 
-test('goes from start of one to start of other', () => {
+test('goes from start of one block to start of other', () => {
   assertGetDraftEditorSelection({
     rangeCount: 1,
     anchorNode: blocks[0],
@@ -522,7 +522,7 @@ test('goes from start of one to start of other', () => {
   });
 });
 
-test('goes from end of one to end of other', () => {
+test('goes from end of one to end of other block', () => {
   assertGetDraftEditorSelection({
     rangeCount: 1,
     anchorNode: blocks[0],
@@ -532,7 +532,7 @@ test('goes from end of one to end of other', () => {
   });
 });
 
-test('goes from within one to within another', () => {
+test('goes from within one block to within another block', () => {
   assertGetDraftEditorSelection({
     rangeCount: 1,
     anchorNode: blocks[0],

--- a/src/model/decorators/__tests__/CompositeDraftDecorator-test.js
+++ b/src/model/decorators/__tests__/CompositeDraftDecorator-test.js
@@ -12,209 +12,88 @@
 
 jest.disableAutomock().mock('ContentState');
 
-var CompositeDraftDecorator = require('CompositeDraftDecorator');
+const CompositeDraftDecorator = require('CompositeDraftDecorator');
 const ContentState = require('ContentState');
 
-describe('CompositeDraftDecorator', () => {
-  class ContentBlock {
-    constructor(/*string*/ text) {
-      this._text = text;
-    }
-    getText() /*string*/ {
-      return this._text;
-    }
+class ContentBlock {
+  constructor(text) {
+    this._text = text;
   }
 
-  function searchWith(regex) {
-    return function(block, callback, contentState) {
-      var text = block.getText();
-      text.replace(regex, function(/*string*/ match, /*number*/ offset) {
-        callback(offset, offset + match.length);
-      });
-    };
+  getText() {
+    return this._text;
   }
+}
 
-  var FooSpan = jest.fn();
-  var FooDecorator = {
-    strategy: searchWith(/foo/gi),
-    component: FooSpan,
-  };
-
-  var BarSpan = jest.fn();
-  var BarDecorator = {
-    strategy: searchWith(/bar/gi),
-    component: BarSpan,
-  };
-
-  var BartSpan = jest.fn();
-  var BartDecorator = {
-    strategy: searchWith(/bart/gi),
-    component: BartSpan,
-  };
-
-  function getCompositeDecorator() {
-    var decorators = [FooDecorator, BarDecorator];
-    return new CompositeDraftDecorator(decorators);
-  }
-
-  function isOccupied(arr) {
-    for (var ii = 0; ii < arr.length; ii++) {
-      if (arr[ii] == null) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  function isEntirelyNull(arr) {
-    for (var ii = 0; ii < arr.length; ii++) {
-      if (arr[ii] != null) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  it('must behave correctly if there are no matches', () => {
-    var composite = getCompositeDecorator();
-    var text = 'take a sad song and make it better';
-    var content = new ContentBlock(text);
-    var contentState = ContentState.createFromText(text);
-    var decorations = composite.getDecorations(content, contentState).toArray();
-    expect(decorations.length).toBe(text.length);
-    expect(decorations).toEqual(Array(text.length).fill(null));
+const searchWith = regex => (block, callback, contentState) => {
+  block.getText().replace(regex, (match, offset) => {
+    callback(offset, offset + match.length);
   });
+};
 
-  it('must find decoration matches', () => {
-    var composite = getCompositeDecorator();
-    var text = 'a footballing fool';
-    var content = new ContentBlock(text);
-    var contentState = ContentState.createFromText(text);
-    var decorations = composite.getDecorations(content, contentState).toArray();
-    expect(decorations.length).toBe(text.length);
+const BarDecorator = {
+  strategy: searchWith(/bar/gi),
+};
 
-    expect(isOccupied(decorations.slice(2, 5))).toBe(true);
-    expect(decorations[2]).toEqual(decorations[4]);
-    expect(composite.getComponentForKey(decorations[2])).toBe(FooSpan);
+const BartDecorator = {
+  strategy: searchWith(/bart/gi),
+};
 
-    expect(isEntirelyNull(decorations.slice(5, 14))).toBe(true);
+const FooDecorator = {
+  strategy: searchWith(/foo/gi),
+};
 
-    expect(isOccupied(decorations.slice(14, 17))).toBe(true);
-    expect(decorations[14]).toEqual(decorations[16]);
-    expect(composite.getComponentForKey(decorations[14])).toBe(FooSpan);
-  });
+const assertCompositeDraftDecorator = (
+  text,
+  decorators = [FooDecorator, BarDecorator],
+) => {
+  expect(
+    new CompositeDraftDecorator(decorators).getDecorations(
+      new ContentBlock(text),
+      ContentState.createFromText(text),
+    ),
+  ).toMatchSnapshot();
+};
 
-  it('must find matches for multiple decorators', () => {
-    var composite = getCompositeDecorator();
-    var text = 'a foosball bar';
-    var content = new ContentBlock(text);
-    var contentState = ContentState.createFromText(text);
-    var decorations = composite.getDecorations(content, contentState).toArray();
+test('must behave correctly if there are no matches', () => {
+  assertCompositeDraftDecorator('take a sad song and make it better');
+});
 
-    // Match the "Foo" decorator.
-    expect(isOccupied(decorations.slice(2, 5))).toBe(true);
-    expect(decorations[2]).toEqual(decorations[4]);
-    expect(composite.getComponentForKey(decorations[2])).toBe(FooSpan);
+test('must find decoration matches', () => {
+  assertCompositeDraftDecorator('a footballing fool');
+});
 
-    expect(isEntirelyNull(decorations.slice(5, 11))).toBe(true);
+test('must find matches for multiple decorators', () => {
+  // Match the "Foo" decorator and "Bar" decorator.
+  assertCompositeDraftDecorator('a foosball bar');
+});
 
-    // Match the "Bar" decorator.
-    expect(isOccupied(decorations.slice(11, 14))).toBe(true);
-    expect(decorations[11]).toEqual(decorations[13]);
-    expect(composite.getComponentForKey(decorations[11])).toBe(BarSpan);
-  });
+// Reverse the order of the matches from above. "foo" comes after "bar" in
+// the document text.
+test('must find matches regardless of text location', () => {
+  // Match the "Foo" decorator and "Bar" decorator.
+  assertCompositeDraftDecorator('some bar food');
+});
 
-  // Reverse the order of the matches from above. "foo" comes after "bar" in
-  // the document text.
-  it('must find matches regardless of text location', () => {
-    var composite = getCompositeDecorator();
-    var text = 'some bar food';
-    var content = new ContentBlock(text);
-    var contentState = ContentState.createFromText(text);
-    var decorations = composite.getDecorations(content, contentState).toArray();
+test('must throw out overlaps with existing decorations', () => {
+  // Even though "bart" matches our "bar" strategy, "bart" comes first
+  // in our decoration order and will claim those letters first.
+  assertCompositeDraftDecorator('bart has a bar', [
+    BartDecorator,
+    BarDecorator,
+  ]);
+});
 
-    // Match the "Foo" decorator.
-    expect(isOccupied(decorations.slice(9, 12))).toBe(true);
-    expect(decorations[9]).toEqual(decorations[11]);
-    expect(composite.getComponentForKey(decorations[9])).toBe(FooSpan);
+// Swap the order of "bar" and "bart".
+test('must throw out matches if earlier match is shorter', () => {
+  // There are no "bart" matches, since "bar" has claimed the relevant
+  // strings.
+  assertCompositeDraftDecorator('bart has a bar', [
+    BarDecorator,
+    BartDecorator,
+  ]);
+});
 
-    // Match the "Bar" decorator.
-    expect(isOccupied(decorations.slice(5, 8))).toBe(true);
-    expect(decorations[5]).toEqual(decorations[7]);
-    expect(composite.getComponentForKey(decorations[5])).toBe(BarSpan);
-  });
-
-  it('must throw out overlaps with existing decorations', () => {
-    var decorators = [BartDecorator, BarDecorator];
-    var composite = new CompositeDraftDecorator(decorators);
-
-    var text = 'bart has a bar';
-    var content = new ContentBlock(text);
-    var contentState = ContentState.createFromText(text);
-    var decorations = composite.getDecorations(content, contentState).toArray();
-
-    // Even though "bart" matches our "bar" strategy, "bart" comes first
-    // in our decoration order and will claim those letters first.
-    expect(isOccupied(decorations.slice(0, 4))).toBe(true);
-    expect(decorations[0]).toEqual(decorations[3]);
-    expect(composite.getComponentForKey(decorations[0])).toBe(BartSpan);
-
-    // Verify empty space between matches.
-    expect(isEntirelyNull(decorations.slice(4, 11))).toBe(true);
-
-    // "bar" match
-    expect(isOccupied(decorations.slice(11, 14))).toBe(true);
-    expect(decorations[11]).toEqual(decorations[13]);
-    expect(composite.getComponentForKey(decorations[11])).toBe(BarSpan);
-  });
-
-  // Swap the order of "bar" and "bart".
-  it('must throw out matches if earlier match is shorter', () => {
-    var decorators = [BarDecorator, BartDecorator];
-    var composite = new CompositeDraftDecorator(decorators);
-
-    var text = 'bart has a bar';
-    var content = new ContentBlock(text);
-    var contentState = ContentState.createFromText(text);
-    var decorations = composite.getDecorations(content, contentState).toArray();
-
-    // "bar" comes first and claims two strings.
-    expect(isOccupied(decorations.slice(0, 3))).toBe(true);
-    expect(decorations[0]).toEqual(decorations[2]);
-    expect(composite.getComponentForKey(decorations[0])).toBe(BarSpan);
-
-    expect(isOccupied(decorations.slice(11, 14))).toBe(true);
-    expect(decorations[11]).toEqual(decorations[13]);
-    expect(composite.getComponentForKey(decorations[11])).toBe(BarSpan);
-
-    // There are no "bart" matches, since "bar" has claimed the relevant
-    // strings.
-    expect(isEntirelyNull(decorations.slice(3, 11))).toBe(true);
-  });
-
-  it('must separate adjacent ranges that have the same decorator', () => {
-    var decorators = [BarDecorator];
-    var composite = new CompositeDraftDecorator(decorators);
-
-    var text = 'barbarbar';
-    var content = new ContentBlock(text);
-    var contentState = ContentState.createFromText(text);
-    var decorations = composite.getDecorations(content, contentState).toArray();
-
-    expect(isOccupied(decorations.slice(0, 3))).toBe(true);
-    expect(decorations[0]).toEqual(decorations[2]);
-    expect(composite.getComponentForKey(decorations[0])).toBe(BarSpan);
-
-    expect(isOccupied(decorations.slice(3, 6))).toBe(true);
-    expect(decorations[3]).toEqual(decorations[5]);
-    expect(composite.getComponentForKey(decorations[3])).toBe(BarSpan);
-
-    expect(isOccupied(decorations.slice(6, 9))).toBe(true);
-    expect(decorations[6]).toEqual(decorations[8]);
-    expect(composite.getComponentForKey(decorations[6])).toBe(BarSpan);
-
-    expect(decorations[2]).not.toEqual(decorations[3]);
-    expect(decorations[5]).not.toEqual(decorations[6]);
-    expect(decorations[8]).not.toEqual(decorations[9]);
-  });
+test('must separate adjacent ranges that have the same decorator', () => {
+  assertCompositeDraftDecorator('barbarbar', [BarDecorator]);
 });

--- a/src/model/decorators/__tests__/__snapshots__/CompositeDraftDecorator-test.js.snap
+++ b/src/model/decorators/__tests__/__snapshots__/CompositeDraftDecorator-test.js.snap
@@ -1,0 +1,152 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must behave correctly if there are no matches 1`] = `
+Immutable.List [
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+]
+`;
+
+exports[`must find decoration matches 1`] = `
+Immutable.List [
+  null,
+  null,
+  "0.0",
+  "0.0",
+  "0.0",
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  "0.1",
+  "0.1",
+  "0.1",
+  null,
+]
+`;
+
+exports[`must find matches for multiple decorators 1`] = `
+Immutable.List [
+  null,
+  null,
+  "0.0",
+  "0.0",
+  "0.0",
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  "1.0",
+  "1.0",
+  "1.0",
+]
+`;
+
+exports[`must find matches regardless of text location 1`] = `
+Immutable.List [
+  null,
+  null,
+  null,
+  null,
+  null,
+  "1.0",
+  "1.0",
+  "1.0",
+  null,
+  "0.0",
+  "0.0",
+  "0.0",
+  null,
+]
+`;
+
+exports[`must separate adjacent ranges that have the same decorator 1`] = `
+Immutable.List [
+  "0.0",
+  "0.0",
+  "0.0",
+  "0.1",
+  "0.1",
+  "0.1",
+  "0.2",
+  "0.2",
+  "0.2",
+]
+`;
+
+exports[`must throw out matches if earlier match is shorter 1`] = `
+Immutable.List [
+  "0.0",
+  "0.0",
+  "0.0",
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  "0.1",
+  "0.1",
+  "0.1",
+]
+`;
+
+exports[`must throw out overlaps with existing decorations 1`] = `
+Immutable.List [
+  "0.0",
+  "0.0",
+  "0.0",
+  "0.0",
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  "1.0",
+  "1.0",
+  "1.0",
+]
+`;

--- a/src/model/encoding/__tests__/__snapshots__/convertFromHTMLToContentBlocks-test.js.snap
+++ b/src/model/encoding/__tests__/__snapshots__/convertFromHTMLToContentBlocks-test.js.snap
@@ -1,0 +1,377 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`img with data protocol should be correctly parsed 1`] = `"📷"`;
+
+exports[`img with http protocol should have camera emoji content 1`] = `"📷"`;
+
+exports[`must not merge tags when converting adjacent <blockquote /> 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key0",
+    "type": "blockquote",
+    "text": "a",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  Immutable.Record {
+    "key": "key1",
+    "type": "blockquote",
+    "text": "b",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must not merge tags when converting adjacent <div /> 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key2",
+    "type": "unstyled",
+    "text": "a",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  Immutable.Record {
+    "key": "key3",
+    "type": "unstyled",
+    "text": "b",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must not merge tags when converting adjacent <figure /> 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key4",
+    "type": "atomic",
+    "text": "a",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  Immutable.Record {
+    "key": "key5",
+    "type": "atomic",
+    "text": "b",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must not merge tags when converting adjacent <h1 /> 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key6",
+    "type": "header-one",
+    "text": "a",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  Immutable.Record {
+    "key": "key7",
+    "type": "header-one",
+    "text": "b",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must not merge tags when converting adjacent <h2 /> 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key8",
+    "type": "header-two",
+    "text": "a",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  Immutable.Record {
+    "key": "key9",
+    "type": "header-two",
+    "text": "b",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must not merge tags when converting adjacent <h3 /> 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key10",
+    "type": "header-three",
+    "text": "a",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  Immutable.Record {
+    "key": "key11",
+    "type": "header-three",
+    "text": "b",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must not merge tags when converting adjacent <h4 /> 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key12",
+    "type": "header-four",
+    "text": "a",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  Immutable.Record {
+    "key": "key13",
+    "type": "header-four",
+    "text": "b",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must not merge tags when converting adjacent <h5 /> 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key14",
+    "type": "header-five",
+    "text": "a",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  Immutable.Record {
+    "key": "key15",
+    "type": "header-five",
+    "text": "b",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must not merge tags when converting adjacent <h6 /> 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key16",
+    "type": "header-six",
+    "text": "a",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  Immutable.Record {
+    "key": "key17",
+    "type": "header-six",
+    "text": "b",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must not merge tags when converting adjacent <li /> 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key18",
+    "type": "unordered-list-item",
+    "text": "a",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  Immutable.Record {
+    "key": "key19",
+    "type": "unordered-list-item",
+    "text": "b",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must not merge tags when converting adjacent <p /> 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key20",
+    "type": "unstyled",
+    "text": "a",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  Immutable.Record {
+    "key": "key21",
+    "type": "unstyled",
+    "text": "b",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must not merge tags when converting adjacent <pre /> 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key22",
+    "type": "code-block",
+    "text": "a",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  Immutable.Record {
+    "key": "key23",
+    "type": "code-block",
+    "text": "b",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;

--- a/src/model/encoding/__tests__/__snapshots__/convertFromRawToDraftState-test.js.snap
+++ b/src/model/encoding/__tests__/__snapshots__/convertFromRawToDraftState-test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must map falsey block types to default value of unstyled 1`] = `"unstyled"`;
+
+exports[`must map falsey block types to default value of unstyled 2`] = `"unstyled"`;
+
+exports[`must map falsey block types to default value of unstyled 3`] = `"unstyled"`;

--- a/src/model/encoding/__tests__/__snapshots__/convertFromRawToDraftState-test.js.snap
+++ b/src/model/encoding/__tests__/__snapshots__/convertFromRawToDraftState-test.js.snap
@@ -1,7 +1,81 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`must map falsey block types to default value of unstyled 1`] = `"unstyled"`;
-
-exports[`must map falsey block types to default value of unstyled 2`] = `"unstyled"`;
-
-exports[`must map falsey block types to default value of unstyled 3`] = `"unstyled"`;
+exports[`must map falsey block types to default value of unstyled 1`] = `
+Immutable.OrderedMap {
+  "key0": Immutable.Record {
+    "key": "key0",
+    "type": "unstyled",
+    "text": "AAAA",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "key1": Immutable.Record {
+    "key": "key1",
+    "type": "unstyled",
+    "text": "BBBB",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "key2": Immutable.Record {
+    "key": "key2",
+    "type": "unstyled",
+    "text": "CCCC",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;

--- a/src/model/encoding/__tests__/__snapshots__/convertFromRawToDraftState-test.js.snap
+++ b/src/model/encoding/__tests__/__snapshots__/convertFromRawToDraftState-test.js.snap
@@ -1,81 +1,81 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`must map falsey block types to default value of unstyled 1`] = `
-Immutable.OrderedMap {
-  "key0": Immutable.Record {
+Object {
+  "key0": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "key0",
-    "type": "unstyled",
     "text": "AAAA",
-    "characterList": Immutable.List [
-      Immutable.Record {
-        "style": Immutable.OrderedSet [],
+    "type": "unstyled",
+  },
+  "key1": Object {
+    "characterList": Array [
+      Object {
         "entity": null,
+        "style": Array [],
       },
-      Immutable.Record {
-        "style": Immutable.OrderedSet [],
+      Object {
         "entity": null,
+        "style": Array [],
       },
-      Immutable.Record {
-        "style": Immutable.OrderedSet [],
+      Object {
         "entity": null,
+        "style": Array [],
       },
-      Immutable.Record {
-        "style": Immutable.OrderedSet [],
+      Object {
         "entity": null,
+        "style": Array [],
       },
     ],
+    "data": Object {},
     "depth": 0,
-    "data": Immutable.Map {},
-  },
-  "key1": Immutable.Record {
     "key": "key1",
-    "type": "unstyled",
     "text": "BBBB",
-    "characterList": Immutable.List [
-      Immutable.Record {
-        "style": Immutable.OrderedSet [],
-        "entity": null,
-      },
-      Immutable.Record {
-        "style": Immutable.OrderedSet [],
-        "entity": null,
-      },
-      Immutable.Record {
-        "style": Immutable.OrderedSet [],
-        "entity": null,
-      },
-      Immutable.Record {
-        "style": Immutable.OrderedSet [],
-        "entity": null,
-      },
-    ],
-    "depth": 0,
-    "data": Immutable.Map {},
-  },
-  "key2": Immutable.Record {
-    "key": "key2",
     "type": "unstyled",
-    "text": "CCCC",
-    "characterList": Immutable.List [
-      Immutable.Record {
-        "style": Immutable.OrderedSet [],
+  },
+  "key2": Object {
+    "characterList": Array [
+      Object {
         "entity": null,
+        "style": Array [],
       },
-      Immutable.Record {
-        "style": Immutable.OrderedSet [],
+      Object {
         "entity": null,
+        "style": Array [],
       },
-      Immutable.Record {
-        "style": Immutable.OrderedSet [],
+      Object {
         "entity": null,
+        "style": Array [],
       },
-      Immutable.Record {
-        "style": Immutable.OrderedSet [],
+      Object {
         "entity": null,
+        "style": Array [],
       },
     ],
+    "data": Object {},
     "depth": 0,
-    "data": Immutable.Map {},
+    "key": "key2",
+    "text": "CCCC",
+    "type": "unstyled",
   },
 }
 `;

--- a/src/model/encoding/__tests__/__snapshots__/decodeEntityRanges-test.js.snap
+++ b/src/model/encoding/__tests__/__snapshots__/decodeEntityRanges-test.js.snap
@@ -1,0 +1,84 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must decode when an entity is present 1`] = `
+Array [
+  null,
+  null,
+  "6",
+  "6",
+  null,
+]
+`;
+
+exports[`must decode when an entity is present more than once 1`] = `
+Array [
+  null,
+  null,
+  "6",
+  "6",
+  null,
+  "6",
+  "6",
+  null,
+]
+`;
+
+exports[`must decode when multiple entities present 1`] = `
+Array [
+  null,
+  null,
+  "6",
+  "6",
+  null,
+  "8",
+  "8",
+  null,
+]
+`;
+
+exports[`must decode when no entities present 1`] = `
+Array [
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+]
+`;
+
+exports[`must handle ranges that include surrogate pairs 1`] = `
+Array [
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+  "6",
+  "6",
+  "6",
+  "6",
+  "6",
+  "6",
+  null,
+  null,
+  "8",
+  "8",
+  null,
+]
+`;

--- a/src/model/encoding/__tests__/__snapshots__/decodeInlineStyleRanges-test.js.snap
+++ b/src/model/encoding/__tests__/__snapshots__/decodeInlineStyleRanges-test.js.snap
@@ -1,0 +1,102 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must decode for a flat styled block 1`] = `
+Array [
+  Immutable.OrderedSet [
+    "BOLD",
+  ],
+  Immutable.OrderedSet [
+    "BOLD",
+  ],
+  Immutable.OrderedSet [
+    "BOLD",
+  ],
+  Immutable.OrderedSet [
+    "BOLD",
+  ],
+  Immutable.OrderedSet [
+    "BOLD",
+  ],
+]
+`;
+
+exports[`must decode for a mixed-style block 1`] = `
+Array [
+  Immutable.OrderedSet [
+    "BOLD",
+    "UNDERLINE",
+  ],
+  Immutable.OrderedSet [
+    "BOLD",
+    "ITALIC",
+    "UNDERLINE",
+  ],
+  Immutable.OrderedSet [
+    "BOLD",
+    "ITALIC",
+  ],
+  Immutable.OrderedSet [
+    "ITALIC",
+  ],
+  Immutable.OrderedSet [
+    "BOLD",
+  ],
+]
+`;
+
+exports[`must decode for an unstyled block 1`] = `
+Array [
+  Immutable.OrderedSet [],
+  Immutable.OrderedSet [],
+  Immutable.OrderedSet [],
+  Immutable.OrderedSet [],
+  Immutable.OrderedSet [],
+]
+`;
+
+exports[`must decode for strings that contain surrogate pairs in UTF-16 1`] = `
+Array [
+  Immutable.OrderedSet [],
+  Immutable.OrderedSet [],
+  Immutable.OrderedSet [],
+  Immutable.OrderedSet [],
+  Immutable.OrderedSet [
+    "BOLD",
+  ],
+  Immutable.OrderedSet [
+    "BOLD",
+  ],
+  Immutable.OrderedSet [
+    "BOLD",
+    "ITALIC",
+  ],
+  Immutable.OrderedSet [
+    "BOLD",
+    "ITALIC",
+  ],
+  Immutable.OrderedSet [
+    "BOLD",
+    "ITALIC",
+  ],
+  Immutable.OrderedSet [
+    "ITALIC",
+  ],
+  Immutable.OrderedSet [
+    "ITALIC",
+  ],
+  Immutable.OrderedSet [
+    "ITALIC",
+  ],
+  Immutable.OrderedSet [
+    "ITALIC",
+  ],
+  Immutable.OrderedSet [
+    "ITALIC",
+  ],
+  Immutable.OrderedSet [
+    "ITALIC",
+  ],
+  Immutable.OrderedSet [],
+  Immutable.OrderedSet [],
+]
+`;

--- a/src/model/encoding/__tests__/__snapshots__/decodeInlineStyleRanges-test.js.snap
+++ b/src/model/encoding/__tests__/__snapshots__/decodeInlineStyleRanges-test.js.snap
@@ -2,19 +2,19 @@
 
 exports[`must decode for a flat styled block 1`] = `
 Array [
-  Immutable.OrderedSet [
+  Array [
     "BOLD",
   ],
-  Immutable.OrderedSet [
+  Array [
     "BOLD",
   ],
-  Immutable.OrderedSet [
+  Array [
     "BOLD",
   ],
-  Immutable.OrderedSet [
+  Array [
     "BOLD",
   ],
-  Immutable.OrderedSet [
+  Array [
     "BOLD",
   ],
 ]
@@ -22,23 +22,23 @@ Array [
 
 exports[`must decode for a mixed-style block 1`] = `
 Array [
-  Immutable.OrderedSet [
+  Array [
     "BOLD",
     "UNDERLINE",
   ],
-  Immutable.OrderedSet [
+  Array [
     "BOLD",
     "ITALIC",
     "UNDERLINE",
   ],
-  Immutable.OrderedSet [
+  Array [
     "BOLD",
     "ITALIC",
   ],
-  Immutable.OrderedSet [
+  Array [
     "ITALIC",
   ],
-  Immutable.OrderedSet [
+  Array [
     "BOLD",
   ],
 ]
@@ -46,57 +46,57 @@ Array [
 
 exports[`must decode for an unstyled block 1`] = `
 Array [
-  Immutable.OrderedSet [],
-  Immutable.OrderedSet [],
-  Immutable.OrderedSet [],
-  Immutable.OrderedSet [],
-  Immutable.OrderedSet [],
+  Array [],
+  Array [],
+  Array [],
+  Array [],
+  Array [],
 ]
 `;
 
 exports[`must decode for strings that contain surrogate pairs in UTF-16 1`] = `
 Array [
-  Immutable.OrderedSet [],
-  Immutable.OrderedSet [],
-  Immutable.OrderedSet [],
-  Immutable.OrderedSet [],
-  Immutable.OrderedSet [
+  Array [],
+  Array [],
+  Array [],
+  Array [],
+  Array [
     "BOLD",
   ],
-  Immutable.OrderedSet [
+  Array [
     "BOLD",
   ],
-  Immutable.OrderedSet [
-    "BOLD",
-    "ITALIC",
-  ],
-  Immutable.OrderedSet [
+  Array [
     "BOLD",
     "ITALIC",
   ],
-  Immutable.OrderedSet [
+  Array [
     "BOLD",
     "ITALIC",
   ],
-  Immutable.OrderedSet [
+  Array [
+    "BOLD",
     "ITALIC",
   ],
-  Immutable.OrderedSet [
+  Array [
     "ITALIC",
   ],
-  Immutable.OrderedSet [
+  Array [
     "ITALIC",
   ],
-  Immutable.OrderedSet [
+  Array [
     "ITALIC",
   ],
-  Immutable.OrderedSet [
+  Array [
     "ITALIC",
   ],
-  Immutable.OrderedSet [
+  Array [
     "ITALIC",
   ],
-  Immutable.OrderedSet [],
-  Immutable.OrderedSet [],
+  Array [
+    "ITALIC",
+  ],
+  Array [],
+  Array [],
 ]
 `;

--- a/src/model/encoding/__tests__/__snapshots__/encodeEntityRanges-test.js.snap
+++ b/src/model/encoding/__tests__/__snapshots__/encodeEntityRanges-test.js.snap
@@ -1,0 +1,60 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must handle ranges that include surrogate pairs 1`] = `
+Array [
+  Object {
+    "key": 0,
+    "length": 5,
+    "offset": 6,
+  },
+  Object {
+    "key": 1,
+    "length": 2,
+    "offset": 13,
+  },
+]
+`;
+
+exports[`must return an empty array if no entities present 1`] = `Array []`;
+
+exports[`must return an empty array if no entities present 2`] = `Array []`;
+
+exports[`must return ranges with an entity present more than once 1`] = `
+Array [
+  Object {
+    "key": 0,
+    "length": 2,
+    "offset": 2,
+  },
+  Object {
+    "key": 0,
+    "length": 2,
+    "offset": 5,
+  },
+]
+`;
+
+exports[`must return ranges with multiple entities present 1`] = `
+Array [
+  Object {
+    "key": 0,
+    "length": 2,
+    "offset": 2,
+  },
+  Object {
+    "key": 1,
+    "length": 2,
+    "offset": 5,
+  },
+]
+`;
+
+exports[`must return ranges with the storage-mapped key 1`] = `
+Array [
+  Object {
+    "key": 0,
+    "length": 2,
+    "offset": 2,
+  },
+]
+`;

--- a/src/model/encoding/__tests__/__snapshots__/encodeInlineStyleRanges-test.js.snap
+++ b/src/model/encoding/__tests__/__snapshots__/encodeInlineStyleRanges-test.js.snap
@@ -1,0 +1,124 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must encode custom styles 1`] = `
+Array [
+  Object {
+    "length": 4,
+    "offset": 0,
+    "style": "foo",
+  },
+  Object {
+    "length": 2,
+    "offset": 2,
+    "style": "bar",
+  },
+  Object {
+    "length": 2,
+    "offset": 4,
+    "style": "BOLD",
+  },
+]
+`;
+
+exports[`must encode for a complex styled document 1`] = `
+Array [
+  Object {
+    "length": 4,
+    "offset": 0,
+    "style": "BOLD",
+  },
+  Object {
+    "length": 2,
+    "offset": 5,
+    "style": "BOLD",
+  },
+  Object {
+    "length": 2,
+    "offset": 8,
+    "style": "BOLD",
+  },
+  Object {
+    "length": 3,
+    "offset": 5,
+    "style": "ITALIC",
+  },
+  Object {
+    "length": 1,
+    "offset": 9,
+    "style": "ITALIC",
+  },
+  Object {
+    "length": 3,
+    "offset": 7,
+    "style": "UNDERLINE",
+  },
+]
+`;
+
+exports[`must encode for a flat styled document 1`] = `
+Array [
+  Object {
+    "length": 20,
+    "offset": 0,
+    "style": "BOLD",
+  },
+]
+`;
+
+exports[`must encode for a flat styled document 2`] = `
+Array [
+  Object {
+    "length": 20,
+    "offset": 0,
+    "style": "BOLD",
+  },
+  Object {
+    "length": 20,
+    "offset": 0,
+    "style": "ITALIC",
+  },
+]
+`;
+
+exports[`must encode for a flat styled document 3`] = `
+Array [
+  Object {
+    "length": 20,
+    "offset": 0,
+    "style": "BOLD",
+  },
+  Object {
+    "length": 20,
+    "offset": 0,
+    "style": "ITALIC",
+  },
+  Object {
+    "length": 20,
+    "offset": 0,
+    "style": "UNDERLINE",
+  },
+]
+`;
+
+exports[`must encode for an unstyled document 1`] = `Array []`;
+
+exports[`must encode for an unstyled document 2`] = `Array []`;
+
+exports[`must encode for an unstyled document 3`] = `Array []`;
+
+exports[`must encode for an unstyled document 4`] = `Array []`;
+
+exports[`must encode for strings with surrogate pairs 1`] = `
+Array [
+  Object {
+    "length": 4,
+    "offset": 4,
+    "style": "BOLD",
+  },
+  Object {
+    "length": 8,
+    "offset": 6,
+    "style": "ITALIC",
+  },
+]
+`;

--- a/src/model/encoding/__tests__/__snapshots__/sanitizeDraftText-test.js.snap
+++ b/src/model/encoding/__tests__/__snapshots__/sanitizeDraftText-test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must strip all carriage returns 1`] = `"test"`;
+
+exports[`must strip leading carriage returns 1`] = `"test"`;
+
+exports[`must strip trailing carriage returns 1`] = `"test"`;
+
+exports[`must strip two trailing carriage returns 1`] = `"test"`;
+
+exports[`must strip within carriage returns 1`] = `"test"`;

--- a/src/model/encoding/__tests__/convertFromHTMLToContentBlocks-test.js
+++ b/src/model/encoding/__tests__/convertFromHTMLToContentBlocks-test.js
@@ -22,7 +22,7 @@ const IMAGE_DATA_URL =
   'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///' +
   'yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 
-const testConvertingAdjacentHtmlElementsToContentBlocks = tag => {
+const testConvertingAdjacentHtmlElementsToContentBlocks = (tag: string) => {
   it(`must not merge tags when converting adjacent <${tag} />`, () => {
     const html_string = `
       <${tag}>a</${tag}>

--- a/src/model/encoding/__tests__/convertFromHTMLToContentBlocks-test.js
+++ b/src/model/encoding/__tests__/convertFromHTMLToContentBlocks-test.js
@@ -14,54 +14,52 @@
 
 jest.disableAutomock();
 
+jest.mock('generateRandomKey');
+
 const convertFromHTMLToContentBlocks = require('convertFromHTMLToContentBlocks');
 
 const IMAGE_DATA_URL =
   'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///' +
   'yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 
-function testConvertingAdjacentHtmlElementsToContentBlocks(tag: string) {
+const testConvertingAdjacentHtmlElementsToContentBlocks = tag => {
   it(`must not merge tags when converting adjacent <${tag} />`, () => {
     const html_string = `
       <${tag}>a</${tag}>
       <${tag}>b</${tag}>
     `;
 
-    const blocks = convertFromHTMLToContentBlocks(html_string);
-
-    expect(blocks.contentBlocks.length).toBe(2);
+    expect(
+      convertFromHTMLToContentBlocks(html_string).contentBlocks,
+    ).toMatchSnapshot();
   });
-}
+};
 
-describe('convertFromHTMLToContentBlocks', () => {
-  [
-    'blockquote',
-    'div',
-    'figure',
-    'h1',
-    'h2',
-    'h3',
-    'h4',
-    'h5',
-    'h6',
-    'li',
-    'p',
-    'pre',
-  ].forEach(tag => testConvertingAdjacentHtmlElementsToContentBlocks(tag));
+[
+  'blockquote',
+  'div',
+  'figure',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'li',
+  'p',
+  'pre',
+].forEach(tag => testConvertingAdjacentHtmlElementsToContentBlocks(tag));
 
-  describe('img tag', function() {
-    test('img with http protocol should have camera emoji content', function() {
-      const blocks = convertFromHTMLToContentBlocks(
-        '<img src="http://www.facebook.com">',
-      );
-      expect(blocks.contentBlocks[0].text).toBe('\ud83d\udcf7');
-    });
+test('img with http protocol should have camera emoji content', () => {
+  const blocks = convertFromHTMLToContentBlocks(
+    '<img src="http://www.facebook.com">',
+  );
+  expect(blocks.contentBlocks[0].text).toMatchSnapshot();
+});
 
-    test('img with data protocol should be correctly parsed', function() {
-      const blocks = convertFromHTMLToContentBlocks(
-        `<img src="${IMAGE_DATA_URL}">`,
-      );
-      expect(blocks.contentBlocks[0].text).toBe('\ud83d\udcf7');
-    });
-  });
+test('img with data protocol should be correctly parsed', () => {
+  const blocks = convertFromHTMLToContentBlocks(
+    `<img src="${IMAGE_DATA_URL}">`,
+  );
+  expect(blocks.contentBlocks[0].text).toMatchSnapshot();
 });

--- a/src/model/encoding/__tests__/convertFromRawToDraftState-test.js
+++ b/src/model/encoding/__tests__/convertFromRawToDraftState-test.js
@@ -28,5 +28,5 @@ test('must map falsey block types to default value of unstyled', () => {
     entityMap: {},
   };
 
-  expect(convertFromRawToDraftState(rawState).getBlockMap()).toMatchSnapshot();
+  expect(convertFromRawToDraftState(rawState).getBlockMap().toJS()).toMatchSnapshot();
 });

--- a/src/model/encoding/__tests__/convertFromRawToDraftState-test.js
+++ b/src/model/encoding/__tests__/convertFromRawToDraftState-test.js
@@ -14,21 +14,21 @@
 
 jest.disableAutomock();
 
+jest.mock('generateRandomKey');
+
 const convertFromRawToDraftState = require('convertFromRawToDraftState');
 
-describe('convertFromRawToDraftState', () => {
-  it('must map falsey block types to default value of unstyled', () => {
-    const rawState = {
-      blocks: [
-        {text: 'AAAA'},
-        {text: 'BBBB', type: null},
-        {text: 'CCCC', type: undefined},
-      ],
-      entityMap: {},
-    };
+test('must map falsey block types to default value of unstyled', () => {
+  const rawState = {
+    blocks: [
+      {text: 'AAAA'},
+      {text: 'BBBB', type: null},
+      {text: 'CCCC', type: undefined},
+    ],
+    entityMap: {},
+  };
 
-    const contentState = convertFromRawToDraftState(rawState);
-    const blockMap = contentState.getBlockMap();
-    blockMap.forEach(block => expect(block.type).toEqual('unstyled'));
-  });
+  const contentState = convertFromRawToDraftState(rawState);
+  const blockMap = contentState.getBlockMap();
+  blockMap.forEach(block => expect(block.type).toMatchSnapshot());
 });

--- a/src/model/encoding/__tests__/convertFromRawToDraftState-test.js
+++ b/src/model/encoding/__tests__/convertFromRawToDraftState-test.js
@@ -28,7 +28,5 @@ test('must map falsey block types to default value of unstyled', () => {
     entityMap: {},
   };
 
-  const contentState = convertFromRawToDraftState(rawState);
-  const blockMap = contentState.getBlockMap();
-  blockMap.forEach(block => expect(block.type).toMatchSnapshot());
+  expect(convertFromRawToDraftState(rawState).getBlockMap()).toMatchSnapshot();
 });

--- a/src/model/encoding/__tests__/decodeEntityRanges-test.js
+++ b/src/model/encoding/__tests__/decodeEntityRanges-test.js
@@ -16,76 +16,66 @@ jest.disableAutomock();
 
 var decodeEntityRanges = require('decodeEntityRanges');
 
-describe('decodeEntityRanges', () => {
-  it('must decode when no entities present', () => {
-    var decoded = decodeEntityRanges(' '.repeat(20), []);
-    expect(decoded).toEqual(Array(20).fill(null));
-  });
+test('must decode when no entities present', () => {
+  var decoded = decodeEntityRanges(' '.repeat(20), []);
+  expect(decoded).toMatchSnapshot();
+});
 
-  it('must decode when an entity is present', () => {
-    var decoded = decodeEntityRanges(' '.repeat(5), [
-      {
-        offset: 2,
-        length: 2,
-        key: '6',
-      },
-    ]);
-    expect(decoded).toEqual([null, null, '6', '6', null]);
-  });
+test('must decode when an entity is present', () => {
+  var decoded = decodeEntityRanges(' '.repeat(5), [
+    {
+      offset: 2,
+      length: 2,
+      key: '6',
+    },
+  ]);
+  expect(decoded).toMatchSnapshot();
+});
 
-  it('must decode when multiple entities present', () => {
-    var decoded = decodeEntityRanges(' '.repeat(8), [
-      {
-        offset: 2,
-        length: 2,
-        key: '6',
-      },
-      {
-        offset: 5,
-        length: 2,
-        key: '8',
-      },
-    ]);
-    expect(decoded).toEqual([null, null, '6', '6', null, '8', '8', null]);
-  });
+test('must decode when multiple entities present', () => {
+  var decoded = decodeEntityRanges(' '.repeat(8), [
+    {
+      offset: 2,
+      length: 2,
+      key: '6',
+    },
+    {
+      offset: 5,
+      length: 2,
+      key: '8',
+    },
+  ]);
+  expect(decoded).toMatchSnapshot();
+});
 
-  it('must decode when an entity is present more than once', () => {
-    var decoded = decodeEntityRanges(' '.repeat(8), [
-      {
-        offset: 2,
-        length: 2,
-        key: '6',
-      },
-      {
-        offset: 5,
-        length: 2,
-        key: '6',
-      },
-    ]);
-    expect(decoded).toEqual([null, null, '6', '6', null, '6', '6', null]);
-  });
+test('must decode when an entity is present more than once', () => {
+  var decoded = decodeEntityRanges(' '.repeat(8), [
+    {
+      offset: 2,
+      length: 2,
+      key: '6',
+    },
+    {
+      offset: 5,
+      length: 2,
+      key: '6',
+    },
+  ]);
+  expect(decoded).toMatchSnapshot();
+});
 
-  it('must handle ranges that include surrogate pairs', () => {
-    var decoded = decodeEntityRanges('Take a \uD83D\uDCF7 #selfie', [
-      {
-        offset: 6,
-        length: 5,
-        key: '6',
-      },
-      {
-        offset: 13,
-        length: 2,
-        key: '8',
-      },
-    ]);
-
-    // prettier-ignore
-    var entities = [
-      null, null, null, null, null, null, // `Take a`
-      '6', '6', '6', '6', '6', '6',       // ` [camera] #s`
-      null, null, '8', '8', null,         // `elfie`
-    ];
-
-    expect(decoded).toEqual(entities);
-  });
+test('must handle ranges that include surrogate pairs', () => {
+  var decoded = decodeEntityRanges('Take a \uD83D\uDCF7 #selfie', [
+    {
+      offset: 6,
+      length: 5,
+      key: '6',
+    },
+    {
+      offset: 13,
+      length: 2,
+      key: '8',
+    },
+  ]);
+  expect(decoded).toMatchSnapshot();
 });

--- a/src/model/encoding/__tests__/decodeInlineStyleRanges-test.js
+++ b/src/model/encoding/__tests__/decodeInlineStyleRanges-test.js
@@ -19,7 +19,7 @@ const decodeInlineStyleRanges = require('decodeInlineStyleRanges');
 test('must decode for an unstyled block', () => {
   const block = {text: 'Hello'};
   expect(
-    decodeInlineStyleRanges(block.text, block.inlineStyleRanges),
+    decodeInlineStyleRanges(block.text, block.inlineStyleRanges).map(r => r.toJS()),
   ).toMatchSnapshot();
 });
 
@@ -29,7 +29,7 @@ test('must decode for a flat styled block', () => {
     inlineStyleRanges: [{style: 'BOLD', offset: 0, length: 5}],
   };
   expect(
-    decodeInlineStyleRanges(block.text, block.inlineStyleRanges),
+    decodeInlineStyleRanges(block.text, block.inlineStyleRanges).map(r => r.toJS()),
   ).toMatchSnapshot();
 });
 
@@ -44,7 +44,7 @@ test('must decode for a mixed-style block', () => {
     ],
   };
   expect(
-    decodeInlineStyleRanges(block.text, block.inlineStyleRanges),
+    decodeInlineStyleRanges(block.text, block.inlineStyleRanges).map(r => r.toJS()),
   ).toMatchSnapshot();
 });
 
@@ -58,6 +58,6 @@ test('must decode for strings that contain surrogate pairs in UTF-16', () => {
   };
 
   expect(
-    decodeInlineStyleRanges(block.text, block.inlineStyleRanges),
+    decodeInlineStyleRanges(block.text, block.inlineStyleRanges).map(r => r.toJS()),
   ).toMatchSnapshot();
 });

--- a/src/model/encoding/__tests__/decodeInlineStyleRanges-test.js
+++ b/src/model/encoding/__tests__/decodeInlineStyleRanges-test.js
@@ -14,87 +14,50 @@
 
 jest.disableAutomock();
 
-var {List} = require('immutable');
-var {
-  BOLD,
-  BOLD_ITALIC,
-  BOLD_ITALIC_UNDERLINE,
-  BOLD_UNDERLINE,
-  ITALIC,
-  NONE,
-} = require('SampleDraftInlineStyle');
+const decodeInlineStyleRanges = require('decodeInlineStyleRanges');
 
-var decodeInlineStyleRanges = require('decodeInlineStyleRanges');
+test('must decode for an unstyled block', () => {
+  const block = {text: 'Hello'};
+  expect(
+    decodeInlineStyleRanges(block.text, block.inlineStyleRanges),
+  ).toMatchSnapshot();
+});
 
-function areEqual(a, b) {
-  expect(List(a).equals(List(b))).toBeTruthy();
-}
+test('must decode for a flat styled block', () => {
+  const block = {
+    text: 'Hello',
+    inlineStyleRanges: [{style: 'BOLD', offset: 0, length: 5}],
+  };
+  expect(
+    decodeInlineStyleRanges(block.text, block.inlineStyleRanges),
+  ).toMatchSnapshot();
+});
 
-describe('decodeInlineStyleRanges', function() {
-  it('must decode for an unstyled block', function() {
-    var block = {text: 'Hello'};
-    var decoded = decodeInlineStyleRanges(block.text);
-    areEqual(decoded, Array(block.text.length).fill(NONE));
-  });
+test('must decode for a mixed-style block', () => {
+  const block = {
+    text: 'Hello',
+    inlineStyleRanges: [
+      {style: 'BOLD', offset: 0, length: 3},
+      {style: 'ITALIC', offset: 1, length: 3},
+      {style: 'UNDERLINE', offset: 0, length: 2},
+      {style: 'BOLD', offset: 4, length: 1},
+    ],
+  };
+  expect(
+    decodeInlineStyleRanges(block.text, block.inlineStyleRanges),
+  ).toMatchSnapshot();
+});
 
-  it('must decode for a flat styled block', function() {
-    var block = {
-      text: 'Hello',
-      inlineStyleRanges: [{style: 'BOLD', offset: 0, length: 5}],
-    };
-    var decoded = decodeInlineStyleRanges(block.text, block.inlineStyleRanges);
-    areEqual(decoded, Array(block.text.length).fill(BOLD));
-  });
+test('must decode for strings that contain surrogate pairs in UTF-16', () => {
+  const block = {
+    text: 'Take a \uD83D\uDCF7 #selfie',
+    inlineStyleRanges: [
+      {offset: 4, length: 4, style: 'BOLD'},
+      {offset: 6, length: 8, style: 'ITALIC'},
+    ],
+  };
 
-  it('must decode for a mixed-style block', function() {
-    var block = {
-      text: 'Hello',
-      inlineStyleRanges: [
-        {style: 'BOLD', offset: 0, length: 3},
-        {style: 'ITALIC', offset: 1, length: 3},
-        {style: 'UNDERLINE', offset: 0, length: 2},
-        {style: 'BOLD', offset: 4, length: 1},
-      ],
-    };
-    var decoded = decodeInlineStyleRanges(block.text, block.inlineStyleRanges);
-    areEqual(decoded, [
-      BOLD_UNDERLINE,
-      BOLD_ITALIC_UNDERLINE,
-      BOLD_ITALIC,
-      ITALIC,
-      BOLD,
-    ]);
-  });
-
-  it('must decode for strings that contain surrogate pairs in UTF-16', () => {
-    var block = {
-      text: 'Take a \uD83D\uDCF7 #selfie',
-      inlineStyleRanges: [
-        {offset: 4, length: 4, style: 'BOLD'},
-        {offset: 6, length: 8, style: 'ITALIC'},
-      ],
-    };
-
-    var decoded = decodeInlineStyleRanges(block.text, block.inlineStyleRanges);
-
-    areEqual(decoded, [
-      NONE,
-      NONE,
-      NONE,
-      NONE,
-      BOLD,
-      BOLD,
-      BOLD_ITALIC,
-      BOLD_ITALIC,
-      BOLD_ITALIC,
-      ITALIC,
-      ITALIC,
-      ITALIC,
-      ITALIC,
-      ITALIC,
-      ITALIC,
-      NONE,
-      NONE,
-    ]);
-  });
+  expect(
+    decodeInlineStyleRanges(block.text, block.inlineStyleRanges),
+  ).toMatchSnapshot();
 });

--- a/src/model/encoding/__tests__/encodeEntityRanges-test.js
+++ b/src/model/encoding/__tests__/encodeEntityRanges-test.js
@@ -14,108 +14,67 @@
 
 jest.disableAutomock();
 
-var ContentBlock = require('ContentBlock');
-var Immutable = require('immutable');
+const ContentBlock = require('ContentBlock');
+const Immutable = require('immutable');
 
-var createCharacterList = require('createCharacterList');
-var encodeEntityRanges = require('encodeEntityRanges');
+const createCharacterList = require('createCharacterList');
+const encodeEntityRanges = require('encodeEntityRanges');
 
-var {OrderedSet, Repeat} = Immutable;
+const {OrderedSet, Repeat} = Immutable;
 
-describe('encodeEntityRanges', () => {
-  function createBlock(text, entities) {
-    const style = OrderedSet();
-    return new ContentBlock({
-      key: 'a',
-      text,
-      type: 'unstyled',
-      characterList: createCharacterList(
-        Repeat(style, text.length).toArray(),
-        entities,
-      ),
-    });
-  }
-
-  it('must return an empty array if no entities present', () => {
-    var block = createBlock(' '.repeat(20), Repeat(null, 20).toArray());
-    var encoded = encodeEntityRanges(block, {});
-    expect(encoded).toEqual([]);
-
-    encoded = encodeEntityRanges(block, {'0': '0'});
-    expect(encoded).toEqual([]);
+const createBlock = (text, entities) => {
+  const style = OrderedSet();
+  return new ContentBlock({
+    key: 'a',
+    text,
+    type: 'unstyled',
+    characterList: createCharacterList(
+      Repeat(style, text.length).toArray(),
+      entities,
+    ),
   });
+};
 
-  it('must return ranges with the storage-mapped key', () => {
-    var entities = [null, null, '6', '6', null];
-    var block = createBlock(' '.repeat(entities.length), entities);
-    var encoded = encodeEntityRanges(block, {_6: '0'});
-    expect(encoded).toEqual([
-      {
-        offset: 2,
-        length: 2,
-        key: 0,
-      },
-    ]);
-  });
+test('must return an empty array if no entities present', () => {
+  const block = createBlock(' '.repeat(20), Repeat(null, 20).toArray());
+  let encoded = encodeEntityRanges(block, {});
+  expect(encoded).toMatchSnapshot();
 
-  it('must return ranges with multiple entities present', () => {
-    var entities = [null, null, '6', '6', null, '8', '8', null];
-    var block = createBlock(' '.repeat(entities.length), entities);
-    var encoded = encodeEntityRanges(block, {_6: '0', _8: '1'});
-    expect(encoded).toEqual([
-      {
-        offset: 2,
-        length: 2,
-        key: 0,
-      },
-      {
-        offset: 5,
-        length: 2,
-        key: 1,
-      },
-    ]);
-  });
+  encoded = encodeEntityRanges(block, {'0': '0'});
+  expect(encoded).toMatchSnapshot();
+});
 
-  it('must return ranges with an entity present more than once', () => {
-    var entities = [null, null, '6', '6', null, '6', '6', null];
-    var block = createBlock(' '.repeat(entities.length), entities);
-    var encoded = encodeEntityRanges(block, {_6: '0', _8: '1'});
-    expect(encoded).toEqual([
-      {
-        offset: 2,
-        length: 2,
-        key: 0,
-      },
-      {
-        offset: 5,
-        length: 2,
-        key: 0,
-      },
-    ]);
-  });
+test('must return ranges with the storage-mapped key', () => {
+  const entities = [null, null, '6', '6', null];
+  const block = createBlock(' '.repeat(entities.length), entities);
+  const encoded = encodeEntityRanges(block, {_6: '0'});
+  expect(encoded).toMatchSnapshot();
+});
 
-  it('must handle ranges that include surrogate pairs', () => {
-    var str = 'Take a \uD83D\uDCF7 #selfie';
-    // prettier-ignore
-    var entities = [
+test('must return ranges with multiple entities present', () => {
+  const entities = [null, null, '6', '6', null, '8', '8', null];
+  const block = createBlock(' '.repeat(entities.length), entities);
+  const encoded = encodeEntityRanges(block, {_6: '0', _8: '1'});
+  expect(encoded).toMatchSnapshot();
+});
+
+test('must return ranges with an entity present more than once', () => {
+  const entities = [null, null, '6', '6', null, '6', '6', null];
+  const block = createBlock(' '.repeat(entities.length), entities);
+  const encoded = encodeEntityRanges(block, {_6: '0', _8: '1'});
+  expect(encoded).toMatchSnapshot();
+});
+
+test('must handle ranges that include surrogate pairs', () => {
+  const str = 'Take a \uD83D\uDCF7 #selfie';
+  // prettier-ignore
+  const entities = [
       null, null, null, null, null, null, // `Take a`
       '6', '6', '6', '6', '6', '6',       // ` [camera] #s`
       null, null, '8', '8', null,         // `elfie`
     ];
 
-    var block = createBlock(str, entities);
-    var encoded = encodeEntityRanges(block, {_6: '0', _8: '1'});
-    expect(encoded).toEqual([
-      {
-        offset: 6,
-        length: 5,
-        key: 0,
-      },
-      {
-        offset: 13,
-        length: 2,
-        key: 1,
-      },
-    ]);
-  });
+  const block = createBlock(str, entities);
+  const encoded = encodeEntityRanges(block, {_6: '0', _8: '1'});
+  expect(encoded).toMatchSnapshot();
 });

--- a/src/model/encoding/__tests__/encodeInlineStyleRanges-test.js
+++ b/src/model/encoding/__tests__/encodeInlineStyleRanges-test.js
@@ -14,14 +14,14 @@
 
 jest.disableAutomock();
 
-var ContentBlock = require('ContentBlock');
-var Immutable = require('immutable');
-var SampleDraftInlineStyle = require('SampleDraftInlineStyle');
+const ContentBlock = require('ContentBlock');
+const Immutable = require('immutable');
+const SampleDraftInlineStyle = require('SampleDraftInlineStyle');
 
-var createCharacterList = require('createCharacterList');
-var encodeInlineStyleRanges = require('encodeInlineStyleRanges');
+const createCharacterList = require('createCharacterList');
+const encodeInlineStyleRanges = require('encodeInlineStyleRanges');
 
-var {
+const {
   BOLD,
   BOLD_ITALIC,
   BOLD_UNDERLINE,
@@ -36,104 +36,78 @@ const {List, OrderedSet, Repeat} = Immutable;
 const FOO = OrderedSet.of('foo');
 const FOO_BAR = OrderedSet.of('foo', 'bar');
 
-describe('encodeInlineStyleRanges', () => {
-  function createBlock(text, inlineStyles) {
-    return new ContentBlock({
-      key: 'a',
-      text,
-      type: 'unstyled',
-      characterList: createCharacterList(
-        inlineStyles.toArray(),
-        Repeat(null, text.length).toArray(),
-      ),
-    });
-  }
-
-  it('must encode for an unstyled document', () => {
-    expect(
-      encodeInlineStyleRanges(createBlock(' '.repeat(2), Repeat(NONE, 2))),
-    ).toEqual([]);
-    expect(
-      encodeInlineStyleRanges(createBlock(' '.repeat(20), Repeat(NONE, 20))),
-    ).toEqual([]);
-    expect(
-      encodeInlineStyleRanges(createBlock(' '.repeat(200), Repeat(NONE, 200))),
-    ).toEqual([]);
-    expect(
-      encodeInlineStyleRanges(
-        createBlock(' '.repeat(2000), Repeat(NONE, 2000)),
-      ),
-    ).toEqual([]);
+const createBlock = (text, inlineStyles) => {
+  return new ContentBlock({
+    key: 'a',
+    text,
+    type: 'unstyled',
+    characterList: createCharacterList(
+      inlineStyles.toArray(),
+      Repeat(null, text.length).toArray(),
+    ),
   });
+};
 
-  it('must encode for a flat styled document', () => {
-    expect(
-      encodeInlineStyleRanges(createBlock(' '.repeat(20), Repeat(BOLD, 20))),
-    ).toEqual([{offset: 0, length: 20, style: 'BOLD'}]);
-    expect(
-      encodeInlineStyleRanges(
-        createBlock(' '.repeat(20), Repeat(BOLD_ITALIC, 20)),
-      ),
-    ).toEqual([
-      {offset: 0, length: 20, style: 'BOLD'},
-      {offset: 0, length: 20, style: 'ITALIC'},
-    ]);
+test('must encode for an unstyled document', () => {
+  expect(
+    encodeInlineStyleRanges(createBlock(' '.repeat(2), Repeat(NONE, 2))),
+  ).toMatchSnapshot();
+  expect(
+    encodeInlineStyleRanges(createBlock(' '.repeat(20), Repeat(NONE, 20))),
+  ).toMatchSnapshot();
+  expect(
+    encodeInlineStyleRanges(createBlock(' '.repeat(200), Repeat(NONE, 200))),
+  ).toMatchSnapshot();
+  expect(
+    encodeInlineStyleRanges(createBlock(' '.repeat(2000), Repeat(NONE, 2000))),
+  ).toMatchSnapshot();
+});
 
-    var all = BOLD_ITALIC_UNDERLINE;
-    expect(
-      encodeInlineStyleRanges(createBlock(' '.repeat(20), Repeat(all, 20))),
-    ).toEqual([
-      {offset: 0, length: 20, style: 'BOLD'},
-      {offset: 0, length: 20, style: 'ITALIC'},
-      {offset: 0, length: 20, style: 'UNDERLINE'},
-    ]);
-  });
+test('must encode for a flat styled document', () => {
+  const all = BOLD_ITALIC_UNDERLINE;
+  expect(
+    encodeInlineStyleRanges(createBlock(' '.repeat(20), Repeat(BOLD, 20))),
+  ).toMatchSnapshot();
+  expect(
+    encodeInlineStyleRanges(
+      createBlock(' '.repeat(20), Repeat(BOLD_ITALIC, 20)),
+    ),
+  ).toMatchSnapshot();
+  expect(
+    encodeInlineStyleRanges(createBlock(' '.repeat(20), Repeat(all, 20))),
+  ).toMatchSnapshot();
+});
 
-  it('must encode custom styles', () => {
-    const custom = List([FOO, FOO, FOO_BAR, FOO_BAR, BOLD, BOLD]);
-    expect(
-      encodeInlineStyleRanges(createBlock(' '.repeat(6), custom)),
-    ).toEqual([
-      {offset: 0, length: 4, style: 'foo'},
-      {offset: 2, length: 2, style: 'bar'},
-      {offset: 4, length: 2, style: 'BOLD'},
-    ]);
-  });
+test('must encode custom styles', () => {
+  const custom = List([FOO, FOO, FOO_BAR, FOO_BAR, BOLD, BOLD]);
+  expect(
+    encodeInlineStyleRanges(createBlock(' '.repeat(6), custom)),
+  ).toMatchSnapshot();
+});
 
-  it('must encode for a complex styled document', () => {
-    // prettier-ignore
-    var complex = List([
+test('must encode for a complex styled document', () => {
+  // prettier-ignore
+  const complex = List([
       BOLD, BOLD, BOLD, BOLD, NONE,     // "four "
       BOLD_ITALIC, BOLD_ITALIC,         // "sc"
       ITALIC_UNDERLINE, BOLD_UNDERLINE, // "or"
       BOLD_ITALIC_UNDERLINE,            // "e"
     ]);
 
-    expect(
-      encodeInlineStyleRanges(createBlock(' '.repeat(10), complex)),
-    ).toEqual([
-      {offset: 0, length: 4, style: 'BOLD'},
-      {offset: 5, length: 2, style: 'BOLD'},
-      {offset: 8, length: 2, style: 'BOLD'},
-      {offset: 5, length: 3, style: 'ITALIC'},
-      {offset: 9, length: 1, style: 'ITALIC'},
-      {offset: 7, length: 3, style: 'UNDERLINE'},
-    ]);
-  });
+  expect(
+    encodeInlineStyleRanges(createBlock(' '.repeat(10), complex)),
+  ).toMatchSnapshot();
+});
 
-  it('must encode for strings with surrogate pairs', () => {
-    var str = 'Take a \uD83D\uDCF7 #selfie';
-    // prettier-ignore
-    var styles = List([
+test('must encode for strings with surrogate pairs', () => {
+  const str = 'Take a \uD83D\uDCF7 #selfie';
+  // prettier-ignore
+  const styles = List([
       NONE, NONE, NONE, NONE,                            // `Take`
       BOLD, BOLD, BOLD_ITALIC, BOLD_ITALIC, BOLD_ITALIC, // ` a [camera]`
       ITALIC, ITALIC, ITALIC, ITALIC, ITALIC, ITALIC,    // ` #self`
       NONE, NONE,                                        // `ie`
     ]);
 
-    expect(encodeInlineStyleRanges(createBlock(str, styles))).toEqual([
-      {offset: 4, length: 4, style: 'BOLD'},
-      {offset: 6, length: 8, style: 'ITALIC'},
-    ]);
-  });
+  expect(encodeInlineStyleRanges(createBlock(str, styles))).toMatchSnapshot();
 });

--- a/src/model/encoding/__tests__/sanitizeDraftText-test.js
+++ b/src/model/encoding/__tests__/sanitizeDraftText-test.js
@@ -12,18 +12,26 @@
 
 jest.disableAutomock();
 
-describe('sanitizeDraftText', () => {
-  var sanitizeDraftText = require('sanitizeDraftText');
-  it('must strip carriage returns', () => {
-    var trailing = 'test\u000d';
-    expect(sanitizeDraftText(trailing)).toBe('test');
-    var twoTrailing = 'test\u000d\u000d';
-    expect(sanitizeDraftText(twoTrailing)).toBe('test');
-    var within = 'te\u000dst';
-    expect(sanitizeDraftText(within)).toBe('test');
-    var leading = '\u000dtest';
-    expect(sanitizeDraftText(leading)).toBe('test');
-    var all = '\u000dt\u000des\u000dt\u000d\u000d';
-    expect(sanitizeDraftText(all)).toBe('test');
-  });
+const sanitizeDraftText = require('sanitizeDraftText');
+
+test('must strip trailing carriage returns', () => {
+  expect(sanitizeDraftText('test\u000d')).toMatchSnapshot();
+});
+
+test('must strip two trailing carriage returns', () => {
+  expect(sanitizeDraftText('test\u000d\u000d')).toMatchSnapshot();
+});
+
+test('must strip within carriage returns', () => {
+  expect(sanitizeDraftText('te\u000dst')).toMatchSnapshot();
+});
+
+test('must strip leading carriage returns', () => {
+  expect(sanitizeDraftText('\u000dtest')).toMatchSnapshot();
+});
+
+test('must strip all carriage returns', () => {
+  expect(
+    sanitizeDraftText('\u000dt\u000des\u000dt\u000d\u000d'),
+  ).toMatchSnapshot();
 });

--- a/src/model/entity/__tests__/DraftEntity-test.js
+++ b/src/model/entity/__tests__/DraftEntity-test.js
@@ -14,55 +14,48 @@
 
 jest.disableAutomock();
 
-var DraftEntity = require('DraftEntity');
+const DraftEntity = require('DraftEntity');
 
-describe('DraftEntity', () => {
-  beforeEach(() => {
-    jest.resetModules();
-  });
+beforeEach(() => {
+  jest.resetModules();
+});
 
-  function createLink() {
-    return DraftEntity.__create('LINK', 'MUTABLE', {uri: 'zombo.com'});
-  }
+const createLink = () => {
+  return DraftEntity.__create('LINK', 'MUTABLE', {uri: 'zombo.com'});
+};
 
-  it('must create instances', () => {
-    var key = createLink();
-    expect(typeof key).toBe('string');
-  });
+test('must create instances', () => {
+  const key = createLink();
+  expect(typeof key).toMatchSnapshot();
+});
 
-  it('must retrieve an instance given a key', () => {
-    var key = createLink();
-    var retrieved = DraftEntity.__get(key);
-    expect(retrieved.getType()).toBe('LINK');
-    expect(retrieved.getMutability()).toBe('MUTABLE');
-    expect(retrieved.getData()).toEqual({uri: 'zombo.com'});
-  });
+test('must retrieve an instance given a key', () => {
+  const key = createLink();
+  const retrieved = DraftEntity.__get(key);
+  expect(retrieved.getType()).toMatchSnapshot();
+  expect(retrieved.getMutability()).toMatchSnapshot();
+  expect(retrieved.getData()).toMatchSnapshot();
+});
 
-  it('must throw when retrieving for an invalid key', () => {
-    createLink();
-    expect(() => DraftEntity.__get('asdfzxcvqweriuop')).toThrow();
-    expect(() => DraftEntity.__get(null)).toThrow();
-  });
+test('must throw when retrieving for an invalid key', () => {
+  createLink();
+  expect(() => DraftEntity.__get('asdfzxcvqweriuop')).toThrow();
+  expect(() => DraftEntity.__get(null)).toThrow();
+});
 
-  it('must merge data', () => {
-    var key = createLink();
+test('must merge data', () => {
+  const key = createLink();
 
-    // Merge new property.
-    var newData = {foo: 'bar'};
-    DraftEntity.__mergeData(key, newData);
-    var newEntity = DraftEntity.__get(key);
-    expect(newEntity.getData()).toEqual({
-      uri: 'zombo.com',
-      foo: 'bar',
-    });
+  // Merge new property.
+  const newData = {foo: 'bar'};
+  DraftEntity.__mergeData(key, newData);
+  const newEntity = DraftEntity.__get(key);
 
-    // Replace existing property.
-    var withNewURI = {uri: 'homestarrunner.com'};
-    DraftEntity.__mergeData(key, withNewURI);
-    var entityWithNewURI = DraftEntity.__get(key);
-    expect(entityWithNewURI.getData()).toEqual({
-      uri: 'homestarrunner.com',
-      foo: 'bar',
-    });
-  });
+  // Replace existing property.
+  const withNewURI = {uri: 'homestarrunner.com'};
+  DraftEntity.__mergeData(key, withNewURI);
+  const entityWithNewURI = DraftEntity.__get(key);
+
+  expect(newEntity.getData()).toMatchSnapshot();
+  expect(entityWithNewURI.getData()).toMatchSnapshot();
 });

--- a/src/model/entity/__tests__/__snapshots__/DraftEntity-test.js.snap
+++ b/src/model/entity/__tests__/__snapshots__/DraftEntity-test.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must create instances 1`] = `"string"`;
+
+exports[`must merge data 1`] = `
+Object {
+  "foo": "bar",
+  "uri": "zombo.com",
+}
+`;
+
+exports[`must merge data 2`] = `
+Object {
+  "foo": "bar",
+  "uri": "homestarrunner.com",
+}
+`;
+
+exports[`must retrieve an instance given a key 1`] = `"LINK"`;
+
+exports[`must retrieve an instance given a key 2`] = `"MUTABLE"`;
+
+exports[`must retrieve an instance given a key 3`] = `
+Object {
+  "uri": "zombo.com",
+}
+`;

--- a/src/model/entity/__tests__/__snapshots__/getEntityKeyForSelection-test.js.snap
+++ b/src/model/entity/__tests__/__snapshots__/getEntityKeyForSelection-test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must not return key if immutable 1`] = `null`;
+
+exports[`must not return key if immutable with collapsed selection 1`] = `null`;
+
+exports[`must not return key if segmented 1`] = `null`;
+
+exports[`must not return key if segmented with collapsed selection 1`] = `null`;
+
+exports[`must return key if mutable 1`] = `"123"`;
+
+exports[`must return key if mutable with collapsed selection 1`] = `"123"`;
+
+exports[`must return null at start of block with collapsed selection 1`] = `null`;
+
+exports[`must return null if start is at end of block 1`] = `null`;

--- a/src/model/entity/__tests__/__snapshots__/getEntityKeyForSelection-test.js.snap
+++ b/src/model/entity/__tests__/__snapshots__/getEntityKeyForSelection-test.js.snap
@@ -8,9 +8,9 @@ exports[`must not return key if segmented 1`] = `null`;
 
 exports[`must not return key if segmented with collapsed selection 1`] = `null`;
 
-exports[`must return key if mutable 1`] = `"123"`;
+exports[`must return key if mutable 1`] = `"1"`;
 
-exports[`must return key if mutable with collapsed selection 1`] = `"123"`;
+exports[`must return key if mutable with collapsed selection 1`] = `"1"`;
 
 exports[`must return null at start of block with collapsed selection 1`] = `null`;
 

--- a/src/model/entity/__tests__/getEntityKeyForSelection-test.js
+++ b/src/model/entity/__tests__/getEntityKeyForSelection-test.js
@@ -12,83 +12,78 @@
 
 jest.disableAutomock();
 
-var getEntityKeyForSelection = require('getEntityKeyForSelection');
-var getSampleStateForTesting = require('getSampleStateForTesting');
+const getEntityKeyForSelection = require('getEntityKeyForSelection');
+const getSampleStateForTesting = require('getSampleStateForTesting');
 
-var {contentState, selectionState} = getSampleStateForTesting();
+const {contentState, selectionState} = getSampleStateForTesting();
 
-selectionState = selectionState.merge({
+const initialSelectionState = selectionState.merge({
   anchorKey: 'b',
   focusKey: 'b',
 });
 
-function setEntityMutability(mutability) {
+const COLLAPSED_SELECTION = initialSelectionState.merge({
+  anchorOffset: 2,
+  focusOffset: 2,
+});
+
+const NON_COLLAPSED_SELECTION = initialSelectionState.merge({
+  anchorOffset: 2,
+  focusKey: 'c',
+  focusOffset: 2,
+});
+
+const setEntityMutability = mutability => {
   contentState.getEntityMap().__get = () => ({
     getMutability: () => mutability,
   });
-}
-describe('getEntityKeyForSelection', () => {
-  describe('collapsed selection', () => {
-    var collapsed = selectionState.merge({
-      anchorOffset: 2,
-      focusOffset: 2,
-    });
+};
 
-    it('must return null at start of block', () => {
-      var key = getEntityKeyForSelection(contentState, selectionState);
-      expect(key).toBe(null);
-    });
+test('must return null at start of block with collapsed selection', () => {
+  const key = getEntityKeyForSelection(contentState, initialSelectionState);
+  expect(key).toMatchSnapshot();
+});
 
-    it('must return key if mutable', () => {
-      setEntityMutability('MUTABLE');
-      var key = getEntityKeyForSelection(contentState, collapsed);
-      expect(key).toBe('1');
-    });
+test('must return key if mutable with collapsed selection', () => {
+  setEntityMutability('MUTABLE');
+  const key = getEntityKeyForSelection(contentState, COLLAPSED_SELECTION);
+  expect(key).toMatchSnapshot();
+});
 
-    it('must not return key if immutable', () => {
-      setEntityMutability('IMMUTABLE');
-      var key = getEntityKeyForSelection(contentState, collapsed);
-      expect(key).toBe(null);
-    });
+test('must not return key if immutable with collapsed selection', () => {
+  setEntityMutability('IMMUTABLE');
+  const key = getEntityKeyForSelection(contentState, COLLAPSED_SELECTION);
+  expect(key).toMatchSnapshot();
+});
 
-    it('must not return key if segmented', () => {
-      setEntityMutability('SEGMENTED');
-      var key = getEntityKeyForSelection(contentState, collapsed);
-      expect(key).toBe(null);
-    });
+test('must not return key if segmented with collapsed selection', () => {
+  setEntityMutability('SEGMENTED');
+  const key = getEntityKeyForSelection(contentState, COLLAPSED_SELECTION);
+  expect(key).toMatchSnapshot();
+});
+
+test('must return null if start is at end of block', () => {
+  const startsAtEnd = NON_COLLAPSED_SELECTION.merge({
+    anchorOffset: contentState.getBlockForKey('b').getLength(),
   });
+  const key = getEntityKeyForSelection(contentState, startsAtEnd);
+  expect(key).toMatchSnapshot();
+});
 
-  describe('non-collapsed selection', () => {
-    var nonCollapsed = selectionState.merge({
-      anchorOffset: 2,
-      focusKey: 'c',
-      focusOffset: 2,
-    });
+test('must return key if mutable', () => {
+  setEntityMutability('MUTABLE');
+  const key = getEntityKeyForSelection(contentState, NON_COLLAPSED_SELECTION);
+  expect(key).toMatchSnapshot();
+});
 
-    it('must return null if start is at end of block', () => {
-      var startsAtEnd = nonCollapsed.merge({
-        anchorOffset: contentState.getBlockForKey('b').getLength(),
-      });
-      var key = getEntityKeyForSelection(contentState, startsAtEnd);
-      expect(key).toBe(null);
-    });
+test('must not return key if immutable', () => {
+  setEntityMutability('IMMUTABLE');
+  const key = getEntityKeyForSelection(contentState, NON_COLLAPSED_SELECTION);
+  expect(key).toMatchSnapshot();
+});
 
-    it('must return key if mutable', () => {
-      setEntityMutability('MUTABLE');
-      var key = getEntityKeyForSelection(contentState, nonCollapsed);
-      expect(key).toBe('1');
-    });
-
-    it('must not return key if immutable', () => {
-      setEntityMutability('IMMUTABLE');
-      var key = getEntityKeyForSelection(contentState, nonCollapsed);
-      expect(key).toBe(null);
-    });
-
-    it('must not return key if segmented', () => {
-      setEntityMutability('SEGMENTED');
-      var key = getEntityKeyForSelection(contentState, nonCollapsed);
-      expect(key).toBe(null);
-    });
-  });
+test('must not return key if segmented', () => {
+  setEntityMutability('SEGMENTED');
+  const key = getEntityKeyForSelection(contentState, NON_COLLAPSED_SELECTION);
+  expect(key).toMatchSnapshot();
 });

--- a/src/model/immutable/__tests__/BlockTree-test.js
+++ b/src/model/immutable/__tests__/BlockTree-test.js
@@ -14,322 +14,115 @@
 
 jest.disableAutomock();
 
-var BlockTree = require('BlockTree');
-var CharacterMetadata = require('CharacterMetadata');
-var ContentBlock = require('ContentBlock');
+const BlockTree = require('BlockTree');
+const CharacterMetadata = require('CharacterMetadata');
+const ContentBlock = require('ContentBlock');
 const ContentState = require('ContentState');
-var Immutable = require('immutable');
-var {BOLD} = require('SampleDraftInlineStyle');
+const Immutable = require('immutable');
+const {BOLD} = require('SampleDraftInlineStyle');
 
-var {EMPTY} = CharacterMetadata;
+const {EMPTY} = CharacterMetadata;
 
-var {Repeat} = Immutable;
+const {Repeat} = Immutable;
 
-var PLAIN_BLOCK = {
+const PLAIN_BLOCK = {
   key: 'a',
   text: 'Lincoln',
   characterList: Repeat(EMPTY, 7).toList(),
 };
 
-var boldChar = CharacterMetadata.create({style: BOLD});
-var styledChars = Repeat(EMPTY, 4).concat(
-  Repeat(boldChar, 4),
-  Repeat(EMPTY, 2),
-);
-
-var STYLED_BLOCK = {
+const STYLED_BLOCK = {
   key: 'b',
   text: 'Washington',
-  characterList: styledChars,
+  characterList: Repeat(EMPTY, 4).concat(
+    Repeat(CharacterMetadata.create({style: BOLD}), 4),
+    Repeat(EMPTY, 2),
+  ),
 };
 
-function assertLeafSetValues(leafSet, values) {
-  var {start, end, decoratorKey} = values;
-  expect(leafSet.get('start')).toBe(start);
-  expect(leafSet.get('end')).toBe(end);
-  expect(leafSet.get('decoratorKey')).toBe(decoratorKey);
-}
+class Decorator {}
+Decorator.prototype.getDecorations = jest.fn();
 
-function assertLeafValues(leaf, values) {
-  expect(leaf.get('start')).toBe(values.start);
-  expect(leaf.get('end')).toBe(values.end);
-}
+beforeEach(() => {
+  jest.resetModules();
+});
 
-describe('BlockTree', () => {
-  class Decorator {}
-  Decorator.prototype.getDecorations = jest.fn();
-  beforeEach(() => {
-    jest.resetModules();
+// empty decorator
+const emptyDecoratorFactory = length => {
+  Decorator.prototype.getDecorations.mockImplementation(() =>
+    Repeat(null, length).toList(),
+  );
+  return new Decorator();
+};
+
+// single decorator
+const singleDecoratorFactory = length => {
+  const DECORATOR_KEY = 'x';
+  const RANGE_LENGTH = 3;
+
+  Decorator.prototype.getDecorations.mockImplementation(() => {
+    return Repeat(null, RANGE_LENGTH)
+      .concat(
+        Repeat(DECORATOR_KEY, RANGE_LENGTH),
+        Repeat(null, length - 2 * RANGE_LENGTH),
+      )
+      .toList();
   });
+  return new Decorator();
+};
 
-  describe('generate tree with zero decorations', () => {
-    function getDecorator(length) {
-      Decorator.prototype.getDecorations.mockImplementation(() =>
-        Repeat(null, length).toList(),
-      );
-      return new Decorator();
-    }
+const multiDecoratorFactory = length => {
+  const DECORATOR_KEY_A = 'y';
+  const DECORATOR_KEY_B = 'z';
+  const RANGE_LENGTH = 3;
 
-    it('must generate for unstyled block', () => {
-      var block = new ContentBlock(PLAIN_BLOCK);
-      var length = PLAIN_BLOCK.text.length;
-      var decorator = getDecorator(length);
-      const contentState = ContentState.createFromText(PLAIN_BLOCK.text);
-      var tree = BlockTree.generate(contentState, block, decorator);
-
-      // No decorations, so only one leaf set.
-      expect(tree.size).toBe(1);
-      var leafSet = tree.get(0);
-      assertLeafSetValues(leafSet, {
-        start: 0,
-        end: length,
-        decoratorKey: null,
-      });
-
-      var leaves = leafSet.get('leaves');
-      expect(leaves.size).toBe(1);
-
-      var leaf = leaves.get(0);
-      assertLeafValues(leaf, {start: 0, end: length});
-
-      expect(BlockTree.getFingerprint(tree)).toBe('.1');
-    });
-
-    it('must generate for styled block', () => {
-      var block = new ContentBlock(STYLED_BLOCK);
-      var length = STYLED_BLOCK.text.length;
-      var decorator = getDecorator(length);
-      const contentState = ContentState.createFromText(STYLED_BLOCK.text);
-      var tree = BlockTree.generate(contentState, block, decorator);
-
-      // No decorations, so only one leaf set.
-      expect(tree.size).toBe(1);
-      var leafSet = tree.get(0);
-      assertLeafSetValues(leafSet, {
-        start: 0,
-        end: length,
-        decoratorKey: null,
-      });
-
-      // Three styled sections, so three leaves in this leaf set.
-      var leaves = leafSet.get('leaves');
-      expect(leaves.size).toBe(3);
-
-      assertLeafValues(leaves.get(0), {start: 0, end: 4});
-      assertLeafValues(leaves.get(1), {start: 4, end: 8});
-      assertLeafValues(leaves.get(2), {start: 8, end: 10});
-
-      expect(BlockTree.getFingerprint(tree)).toBe('.3');
-    });
+  Decorator.prototype.getDecorations.mockImplementation(() => {
+    return Repeat(DECORATOR_KEY_A, RANGE_LENGTH)
+      .concat(
+        Repeat(null, RANGE_LENGTH),
+        Repeat(DECORATOR_KEY_B, length - 2 * RANGE_LENGTH),
+      )
+      .toList();
   });
+  return new Decorator();
+};
 
-  describe('generate tree with single decoration', () => {
-    var DECORATOR_KEY = 'x';
-    var RANGE_LENGTH = 3;
+const assertBlockTreeGenerate = (
+  config,
+  getDecorator = emptyDecoratorFactory,
+) => {
+  const block = new ContentBlock(config);
+  const content = ContentState.createFromText(config.text);
+  const decorator = getDecorator(config.text.length);
+  const tree = BlockTree.generate(content, block, decorator);
 
-    function getDecorator(length) {
-      Decorator.prototype.getDecorations.mockImplementation(() => {
-        return Repeat(null, RANGE_LENGTH)
-          .concat(
-            Repeat(DECORATOR_KEY, RANGE_LENGTH),
-            Repeat(null, length - 2 * RANGE_LENGTH),
-          )
-          .toList();
-      });
-      return new Decorator();
-    }
+  expect(tree).toMatchSnapshot();
+  expect(BlockTree.getFingerprint(tree)).toMatchSnapshot();
 
-    it('must generate for unstyled block', () => {
-      var block = new ContentBlock(PLAIN_BLOCK);
-      var length = PLAIN_BLOCK.text.length;
-      var decorator = getDecorator(length);
-      const contentState = ContentState.createFromText(PLAIN_BLOCK.text);
-      var tree = BlockTree.generate(contentState, block, decorator);
+  // to remove
+  return tree;
+};
 
-      // One leaf set for each decoration range.
-      expect(tree.size).toBe(3);
-      assertLeafSetValues(tree.get(0), {
-        start: 0,
-        end: RANGE_LENGTH,
-        decoratorKey: null,
-      });
-      assertLeafSetValues(tree.get(1), {
-        start: RANGE_LENGTH,
-        end: RANGE_LENGTH * 2,
-        decoratorKey: DECORATOR_KEY,
-      });
-      assertLeafSetValues(tree.get(2), {
-        start: RANGE_LENGTH * 2,
-        end: length,
-        decoratorKey: null,
-      });
+it('must generate for unstyled block with emtpy decorator', () => {
+  assertBlockTreeGenerate(PLAIN_BLOCK);
+});
 
-      expect(tree.get(0).get('leaves').size).toBe(1);
-      expect(tree.get(1).get('leaves').size).toBe(1);
-      expect(tree.get(2).get('leaves').size).toBe(1);
+it('must generate for styled block with empty decorator', () => {
+  assertBlockTreeGenerate(STYLED_BLOCK);
+});
 
-      expect(BlockTree.getFingerprint(tree)).toBe('.1-x.3.1-.1');
-    });
+it('must generate for unstyled block with single decorator', () => {
+  assertBlockTreeGenerate(PLAIN_BLOCK, singleDecoratorFactory);
+});
 
-    it('must generate for styled block', () => {
-      var block = new ContentBlock(STYLED_BLOCK);
-      var length = STYLED_BLOCK.text.length;
-      var decorator = getDecorator(length);
-      const contentState = ContentState.createFromText(STYLED_BLOCK.text);
-      var tree = BlockTree.generate(contentState, block, decorator);
+it('must generate for styled block with single decorator', () => {
+  assertBlockTreeGenerate(STYLED_BLOCK, singleDecoratorFactory);
+});
 
-      // Leaf Sets: ['Was', 'hin', 'gton']
-      // Set 0 leaves (null entity): ['Was'] with NONE
-      // Set 1 leaves ('x' entity): ['h', 'in'] with NONE, BOLD
-      // Set 2 leaves (null entity): ['gt', 'on'] with BOLD, NONE
+it('must generate for unstyled block with multiple decorators', () => {
+  assertBlockTreeGenerate(PLAIN_BLOCK, multiDecoratorFactory);
+});
 
-      // One leaf set for each decoration range.
-      expect(tree.size).toBe(3);
-      assertLeafSetValues(tree.get(0), {
-        start: 0,
-        end: RANGE_LENGTH,
-        decoratorKey: null,
-      });
-      assertLeafSetValues(tree.get(1), {
-        start: RANGE_LENGTH,
-        end: RANGE_LENGTH * 2,
-        decoratorKey: DECORATOR_KEY,
-      });
-      assertLeafSetValues(tree.get(2), {
-        start: RANGE_LENGTH * 2,
-        end: length,
-        decoratorKey: null,
-      });
-
-      expect(tree.get(0).get('leaves').size).toBe(1);
-      expect(tree.get(1).get('leaves').size).toBe(2);
-      expect(tree.get(2).get('leaves').size).toBe(2);
-
-      expect(BlockTree.getFingerprint(tree)).toBe('.1-x.3.2-.2');
-    });
-  });
-
-  describe('generate tree with multiple decorations', () => {
-    var DECORATOR_KEY_A = 'y';
-    var DECORATOR_KEY_B = 'z';
-    var RANGE_LENGTH = 3;
-
-    function getDecorator(length) {
-      Decorator.prototype.getDecorations.mockImplementation(() => {
-        return Repeat(DECORATOR_KEY_A, RANGE_LENGTH)
-          .concat(
-            Repeat(null, RANGE_LENGTH),
-            Repeat(DECORATOR_KEY_B, length - 2 * RANGE_LENGTH),
-          )
-          .toList();
-      });
-      return new Decorator();
-    }
-
-    it('must generate for unstyled block', () => {
-      var block = new ContentBlock(PLAIN_BLOCK);
-      var length = PLAIN_BLOCK.text.length;
-      var decorator = getDecorator(length);
-      const contentState = ContentState.createFromText(PLAIN_BLOCK.text);
-      var tree = BlockTree.generate(contentState, block, decorator);
-
-      // One leaf set for each decoration range.
-      expect(tree.size).toBe(3);
-      assertLeafSetValues(tree.get(0), {
-        start: 0,
-        end: RANGE_LENGTH,
-        decoratorKey: DECORATOR_KEY_A,
-      });
-      assertLeafSetValues(tree.get(1), {
-        start: RANGE_LENGTH,
-        end: RANGE_LENGTH * 2,
-        decoratorKey: null,
-      });
-      assertLeafSetValues(tree.get(2), {
-        start: RANGE_LENGTH * 2,
-        end: length,
-        decoratorKey: DECORATOR_KEY_B,
-      });
-
-      expect(tree.get(0).get('leaves').size).toBe(1);
-      expect(tree.get(1).get('leaves').size).toBe(1);
-      expect(tree.get(2).get('leaves').size).toBe(1);
-
-      expect(BlockTree.getFingerprint(tree)).toBe('y.3.1-.1-z.1.1');
-    });
-
-    it('must generate for styled block', () => {
-      var block = new ContentBlock(STYLED_BLOCK);
-      var length = STYLED_BLOCK.text.length;
-      var decorator = getDecorator(length);
-      const contentState = ContentState.createFromText(STYLED_BLOCK.text);
-      var tree = BlockTree.generate(contentState, block, decorator);
-
-      // Leaf Sets: ['Was', 'hin', 'gton']
-      // Set 0 leaves ('y' entity): ['Was'] with NONE
-      // Set 1 leaves (null entity): ['h', 'in'] with NONE, BOLD
-      // Set 2 leaves ('z' entity): ['gt', 'on'] with BOLD, NONE
-
-      // One leaf set for each decoration range.
-      expect(tree.size).toBe(3);
-      assertLeafSetValues(tree.get(0), {
-        start: 0,
-        end: RANGE_LENGTH,
-        decoratorKey: DECORATOR_KEY_A,
-      });
-      assertLeafSetValues(tree.get(1), {
-        start: RANGE_LENGTH,
-        end: RANGE_LENGTH * 2,
-        decoratorKey: null,
-      });
-      assertLeafSetValues(tree.get(2), {
-        start: RANGE_LENGTH * 2,
-        end: length,
-        decoratorKey: DECORATOR_KEY_B,
-      });
-
-      expect(tree.get(0).get('leaves').size).toBe(1);
-      expect(
-        tree
-          .get(0)
-          .get('leaves')
-          .get(0)
-          .toJS(),
-      ).toEqual({start: 0, end: 3});
-
-      expect(tree.get(1).get('leaves').size).toBe(2);
-      expect(
-        tree
-          .get(1)
-          .get('leaves')
-          .get(0)
-          .toJS(),
-      ).toEqual({start: 3, end: 4});
-      expect(
-        tree
-          .get(1)
-          .get('leaves')
-          .get(1)
-          .toJS(),
-      ).toEqual({start: 4, end: 6});
-
-      expect(tree.get(2).get('leaves').size).toBe(2);
-      expect(
-        tree
-          .get(2)
-          .get('leaves')
-          .get(0)
-          .toJS(),
-      ).toEqual({start: 6, end: 8});
-      expect(
-        tree
-          .get(2)
-          .get('leaves')
-          .get(1)
-          .toJS(),
-      ).toEqual({start: 8, end: 10});
-
-      expect(BlockTree.getFingerprint(tree)).toBe('y.3.1-.2-z.4.2');
-    });
-  });
+it('must generate for styled block with multiple decorators', () => {
+  assertBlockTreeGenerate(STYLED_BLOCK, multiDecoratorFactory);
 });

--- a/src/model/immutable/__tests__/BlockTree-test.js
+++ b/src/model/immutable/__tests__/BlockTree-test.js
@@ -96,7 +96,7 @@ const assertBlockTreeGenerate = (
   const decorator = getDecorator(config.text.length);
   const tree = BlockTree.generate(content, block, decorator);
 
-  expect(tree).toMatchSnapshot();
+  expect(tree.toJS()).toMatchSnapshot();
   expect(BlockTree.getFingerprint(tree)).toMatchSnapshot();
 
   // to remove

--- a/src/model/immutable/__tests__/BlockTree-test.js
+++ b/src/model/immutable/__tests__/BlockTree-test.js
@@ -103,7 +103,7 @@ const assertBlockTreeGenerate = (
   return tree;
 };
 
-it('must generate for unstyled block with emtpy decorator', () => {
+it('must generate for unstyled block with empty decorator', () => {
   assertBlockTreeGenerate(PLAIN_BLOCK);
 });
 

--- a/src/model/immutable/__tests__/CharacterMetadata-test.js
+++ b/src/model/immutable/__tests__/CharacterMetadata-test.js
@@ -31,7 +31,7 @@ const withStyleAndEntity = CharacterMetadata.create({
 
 test('must have appropriate default values', () => {
   const character = CharacterMetadata.create();
-  expect(character).toMatchSnapshot();
+  expect(character.toJS()).toMatchSnapshot();
   expect(character.getStyle().size).toMatchSnapshot();
   expect(character.getEntity()).toMatchSnapshot();
 });

--- a/src/model/immutable/__tests__/CharacterMetadata-test.js
+++ b/src/model/immutable/__tests__/CharacterMetadata-test.js
@@ -24,7 +24,6 @@ const fancy = CharacterMetadata.create({style: BOLD_ITALIC});
 const withoutEntity = CharacterMetadata.create();
 const withEntity = CharacterMetadata.create({entity: 'a'});
 
-const empty = CharacterMetadata.create();
 const withStyleAndEntity = CharacterMetadata.create({
   entity: 'a',
   style: BOLD,
@@ -79,7 +78,7 @@ test('must remove entity correctly', () => {
 });
 
 test('must reuse the same objects', () => {
-  expect(CharacterMetadata.create() === empty).toMatchSnapshot();
+  expect(CharacterMetadata.create() === plain).toMatchSnapshot();
   expect(CharacterMetadata.create({style: BOLD}) === bold).toMatchSnapshot();
   expect(
     CharacterMetadata.create({style: BOLD_ITALIC}) === fancy,

--- a/src/model/immutable/__tests__/CharacterMetadata-test.js
+++ b/src/model/immutable/__tests__/CharacterMetadata-test.js
@@ -14,104 +14,99 @@
 
 jest.disableAutomock();
 
-var CharacterMetadata = require('CharacterMetadata');
-var {BOLD, BOLD_ITALIC, NONE, UNDERLINE} = require('SampleDraftInlineStyle');
+const CharacterMetadata = require('CharacterMetadata');
+const {BOLD, BOLD_ITALIC, NONE, UNDERLINE} = require('SampleDraftInlineStyle');
 
-describe('CharacterMetadata', () => {
-  it('must have appropriate default values', () => {
-    var character = CharacterMetadata.create();
-    expect(character.getStyle().size).toBe(0);
-    expect(character.getEntity()).toBe(null);
+const plain = CharacterMetadata.create();
+const bold = CharacterMetadata.create({style: BOLD});
+const fancy = CharacterMetadata.create({style: BOLD_ITALIC});
+
+const withoutEntity = CharacterMetadata.create();
+const withEntity = CharacterMetadata.create({entity: 'a'});
+
+const empty = CharacterMetadata.create();
+const withStyleAndEntity = CharacterMetadata.create({
+  entity: 'a',
+  style: BOLD,
+});
+
+test('must have appropriate default values', () => {
+  const character = CharacterMetadata.create();
+  expect(character).toMatchSnapshot();
+  expect(character.getStyle().size).toMatchSnapshot();
+  expect(character.getEntity()).toMatchSnapshot();
+});
+
+test('must run `hasStyle` correctly', () => {
+  expect(plain.hasStyle('BOLD')).toMatchSnapshot();
+  expect(bold.hasStyle('BOLD')).toMatchSnapshot();
+  expect(fancy.hasStyle('BOLD')).toMatchSnapshot();
+  expect(plain.hasStyle('ITALIC')).toMatchSnapshot();
+  expect(bold.hasStyle('ITALIC')).toMatchSnapshot();
+  expect(fancy.hasStyle('ITALIC')).toMatchSnapshot();
+});
+
+test('must apply style', () => {
+  const newlyBold = CharacterMetadata.applyStyle(plain, 'BOLD');
+  expect(newlyBold.hasStyle('BOLD')).toMatchSnapshot();
+  const alsoItalic = CharacterMetadata.applyStyle(newlyBold, 'ITALIC');
+  expect(alsoItalic.hasStyle('BOLD')).toMatchSnapshot();
+  expect(alsoItalic.hasStyle('ITALIC')).toMatchSnapshot();
+});
+
+test('must remove style', () => {
+  const justBold = CharacterMetadata.removeStyle(fancy, 'ITALIC');
+  expect(justBold.hasStyle('BOLD')).toMatchSnapshot();
+  expect(justBold.hasStyle('ITALIC')).toMatchSnapshot();
+  const justPlain = CharacterMetadata.removeStyle(justBold, 'BOLD');
+  expect(justPlain.hasStyle('BOLD')).toMatchSnapshot();
+  expect(justPlain.hasStyle('ITALIC')).toMatchSnapshot();
+});
+
+test('must apply entity correctly', () => {
+  const newKey = 'x';
+  const modifiedA = CharacterMetadata.applyEntity(withoutEntity, newKey);
+  const modifiedB = CharacterMetadata.applyEntity(withEntity, newKey);
+  expect(modifiedA.getEntity()).toMatchSnapshot();
+  expect(modifiedB.getEntity()).toMatchSnapshot();
+});
+
+test('must remove entity correctly', () => {
+  const modifiedA = CharacterMetadata.applyEntity(withoutEntity, null);
+  const modifiedB = CharacterMetadata.applyEntity(withEntity, null);
+  expect(modifiedA.getEntity()).toMatchSnapshot();
+  expect(modifiedB.getEntity()).toMatchSnapshot();
+});
+
+test('must reuse the same objects', () => {
+  expect(CharacterMetadata.create() === empty).toMatchSnapshot();
+  expect(CharacterMetadata.create({style: BOLD}) === bold).toMatchSnapshot();
+  expect(
+    CharacterMetadata.create({style: BOLD_ITALIC}) === fancy,
+  ).toMatchSnapshot();
+  expect(
+    CharacterMetadata.create({entity: 'a'}) === withEntity,
+  ).toMatchSnapshot();
+  expect(
+    CharacterMetadata.create({entity: 'a', style: BOLD}) === withStyleAndEntity,
+  ).toMatchSnapshot();
+});
+
+test('must reuse objects by defaulting config properties', () => {
+  expect(
+    CharacterMetadata.create({style: NONE, entity: 'a'}) === withEntity,
+  ).toMatchSnapshot();
+
+  expect(
+    CharacterMetadata.create({style: BOLD, entity: null}) === bold,
+  ).toMatchSnapshot();
+
+  const underlined = CharacterMetadata.create({
+    style: UNDERLINE,
+    entity: null,
   });
 
-  describe('Style handling', () => {
-    var plain = CharacterMetadata.create();
-    var bold = CharacterMetadata.create({style: BOLD});
-    var fancy = CharacterMetadata.create({style: BOLD_ITALIC});
-
-    it('must run `hasStyle` correctly', () => {
-      expect(plain.hasStyle('BOLD')).toBe(false);
-      expect(bold.hasStyle('BOLD')).toBe(true);
-      expect(fancy.hasStyle('BOLD')).toBe(true);
-      expect(plain.hasStyle('ITALIC')).toBe(false);
-      expect(bold.hasStyle('ITALIC')).toBe(false);
-      expect(fancy.hasStyle('ITALIC')).toBe(true);
-    });
-
-    it('must apply style', () => {
-      var newlyBold = CharacterMetadata.applyStyle(plain, 'BOLD');
-      expect(newlyBold.hasStyle('BOLD')).toBe(true);
-      var alsoItalic = CharacterMetadata.applyStyle(newlyBold, 'ITALIC');
-      expect(alsoItalic.hasStyle('BOLD')).toBe(true);
-      expect(alsoItalic.hasStyle('ITALIC')).toBe(true);
-    });
-
-    it('must remove style', () => {
-      var justBold = CharacterMetadata.removeStyle(fancy, 'ITALIC');
-      expect(justBold.hasStyle('BOLD')).toBe(true);
-      expect(justBold.hasStyle('ITALIC')).toBe(false);
-      var justPlain = CharacterMetadata.removeStyle(justBold, 'BOLD');
-      expect(justPlain.hasStyle('BOLD')).toBe(false);
-      expect(justPlain.hasStyle('ITALIC')).toBe(false);
-    });
-  });
-
-  describe('Entity handling', () => {
-    var withoutEntity = CharacterMetadata.create();
-    var withEntity = CharacterMetadata.create({entity: 'a'});
-
-    it('must apply entity correctly', () => {
-      var newKey = 'x';
-      var modifiedA = CharacterMetadata.applyEntity(withoutEntity, newKey);
-      var modifiedB = CharacterMetadata.applyEntity(withEntity, newKey);
-      expect(modifiedA.getEntity()).toBe(newKey);
-      expect(modifiedB.getEntity()).toBe(newKey);
-    });
-
-    it('must remove entity correctly', () => {
-      var modifiedA = CharacterMetadata.applyEntity(withoutEntity, null);
-      var modifiedB = CharacterMetadata.applyEntity(withEntity, null);
-      expect(modifiedA.getEntity()).toBe(null);
-      expect(modifiedB.getEntity()).toBe(null);
-    });
-  });
-
-  describe('Metadata Reuse', () => {
-    var empty = CharacterMetadata.create();
-    var withStyle = CharacterMetadata.create({style: BOLD});
-    var withTwoStyles = CharacterMetadata.create({style: BOLD_ITALIC});
-    var withEntity = CharacterMetadata.create({entity: '1234'});
-    var withStyleAndEntity = CharacterMetadata.create({
-      entity: '1234',
-      style: BOLD,
-    });
-
-    it('must reuse the same objects', () => {
-      expect(CharacterMetadata.create()).toBe(empty);
-      expect(CharacterMetadata.create({style: BOLD})).toBe(withStyle);
-      expect(CharacterMetadata.create({style: BOLD_ITALIC})).toBe(
-        withTwoStyles,
-      );
-      expect(CharacterMetadata.create({entity: '1234'})).toBe(withEntity);
-      expect(CharacterMetadata.create({entity: '1234', style: BOLD})).toBe(
-        withStyleAndEntity,
-      );
-    });
-
-    it('must reuse objects by defaulting config properties', () => {
-      expect(CharacterMetadata.create({style: BOLD, entity: null})).toBe(
-        withStyle,
-      );
-      expect(CharacterMetadata.create({style: NONE, entity: '1234'})).toBe(
-        withEntity,
-      );
-
-      var underlined = CharacterMetadata.create({
-        style: UNDERLINE,
-        entity: null,
-      });
-
-      expect(CharacterMetadata.create({style: UNDERLINE})).toBe(underlined);
-    });
-  });
+  expect(
+    CharacterMetadata.create({style: UNDERLINE}) === underlined,
+  ).toMatchSnapshot();
 });

--- a/src/model/immutable/__tests__/ContentBlock-test.js
+++ b/src/model/immutable/__tests__/ContentBlock-test.js
@@ -14,113 +14,90 @@
 
 jest.disableAutomock();
 
-var CharacterMetadata = require('CharacterMetadata');
-var ContentBlock = require('ContentBlock');
-var Immutable = require('immutable');
-var {NONE, BOLD} = require('SampleDraftInlineStyle');
+const CharacterMetadata = require('CharacterMetadata');
+const ContentBlock = require('ContentBlock');
+const Immutable = require('immutable');
+const {BOLD} = require('SampleDraftInlineStyle');
 
-describe('ContentBlock', () => {
-  var ENTITY_KEY = 'x';
+const ENTITY_KEY = 'x';
 
-  function getSampleBlock() {
-    return new ContentBlock({
-      key: 'a',
-      type: 'unstyled',
-      text: 'Alpha',
-      characterList: Immutable.List.of(
-        CharacterMetadata.create({style: BOLD, entity: ENTITY_KEY}),
-        CharacterMetadata.EMPTY,
-        CharacterMetadata.EMPTY,
-        CharacterMetadata.create({style: BOLD}),
-        CharacterMetadata.create({entity: ENTITY_KEY}),
-      ),
-    });
+const getSampleBlock = () => {
+  return new ContentBlock({
+    key: 'a',
+    type: 'unstyled',
+    text: 'Alpha',
+    characterList: Immutable.List.of(
+      CharacterMetadata.create({style: BOLD, entity: ENTITY_KEY}),
+      CharacterMetadata.EMPTY,
+      CharacterMetadata.EMPTY,
+      CharacterMetadata.create({style: BOLD}),
+      CharacterMetadata.create({entity: ENTITY_KEY}),
+    ),
+  });
+};
+
+test('must have appropriate default values', () => {
+  const text = 'Alpha';
+  const block = new ContentBlock({
+    key: 'a',
+    type: 'unstyled',
+    text,
+  });
+
+  expect(block.getKey()).toMatchSnapshot();
+  expect(block.getText()).toMatchSnapshot();
+  expect(block.getType()).toMatchSnapshot();
+  expect(block.getLength()).toMatchSnapshot();
+  expect(block.getCharacterList().count()).toMatchSnapshot();
+  expect(block.getCharacterList()).toMatchSnapshot();
+});
+
+test('must provide default values', () => {
+  const block = new ContentBlock();
+  expect(block.getType()).toMatchSnapshot();
+  expect(block.getText()).toMatchSnapshot();
+  expect(
+    Immutable.is(block.getCharacterList(), Immutable.List()),
+  ).toMatchSnapshot();
+});
+
+test('must retrieve properties', () => {
+  const block = getSampleBlock();
+  expect(block.getKey()).toMatchSnapshot();
+  expect(block.getText()).toMatchSnapshot();
+  expect(block.getType()).toMatchSnapshot();
+  expect(block.getLength()).toMatchSnapshot();
+  expect(block.getCharacterList().count()).toMatchSnapshot();
+});
+
+test('must properly retrieve style at offset', () => {
+  const block = getSampleBlock();
+
+  for (let i = 0; i <= 4; i++) {
+    expect(block.getInlineStyleAt(i)).toMatchSnapshot();
   }
+});
 
-  it('must have appropriate default values', () => {
-    const text = 'Alpha';
-    const block = new ContentBlock({
-      key: 'a',
-      type: 'unstyled',
-      text,
-    });
+test('must correctly identify ranges of styles', () => {
+  const block = getSampleBlock();
+  const cb = jest.fn();
+  block.findStyleRanges(() => true, cb);
 
-    const characterList = Immutable.List(
-      Immutable.Repeat(CharacterMetadata.EMPTY, text.length),
-    );
+  expect(cb.mock.calls).toMatchSnapshot();
+});
 
-    expect(block.getKey()).toBe('a');
-    expect(block.getText()).toBe('Alpha');
-    expect(block.getType()).toBe('unstyled');
-    expect(block.getLength()).toBe(5);
-    expect(block.getCharacterList().count()).toBe(5);
-    expect(block.getCharacterList()).toEqual(characterList);
-  });
+test('must properly retrieve entity at offset', () => {
+  const block = getSampleBlock();
 
-  describe('basic retrieval', () => {
-    it('must provide default values', () => {
-      var block = new ContentBlock();
-      expect(block.getType()).toBe('unstyled');
-      expect(block.getText()).toBe('');
-      expect(Immutable.is(block.getCharacterList(), Immutable.List())).toBe(
-        true,
-      );
-    });
+  for (let i = 0; i <= 4; i++) {
+    expect(block.getEntityAt(i)).toMatchSnapshot();
+  }
+});
 
-    it('must retrieve properties', () => {
-      var block = getSampleBlock();
-      expect(block.getKey()).toBe('a');
-      expect(block.getText()).toBe('Alpha');
-      expect(block.getType()).toBe('unstyled');
-      expect(block.getLength()).toBe(5);
-      expect(block.getCharacterList().count()).toBe(5);
-    });
-  });
+test('must correctly identify ranges of entities', () => {
+  const block = getSampleBlock();
+  const cb = jest.fn();
+  block.findEntityRanges(() => true, cb);
 
-  describe('style retrieval', () => {
-    it('must properly retrieve style at offset', () => {
-      var block = getSampleBlock();
-      expect(block.getInlineStyleAt(0)).toBe(BOLD);
-      expect(block.getInlineStyleAt(1)).toBe(NONE);
-      expect(block.getInlineStyleAt(2)).toBe(NONE);
-      expect(block.getInlineStyleAt(3)).toBe(BOLD);
-      expect(block.getInlineStyleAt(4)).toBe(NONE);
-    });
-
-    it('must correctly identify ranges of styles', () => {
-      var block = getSampleBlock();
-      var cb = jest.fn();
-      block.findStyleRanges(() => true, cb);
-
-      var calls = cb.mock.calls;
-      expect(calls.length).toBe(4);
-      expect(calls[0]).toEqual([0, 1]);
-      expect(calls[1]).toEqual([1, 3]);
-      expect(calls[2]).toEqual([3, 4]);
-      expect(calls[3]).toEqual([4, 5]);
-    });
-  });
-
-  describe('entity retrieval', () => {
-    it('must properly retrieve entity at offset', () => {
-      var block = getSampleBlock();
-      expect(block.getEntityAt(0)).toBe(ENTITY_KEY);
-      expect(block.getEntityAt(1)).toBe(null);
-      expect(block.getEntityAt(2)).toBe(null);
-      expect(block.getEntityAt(3)).toBe(null);
-      expect(block.getEntityAt(4)).toBe(ENTITY_KEY);
-    });
-
-    it('must correctly identify ranges of entities', () => {
-      var block = getSampleBlock();
-      var cb = jest.fn();
-      block.findEntityRanges(() => true, cb);
-
-      var calls = cb.mock.calls;
-      expect(calls.length).toBe(3);
-      expect(calls[0]).toEqual([0, 1]);
-      expect(calls[1]).toEqual([1, 4]);
-      expect(calls[2]).toEqual([4, 5]);
-    });
-  });
+  expect(cb.mock.calls).toMatchSnapshot();
 });

--- a/src/model/immutable/__tests__/ContentState-test.js
+++ b/src/model/immutable/__tests__/ContentState-test.js
@@ -12,156 +12,130 @@
 
 'use strict';
 
-jest.disableAutomock().mock('SelectionState');
+jest.disableAutomock();
 
-var BlockMapBuilder = require('BlockMapBuilder');
-var ContentBlock = require('ContentBlock');
-var ContentState = require('ContentState');
+jest.mock('SelectionState');
 
-var SINGLE_BLOCK = [{text: 'Lorem ipsum', key: 'a'}];
-var MULTI_BLOCK = [
+let contentState;
+
+const BlockMapBuilder = require('BlockMapBuilder');
+const ContentBlock = require('ContentBlock');
+const ContentState = require('ContentState');
+
+const SINGLE_BLOCK = [{text: 'Lorem ipsum', key: 'a'}];
+const MULTI_BLOCK = [
   {text: 'Four score', key: 'b'},
   {text: 'and seven', key: 'c'},
 ];
 
-var SelectionState = require('SelectionState');
+const SelectionState = require('SelectionState');
 
-describe('ContentState', () => {
-  function getContentBlocks(textBlocks) {
-    return textBlocks.map(block => new ContentBlock(block));
-  }
+const createLink = () => {
+  return contentState.createEntity('LINK', 'MUTABLE', {uri: 'zombo.com'});
+};
 
-  function getConfigForText(textBlocks) {
-    var contentBlocks = getContentBlocks(textBlocks);
-    var blockMap = BlockMapBuilder.createFromArray(contentBlocks);
-    return {
-      blockMap,
-      selectionBefore: new SelectionState(),
-      selectionAfter: new SelectionState(),
-    };
-  }
-
-  function getSampleFromConfig(config) {
-    return new ContentState(config);
-  }
-
-  function getSample(textBlocks) {
-    return getSampleFromConfig(getConfigForText(textBlocks));
-  }
-
-  describe('creation and retrieval', () => {
-    it('must create a new instance', () => {
-      var state = getSample(SINGLE_BLOCK);
-      expect(state instanceof ContentState).toBe(true);
-    });
-
-    it('must create properly with an empty block array', () => {
-      var state = ContentState.createFromBlockArray([]);
-      expect(state instanceof ContentState).toBe(true);
-    });
+const getSample = textBlocks => {
+  const contentBlocks = textBlocks.map(block => new ContentBlock(block));
+  const blockMap = BlockMapBuilder.createFromArray(contentBlocks);
+  return new ContentState({
+    blockMap,
+    selectionBefore: new SelectionState(),
+    selectionAfter: new SelectionState(),
   });
+};
 
-  describe('key fetching', () => {
-    it('must succeed or fail properly', () => {
-      var singleBlock = getSample(SINGLE_BLOCK);
-      var key = SINGLE_BLOCK[0].key;
-      expect(singleBlock.getKeyBefore(key)).toBe(undefined);
-      expect(singleBlock.getKeyAfter(key)).toBe(undefined);
+beforeEach(() => {
+  contentState = ContentState.createFromText('');
+  jest.resetModules();
+});
 
-      var multiBlock = getSample(MULTI_BLOCK);
-      var firstKey = MULTI_BLOCK[0].key;
-      var secondKey = MULTI_BLOCK[1].key;
+test('must create a new instance', () => {
+  const state = getSample(SINGLE_BLOCK);
+  expect(state instanceof ContentState).toMatchSnapshot();
+});
 
-      expect(multiBlock.getKeyBefore(firstKey)).toBe(undefined);
-      expect(multiBlock.getKeyAfter(firstKey)).toBe(secondKey);
-      expect(multiBlock.getKeyBefore(secondKey)).toBe(firstKey);
-      expect(multiBlock.getKeyAfter(secondKey)).toBe(undefined);
-    });
+test('must create properly with an empty block array', () => {
+  const state = ContentState.createFromBlockArray([]);
+  expect(state instanceof ContentState).toMatchSnapshot();
+});
+
+test('key fetching must succeed or fail properly', () => {
+  const singleBlock = getSample(SINGLE_BLOCK);
+  const key = SINGLE_BLOCK[0].key;
+  const multiBlock = getSample(MULTI_BLOCK);
+  const firstKey = MULTI_BLOCK[0].key;
+  const secondKey = MULTI_BLOCK[1].key;
+
+  expect(singleBlock.getKeyAfter(key)).toMatchSnapshot();
+  expect(singleBlock.getKeyBefore(key)).toMatchSnapshot();
+  expect(singleBlock.getKeyAfter(key)).toMatchSnapshot();
+
+  expect(multiBlock.getKeyBefore(firstKey)).toMatchSnapshot();
+  expect(multiBlock.getKeyAfter(firstKey)).toMatchSnapshot();
+  expect(multiBlock.getKeyBefore(secondKey)).toMatchSnapshot();
+  expect(multiBlock.getKeyAfter(secondKey)).toMatchSnapshot();
+});
+
+test('block fetching must retrieve or fail fetching block for key', () => {
+  const state = getSample(SINGLE_BLOCK);
+  const block = state.getBlockForKey('a');
+
+  expect(block instanceof ContentBlock).toMatchSnapshot();
+  expect(block.getText()).toMatchSnapshot();
+  expect(state.getBlockForKey('x')).toMatchSnapshot();
+});
+
+test('must create entities instances', () => {
+  const contentState = createLink();
+  expect(typeof contentState.getLastCreatedEntityKey()).toMatchSnapshot();
+});
+
+test('must retrieve an entities instance given a key', () => {
+  const contentState = createLink();
+  const retrieved = contentState.getEntity(
+    contentState.getLastCreatedEntityKey(),
+  );
+  expect(retrieved.getType()).toMatchSnapshot();
+  expect(retrieved.getMutability()).toMatchSnapshot();
+  expect(retrieved.getData()).toMatchSnapshot();
+});
+
+test('must throw when retrieving entities for an invalid key', () => {
+  const contentState = createLink();
+  expect(() => contentState.getEntity('asdfzxcvqweriuop')).toThrow();
+  expect(() => contentState.getEntity(null)).toThrow();
+});
+
+test('must merge entities data', () => {
+  const contentState = createLink();
+  const key = contentState.getLastCreatedEntityKey();
+
+  // Merge new property.
+  const contentStateWithNewProp = contentState.mergeEntityData(key, {
+    foo: 'bar',
   });
+  const updatedEntity = contentStateWithNewProp.getEntity(key);
 
-  describe('block fetching', () => {
-    it('must retrieve or fail fetching block for key', () => {
-      var state = getSample(SINGLE_BLOCK);
-      var block = state.getBlockForKey('a');
-      expect(block instanceof ContentBlock).toBe(true);
-      expect(block.getText()).toBe(SINGLE_BLOCK[0].text);
-      expect(state.getBlockForKey('x')).toBe(undefined);
-    });
+  // Replace existing property.
+  const contentStateWithUpdatedProp = contentStateWithNewProp.mergeEntityData(
+    key,
+    {uri: 'homestarrunner.com'},
+  );
+  const entityWithNewURI = contentStateWithUpdatedProp.getEntity(key);
+
+  expect(updatedEntity.getData()).toMatchSnapshot();
+  expect(entityWithNewURI.getData()).toMatchSnapshot();
+});
+
+test('must replace entities data', () => {
+  const contentState = createLink();
+  const key = contentState.getLastCreatedEntityKey();
+
+  const updatedContentState = contentState.replaceEntityData(key, {
+    uri: 'something.com',
+    newProp: 'baz',
   });
+  const entityWithReplacedData = updatedContentState.getEntity(key);
 
-  describe('entities', () => {
-    let contentState;
-    beforeEach(() => {
-      contentState = ContentState.createFromText('');
-      jest.resetModules();
-    });
-
-    function createLink() {
-      return contentState.createEntity('LINK', 'MUTABLE', {uri: 'zombo.com'});
-    }
-
-    it('must create instances', () => {
-      const contentState = createLink();
-      expect(typeof contentState.getLastCreatedEntityKey()).toBe('string');
-    });
-
-    it('must retrieve an instance given a key', () => {
-      const contentState = createLink();
-      const retrieved = contentState.getEntity(
-        contentState.getLastCreatedEntityKey(),
-      );
-      expect(retrieved.getType()).toBe('LINK');
-      expect(retrieved.getMutability()).toBe('MUTABLE');
-      expect(retrieved.getData()).toEqual({uri: 'zombo.com'});
-    });
-
-    it('must throw when retrieving for an invalid key', () => {
-      const contentState = createLink();
-      expect(() => contentState.getEntity('asdfzxcvqweriuop')).toThrow();
-      expect(() => contentState.getEntity(null)).toThrow();
-    });
-
-    it('must merge data', () => {
-      const contentState = createLink();
-
-      // Merge new property.
-      const newData = {foo: 'bar'};
-      const key = contentState.getLastCreatedEntityKey();
-      const contentStateWithNewProp = contentState.mergeEntityData(
-        key,
-        newData,
-      );
-      const updatedEntity = contentStateWithNewProp.getEntity(key);
-      expect(updatedEntity.getData()).toEqual({
-        uri: 'zombo.com',
-        foo: 'bar',
-      });
-      // Replace existing property.
-      const withNewURI = {uri: 'homestarrunner.com'};
-      const contentStateWithUpdatedProp = contentStateWithNewProp.mergeEntityData(
-        key,
-        withNewURI,
-      );
-      const entityWithNewURI = contentStateWithUpdatedProp.getEntity(key);
-      expect(entityWithNewURI.getData()).toEqual({
-        uri: 'homestarrunner.com',
-        foo: 'bar',
-      });
-    });
-
-    it('must replace data', () => {
-      const contentState = createLink();
-      const key = contentState.getLastCreatedEntityKey();
-      const replacedData = {
-        uri: 'something.com',
-        newProp: 'baz',
-      };
-      const updatedContentState = contentState.replaceEntityData(
-        key,
-        replacedData,
-      );
-      const entityWithReplacedData = updatedContentState.getEntity(key);
-      expect(entityWithReplacedData.getData()).toEqual(replacedData);
-    });
-  });
+  expect(entityWithReplacedData.getData()).toMatchSnapshot();
 });

--- a/src/model/immutable/__tests__/ContentState-test.js
+++ b/src/model/immutable/__tests__/ContentState-test.js
@@ -95,9 +95,7 @@ test('must retrieve an entities instance given a key', () => {
   const retrieved = contentState.getEntity(
     contentState.getLastCreatedEntityKey(),
   );
-  expect(retrieved.getType()).toMatchSnapshot();
-  expect(retrieved.getMutability()).toMatchSnapshot();
-  expect(retrieved.getData()).toMatchSnapshot();
+  expect(retrieved).toMatchSnapshot();
 });
 
 test('must throw when retrieving entities for an invalid key', () => {

--- a/src/model/immutable/__tests__/EditorBidiService-test.js
+++ b/src/model/immutable/__tests__/EditorBidiService-test.js
@@ -14,134 +14,136 @@
 
 jest.disableAutomock();
 
-var ContentBlock = require('ContentBlock');
-var ContentState = require('ContentState');
-var EditorBidiService = require('EditorBidiService');
-var Immutable = require('immutable');
-var UnicodeBidiDirection = require('UnicodeBidiDirection');
+const ContentBlock = require('ContentBlock');
+const ContentState = require('ContentState');
+const EditorBidiService = require('EditorBidiService');
+const Immutable = require('immutable');
 
-var {OrderedMap, Seq} = Immutable;
+const {OrderedMap, Seq} = Immutable;
 
-var {LTR, RTL} = UnicodeBidiDirection;
-
-var ltr = new ContentBlock({
+const ltr = new ContentBlock({
   key: 'a',
   text: 'hello',
 });
-var rtl = new ContentBlock({
+const rtl = new ContentBlock({
   key: 'b',
   text: '\u05e9\u05d1\u05ea',
 });
-var empty = new ContentBlock({
+const empty = new ContentBlock({
   key: 'c',
   text: '',
 });
 
-describe('EditorBidiService', () => {
-  function getContentState(blocks) {
-    var keys = Seq(blocks.map(b => b.getKey()));
-    var values = Seq(blocks);
-    var blockMap = OrderedMap(keys.zip(values));
-    return new ContentState({blockMap});
-  }
+const getContentState = blocks => {
+  const keys = Seq(blocks.map(b => b.getKey()));
+  const values = Seq(blocks);
+  const blockMap = OrderedMap(keys.zip(values));
+  return new ContentState({blockMap});
+};
 
-  it('must create a new map', () => {
-    var state = getContentState([ltr]);
-    var directions = EditorBidiService.getDirectionMap(state);
-    expect(directions.keySeq().toArray()).toEqual(['a']);
-    expect(directions.valueSeq().toArray()).toEqual([LTR]);
+test('must create a new map', () => {
+  const state = getContentState([ltr]);
+  const directions = EditorBidiService.getDirectionMap(state);
+  expect(directions).toMatchSnapshot();
+});
+
+test('must return the same map if no changes', () => {
+  const state = getContentState([ltr]);
+  const directions = EditorBidiService.getDirectionMap(state);
+
+  const nextState = getContentState([ltr]);
+  const nextDirections = EditorBidiService.getDirectionMap(
+    nextState,
+    directions,
+  );
+
+  expect(state !== nextState).toMatchSnapshot();
+  expect(directions === nextDirections).toMatchSnapshot();
+
+  expect(directions).toMatchSnapshot();
+  expect(nextDirections).toMatchSnapshot();
+});
+
+test('must return the same map if no text changes', () => {
+  const state = getContentState([ltr]);
+  const directions = EditorBidiService.getDirectionMap(state);
+
+  const newLTR = new ContentBlock({
+    key: 'a',
+    text: 'hello',
+  });
+  expect(newLTR !== ltr).toMatchSnapshot();
+
+  const nextState = getContentState([newLTR]);
+  const nextDirections = EditorBidiService.getDirectionMap(
+    nextState,
+    directions,
+  );
+
+  expect(state !== nextState).toMatchSnapshot();
+  expect(directions === nextDirections).toMatchSnapshot();
+
+  expect(directions).toMatchSnapshot();
+  expect(nextDirections).toMatchSnapshot();
+});
+
+test('must return the same map if no directions change', () => {
+  const state = getContentState([ltr]);
+  const directions = EditorBidiService.getDirectionMap(state);
+
+  const newLTR = new ContentBlock({
+    key: 'a',
+    text: 'asdf',
   });
 
-  it('must return the same map if no changes', () => {
-    var state = getContentState([ltr]);
-    var directions = EditorBidiService.getDirectionMap(state);
+  const nextState = getContentState([newLTR]);
+  const nextDirections = EditorBidiService.getDirectionMap(
+    nextState,
+    directions,
+  );
 
-    var nextState = getContentState([ltr]);
-    var nextDirections = EditorBidiService.getDirectionMap(
-      nextState,
-      directions,
-    );
+  expect(newLTR !== ltr).toMatchSnapshot();
+  expect(state !== nextState).toMatchSnapshot();
+  expect(directions === nextDirections).toMatchSnapshot();
 
-    expect(state).not.toBe(nextState);
-    expect(directions).toBe(nextDirections);
+  expect(directions).toMatchSnapshot();
+  expect(nextDirections).toMatchSnapshot();
+});
+
+test('must return a new map if block keys change', () => {
+  const state = getContentState([ltr]);
+  const directions = EditorBidiService.getDirectionMap(state);
+
+  const newLTR = new ContentBlock({
+    key: 'asdf',
+    text: 'asdf',
   });
 
-  it('must return the same map if no text changes', () => {
-    var state = getContentState([ltr]);
-    var directions = EditorBidiService.getDirectionMap(state);
+  const nextState = getContentState([newLTR]);
+  const nextDirections = EditorBidiService.getDirectionMap(
+    nextState,
+    directions,
+  );
 
-    var newLTR = new ContentBlock({
-      key: 'a',
-      text: 'hello',
-    });
-    expect(newLTR).not.toBe(ltr);
+  expect(state !== nextState).toMatchSnapshot();
+  expect(directions !== nextDirections).toMatchSnapshot();
 
-    var nextState = getContentState([newLTR]);
-    var nextDirections = EditorBidiService.getDirectionMap(
-      nextState,
-      directions,
-    );
+  expect(directions).toMatchSnapshot();
+  expect(nextDirections).toMatchSnapshot();
+});
 
-    expect(state).not.toBe(nextState);
-    expect(directions).toBe(nextDirections);
-  });
+test('must return a new map if direction changes', () => {
+  const state = getContentState([ltr, empty]);
+  const directions = EditorBidiService.getDirectionMap(state);
+  const nextState = getContentState([ltr, rtl]);
+  const nextDirections = EditorBidiService.getDirectionMap(
+    nextState,
+    directions,
+  );
 
-  it('must return the same map if no directions change', () => {
-    var state = getContentState([ltr]);
-    var directions = EditorBidiService.getDirectionMap(state);
+  expect(state !== nextState).toMatchSnapshot();
+  expect(directions !== nextDirections).toMatchSnapshot();
 
-    var newLTR = new ContentBlock({
-      key: 'a',
-      text: 'asdf',
-    });
-    expect(newLTR).not.toBe(ltr);
-
-    var nextState = getContentState([newLTR]);
-    var nextDirections = EditorBidiService.getDirectionMap(
-      nextState,
-      directions,
-    );
-
-    expect(state).not.toBe(nextState);
-    expect(directions).toBe(nextDirections);
-  });
-
-  it('must return a new map if block keys change', () => {
-    var state = getContentState([ltr]);
-    var directions = EditorBidiService.getDirectionMap(state);
-
-    var newLTR = new ContentBlock({
-      key: 'asdf',
-      text: 'asdf',
-    });
-
-    var nextState = getContentState([newLTR]);
-    var nextDirections = EditorBidiService.getDirectionMap(
-      nextState,
-      directions,
-    );
-
-    expect(state).not.toBe(nextState);
-    expect(directions).not.toBe(nextDirections);
-
-    expect(nextDirections.keySeq().toArray()).toEqual(['asdf']);
-    expect(nextDirections.valueSeq().toArray()).toEqual([LTR]);
-  });
-
-  it('must return a new map if direction changes', () => {
-    var state = getContentState([ltr, empty]);
-    var directions = EditorBidiService.getDirectionMap(state);
-
-    expect(directions.valueSeq().toArray()).toEqual([LTR, LTR]);
-
-    var nextState = getContentState([ltr, rtl]);
-    var nextDirections = EditorBidiService.getDirectionMap(
-      nextState,
-      directions,
-    );
-
-    expect(state).not.toBe(nextState);
-    expect(directions).not.toBe(nextDirections);
-    expect(nextDirections.valueSeq().toArray()).toEqual([LTR, RTL]);
-  });
+  expect(directions).toMatchSnapshot();
+  expect(nextDirections).toMatchSnapshot();
 });

--- a/src/model/immutable/__tests__/EditorState-test.js
+++ b/src/model/immutable/__tests__/EditorState-test.js
@@ -14,300 +14,275 @@
 
 jest.disableAutomock();
 
-var CharacterMetadata = require('CharacterMetadata');
-var ContentBlock = require('ContentBlock');
-var ContentState = require('ContentState');
-var DraftModifier = require('DraftModifier');
-var EditorState = require('EditorState');
-var Immutable = require('immutable');
-var RichTextEditorUtil = require('RichTextEditorUtil');
-var {NONE, BOLD, ITALIC} = require('SampleDraftInlineStyle');
-var SelectionState = require('SelectionState');
+const CharacterMetadata = require('CharacterMetadata');
+const ContentBlock = require('ContentBlock');
+const ContentState = require('ContentState');
+const DraftModifier = require('DraftModifier');
+const EditorState = require('EditorState');
+const Immutable = require('immutable');
+const RichTextEditorUtil = require('RichTextEditorUtil');
+const {BOLD, ITALIC} = require('SampleDraftInlineStyle');
+const SelectionState = require('SelectionState');
 
-var {EMPTY} = CharacterMetadata;
+const {List, Repeat} = Immutable;
 
-var {List, Repeat} = Immutable;
+class Decorator {}
+Decorator.prototype.getDecorations = jest.fn();
 
-var plainBlock = new ContentBlock({
+const DEFAULT_SELECTION = {
+  anchorKey: 'a',
+  anchorOffset: 0,
+  focusKey: 'a',
+  focusOffset: 0,
+  isBackward: false,
+};
+
+const collapsedSelection = new SelectionState(DEFAULT_SELECTION);
+const rangedSelection = new SelectionState({
+  ...DEFAULT_SELECTION,
+  focusOffset: 1,
+});
+
+const plainBlock = new ContentBlock({
   key: 'a',
   text: 'Arsenal',
-  characterList: List(Repeat(EMPTY, 7)),
 });
-
-var boldChar = CharacterMetadata.create({style: BOLD});
-var boldBlock = new ContentBlock({
+const boldBlock = new ContentBlock({
   key: 'b',
   text: 'Burnley',
-  characterList: List(Repeat(boldChar, 7)),
+  characterList: List(Repeat(CharacterMetadata.create({style: BOLD}), 7)),
 });
-
-var emptyBlockA = new ContentBlock({
+const boldA = List(Repeat('x', boldBlock.getLength()));
+const emptyBlockA = new ContentBlock({
   key: 'emptyA',
   text: '',
-  characterList: List(),
 });
-
-var emptyBlockB = new ContentBlock({
+const emptyBlockB = new ContentBlock({
   key: 'emptyB',
   text: '',
-  characterList: List(),
 });
-
-var italicChar = CharacterMetadata.create({style: ITALIC});
-var italicBlock = new ContentBlock({
+const italicBlock = new ContentBlock({
   key: 'c',
   text: 'Chelsea',
-  characterList: List(Repeat(italicChar, 7)),
+  characterList: List(Repeat(CharacterMetadata.create({style: ITALIC}), 7)),
 });
 
-function getUndecoratedEditorState() {
-  var contentState = ContentState.createFromBlockArray([
-    plainBlock,
-    boldBlock,
-    emptyBlockA,
-    emptyBlockB,
-    italicBlock,
-  ]);
-  return EditorState.createWithContent(contentState);
-}
+const getSampleEditorState = (type, decorator) => {
+  switch (type) {
+    case 'DECORATED':
+      return EditorState.createWithContent(
+        ContentState.createFromBlockArray([boldBlock, italicBlock]),
+        decorator,
+      );
+    case 'MULTI_BLOCK':
+      return EditorState.createWithContent(
+        ContentState.createFromBlockArray([
+          emptyBlockA,
+          emptyBlockB,
+          boldBlock,
+        ]),
+      );
+    case 'UNDECORATED':
+    default:
+      return EditorState.createWithContent(
+        ContentState.createFromBlockArray([
+          plainBlock,
+          boldBlock,
+          emptyBlockA,
+          emptyBlockB,
+          italicBlock,
+        ]),
+      );
+  }
+};
 
-function getEmptyLedMultiBlockEditorState() {
-  var contentState = ContentState.createFromBlockArray([
-    emptyBlockA,
-    emptyBlockB,
-    boldBlock,
-  ]);
-  return EditorState.createWithContent(contentState);
-}
+const UNDECORATED_STATE = getSampleEditorState('UNDECORATED');
 
-function getDecoratedEditorState(decorator) {
-  var contentState = ContentState.createFromBlockArray([
-    boldBlock,
-    italicBlock,
-  ]);
-  return EditorState.createWithContent(contentState, decorator);
-}
+const MULTI_BLOCK_STATE = getSampleEditorState('MULTI_BLOCK');
 
-describe('EditorState', () => {
-  describe('getCurrentInlineStyle', () => {
-    var mainEditor = getUndecoratedEditorState();
+const assertGetCurrentInlineStyle = (selection, state = UNDECORATED_STATE) => {
+  const editorState = EditorState.acceptSelection(state, selection);
+  expect(editorState.getCurrentInlineStyle()).toMatchSnapshot();
+};
 
-    describe('Collapsed selection', () => {
-      var mainSelection = new SelectionState({
-        anchorKey: 'a',
-        anchorOffset: 0,
-        focusKey: 'a',
-        focusOffset: 0,
-        isBackward: false,
-      });
+beforeEach(() => {
+  Decorator.prototype.getDecorations.mockClear();
+  Decorator.prototype.getDecorations.mockImplementation((v, c) => {
+    return v === boldBlock ? boldA : List(Repeat(undefined, v.getLength()));
+  });
+});
 
-      it('uses right of the caret at document start', () => {
-        var editor = EditorState.acceptSelection(mainEditor, mainSelection);
-        expect(editor.getCurrentInlineStyle()).toBe(NONE);
-      });
+test('uses right of the caret at document start', () => {
+  assertGetCurrentInlineStyle(collapsedSelection);
+});
 
-      it('uses left of the caret, at position `1+`', () => {
-        var selection = mainSelection.merge({
-          anchorOffset: 1,
-          focusOffset: 1,
-        });
-        var editor = EditorState.acceptSelection(mainEditor, selection);
-        expect(editor.getCurrentInlineStyle()).toBe(NONE);
-      });
+test('uses left of the caret, at position `1+`', () => {
+  assertGetCurrentInlineStyle(
+    collapsedSelection.merge({
+      anchorOffset: 1,
+      focusOffset: 1,
+    }),
+  );
+});
 
-      it('uses right of the caret at offset `0` within document', () => {
-        var selection = mainSelection.merge({
-          anchorKey: 'b',
-          focusKey: 'b',
-        });
-        var editor = EditorState.acceptSelection(mainEditor, selection);
-        expect(editor.getCurrentInlineStyle()).toBe(BOLD);
-      });
+test('uses right of the caret at offset `0` within document', () => {
+  assertGetCurrentInlineStyle(
+    collapsedSelection.merge({
+      anchorKey: 'b',
+      focusKey: 'b',
+    }),
+  );
+});
 
-      it('uses previous block at offset `0` within empty block', () => {
-        var selection = mainSelection.merge({
-          anchorKey: 'emptyA',
-          focusKey: 'emptyA',
-        });
-        var editor = EditorState.acceptSelection(mainEditor, selection);
-        expect(editor.getCurrentInlineStyle()).toBe(BOLD);
-      });
+test('uses previous block at offset `0` within empty block', () => {
+  assertGetCurrentInlineStyle(
+    collapsedSelection.merge({
+      anchorKey: 'emptyA',
+      focusKey: 'emptyA',
+    }),
+  );
+});
 
-      it('looks upward through empty blocks to find a character', () => {
-        var selection = mainSelection.merge({
-          anchorKey: 'emptyB',
-          focusKey: 'emptyB',
-        });
-        var editor = EditorState.acceptSelection(mainEditor, selection);
-        expect(editor.getCurrentInlineStyle()).toBe(BOLD);
-      });
+test('looks upward through empty blocks to find a character with collapsed selection', () => {
+  assertGetCurrentInlineStyle(
+    collapsedSelection.merge({
+      anchorKey: 'emptyB',
+      focusKey: 'emptyB',
+    }),
+  );
+});
 
-      it('does not discard style override when changing block type', () => {
-        var editor = EditorState.createEmpty();
+test('does not discard style override when changing block type', () => {
+  let editor = EditorState.createEmpty();
 
-        editor = RichTextEditorUtil.toggleInlineStyle(editor, 'BOLD');
-        expect(editor.getCurrentInlineStyle().toJS()).toEqual(['BOLD']);
+  editor = RichTextEditorUtil.toggleInlineStyle(editor, 'BOLD');
+  editor = RichTextEditorUtil.toggleBlockType(editor, 'test-block');
 
-        editor = RichTextEditorUtil.toggleBlockType(editor, 'test-block');
-        expect(editor.getCurrentInlineStyle().toJS()).toEqual(['BOLD']);
-      });
+  expect(editor.getCurrentInlineStyle()).toMatchSnapshot();
+});
 
-      it('does not discard style override when adjusting depth', () => {
-        var editor = EditorState.createEmpty();
+test('does not discard style override when adjusting depth', () => {
+  let editor = EditorState.createEmpty();
 
-        editor = RichTextEditorUtil.toggleInlineStyle(editor, 'BOLD');
-        expect(editor.getCurrentInlineStyle().toJS()).toEqual(['BOLD']);
+  editor = RichTextEditorUtil.toggleInlineStyle(editor, 'BOLD');
+  editor = RichTextEditorUtil.onTab({preventDefault: () => {}}, editor, 1);
 
-        editor = RichTextEditorUtil.onTab(
-          {preventDefault: () => {}},
-          editor,
-          1,
-        );
-        expect(editor.getCurrentInlineStyle().toJS()).toEqual(['BOLD']);
-      });
+  expect(editor.getCurrentInlineStyle()).toMatchSnapshot();
+});
 
-      it('does not discard style override when splitting block', () => {
-        var editor = EditorState.createEmpty();
+test('does not discard style override when splitting block', () => {
+  let editor = EditorState.createEmpty();
 
-        editor = RichTextEditorUtil.toggleInlineStyle(editor, 'BOLD');
-        expect(editor.getCurrentInlineStyle().toJS()).toEqual(['BOLD']);
+  editor = RichTextEditorUtil.toggleInlineStyle(editor, 'BOLD');
+  editor = EditorState.push(
+    editor,
+    DraftModifier.splitBlock(editor.getCurrentContent(), editor.getSelection()),
+    'split-block',
+  );
 
-        var contentState = DraftModifier.splitBlock(
-          editor.getCurrentContent(),
-          editor.getSelection(),
-        );
+  expect(editor.getCurrentInlineStyle()).toMatchSnapshot();
+});
 
-        editor = EditorState.push(editor, contentState, 'split-block');
-        expect(editor.getCurrentInlineStyle().toJS()).toEqual(['BOLD']);
-      });
-    });
+test('uses right of the start for blocks with text', () => {
+  assertGetCurrentInlineStyle(rangedSelection.set('focusKey', 'b'));
+});
 
-    describe('Non-collapsed selection', () => {
-      var selectionState = new SelectionState({
-        anchorKey: 'a',
-        anchorOffset: 0,
-        focusKey: 'a',
-        focusOffset: 1,
-        isBackward: false,
-      });
+test('uses left of the start if starting at end of block', () => {
+  const blockB = UNDECORATED_STATE.getCurrentContent().getBlockForKey('b');
+  assertGetCurrentInlineStyle(
+    collapsedSelection.merge({
+      anchorKey: 'b',
+      anchorOffset: blockB.getLength(),
+      focusKey: 'c',
+      focusOffset: 3,
+    }),
+  );
+});
 
-      it('uses right of the start for blocks with text', () => {
-        var selection = selectionState.set('focusKey', 'b');
-        var editor = EditorState.acceptSelection(mainEditor, selection);
-        expect(editor.getCurrentInlineStyle()).toBe(NONE);
-      });
+test('looks upward through empty blocks to find a character', () => {
+  assertGetCurrentInlineStyle(
+    rangedSelection.merge({
+      anchorKey: 'emptyA',
+      anchorOffset: 0,
+      focusKey: 'c',
+      focusOffset: 3,
+    }),
+  );
+});
 
-      it('uses left of the start if starting at end of block', () => {
-        var blockB = mainEditor.getCurrentContent().getBlockForKey('b');
-        var selection = selectionState.merge({
-          anchorKey: 'b',
-          anchorOffset: blockB.getLength(),
-          focusKey: 'c',
-          focusOffset: 3,
-        });
+test('falls back to no style if in empty block at document start', () => {
+  assertGetCurrentInlineStyle(
+    new SelectionState({
+      anchorKey: 'emptyA',
+      anchorOffset: 0,
+      focusKey: 'c',
+      focusOffset: 3,
+      isBackward: false,
+    }),
+    MULTI_BLOCK_STATE,
+  );
+});
 
-        var editor = EditorState.acceptSelection(mainEditor, selection);
-        expect(editor.getCurrentInlineStyle()).toBe(BOLD);
-      });
+test('must set a new decorator', () => {
+  const decorator = new Decorator();
+  const editorState = getSampleEditorState('DECORATED', decorator);
+  const boldB = List(Repeat('y', boldBlock.getLength()));
 
-      it('looks upward through empty blocks to find a character', () => {
-        var selection = selectionState.merge({
-          anchorKey: 'emptyA',
-          anchorOffset: 0,
-          focusKey: 'c',
-          focusOffset: 3,
-        });
-        var editor = EditorState.acceptSelection(mainEditor, selection);
-        expect(editor.getCurrentInlineStyle()).toBe(BOLD);
-      });
+  expect(decorator.getDecorations.mock.calls.length).toMatchSnapshot();
 
-      it('falls back to no style if in empty block at document start', () => {
-        var editor = getEmptyLedMultiBlockEditorState(
-          new SelectionState({
-            anchorKey: 'emptyA',
-            anchorOffset: 0,
-            focusKey: 'c',
-            focusOffset: 3,
-            isBackward: false,
-          }),
-        );
-        expect(editor.getCurrentInlineStyle()).toBe(NONE);
-      });
-    });
+  Decorator.prototype.getDecorations.mockImplementation((v, c) => {
+    return v === boldBlock ? boldB : List(Repeat(undefined, v.getLength()));
   });
 
-  describe('Decorator handling', () => {
-    var boldA = List(Repeat('x', boldBlock.getLength()));
-    var boldB = List(Repeat('y', boldBlock.getLength()));
+  class NextDecorator {}
+  NextDecorator.prototype.getDecorations = jest.fn();
 
-    function Decorator() {}
-    Decorator.prototype.getDecorations = jest.fn();
+  const newDecorator = new NextDecorator();
 
-    function NextDecorator() {}
-    NextDecorator.prototype.getDecorations = jest.fn();
-
-    beforeEach(() => {
-      Decorator.prototype.getDecorations.mockClear();
-      Decorator.prototype.getDecorations.mockImplementation((v, c) => {
-        return v === boldBlock ? boldA : List(Repeat(undefined, v.getLength()));
-      });
-    });
-
-    it('must set a new decorator', () => {
-      var decorator = new Decorator();
-      var editorState = getDecoratedEditorState(decorator);
-      expect(decorator.getDecorations.mock.calls.length).toBe(2);
-
-      Decorator.prototype.getDecorations.mockImplementation((v, c) => {
-        return v === boldBlock ? boldB : List(Repeat(undefined, v.getLength()));
-      });
-      var newDecorator = new NextDecorator();
-      NextDecorator.prototype.getDecorations.mockImplementation((v, c) => {
-        return v === boldBlock ? boldB : List(Repeat(undefined, v.getLength()));
-      });
-
-      var withNewDecorator = EditorState.set(editorState, {
-        decorator: newDecorator,
-      });
-      expect(withNewDecorator).not.toBe(editorState);
-
-      // Twice for the initial tree map generation, then twice more for
-      // filter comparison.
-      expect(decorator.getDecorations.mock.calls.length).toBe(4);
-
-      // Twice for filter comparison, once for tree generation since one
-      // block has the same decoration list and is filtered out.
-      expect(newDecorator.getDecorations.mock.calls.length).toBe(3);
-
-      expect(withNewDecorator.getDecorator()).toBe(newDecorator);
-
-      // Preserve block trees that had the same decorator list.
-      expect(editorState.getBlockTree(boldBlock.getKey())).toBe(
-        withNewDecorator.getBlockTree(boldBlock.getKey()),
-      );
-
-      expect(editorState.getBlockTree(italicBlock.getKey())).not.toBe(
-        withNewDecorator.getBlockTree(italicBlock.getKey()),
-      );
-    });
-
-    it('must call decorator with correct argument types and order', () => {
-      var decorator = new Decorator();
-      getDecoratedEditorState(decorator);
-      decorator.getDecorations.mock.calls.forEach(call => {
-        expect(call[0] instanceof ContentBlock).toBe(true);
-        expect(call[1] instanceof ContentState).toBe(true);
-      });
-    });
-
-    it('must correctly remove a decorator', () => {
-      var decorator = new Decorator();
-      var editorState = getDecoratedEditorState(decorator);
-      expect(decorator.getDecorations.mock.calls.length).toBe(2);
-      var withNewDecorator = EditorState.set(editorState, {decorator: null});
-      expect(withNewDecorator).not.toBe(editorState);
-      expect(withNewDecorator.getDecorator()).toBe(null);
-      expect(decorator.getDecorations.mock.calls.length).toBe(2);
-    });
+  NextDecorator.prototype.getDecorations.mockImplementation((v, c) => {
+    return v === boldBlock ? boldB : List(Repeat(undefined, v.getLength()));
   });
+
+  const withNewDecorator = EditorState.set(editorState, {
+    decorator: newDecorator,
+  });
+
+  expect(withNewDecorator !== editorState).toMatchSnapshot();
+
+  // Twice for the initial tree map generation, then twice more for
+  // filter comparison.
+  expect(decorator.getDecorations.mock.calls.length).toMatchSnapshot();
+
+  // Twice for filter comparison, once for tree generation since one
+  // block has the same decoration list and is filtered out.
+  expect(newDecorator.getDecorations.mock.calls.length).toMatchSnapshot();
+
+  expect(withNewDecorator.getDecorator() === newDecorator).toMatchSnapshot();
+
+  // Preserve block trees that had the same decorator list.
+  expect(
+    editorState.getBlockTree(boldBlock.getKey()) ===
+      withNewDecorator.getBlockTree(boldBlock.getKey()),
+  ).toMatchSnapshot();
+
+  expect(
+    editorState.getBlockTree(italicBlock.getKey()) !==
+      withNewDecorator.getBlockTree(italicBlock.getKey()),
+  ).toMatchSnapshot();
+});
+
+test('must call decorator with correct argument types and order', () => {
+  const decorator = new Decorator();
+  getSampleEditorState('DECORATED', decorator);
+  expect(decorator.getDecorations.mock.calls.length).toMatchSnapshot();
+});
+
+test('must correctly remove a decorator', () => {
+  const decorator = new Decorator();
+  const editorState = getSampleEditorState('DECORATED', decorator);
+  const withNewDecorator = EditorState.set(editorState, {decorator: null});
+
+  expect(withNewDecorator !== editorState).toMatchSnapshot();
+  expect(decorator.getDecorations.mock.calls.length).toMatchSnapshot();
+  expect(withNewDecorator.getDecorator()).toMatchSnapshot();
 });

--- a/src/model/immutable/__tests__/SelectionState-test.js
+++ b/src/model/immutable/__tests__/SelectionState-test.js
@@ -134,7 +134,7 @@ test('is true if selection range edge overlaps test range', () => {
   expect(MULTI_BLOCK.hasEdgeWithin('c', 5, 20)).toMatchSnapshot();
 });
 
-test('works properly', () => {
+test('detects collapsed selection properly', () => {
   expect(COLLAPSED.isCollapsed()).toMatchSnapshot();
   expect(WITHIN_BLOCK.isCollapsed()).toMatchSnapshot();
   expect(MULTI_BLOCK.isCollapsed()).toMatchSnapshot();
@@ -158,7 +158,7 @@ test('properly identifies start and end offsets', () => {
   expect(MULTI_BLOCK.getEndOffset()).toMatchSnapshot();
 });
 
-test('properly identifies start end end keys when backward', () => {
+test('properly identifies start and end keys when backward', () => {
   const withinBlock = flip(WITHIN_BLOCK);
   const MULTI_BLOCK = getSample('MULTI_BLOCK', {
     isBackward: true,
@@ -170,7 +170,7 @@ test('properly identifies start end end keys when backward', () => {
   expect(MULTI_BLOCK.getEndKey()).toMatchSnapshot();
 });
 
-test('properly identifies start end end offsets when backward', () => {
+test('properly identifies start and end offsets when backward', () => {
   const withinBlock = flip(WITHIN_BLOCK);
   const MULTI_BLOCK = getSample('MULTI_BLOCK', {
     isBackward: true,

--- a/src/model/immutable/__tests__/SelectionState-test.js
+++ b/src/model/immutable/__tests__/SelectionState-test.js
@@ -14,9 +14,9 @@
 
 jest.disableAutomock();
 
-var SelectionState = require('SelectionState');
+const SelectionState = require('SelectionState');
 
-var COLLAPSED = {
+const DEFAULT_CONFIG = {
   anchorKey: 'a',
   anchorOffset: 0,
   focusKey: 'a',
@@ -25,152 +25,159 @@ var COLLAPSED = {
   hasFocus: true,
 };
 
-var WITHIN_BLOCK = {
-  anchorKey: 'a',
-  anchorOffset: 10,
-  focusKey: 'a',
-  focusOffset: 20,
-  isBackward: false,
-  hasFocus: true,
+const flip = selectionState => {
+  return selectionState.merge({
+    anchorKey: selectionState.getFocusKey(),
+    anchorOffset: selectionState.getFocusOffset(),
+    focusKey: selectionState.getAnchorKey(),
+    focusOffset: selectionState.getAnchorOffset(),
+    isBackward: !selectionState.getIsBackward(),
+  });
 };
 
-var MULTIBLOCK = {
-  anchorKey: 'b',
-  anchorOffset: 10,
-  focusKey: 'c',
-  focusOffset: 15,
-  isBackward: false,
-  hasFocus: true,
-};
+const getSample = (type, config = {}) => {
+  let selectionState;
 
-function getSample(config) {
-  return new SelectionState(config);
-}
-
-function verifyValues(state, values) {
-  var {
-    anchorKey,
-    anchorOffset,
-    focusKey,
-    focusOffset,
-    isBackward,
-    hasFocus,
-  } = values;
-
-  expect(state.getAnchorKey()).toBe(anchorKey);
-  expect(state.getAnchorOffset()).toBe(anchorOffset);
-  expect(state.getFocusKey()).toBe(focusKey);
-  expect(state.getFocusOffset()).toBe(focusOffset);
-  expect(state.getIsBackward()).toBe(isBackward);
-  expect(state.getHasFocus()).toBe(hasFocus);
-}
-
-describe('SelectionState', () => {
-  describe('creation and retrieval', () => {
-    it('must create a new instance', () => {
-      var state = getSample(COLLAPSED);
-      expect(state instanceof SelectionState).toBe(true);
-    });
-
-    it('must retrieve properties correctly', () => {
-      var state = getSample(COLLAPSED);
-      verifyValues(state, COLLAPSED);
-    });
-  });
-
-  describe('hasEdgeWithin', () => {
-    it('is false for non-edge block keys', () => {
-      expect(getSample(COLLAPSED).hasEdgeWithin('b', 0, 0)).toBe(false);
-      expect(getSample(WITHIN_BLOCK).hasEdgeWithin('b', 0, 0)).toBe(false);
-      expect(getSample(MULTIBLOCK).hasEdgeWithin('d', 0, 0)).toBe(false);
-    });
-
-    it('is false if offset is outside the selection range', () => {
-      expect(getSample(COLLAPSED).hasEdgeWithin('a', 1, 1)).toBe(false);
-      expect(getSample(WITHIN_BLOCK).hasEdgeWithin('a', 1, 1)).toBe(false);
-      expect(getSample(MULTIBLOCK).hasEdgeWithin('b', 1, 1)).toBe(false);
-    });
-
-    it('is true if key match and offset equals selection edge', () => {
-      expect(getSample(COLLAPSED).hasEdgeWithin('a', 0, 1)).toBe(true);
-      expect(getSample(WITHIN_BLOCK).hasEdgeWithin('a', 10, 15)).toBe(true);
-      expect(getSample(WITHIN_BLOCK).hasEdgeWithin('a', 15, 20)).toBe(true);
-      expect(getSample(MULTIBLOCK).hasEdgeWithin('b', 10, 20)).toBe(true);
-      expect(getSample(MULTIBLOCK).hasEdgeWithin('c', 15, 20)).toBe(true);
-    });
-
-    it('is true if selection range is entirely within test range', () => {
-      expect(
-        getSample({
-          ...COLLAPSED,
-          anchorOffset: 5,
-          focusOffset: 5,
-        }).hasEdgeWithin('a', 0, 10),
-      ).toBe(true);
-      expect(getSample(WITHIN_BLOCK).hasEdgeWithin('a', 0, 40)).toBe(true);
-    });
-
-    it('is true if selection range edge overlaps test range', () => {
-      expect(getSample(WITHIN_BLOCK).hasEdgeWithin('a', 5, 15)).toBe(true);
-      expect(getSample(WITHIN_BLOCK).hasEdgeWithin('a', 15, 25)).toBe(true);
-      expect(getSample(MULTIBLOCK).hasEdgeWithin('b', 5, 20)).toBe(true);
-      expect(getSample(MULTIBLOCK).hasEdgeWithin('c', 5, 20)).toBe(true);
-    });
-  });
-
-  describe('isCollapsed', () => {
-    it('works properly', () => {
-      expect(getSample(COLLAPSED).isCollapsed()).toBe(true);
-      expect(getSample(WITHIN_BLOCK).isCollapsed()).toBe(false);
-      expect(getSample(MULTIBLOCK).isCollapsed()).toBe(false);
-    });
-  });
-
-  describe('start and end retrieval', () => {
-    function flip(selectionState) {
-      return selectionState.merge({
-        anchorKey: selectionState.getFocusKey(),
-        anchorOffset: selectionState.getFocusOffset(),
-        focusKey: selectionState.getAnchorKey(),
-        focusOffset: selectionState.getAnchorOffset(),
-        isBackward: !selectionState.getIsBackward(),
+  switch (type) {
+    case 'MULTI_BLOCK':
+      selectionState = new SelectionState({
+        ...DEFAULT_CONFIG,
+        anchorKey: 'b',
+        focusKey: 'c',
+        anchorOffset: 10,
+        focusOffset: 15,
+        ...config,
       });
-    }
+      break;
+    case 'WITHIN_BLOCK':
+      selectionState = new SelectionState({
+        ...DEFAULT_CONFIG,
+        anchorOffset: 10,
+        focusOffset: 20,
+        ...config,
+      });
+      break;
+    case 'COLLAPSED':
+    default:
+      selectionState = new SelectionState({
+        ...DEFAULT_CONFIG,
+        ...config,
+      });
+  }
 
-    it('properly identifies start and end keys', () => {
-      expect(getSample(COLLAPSED).getStartKey()).toBe('a');
-      expect(getSample(WITHIN_BLOCK).getStartKey()).toBe('a');
-      expect(getSample(MULTIBLOCK).getStartKey()).toBe('b');
-      expect(getSample(COLLAPSED).getEndKey()).toBe('a');
-      expect(getSample(WITHIN_BLOCK).getEndKey()).toBe('a');
-      expect(getSample(MULTIBLOCK).getEndKey()).toBe('c');
-    });
+  expect(selectionState).toMatchSnapshot();
 
-    it('properly identifies start and end offsets', () => {
-      expect(getSample(COLLAPSED).getStartOffset()).toBe(0);
-      expect(getSample(WITHIN_BLOCK).getStartOffset()).toBe(10);
-      expect(getSample(MULTIBLOCK).getStartOffset()).toBe(10);
-      expect(getSample(COLLAPSED).getEndOffset()).toBe(0);
-      expect(getSample(WITHIN_BLOCK).getEndOffset()).toBe(20);
-      expect(getSample(MULTIBLOCK).getEndOffset()).toBe(15);
-    });
+  return selectionState;
+};
 
-    it('properly identifies start end end keys when backward', () => {
-      var withinBlock = flip(getSample(WITHIN_BLOCK));
-      var multiBlock = getSample({...MULTIBLOCK, isBackward: true});
-      expect(withinBlock.getStartKey()).toBe('a');
-      expect(multiBlock.getStartKey()).toBe('c');
-      expect(withinBlock.getEndKey()).toBe('a');
-      expect(multiBlock.getEndKey()).toBe('b');
-    });
+const COLLAPSED = getSample('COLLAPSED');
+const MULTI_BLOCK = getSample('MULTI_BLOCK');
+const WITHIN_BLOCK = getSample('WITHIN_BLOCK');
 
-    it('properly identifies start end end offsets when backward', () => {
-      var withinBlock = flip(getSample(WITHIN_BLOCK));
-      var multiBlock = getSample({...MULTIBLOCK, isBackward: true});
-      expect(withinBlock.getStartOffset()).toBe(10);
-      expect(multiBlock.getStartOffset()).toBe(15);
-      expect(withinBlock.getEndOffset()).toBe(20);
-      expect(multiBlock.getEndOffset()).toBe(10);
-    });
+test('must create a new instance', () => {
+  const state = COLLAPSED;
+  expect(state instanceof SelectionState).toMatchSnapshot();
+});
+
+test('must retrieve properties correctly', () => {
+  const state = COLLAPSED;
+  expect([
+    state.getAnchorKey(),
+    state.getAnchorOffset(),
+    state.getFocusKey(),
+    state.getFocusOffset(),
+    state.getIsBackward(),
+    state.getHasFocus(),
+  ]).toMatchSnapshot();
+});
+
+test('must serialize properties correctly', () => {
+  expect(COLLAPSED.serialize()).toMatchSnapshot();
+  expect(WITHIN_BLOCK.serialize()).toMatchSnapshot();
+  expect(MULTI_BLOCK.serialize()).toMatchSnapshot();
+});
+
+test('is false for non-edge block keys', () => {
+  expect(COLLAPSED.hasEdgeWithin('b', 0, 0)).toMatchSnapshot();
+  expect(WITHIN_BLOCK.hasEdgeWithin('b', 0, 0)).toMatchSnapshot();
+  expect(MULTI_BLOCK.hasEdgeWithin('d', 0, 0)).toMatchSnapshot();
+});
+
+test('is false if offset is outside the selection range', () => {
+  expect(COLLAPSED.hasEdgeWithin('a', 1, 1)).toMatchSnapshot();
+  expect(WITHIN_BLOCK.hasEdgeWithin('a', 1, 1)).toMatchSnapshot();
+  expect(MULTI_BLOCK.hasEdgeWithin('b', 1, 1)).toMatchSnapshot();
+});
+
+test('is true if key match and offset equals selection edge', () => {
+  expect(COLLAPSED.hasEdgeWithin('a', 0, 1)).toMatchSnapshot();
+  expect(WITHIN_BLOCK.hasEdgeWithin('a', 10, 15)).toMatchSnapshot();
+  expect(WITHIN_BLOCK.hasEdgeWithin('a', 15, 20)).toMatchSnapshot();
+  expect(MULTI_BLOCK.hasEdgeWithin('b', 10, 20)).toMatchSnapshot();
+  expect(MULTI_BLOCK.hasEdgeWithin('c', 15, 20)).toMatchSnapshot();
+});
+
+test('is true if selection range is entirely within test range', () => {
+  expect(
+    getSample('COLLAPSED', {
+      anchorOffset: 5,
+      focusOffset: 5,
+    }).hasEdgeWithin('a', 0, 10),
+  ).toMatchSnapshot();
+  expect(WITHIN_BLOCK.hasEdgeWithin('a', 0, 40)).toMatchSnapshot();
+});
+
+test('is true if selection range edge overlaps test range', () => {
+  expect(WITHIN_BLOCK.hasEdgeWithin('a', 5, 15)).toMatchSnapshot();
+  expect(WITHIN_BLOCK.hasEdgeWithin('a', 15, 25)).toMatchSnapshot();
+  expect(MULTI_BLOCK.hasEdgeWithin('b', 5, 20)).toMatchSnapshot();
+  expect(MULTI_BLOCK.hasEdgeWithin('c', 5, 20)).toMatchSnapshot();
+});
+
+test('works properly', () => {
+  expect(COLLAPSED.isCollapsed()).toMatchSnapshot();
+  expect(WITHIN_BLOCK.isCollapsed()).toMatchSnapshot();
+  expect(MULTI_BLOCK.isCollapsed()).toMatchSnapshot();
+});
+
+test('properly identifies start and end keys', () => {
+  expect(COLLAPSED.getStartKey()).toMatchSnapshot();
+  expect(WITHIN_BLOCK.getStartKey()).toMatchSnapshot();
+  expect(MULTI_BLOCK.getStartKey()).toMatchSnapshot();
+  expect(COLLAPSED.getEndKey()).toMatchSnapshot();
+  expect(WITHIN_BLOCK.getEndKey()).toMatchSnapshot();
+  expect(MULTI_BLOCK.getEndKey()).toMatchSnapshot();
+});
+
+test('properly identifies start and end offsets', () => {
+  expect(COLLAPSED.getStartOffset()).toMatchSnapshot();
+  expect(WITHIN_BLOCK.getStartOffset()).toMatchSnapshot();
+  expect(MULTI_BLOCK.getStartOffset()).toMatchSnapshot();
+  expect(COLLAPSED.getEndOffset()).toMatchSnapshot();
+  expect(WITHIN_BLOCK.getEndOffset()).toMatchSnapshot();
+  expect(MULTI_BLOCK.getEndOffset()).toMatchSnapshot();
+});
+
+test('properly identifies start end end keys when backward', () => {
+  const withinBlock = flip(WITHIN_BLOCK);
+  const MULTI_BLOCK = getSample('MULTI_BLOCK', {
+    isBackward: true,
   });
+
+  expect(withinBlock.getStartKey()).toMatchSnapshot();
+  expect(MULTI_BLOCK.getStartKey()).toMatchSnapshot();
+  expect(withinBlock.getEndKey()).toMatchSnapshot();
+  expect(MULTI_BLOCK.getEndKey()).toMatchSnapshot();
+});
+
+test('properly identifies start end end offsets when backward', () => {
+  const withinBlock = flip(WITHIN_BLOCK);
+  const MULTI_BLOCK = getSample('MULTI_BLOCK', {
+    isBackward: true,
+  });
+
+  expect(withinBlock.getStartOffset()).toMatchSnapshot();
+  expect(MULTI_BLOCK.getStartOffset()).toMatchSnapshot();
+  expect(withinBlock.getEndOffset()).toMatchSnapshot();
+  expect(MULTI_BLOCK.getEndOffset()).toMatchSnapshot();
 });

--- a/src/model/immutable/__tests__/__snapshots__/BlockTree-test.js.snap
+++ b/src/model/immutable/__tests__/__snapshots__/BlockTree-test.js.snap
@@ -122,7 +122,7 @@ Immutable.List [
 
 exports[`must generate for styled block with single decorator 2`] = `".1-x.3.2-.2"`;
 
-exports[`must generate for unstyled block with emtpy decorator 1`] = `
+exports[`must generate for unstyled block with empty decorator 1`] = `
 Immutable.List [
   Immutable.Record {
     "start": 0,
@@ -138,7 +138,7 @@ Immutable.List [
 ]
 `;
 
-exports[`must generate for unstyled block with emtpy decorator 2`] = `".1"`;
+exports[`must generate for unstyled block with empty decorator 2`] = `".1"`;
 
 exports[`must generate for unstyled block with multiple decorators 1`] = `
 Immutable.List [

--- a/src/model/immutable/__tests__/__snapshots__/BlockTree-test.js.snap
+++ b/src/model/immutable/__tests__/__snapshots__/BlockTree-test.js.snap
@@ -1,0 +1,221 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must generate for styled block with empty decorator 1`] = `
+Immutable.List [
+  Immutable.Record {
+    "start": 0,
+    "end": 10,
+    "decoratorKey": null,
+    "leaves": Immutable.List [
+      Immutable.Record {
+        "start": 0,
+        "end": 4,
+      },
+      Immutable.Record {
+        "start": 4,
+        "end": 8,
+      },
+      Immutable.Record {
+        "start": 8,
+        "end": 10,
+      },
+    ],
+  },
+]
+`;
+
+exports[`must generate for styled block with empty decorator 2`] = `".3"`;
+
+exports[`must generate for styled block with multiple decorators 1`] = `
+Immutable.List [
+  Immutable.Record {
+    "start": 0,
+    "end": 3,
+    "decoratorKey": "y",
+    "leaves": Immutable.List [
+      Immutable.Record {
+        "start": 0,
+        "end": 3,
+      },
+    ],
+  },
+  Immutable.Record {
+    "start": 3,
+    "end": 6,
+    "decoratorKey": null,
+    "leaves": Immutable.List [
+      Immutable.Record {
+        "start": 3,
+        "end": 4,
+      },
+      Immutable.Record {
+        "start": 4,
+        "end": 6,
+      },
+    ],
+  },
+  Immutable.Record {
+    "start": 6,
+    "end": 10,
+    "decoratorKey": "z",
+    "leaves": Immutable.List [
+      Immutable.Record {
+        "start": 6,
+        "end": 8,
+      },
+      Immutable.Record {
+        "start": 8,
+        "end": 10,
+      },
+    ],
+  },
+]
+`;
+
+exports[`must generate for styled block with multiple decorators 2`] = `"y.3.1-.2-z.4.2"`;
+
+exports[`must generate for styled block with single decorator 1`] = `
+Immutable.List [
+  Immutable.Record {
+    "start": 0,
+    "end": 3,
+    "decoratorKey": null,
+    "leaves": Immutable.List [
+      Immutable.Record {
+        "start": 0,
+        "end": 3,
+      },
+    ],
+  },
+  Immutable.Record {
+    "start": 3,
+    "end": 6,
+    "decoratorKey": "x",
+    "leaves": Immutable.List [
+      Immutable.Record {
+        "start": 3,
+        "end": 4,
+      },
+      Immutable.Record {
+        "start": 4,
+        "end": 6,
+      },
+    ],
+  },
+  Immutable.Record {
+    "start": 6,
+    "end": 10,
+    "decoratorKey": null,
+    "leaves": Immutable.List [
+      Immutable.Record {
+        "start": 6,
+        "end": 8,
+      },
+      Immutable.Record {
+        "start": 8,
+        "end": 10,
+      },
+    ],
+  },
+]
+`;
+
+exports[`must generate for styled block with single decorator 2`] = `".1-x.3.2-.2"`;
+
+exports[`must generate for unstyled block with emtpy decorator 1`] = `
+Immutable.List [
+  Immutable.Record {
+    "start": 0,
+    "end": 7,
+    "decoratorKey": null,
+    "leaves": Immutable.List [
+      Immutable.Record {
+        "start": 0,
+        "end": 7,
+      },
+    ],
+  },
+]
+`;
+
+exports[`must generate for unstyled block with emtpy decorator 2`] = `".1"`;
+
+exports[`must generate for unstyled block with multiple decorators 1`] = `
+Immutable.List [
+  Immutable.Record {
+    "start": 0,
+    "end": 3,
+    "decoratorKey": "y",
+    "leaves": Immutable.List [
+      Immutable.Record {
+        "start": 0,
+        "end": 3,
+      },
+    ],
+  },
+  Immutable.Record {
+    "start": 3,
+    "end": 6,
+    "decoratorKey": null,
+    "leaves": Immutable.List [
+      Immutable.Record {
+        "start": 3,
+        "end": 6,
+      },
+    ],
+  },
+  Immutable.Record {
+    "start": 6,
+    "end": 7,
+    "decoratorKey": "z",
+    "leaves": Immutable.List [
+      Immutable.Record {
+        "start": 6,
+        "end": 7,
+      },
+    ],
+  },
+]
+`;
+
+exports[`must generate for unstyled block with multiple decorators 2`] = `"y.3.1-.1-z.1.1"`;
+
+exports[`must generate for unstyled block with single decorator 1`] = `
+Immutable.List [
+  Immutable.Record {
+    "start": 0,
+    "end": 3,
+    "decoratorKey": null,
+    "leaves": Immutable.List [
+      Immutable.Record {
+        "start": 0,
+        "end": 3,
+      },
+    ],
+  },
+  Immutable.Record {
+    "start": 3,
+    "end": 6,
+    "decoratorKey": "x",
+    "leaves": Immutable.List [
+      Immutable.Record {
+        "start": 3,
+        "end": 6,
+      },
+    ],
+  },
+  Immutable.Record {
+    "start": 6,
+    "end": 7,
+    "decoratorKey": null,
+    "leaves": Immutable.List [
+      Immutable.Record {
+        "start": 6,
+        "end": 7,
+      },
+    ],
+  },
+]
+`;
+
+exports[`must generate for unstyled block with single decorator 2`] = `".1-x.3.1-.1"`;

--- a/src/model/immutable/__tests__/__snapshots__/BlockTree-test.js.snap
+++ b/src/model/immutable/__tests__/__snapshots__/BlockTree-test.js.snap
@@ -1,25 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`must generate for styled block with empty decorator 1`] = `
-Immutable.List [
-  Immutable.Record {
-    "start": 0,
-    "end": 10,
+Array [
+  Object {
     "decoratorKey": null,
-    "leaves": Immutable.List [
-      Immutable.Record {
-        "start": 0,
+    "end": 10,
+    "leaves": Array [
+      Object {
         "end": 4,
+        "start": 0,
       },
-      Immutable.Record {
-        "start": 4,
+      Object {
         "end": 8,
+        "start": 4,
       },
-      Immutable.Record {
-        "start": 8,
+      Object {
         "end": 10,
+        "start": 8,
       },
     ],
+    "start": 0,
   },
 ]
 `;
@@ -27,47 +27,47 @@ Immutable.List [
 exports[`must generate for styled block with empty decorator 2`] = `".3"`;
 
 exports[`must generate for styled block with multiple decorators 1`] = `
-Immutable.List [
-  Immutable.Record {
-    "start": 0,
-    "end": 3,
+Array [
+  Object {
     "decoratorKey": "y",
-    "leaves": Immutable.List [
-      Immutable.Record {
-        "start": 0,
+    "end": 3,
+    "leaves": Array [
+      Object {
         "end": 3,
+        "start": 0,
       },
     ],
+    "start": 0,
   },
-  Immutable.Record {
-    "start": 3,
-    "end": 6,
+  Object {
     "decoratorKey": null,
-    "leaves": Immutable.List [
-      Immutable.Record {
-        "start": 3,
+    "end": 6,
+    "leaves": Array [
+      Object {
         "end": 4,
+        "start": 3,
       },
-      Immutable.Record {
-        "start": 4,
+      Object {
         "end": 6,
+        "start": 4,
       },
     ],
+    "start": 3,
   },
-  Immutable.Record {
-    "start": 6,
-    "end": 10,
+  Object {
     "decoratorKey": "z",
-    "leaves": Immutable.List [
-      Immutable.Record {
-        "start": 6,
+    "end": 10,
+    "leaves": Array [
+      Object {
         "end": 8,
+        "start": 6,
       },
-      Immutable.Record {
-        "start": 8,
+      Object {
         "end": 10,
+        "start": 8,
       },
     ],
+    "start": 6,
   },
 ]
 `;
@@ -75,47 +75,47 @@ Immutable.List [
 exports[`must generate for styled block with multiple decorators 2`] = `"y.3.1-.2-z.4.2"`;
 
 exports[`must generate for styled block with single decorator 1`] = `
-Immutable.List [
-  Immutable.Record {
-    "start": 0,
+Array [
+  Object {
+    "decoratorKey": null,
     "end": 3,
-    "decoratorKey": null,
-    "leaves": Immutable.List [
-      Immutable.Record {
-        "start": 0,
+    "leaves": Array [
+      Object {
         "end": 3,
+        "start": 0,
       },
     ],
+    "start": 0,
   },
-  Immutable.Record {
-    "start": 3,
-    "end": 6,
+  Object {
     "decoratorKey": "x",
-    "leaves": Immutable.List [
-      Immutable.Record {
-        "start": 3,
+    "end": 6,
+    "leaves": Array [
+      Object {
         "end": 4,
+        "start": 3,
       },
-      Immutable.Record {
-        "start": 4,
+      Object {
         "end": 6,
+        "start": 4,
       },
     ],
+    "start": 3,
   },
-  Immutable.Record {
-    "start": 6,
-    "end": 10,
+  Object {
     "decoratorKey": null,
-    "leaves": Immutable.List [
-      Immutable.Record {
-        "start": 6,
+    "end": 10,
+    "leaves": Array [
+      Object {
         "end": 8,
+        "start": 6,
       },
-      Immutable.Record {
-        "start": 8,
+      Object {
         "end": 10,
+        "start": 8,
       },
     ],
+    "start": 6,
   },
 ]
 `;
@@ -123,17 +123,17 @@ Immutable.List [
 exports[`must generate for styled block with single decorator 2`] = `".1-x.3.2-.2"`;
 
 exports[`must generate for unstyled block with empty decorator 1`] = `
-Immutable.List [
-  Immutable.Record {
-    "start": 0,
-    "end": 7,
+Array [
+  Object {
     "decoratorKey": null,
-    "leaves": Immutable.List [
-      Immutable.Record {
-        "start": 0,
+    "end": 7,
+    "leaves": Array [
+      Object {
         "end": 7,
+        "start": 0,
       },
     ],
+    "start": 0,
   },
 ]
 `;
@@ -141,39 +141,39 @@ Immutable.List [
 exports[`must generate for unstyled block with empty decorator 2`] = `".1"`;
 
 exports[`must generate for unstyled block with multiple decorators 1`] = `
-Immutable.List [
-  Immutable.Record {
-    "start": 0,
-    "end": 3,
+Array [
+  Object {
     "decoratorKey": "y",
-    "leaves": Immutable.List [
-      Immutable.Record {
-        "start": 0,
+    "end": 3,
+    "leaves": Array [
+      Object {
         "end": 3,
+        "start": 0,
       },
     ],
+    "start": 0,
   },
-  Immutable.Record {
-    "start": 3,
-    "end": 6,
+  Object {
     "decoratorKey": null,
-    "leaves": Immutable.List [
-      Immutable.Record {
-        "start": 3,
+    "end": 6,
+    "leaves": Array [
+      Object {
         "end": 6,
+        "start": 3,
       },
     ],
+    "start": 3,
   },
-  Immutable.Record {
-    "start": 6,
-    "end": 7,
+  Object {
     "decoratorKey": "z",
-    "leaves": Immutable.List [
-      Immutable.Record {
-        "start": 6,
+    "end": 7,
+    "leaves": Array [
+      Object {
         "end": 7,
+        "start": 6,
       },
     ],
+    "start": 6,
   },
 ]
 `;
@@ -181,39 +181,39 @@ Immutable.List [
 exports[`must generate for unstyled block with multiple decorators 2`] = `"y.3.1-.1-z.1.1"`;
 
 exports[`must generate for unstyled block with single decorator 1`] = `
-Immutable.List [
-  Immutable.Record {
-    "start": 0,
+Array [
+  Object {
+    "decoratorKey": null,
     "end": 3,
-    "decoratorKey": null,
-    "leaves": Immutable.List [
-      Immutable.Record {
-        "start": 0,
+    "leaves": Array [
+      Object {
         "end": 3,
+        "start": 0,
       },
     ],
+    "start": 0,
   },
-  Immutable.Record {
-    "start": 3,
-    "end": 6,
+  Object {
     "decoratorKey": "x",
-    "leaves": Immutable.List [
-      Immutable.Record {
-        "start": 3,
+    "end": 6,
+    "leaves": Array [
+      Object {
         "end": 6,
+        "start": 3,
       },
     ],
+    "start": 3,
   },
-  Immutable.Record {
-    "start": 6,
-    "end": 7,
+  Object {
     "decoratorKey": null,
-    "leaves": Immutable.List [
-      Immutable.Record {
-        "start": 6,
+    "end": 7,
+    "leaves": Array [
+      Object {
         "end": 7,
+        "start": 6,
       },
     ],
+    "start": 6,
   },
 ]
 `;

--- a/src/model/immutable/__tests__/__snapshots__/CharacterMetadata-test.js.snap
+++ b/src/model/immutable/__tests__/__snapshots__/CharacterMetadata-test.js.snap
@@ -11,9 +11,9 @@ exports[`must apply style 2`] = `true`;
 exports[`must apply style 3`] = `true`;
 
 exports[`must have appropriate default values 1`] = `
-Immutable.Record {
-  "style": Immutable.OrderedSet [],
+Object {
   "entity": null,
+  "style": Array [],
 }
 `;
 

--- a/src/model/immutable/__tests__/__snapshots__/CharacterMetadata-test.js.snap
+++ b/src/model/immutable/__tests__/__snapshots__/CharacterMetadata-test.js.snap
@@ -1,0 +1,62 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must apply entity correctly 1`] = `"x"`;
+
+exports[`must apply entity correctly 2`] = `"x"`;
+
+exports[`must apply style 1`] = `true`;
+
+exports[`must apply style 2`] = `true`;
+
+exports[`must apply style 3`] = `true`;
+
+exports[`must have appropriate default values 1`] = `
+Immutable.Record {
+  "style": Immutable.OrderedSet [],
+  "entity": null,
+}
+`;
+
+exports[`must have appropriate default values 2`] = `0`;
+
+exports[`must have appropriate default values 3`] = `null`;
+
+exports[`must remove entity correctly 1`] = `null`;
+
+exports[`must remove entity correctly 2`] = `null`;
+
+exports[`must remove style 1`] = `true`;
+
+exports[`must remove style 2`] = `false`;
+
+exports[`must remove style 3`] = `false`;
+
+exports[`must remove style 4`] = `false`;
+
+exports[`must reuse objects by defaulting config properties 1`] = `true`;
+
+exports[`must reuse objects by defaulting config properties 2`] = `true`;
+
+exports[`must reuse objects by defaulting config properties 3`] = `true`;
+
+exports[`must reuse the same objects 1`] = `true`;
+
+exports[`must reuse the same objects 2`] = `true`;
+
+exports[`must reuse the same objects 3`] = `true`;
+
+exports[`must reuse the same objects 4`] = `true`;
+
+exports[`must reuse the same objects 5`] = `true`;
+
+exports[`must run \`hasStyle\` correctly 1`] = `false`;
+
+exports[`must run \`hasStyle\` correctly 2`] = `true`;
+
+exports[`must run \`hasStyle\` correctly 3`] = `true`;
+
+exports[`must run \`hasStyle\` correctly 4`] = `false`;
+
+exports[`must run \`hasStyle\` correctly 5`] = `false`;
+
+exports[`must run \`hasStyle\` correctly 6`] = `true`;

--- a/src/model/immutable/__tests__/__snapshots__/ContentBlock-test.js.snap
+++ b/src/model/immutable/__tests__/__snapshots__/ContentBlock-test.js.snap
@@ -1,0 +1,118 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must correctly identify ranges of entities 1`] = `
+Array [
+  Array [
+    0,
+    1,
+  ],
+  Array [
+    1,
+    4,
+  ],
+  Array [
+    4,
+    5,
+  ],
+]
+`;
+
+exports[`must correctly identify ranges of styles 1`] = `
+Array [
+  Array [
+    0,
+    1,
+  ],
+  Array [
+    1,
+    3,
+  ],
+  Array [
+    3,
+    4,
+  ],
+  Array [
+    4,
+    5,
+  ],
+]
+`;
+
+exports[`must have appropriate default values 1`] = `"a"`;
+
+exports[`must have appropriate default values 2`] = `"Alpha"`;
+
+exports[`must have appropriate default values 3`] = `"unstyled"`;
+
+exports[`must have appropriate default values 4`] = `5`;
+
+exports[`must have appropriate default values 5`] = `5`;
+
+exports[`must have appropriate default values 6`] = `
+Immutable.List [
+  Immutable.Record {
+    "style": Immutable.OrderedSet [],
+    "entity": null,
+  },
+  Immutable.Record {
+    "style": Immutable.OrderedSet [],
+    "entity": null,
+  },
+  Immutable.Record {
+    "style": Immutable.OrderedSet [],
+    "entity": null,
+  },
+  Immutable.Record {
+    "style": Immutable.OrderedSet [],
+    "entity": null,
+  },
+  Immutable.Record {
+    "style": Immutable.OrderedSet [],
+    "entity": null,
+  },
+]
+`;
+
+exports[`must properly retrieve entity at offset 1`] = `"x"`;
+
+exports[`must properly retrieve entity at offset 2`] = `null`;
+
+exports[`must properly retrieve entity at offset 3`] = `null`;
+
+exports[`must properly retrieve entity at offset 4`] = `null`;
+
+exports[`must properly retrieve entity at offset 5`] = `"x"`;
+
+exports[`must properly retrieve style at offset 1`] = `
+Immutable.OrderedSet [
+  "BOLD",
+]
+`;
+
+exports[`must properly retrieve style at offset 2`] = `Immutable.OrderedSet []`;
+
+exports[`must properly retrieve style at offset 3`] = `Immutable.OrderedSet []`;
+
+exports[`must properly retrieve style at offset 4`] = `
+Immutable.OrderedSet [
+  "BOLD",
+]
+`;
+
+exports[`must properly retrieve style at offset 5`] = `Immutable.OrderedSet []`;
+
+exports[`must provide default values 1`] = `"unstyled"`;
+
+exports[`must provide default values 2`] = `""`;
+
+exports[`must provide default values 3`] = `true`;
+
+exports[`must retrieve properties 1`] = `"a"`;
+
+exports[`must retrieve properties 2`] = `"Alpha"`;
+
+exports[`must retrieve properties 3`] = `"unstyled"`;
+
+exports[`must retrieve properties 4`] = `5`;
+
+exports[`must retrieve properties 5`] = `5`;

--- a/src/model/immutable/__tests__/__snapshots__/ContentState-test.js.snap
+++ b/src/model/immutable/__tests__/__snapshots__/ContentState-test.js.snap
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`block fetching must retrieve or fail fetching block for key 1`] = `true`;
+
+exports[`block fetching must retrieve or fail fetching block for key 2`] = `"Lorem ipsum"`;
+
+exports[`block fetching must retrieve or fail fetching block for key 3`] = `undefined`;
+
+exports[`key fetching must succeed or fail properly 1`] = `undefined`;
+
+exports[`key fetching must succeed or fail properly 2`] = `undefined`;
+
+exports[`key fetching must succeed or fail properly 3`] = `undefined`;
+
+exports[`key fetching must succeed or fail properly 4`] = `undefined`;
+
+exports[`key fetching must succeed or fail properly 5`] = `"c"`;
+
+exports[`key fetching must succeed or fail properly 6`] = `"b"`;
+
+exports[`key fetching must succeed or fail properly 7`] = `undefined`;
+
+exports[`must create a new instance 1`] = `true`;
+
+exports[`must create entities instances 1`] = `"string"`;
+
+exports[`must create properly with an empty block array 1`] = `true`;
+
+exports[`must merge entities data 1`] = `
+Object {
+  "foo": "bar",
+  "uri": "zombo.com",
+}
+`;
+
+exports[`must merge entities data 2`] = `
+Object {
+  "foo": "bar",
+  "uri": "homestarrunner.com",
+}
+`;
+
+exports[`must replace entities data 1`] = `
+Object {
+  "newProp": "baz",
+  "uri": "something.com",
+}
+`;
+
+exports[`must retrieve an entities instance given a key 1`] = `"LINK"`;
+
+exports[`must retrieve an entities instance given a key 2`] = `"MUTABLE"`;
+
+exports[`must retrieve an entities instance given a key 3`] = `
+Object {
+  "uri": "zombo.com",
+}
+`;

--- a/src/model/immutable/__tests__/__snapshots__/ContentState-test.js.snap
+++ b/src/model/immutable/__tests__/__snapshots__/ContentState-test.js.snap
@@ -47,12 +47,12 @@ Object {
 }
 `;
 
-exports[`must retrieve an entities instance given a key 1`] = `"LINK"`;
-
-exports[`must retrieve an entities instance given a key 2`] = `"MUTABLE"`;
-
-exports[`must retrieve an entities instance given a key 3`] = `
-Object {
-  "uri": "zombo.com",
+exports[`must retrieve an entities instance given a key 1`] = `
+Immutable.Record {
+  "type": "LINK",
+  "mutability": "MUTABLE",
+  "data": Object {
+    "uri": "zombo.com",
+  },
 }
 `;

--- a/src/model/immutable/__tests__/__snapshots__/EditorBidiService-test.js.snap
+++ b/src/model/immutable/__tests__/__snapshots__/EditorBidiService-test.js.snap
@@ -1,0 +1,93 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must create a new map 1`] = `
+Immutable.OrderedMap {
+  "a": "LTR",
+}
+`;
+
+exports[`must return a new map if block keys change 1`] = `true`;
+
+exports[`must return a new map if block keys change 2`] = `true`;
+
+exports[`must return a new map if block keys change 3`] = `
+Immutable.OrderedMap {
+  "a": "LTR",
+}
+`;
+
+exports[`must return a new map if block keys change 4`] = `
+Immutable.OrderedMap {
+  "asdf": "LTR",
+}
+`;
+
+exports[`must return a new map if direction changes 1`] = `true`;
+
+exports[`must return a new map if direction changes 2`] = `true`;
+
+exports[`must return a new map if direction changes 3`] = `
+Immutable.OrderedMap {
+  "a": "LTR",
+  "c": "LTR",
+}
+`;
+
+exports[`must return a new map if direction changes 4`] = `
+Immutable.OrderedMap {
+  "a": "LTR",
+  "b": "RTL",
+}
+`;
+
+exports[`must return the same map if no changes 1`] = `true`;
+
+exports[`must return the same map if no changes 2`] = `true`;
+
+exports[`must return the same map if no changes 3`] = `
+Immutable.OrderedMap {
+  "a": "LTR",
+}
+`;
+
+exports[`must return the same map if no changes 4`] = `
+Immutable.OrderedMap {
+  "a": "LTR",
+}
+`;
+
+exports[`must return the same map if no directions change 1`] = `true`;
+
+exports[`must return the same map if no directions change 2`] = `true`;
+
+exports[`must return the same map if no directions change 3`] = `true`;
+
+exports[`must return the same map if no directions change 4`] = `
+Immutable.OrderedMap {
+  "a": "LTR",
+}
+`;
+
+exports[`must return the same map if no directions change 5`] = `
+Immutable.OrderedMap {
+  "a": "LTR",
+}
+`;
+
+exports[`must return the same map if no text changes 1`] = `true`;
+
+exports[`must return the same map if no text changes 2`] = `true`;
+
+exports[`must return the same map if no text changes 3`] = `true`;
+
+exports[`must return the same map if no text changes 4`] = `
+Immutable.OrderedMap {
+  "a": "LTR",
+}
+`;
+
+exports[`must return the same map if no text changes 5`] = `
+Immutable.OrderedMap {
+  "a": "LTR",
+}
+`;

--- a/src/model/immutable/__tests__/__snapshots__/EditorState-test.js.snap
+++ b/src/model/immutable/__tests__/__snapshots__/EditorState-test.js.snap
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`does not discard style override when adjusting depth 1`] = `
+Immutable.OrderedSet [
+  "BOLD",
+]
+`;
+
+exports[`does not discard style override when changing block type 1`] = `
+Immutable.OrderedSet [
+  "BOLD",
+]
+`;
+
+exports[`does not discard style override when splitting block 1`] = `
+Immutable.OrderedSet [
+  "BOLD",
+]
+`;
+
+exports[`falls back to no style if in empty block at document start 1`] = `Immutable.OrderedSet []`;
+
+exports[`looks upward through empty blocks to find a character 1`] = `
+Immutable.OrderedSet [
+  "BOLD",
+]
+`;
+
+exports[`looks upward through empty blocks to find a character with collapsed selection 1`] = `
+Immutable.OrderedSet [
+  "BOLD",
+]
+`;
+
+exports[`must call decorator with correct argument types and order 1`] = `2`;
+
+exports[`must correctly remove a decorator 1`] = `true`;
+
+exports[`must correctly remove a decorator 2`] = `2`;
+
+exports[`must correctly remove a decorator 3`] = `null`;
+
+exports[`must set a new decorator 1`] = `2`;
+
+exports[`must set a new decorator 2`] = `true`;
+
+exports[`must set a new decorator 3`] = `4`;
+
+exports[`must set a new decorator 4`] = `3`;
+
+exports[`must set a new decorator 5`] = `true`;
+
+exports[`must set a new decorator 6`] = `true`;
+
+exports[`must set a new decorator 7`] = `true`;
+
+exports[`uses left of the caret, at position \`1+\` 1`] = `Immutable.OrderedSet []`;
+
+exports[`uses left of the start if starting at end of block 1`] = `
+Immutable.OrderedSet [
+  "BOLD",
+]
+`;
+
+exports[`uses previous block at offset \`0\` within empty block 1`] = `
+Immutable.OrderedSet [
+  "BOLD",
+]
+`;
+
+exports[`uses right of the caret at document start 1`] = `Immutable.OrderedSet []`;
+
+exports[`uses right of the caret at offset \`0\` within document 1`] = `
+Immutable.OrderedSet [
+  "BOLD",
+]
+`;
+
+exports[`uses right of the start for blocks with text 1`] = `Immutable.OrderedSet []`;

--- a/src/model/immutable/__tests__/__snapshots__/SelectionState-test.js.snap
+++ b/src/model/immutable/__tests__/__snapshots__/SelectionState-test.js.snap
@@ -33,6 +33,12 @@ Immutable.Record {
 }
 `;
 
+exports[`detects collapsed selection properly 1`] = `true`;
+
+exports[`detects collapsed selection properly 2`] = `false`;
+
+exports[`detects collapsed selection properly 3`] = `false`;
+
 exports[`is false for non-edge block keys 1`] = `false`;
 
 exports[`is false for non-edge block keys 2`] = `false`;
@@ -109,6 +115,25 @@ exports[`properly identifies start and end keys 5`] = `"a"`;
 
 exports[`properly identifies start and end keys 6`] = `"c"`;
 
+exports[`properly identifies start and end keys when backward 1`] = `
+Immutable.Record {
+  "anchorKey": "b",
+  "anchorOffset": 10,
+  "focusKey": "c",
+  "focusOffset": 15,
+  "isBackward": true,
+  "hasFocus": true,
+}
+`;
+
+exports[`properly identifies start and end keys when backward 2`] = `"a"`;
+
+exports[`properly identifies start and end keys when backward 3`] = `"c"`;
+
+exports[`properly identifies start and end keys when backward 4`] = `"a"`;
+
+exports[`properly identifies start and end keys when backward 5`] = `"b"`;
+
 exports[`properly identifies start and end offsets 1`] = `0`;
 
 exports[`properly identifies start and end offsets 2`] = `10`;
@@ -121,7 +146,7 @@ exports[`properly identifies start and end offsets 5`] = `20`;
 
 exports[`properly identifies start and end offsets 6`] = `15`;
 
-exports[`properly identifies start end end keys when backward 1`] = `
+exports[`properly identifies start and end offsets when backward 1`] = `
 Immutable.Record {
   "anchorKey": "b",
   "anchorOffset": 10,
@@ -132,35 +157,10 @@ Immutable.Record {
 }
 `;
 
-exports[`properly identifies start end end keys when backward 2`] = `"a"`;
+exports[`properly identifies start and end offsets when backward 2`] = `10`;
 
-exports[`properly identifies start end end keys when backward 3`] = `"c"`;
+exports[`properly identifies start and end offsets when backward 3`] = `15`;
 
-exports[`properly identifies start end end keys when backward 4`] = `"a"`;
+exports[`properly identifies start and end offsets when backward 4`] = `20`;
 
-exports[`properly identifies start end end keys when backward 5`] = `"b"`;
-
-exports[`properly identifies start end end offsets when backward 1`] = `
-Immutable.Record {
-  "anchorKey": "b",
-  "anchorOffset": 10,
-  "focusKey": "c",
-  "focusOffset": 15,
-  "isBackward": true,
-  "hasFocus": true,
-}
-`;
-
-exports[`properly identifies start end end offsets when backward 2`] = `10`;
-
-exports[`properly identifies start end end offsets when backward 3`] = `15`;
-
-exports[`properly identifies start end end offsets when backward 4`] = `20`;
-
-exports[`properly identifies start end end offsets when backward 5`] = `10`;
-
-exports[`works properly 1`] = `true`;
-
-exports[`works properly 2`] = `false`;
-
-exports[`works properly 3`] = `false`;
+exports[`properly identifies start and end offsets when backward 5`] = `10`;

--- a/src/model/immutable/__tests__/__snapshots__/SelectionState-test.js.snap
+++ b/src/model/immutable/__tests__/__snapshots__/SelectionState-test.js.snap
@@ -1,0 +1,166 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[` 1`] = `
+Immutable.Record {
+  "anchorKey": "a",
+  "anchorOffset": 0,
+  "focusKey": "a",
+  "focusOffset": 0,
+  "isBackward": false,
+  "hasFocus": true,
+}
+`;
+
+exports[` 2`] = `
+Immutable.Record {
+  "anchorKey": "b",
+  "anchorOffset": 10,
+  "focusKey": "c",
+  "focusOffset": 15,
+  "isBackward": false,
+  "hasFocus": true,
+}
+`;
+
+exports[` 3`] = `
+Immutable.Record {
+  "anchorKey": "a",
+  "anchorOffset": 10,
+  "focusKey": "a",
+  "focusOffset": 20,
+  "isBackward": false,
+  "hasFocus": true,
+}
+`;
+
+exports[`is false for non-edge block keys 1`] = `false`;
+
+exports[`is false for non-edge block keys 2`] = `false`;
+
+exports[`is false for non-edge block keys 3`] = `false`;
+
+exports[`is false if offset is outside the selection range 1`] = `false`;
+
+exports[`is false if offset is outside the selection range 2`] = `false`;
+
+exports[`is false if offset is outside the selection range 3`] = `false`;
+
+exports[`is true if key match and offset equals selection edge 1`] = `true`;
+
+exports[`is true if key match and offset equals selection edge 2`] = `true`;
+
+exports[`is true if key match and offset equals selection edge 3`] = `true`;
+
+exports[`is true if key match and offset equals selection edge 4`] = `true`;
+
+exports[`is true if key match and offset equals selection edge 5`] = `true`;
+
+exports[`is true if selection range edge overlaps test range 1`] = `true`;
+
+exports[`is true if selection range edge overlaps test range 2`] = `true`;
+
+exports[`is true if selection range edge overlaps test range 3`] = `true`;
+
+exports[`is true if selection range edge overlaps test range 4`] = `true`;
+
+exports[`is true if selection range is entirely within test range 1`] = `
+Immutable.Record {
+  "anchorKey": "a",
+  "anchorOffset": 5,
+  "focusKey": "a",
+  "focusOffset": 5,
+  "isBackward": false,
+  "hasFocus": true,
+}
+`;
+
+exports[`is true if selection range is entirely within test range 2`] = `true`;
+
+exports[`is true if selection range is entirely within test range 3`] = `true`;
+
+exports[`must create a new instance 1`] = `true`;
+
+exports[`must retrieve properties correctly 1`] = `
+Array [
+  "a",
+  0,
+  "a",
+  0,
+  false,
+  true,
+]
+`;
+
+exports[`must serialize properties correctly 1`] = `"Anchor: a:0, Focus: a:0, Is Backward: false, Has Focus: true"`;
+
+exports[`must serialize properties correctly 2`] = `"Anchor: a:10, Focus: a:20, Is Backward: false, Has Focus: true"`;
+
+exports[`must serialize properties correctly 3`] = `"Anchor: b:10, Focus: c:15, Is Backward: false, Has Focus: true"`;
+
+exports[`properly identifies start and end keys 1`] = `"a"`;
+
+exports[`properly identifies start and end keys 2`] = `"a"`;
+
+exports[`properly identifies start and end keys 3`] = `"b"`;
+
+exports[`properly identifies start and end keys 4`] = `"a"`;
+
+exports[`properly identifies start and end keys 5`] = `"a"`;
+
+exports[`properly identifies start and end keys 6`] = `"c"`;
+
+exports[`properly identifies start and end offsets 1`] = `0`;
+
+exports[`properly identifies start and end offsets 2`] = `10`;
+
+exports[`properly identifies start and end offsets 3`] = `10`;
+
+exports[`properly identifies start and end offsets 4`] = `0`;
+
+exports[`properly identifies start and end offsets 5`] = `20`;
+
+exports[`properly identifies start and end offsets 6`] = `15`;
+
+exports[`properly identifies start end end keys when backward 1`] = `
+Immutable.Record {
+  "anchorKey": "b",
+  "anchorOffset": 10,
+  "focusKey": "c",
+  "focusOffset": 15,
+  "isBackward": true,
+  "hasFocus": true,
+}
+`;
+
+exports[`properly identifies start end end keys when backward 2`] = `"a"`;
+
+exports[`properly identifies start end end keys when backward 3`] = `"c"`;
+
+exports[`properly identifies start end end keys when backward 4`] = `"a"`;
+
+exports[`properly identifies start end end keys when backward 5`] = `"b"`;
+
+exports[`properly identifies start end end offsets when backward 1`] = `
+Immutable.Record {
+  "anchorKey": "b",
+  "anchorOffset": 10,
+  "focusKey": "c",
+  "focusOffset": 15,
+  "isBackward": true,
+  "hasFocus": true,
+}
+`;
+
+exports[`properly identifies start end end offsets when backward 2`] = `10`;
+
+exports[`properly identifies start end end offsets when backward 3`] = `15`;
+
+exports[`properly identifies start end end offsets when backward 4`] = `20`;
+
+exports[`properly identifies start end end offsets when backward 5`] = `10`;
+
+exports[`works properly 1`] = `true`;
+
+exports[`works properly 2`] = `false`;
+
+exports[`works properly 3`] = `false`;

--- a/src/model/immutable/__tests__/__snapshots__/findRangesImmutable-test.js.snap
+++ b/src/model/immutable/__tests__/__snapshots__/findRangesImmutable-test.js.snap
@@ -1,0 +1,60 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must be a no-op for an empty list 1`] = `Array []`;
+
+exports[`must identify each range 1`] = `
+Array [
+  Array [
+    0,
+    2,
+  ],
+  Array [
+    2,
+    4,
+  ],
+  Array [
+    4,
+    6,
+  ],
+  Array [
+    6,
+    8,
+  ],
+]
+`;
+
+exports[`must identify the full list as a single range 1`] = `
+Array [
+  Array [
+    0,
+    5,
+  ],
+]
+`;
+
+exports[`must properly use \`areEqualFn\` 1`] = `
+Array [
+  Array [
+    0,
+    1,
+  ],
+  Array [
+    1,
+    2,
+  ],
+  Array [
+    2,
+    3,
+  ],
+  Array [
+    3,
+    4,
+  ],
+  Array [
+    4,
+    5,
+  ],
+]
+`;
+
+exports[`must properly use \`filterFn\` 1`] = `Array []`;

--- a/src/model/immutable/__tests__/findRangesImmutable-test.js
+++ b/src/model/immutable/__tests__/findRangesImmutable-test.js
@@ -14,73 +14,48 @@
 
 jest.disableAutomock();
 
-var Immutable = require('immutable');
+const Immutable = require('immutable');
 
-var findRangesImmutable = require('findRangesImmutable');
+const findRangesImmutable = require('findRangesImmutable');
 
-describe('findRangesImmutable', () => {
-  var returnTrue = () => true;
+const {List} = Immutable;
 
-  it('must be a no-op for an empty list', () => {
-    var cb = jest.fn();
-    findRangesImmutable(Immutable.List(), returnTrue, returnTrue, cb);
-    expect(cb.mock.calls.length).toBe(0);
-  });
+const returnTrue = () => true;
 
-  describe('Function usage', () => {
-    var list = Immutable.List.of(1, 1, 1, 1, 1);
+const SAMPLE_LIST = List.of(1, 1, 1, 1, 1);
 
-    it('must identify the full list as a single range', () => {
-      var cb = jest.fn();
-      findRangesImmutable(list, returnTrue, returnTrue, cb);
-      var calls = cb.mock.calls;
-      expect(calls.length).toBe(1);
-      expect(calls[0]).toEqual([0, 5]);
-    });
+const assertFindRangesImmutable = (
+  list,
+  areEqualFn = returnTrue,
+  filterFn = returnTrue,
+  foundFn = jest.fn(),
+) => {
+  findRangesImmutable(list, areEqualFn, filterFn, foundFn);
+  expect(foundFn.mock.calls).toMatchSnapshot();
+};
 
-    it('must properly use `areEqualFn`', () => {
-      var cb = jest.fn();
-      var areEqual = () => false;
-      findRangesImmutable(
-        list,
-        areEqual, // never equal
-        returnTrue,
-        cb,
-      );
-      var calls = cb.mock.calls;
-      expect(calls.length).toBe(5);
-      expect(calls[0]).toEqual([0, 1]);
-      expect(calls[1]).toEqual([1, 2]);
-      expect(calls[2]).toEqual([2, 3]);
-      expect(calls[3]).toEqual([3, 4]);
-      expect(calls[4]).toEqual([4, 5]);
-    });
+test('must be a no-op for an empty list', () => {
+  assertFindRangesImmutable(List());
+});
 
-    it('must properly use `filterFn`', () => {
-      var cb = jest.fn();
-      findRangesImmutable(
-        list,
-        returnTrue,
-        () => false, // never an accepted filter result
-        cb,
-      );
-      var calls = cb.mock.calls;
-      expect(calls.length).toBe(0);
-    });
-  });
+test('must identify the full list as a single range', () => {
+  assertFindRangesImmutable(SAMPLE_LIST);
+});
 
-  describe('Range finding for multi-value list', () => {
-    var list = Immutable.List.of(0, 0, 1, 1, 0, 0, 2, 2);
+test('must properly use `areEqualFn`', () => {
+  // never equal
+  assertFindRangesImmutable(SAMPLE_LIST, () => false);
+});
 
-    it('must identify each range', () => {
-      var cb = jest.fn();
-      findRangesImmutable(list, (a, b) => a === b, returnTrue, cb);
-      var calls = cb.mock.calls;
-      expect(calls.length).toBe(4);
-      expect(calls[0]).toEqual([0, 2]);
-      expect(calls[1]).toEqual([2, 4]);
-      expect(calls[2]).toEqual([4, 6]);
-      expect(calls[3]).toEqual([6, 8]);
-    });
-  });
+test('must properly use `filterFn`', () => {
+  // never an accepted filter result
+  assertFindRangesImmutable(SAMPLE_LIST, returnTrue, () => false);
+});
+
+test('must identify each range', () => {
+  assertFindRangesImmutable(
+    List.of(0, 0, 1, 1, 0, 0, 2, 2),
+    (a, b) => a === b,
+    returnTrue,
+  );
 });

--- a/src/model/modifier/__tests__/AtomicBlockUtils-test.js
+++ b/src/model/modifier/__tests__/AtomicBlockUtils-test.js
@@ -14,6 +14,8 @@
 
 jest.disableAutomock();
 
+jest.mock('generateRandomKey');
+
 const {insertAtomicBlock, moveAtomicBlock} = require('AtomicBlockUtils');
 const Entity = require('DraftEntity');
 const EditorState = require('EditorState');
@@ -21,849 +23,541 @@ const SelectionState = require('SelectionState');
 
 const getSampleStateForTesting = require('getSampleStateForTesting');
 
-describe('AtomicBlockUtils', () => {
-  const {
-    editorState,
-    contentState,
-    selectionState,
-  } = getSampleStateForTesting();
-  const originalFirstBlock = contentState.getBlockMap().first();
-  const entityKey = Entity.create('TOKEN', 'MUTABLE');
-  const character = ' ';
+const {editorState, contentState, selectionState} = getSampleStateForTesting();
 
-  function assertAtomicBlock(block) {
-    expect(block.getType()).toBe('atomic');
-    expect(block.getText()).toBe(character);
-    expect(
-      block
-        .getCharacterList()
-        .first()
-        .getEntity(),
-    ).toBe(entityKey);
-  }
+const initialBlock = contentState.getBlockMap().first();
+const ENTITY_KEY = Entity.create('TOKEN', 'MUTABLE');
+const CHARACTER = ' ';
 
-  describe('Collapsed cursor', () => {
-    it('must insert atomic at start of block', () => {
-      const resultEditor = insertAtomicBlock(editorState, entityKey, character);
-      const resultContent = resultEditor.getCurrentContent();
+const assertAtomic = state => {
+  expect(
+    state
+      .getCurrentContent()
+      .getBlockMap()
+      .map(block => ({
+        key: block.getKey(),
+        type: block.getType(),
+        text: block.getText(),
+      }))
+      .toArray(),
+  ).toMatchSnapshot();
+};
 
-      // Empty block inserted above content.
-      const firstBlock = resultContent.getBlockMap().first();
-      expect(firstBlock.getType()).toBe('unstyled');
-      expect(firstBlock.getText()).toBe('');
+const assertInsertAtomicBlock = (
+  state = editorState,
+  entity = ENTITY_KEY,
+  character = CHARACTER,
+) => {
+  const newState = insertAtomicBlock(state, entity, character);
+  assertAtomic(newState);
+  return newState;
+};
 
-      const secondBlock = resultContent
-        .getBlockMap()
-        .skip(1)
-        .first();
-      assertAtomicBlock(secondBlock);
+const assertMoveAtomicBlock = (
+  atomicBlock,
+  seletion,
+  state = editorState,
+  insertionType = null,
+) => {
+  const newState = moveAtomicBlock(state, atomicBlock, seletion, insertionType);
+  assertAtomic(newState);
+  return newState;
+};
 
-      const thirdBlock = resultContent
-        .getBlockMap()
-        .skip(2)
-        .first();
-      expect(thirdBlock.getText()).toBe(originalFirstBlock.getText());
-    });
+test('must insert atomic at start of block with collapsed seletion', () => {
+  assertInsertAtomicBlock();
+});
 
-    it('must insert atomic within a block, via split', () => {
-      const targetSelection = selectionState.merge({
+test('must insert atomic within a block, via split with collapsed selection', () => {
+  assertInsertAtomicBlock(
+    EditorState.forceSelection(
+      editorState,
+      selectionState.merge({
         anchorOffset: 2,
         focusOffset: 2,
-      });
-      const targetEditor = EditorState.forceSelection(
-        editorState,
-        targetSelection,
-      );
+      }),
+    ),
+  );
+});
 
-      const resultEditor = insertAtomicBlock(
-        targetEditor,
-        entityKey,
-        character,
-      );
-      const resultContent = resultEditor.getCurrentContent();
+test('must insert atomic after a block with collapsed selection', () => {
+  assertInsertAtomicBlock(
+    EditorState.forceSelection(
+      editorState,
+      selectionState.merge({
+        anchorOffset: initialBlock.getLength(),
+        focusOffset: initialBlock.getLength(),
+      }),
+    ),
+  );
+});
 
-      const firstBlock = resultContent.getBlockMap().first();
-      expect(firstBlock.getType()).toBe(originalFirstBlock.getType());
-      expect(firstBlock.getText()).toBe(
-        originalFirstBlock.getText().slice(0, 2),
-      );
+test('must move atomic at start of block with collapsed selection', () => {
+  // Insert atomic block at the first position
+  const resultEditor = assertInsertAtomicBlock();
+  const resultContent = resultEditor.getCurrentContent();
+  const firstBlock = resultContent.getBlockMap().first();
+  const atomicBlock = resultContent
+    .getBlockMap()
+    .skip(1)
+    .first();
 
-      const secondBlock = resultContent
-        .getBlockMap()
-        .skip(1)
-        .first();
-      assertAtomicBlock(secondBlock);
+  assertMoveAtomicBlock(
+    atomicBlock,
+    new SelectionState({
+      anchorKey: firstBlock.getKey(),
+      focusKey: firstBlock.getKey(),
+    }),
+    resultEditor,
+  );
+});
 
-      const thirdBlock = resultContent
-        .getBlockMap()
-        .skip(2)
-        .first();
-      expect(thirdBlock.getType()).toBe(originalFirstBlock.getType());
-      expect(thirdBlock.getText()).toBe(originalFirstBlock.getText().slice(2));
-    });
+test('must move atomic at end of block with collapsed selection', () => {
+  // Insert atomic block at the first position
+  const resultEditor = assertInsertAtomicBlock();
+  const resultContent = resultEditor.getCurrentContent();
+  const lastBlock = resultContent.getBlockMap().last();
+  const atomicBlock = resultContent
+    .getBlockMap()
+    .skip(1)
+    .first();
 
-    it('must insert atomic after a block', () => {
-      const targetSelection = selectionState.merge({
-        anchorOffset: originalFirstBlock.getLength(),
-        focusOffset: originalFirstBlock.getLength(),
-      });
-      const targetEditor = EditorState.forceSelection(
-        editorState,
-        targetSelection,
-      );
+  // Move atomic block at end of the last block
+  assertMoveAtomicBlock(
+    atomicBlock,
+    new SelectionState({
+      anchorKey: lastBlock.getKey(),
+      anchorOffset: lastBlock.getLength(),
+      focusKey: lastBlock.getKey(),
+      focusOffset: lastBlock.getLength(),
+    }),
+    resultEditor,
+  );
+});
 
-      const resultEditor = insertAtomicBlock(
-        targetEditor,
-        entityKey,
-        character,
-      );
-      const resultContent = resultEditor.getCurrentContent();
+test('must move atomic inbetween block with collapsed selection', () => {
+  // Insert atomic block at the first position
+  const resultEditor = assertInsertAtomicBlock();
+  const resultContent = resultEditor.getCurrentContent();
+  const atomicBlock = resultContent
+    .getBlockMap()
+    .skip(1)
+    .first();
+  const thirdBlock = resultContent
+    .getBlockMap()
+    .skip(2)
+    .first();
 
-      const firstBlock = resultContent.getBlockMap().first();
-      expect(firstBlock.getType()).toBe(originalFirstBlock.getType());
-      expect(firstBlock.getText()).toBe(originalFirstBlock.getText());
+  // Move atomic block inbetween the splitted parts of the third block
+  assertMoveAtomicBlock(
+    atomicBlock,
+    new SelectionState({
+      anchorKey: thirdBlock.getKey(),
+      anchorOffset: 2,
+      focusKey: thirdBlock.getKey(),
+      focusOffset: 2,
+    }),
+    resultEditor,
+  );
+});
 
-      const secondBlock = resultContent
-        .getBlockMap()
-        .skip(1)
-        .first();
-      assertAtomicBlock(secondBlock);
+test('must move atomic before block with collapsed selection', () => {
+  // Insert atomic block at the first position
+  const resultEditor = assertInsertAtomicBlock();
+  const resultContent = resultEditor.getCurrentContent();
+  const firstBlock = resultContent.getBlockMap().first();
+  const atomicBlock = resultContent
+    .getBlockMap()
+    .skip(1)
+    .first();
 
-      const thirdBlock = resultContent
-        .getBlockMap()
-        .skip(2)
-        .first();
-      expect(thirdBlock.getType()).toBe(originalFirstBlock.getType());
-      expect(thirdBlock.getText()).toBe('');
-    });
+  // Move atomic block before the first block
+  assertMoveAtomicBlock(
+    atomicBlock,
+    new SelectionState({
+      anchorKey: firstBlock.getKey(),
+    }),
+    resultEditor,
+    'before',
+  );
+});
 
-    it('must move atomic at start of block', () => {
-      // Insert atomic block at the first position
-      const resultEditor = insertAtomicBlock(editorState, entityKey, character);
-      const resultContent = resultEditor.getCurrentContent();
+test('must move atomic after block with collapsed selection', () => {
+  // Insert atomic block at the first position
+  const resultEditor = assertInsertAtomicBlock();
+  const resultContent = resultEditor.getCurrentContent();
+  const atomicBlock = resultContent
+    .getBlockMap()
+    .skip(1)
+    .first();
+  const lastBlock = resultContent.getBlockMap().last();
 
-      const firstBlock = resultContent.getBlockMap().first();
-      const atomicBlock = resultContent
-        .getBlockMap()
-        .skip(1)
-        .first();
+  // Move atomic block after the last block
+  assertMoveAtomicBlock(
+    atomicBlock,
+    new SelectionState({
+      focusKey: lastBlock.getKey(),
+    }),
+    resultEditor,
+    'after',
+  );
+});
 
-      assertAtomicBlock(atomicBlock);
+test("mustn't move atomic next to itself with collapsed selection", () => {
+  // Insert atomic block at the second position
+  const resultEditor = assertInsertAtomicBlock(
+    EditorState.forceSelection(
+      editorState,
+      selectionState.merge({
+        anchorOffset: initialBlock.getLength(),
+        focusOffset: initialBlock.getLength(),
+      }),
+    ),
+  );
+  const resultContent = resultEditor.getCurrentContent();
+  const beforeAtomicBlock = resultContent.getBlockMap().first();
+  const atomicBlock = resultContent
+    .getBlockMap()
+    .skip(1)
+    .first();
+  const afterAtomicBlock = resultContent
+    .getBlockMap()
+    .skip(2)
+    .first();
 
-      // Move atomic block at start of the first block
-      const atomicResultEditor = moveAtomicBlock(
-        resultEditor,
-        atomicBlock,
-        new SelectionState({
-          anchorKey: firstBlock.getKey(),
-          focusKey: firstBlock.getKey(),
-        }),
-      );
-      const atomicResultContent = atomicResultEditor.getCurrentContent();
+  // Move atomic block above itself by moving it after preceeding block by
+  // replacement
+  expect(() => {
+    moveAtomicBlock(
+      resultEditor,
+      atomicBlock,
+      new SelectionState({
+        anchorKey: beforeAtomicBlock.getKey(),
+        anchorOffset: beforeAtomicBlock.getLength(),
+        focusKey: beforeAtomicBlock.getKey(),
+        focusOffset: beforeAtomicBlock.getLength(),
+      }),
+    );
+  }).toThrow(new Error('Block cannot be moved next to itself.'));
 
-      expect(atomicResultEditor.getLastChangeType()).toBe('move-block');
+  // Move atomic block above itself by moving it after preceeding block
+  expect(() => {
+    moveAtomicBlock(
+      resultEditor,
+      atomicBlock,
+      new SelectionState({
+        anchorKey: beforeAtomicBlock.getKey(),
+        focusKey: beforeAtomicBlock.getKey(),
+      }),
+      'after',
+    );
+  }).toThrow(new Error('Block cannot be moved next to itself.'));
 
-      // Atomic block must be on the first position now
-      const atomicResultFirstBlock = atomicResultContent.getBlockMap().first();
-      assertAtomicBlock(atomicResultFirstBlock);
-    });
+  // Move atomic block above itself by replacement
+  expect(() => {
+    moveAtomicBlock(
+      resultEditor,
+      atomicBlock,
+      new SelectionState({
+        anchorKey: atomicBlock.getKey(),
+        focusKey: atomicBlock.getKey(),
+      }),
+    );
+  }).toThrow(new Error('Block cannot be moved next to itself.'));
 
-    it('must move atomic at end of block', () => {
-      // Insert atomic block at the first position
-      const resultEditor = insertAtomicBlock(editorState, entityKey, character);
-      const resultContent = resultEditor.getCurrentContent();
+  // Move atomic block above itself
+  expect(() => {
+    moveAtomicBlock(
+      resultEditor,
+      atomicBlock,
+      new SelectionState({
+        anchorKey: atomicBlock.getKey(),
+      }),
+      'before',
+    );
+  }).toThrow(new Error('Block cannot be moved next to itself.'));
 
-      const atomicBlock = resultContent
-        .getBlockMap()
-        .skip(1)
-        .first();
-      const lastBlock = resultContent.getBlockMap().last();
+  // Move atomic block below itself by moving it before following block by
+  // replacement
+  expect(() => {
+    moveAtomicBlock(
+      resultEditor,
+      atomicBlock,
+      new SelectionState({
+        anchorKey: afterAtomicBlock.getKey(),
+        focusKey: afterAtomicBlock.getKey(),
+      }),
+    );
+  }).toThrow(new Error('Block cannot be moved next to itself.'));
 
-      assertAtomicBlock(atomicBlock);
+  // Move atomic block below itself by moving it before following block
+  expect(() => {
+    moveAtomicBlock(
+      resultEditor,
+      atomicBlock,
+      new SelectionState({
+        anchorKey: afterAtomicBlock.getKey(),
+        focusKey: afterAtomicBlock.getKey(),
+      }),
+      'before',
+    );
+  }).toThrow(new Error('Block cannot be moved next to itself.'));
 
-      // Move atomic block at end of the last block
-      const atomicResultEditor = moveAtomicBlock(
-        resultEditor,
-        atomicBlock,
-        new SelectionState({
-          anchorKey: lastBlock.getKey(),
-          anchorOffset: lastBlock.getLength(),
-          focusKey: lastBlock.getKey(),
-          focusOffset: lastBlock.getLength(),
-        }),
-      );
-      const atomicResultContent = atomicResultEditor.getCurrentContent();
+  // Move atomic block below itself by replacement
+  expect(() => {
+    moveAtomicBlock(
+      resultEditor,
+      atomicBlock,
+      new SelectionState({
+        anchorKey: atomicBlock.getKey(),
+        anchorOffset: atomicBlock.getLength(),
+        focusKey: atomicBlock.getKey(),
+        focusOffset: atomicBlock.getLength(),
+      }),
+    );
+  }).toThrow(new Error('Block cannot be moved next to itself.'));
 
-      expect(atomicResultEditor.getLastChangeType()).toBe('move-block');
+  // Move atomic block below itself
+  expect(() => {
+    moveAtomicBlock(
+      resultEditor,
+      atomicBlock,
+      new SelectionState({
+        focusKey: atomicBlock.getKey(),
+      }),
+      'after',
+    );
+  }).toThrow(new Error('Block cannot be moved next to itself.'));
+});
 
-      // Atomic block must be on the last position now
-      const atomicResultLastBlock = atomicResultContent.getBlockMap().last();
-      assertAtomicBlock(atomicResultLastBlock);
-    });
-
-    it('must move atomic inbetween block', () => {
-      // Insert atomic block at the first position
-      const resultEditor = insertAtomicBlock(editorState, entityKey, character);
-      const resultContent = resultEditor.getCurrentContent();
-
-      const atomicBlock = resultContent
-        .getBlockMap()
-        .skip(1)
-        .first();
-      const thirdBlock = resultContent
-        .getBlockMap()
-        .skip(2)
-        .first();
-
-      assertAtomicBlock(atomicBlock);
-
-      // Move atomic block inbetween the splitted parts of the third block
-      const atomicResultEditor = moveAtomicBlock(
-        resultEditor,
-        atomicBlock,
-        new SelectionState({
-          anchorKey: thirdBlock.getKey(),
-          anchorOffset: 2,
-          focusKey: thirdBlock.getKey(),
-          focusOffset: 2,
-        }),
-      );
-      const atomicResultContent = atomicResultEditor.getCurrentContent();
-
-      expect(atomicResultEditor.getLastChangeType()).toBe('move-block');
-
-      // Atomic block must be inbetween the splitted block
-      const atomicResultSecondBlock = atomicResultContent
-        .getBlockMap()
-        .skip(1)
-        .first();
-      const atomicResultThirdBlock = atomicResultContent
-        .getBlockMap()
-        .skip(2)
-        .first();
-      const atomicResultFourthBlock = atomicResultContent
-        .getBlockMap()
-        .skip(3)
-        .first();
-
-      expect(atomicResultSecondBlock.getText()).toBe('Al');
-      assertAtomicBlock(atomicResultThirdBlock);
-      expect(atomicResultFourthBlock.getText()).toBe('pha');
-    });
-
-    it('must move atomic before block', () => {
-      // Insert atomic block at the first position
-      const resultEditor = insertAtomicBlock(editorState, entityKey, character);
-      const resultContent = resultEditor.getCurrentContent();
-
-      const firstBlock = resultContent.getBlockMap().first();
-      const atomicBlock = resultContent
-        .getBlockMap()
-        .skip(1)
-        .first();
-
-      assertAtomicBlock(atomicBlock);
-
-      // Move atomic block before the first block
-      const atomicResultEditor = moveAtomicBlock(
-        resultEditor,
-        atomicBlock,
-        new SelectionState({
-          anchorKey: firstBlock.getKey(),
-        }),
-        'before',
-      );
-      const atomicResultContent = atomicResultEditor.getCurrentContent();
-
-      expect(atomicResultEditor.getLastChangeType()).toBe('move-block');
-
-      // Atomic block must be on the first position now
-      const atomicResultFirstBlock = atomicResultContent.getBlockMap().first();
-      assertAtomicBlock(atomicResultFirstBlock);
-    });
-
-    it('must move atomic after block', () => {
-      // Insert atomic block at the first position
-      const resultEditor = insertAtomicBlock(editorState, entityKey, character);
-      const resultContent = resultEditor.getCurrentContent();
-
-      const atomicBlock = resultContent
-        .getBlockMap()
-        .skip(1)
-        .first();
-      const lastBlock = resultContent.getBlockMap().last();
-
-      assertAtomicBlock(atomicBlock);
-
-      // Move atomic block after the last block
-      const atomicResultEditor = moveAtomicBlock(
-        resultEditor,
-        atomicBlock,
-        new SelectionState({
-          focusKey: lastBlock.getKey(),
-        }),
-        'after',
-      );
-      const atomicResultContent = atomicResultEditor.getCurrentContent();
-
-      expect(atomicResultEditor.getLastChangeType()).toBe('move-block');
-
-      // Atomic block must be on the last position now
-      const atomicResultLastBlock = atomicResultContent.getBlockMap().last();
-      assertAtomicBlock(atomicResultLastBlock);
-    });
-
-    it("mustn't move atomic next to itself", () => {
-      const targetSelection = selectionState.merge({
-        anchorOffset: originalFirstBlock.getLength(),
-        focusOffset: originalFirstBlock.getLength(),
-      });
-      const targetEditor = EditorState.forceSelection(
-        editorState,
-        targetSelection,
-      );
-
-      // Insert atomic block at the second position
-      const resultEditor = insertAtomicBlock(
-        targetEditor,
-        entityKey,
-        character,
-      );
-      const resultContent = resultEditor.getCurrentContent();
-
-      const beforeAtomicBlock = resultContent.getBlockMap().first();
-      const atomicBlock = resultContent
-        .getBlockMap()
-        .skip(1)
-        .first();
-      const afterAtomicBlock = resultContent
-        .getBlockMap()
-        .skip(2)
-        .first();
-
-      assertAtomicBlock(atomicBlock);
-
-      // Move atomic block above itself by moving it after preceeding block by
-      // replacement
-      expect(function() {
-        moveAtomicBlock(
-          resultEditor,
-          atomicBlock,
-          new SelectionState({
-            anchorKey: beforeAtomicBlock.getKey(),
-            anchorOffset: beforeAtomicBlock.getLength(),
-            focusKey: beforeAtomicBlock.getKey(),
-            focusOffset: beforeAtomicBlock.getLength(),
-          }),
-        );
-      }).toThrow(new Error('Block cannot be moved next to itself.'));
-
-      // Move atomic block above itself by moving it after preceeding block
-      expect(function() {
-        moveAtomicBlock(
-          resultEditor,
-          atomicBlock,
-          new SelectionState({
-            anchorKey: beforeAtomicBlock.getKey(),
-            focusKey: beforeAtomicBlock.getKey(),
-          }),
-          'after',
-        );
-      }).toThrow(new Error('Block cannot be moved next to itself.'));
-
-      // Move atomic block above itself by replacement
-      expect(function() {
-        moveAtomicBlock(
-          resultEditor,
-          atomicBlock,
-          new SelectionState({
-            anchorKey: atomicBlock.getKey(),
-            focusKey: atomicBlock.getKey(),
-          }),
-        );
-      }).toThrow(new Error('Block cannot be moved next to itself.'));
-
-      // Move atomic block above itself
-      expect(function() {
-        moveAtomicBlock(
-          resultEditor,
-          atomicBlock,
-          new SelectionState({
-            anchorKey: atomicBlock.getKey(),
-          }),
-          'before',
-        );
-      }).toThrow(new Error('Block cannot be moved next to itself.'));
-
-      // Move atomic block below itself by moving it before following block by
-      // replacement
-      expect(function() {
-        moveAtomicBlock(
-          resultEditor,
-          atomicBlock,
-          new SelectionState({
-            anchorKey: afterAtomicBlock.getKey(),
-            focusKey: afterAtomicBlock.getKey(),
-          }),
-        );
-      }).toThrow(new Error('Block cannot be moved next to itself.'));
-
-      // Move atomic block below itself by moving it before following block
-      expect(function() {
-        moveAtomicBlock(
-          resultEditor,
-          atomicBlock,
-          new SelectionState({
-            anchorKey: afterAtomicBlock.getKey(),
-            focusKey: afterAtomicBlock.getKey(),
-          }),
-          'before',
-        );
-      }).toThrow(new Error('Block cannot be moved next to itself.'));
-
-      // Move atomic block below itself by replacement
-      expect(function() {
-        moveAtomicBlock(
-          resultEditor,
-          atomicBlock,
-          new SelectionState({
-            anchorKey: atomicBlock.getKey(),
-            anchorOffset: atomicBlock.getLength(),
-            focusKey: atomicBlock.getKey(),
-            focusOffset: atomicBlock.getLength(),
-          }),
-        );
-      }).toThrow(new Error('Block cannot be moved next to itself.'));
-
-      // Move atomic block below itself
-      expect(function() {
-        moveAtomicBlock(
-          resultEditor,
-          atomicBlock,
-          new SelectionState({
-            focusKey: atomicBlock.getKey(),
-          }),
-          'after',
-        );
-      }).toThrow(new Error('Block cannot be moved next to itself.'));
-    });
-  });
-
-  describe('Non-collapsed cursor', () => {
-    it('must insert atomic at start of block', () => {
-      const targetSelection = selectionState.merge({
+/**
+ * Non collapsed
+ */
+test('must insert atomic at start of block', () => {
+  assertInsertAtomicBlock(
+    EditorState.forceSelection(
+      editorState,
+      selectionState.merge({
         anchorOffset: 0,
         focusOffset: 2,
-      });
-      const targetEditor = EditorState.forceSelection(
-        editorState,
-        targetSelection,
-      );
+      }),
+    ),
+  );
+});
 
-      const resultEditor = insertAtomicBlock(
-        targetEditor,
-        entityKey,
-        character,
-      );
-      const resultContent = resultEditor.getCurrentContent();
-
-      const firstBlock = resultContent.getBlockMap().first();
-      expect(firstBlock.getType()).toBe(originalFirstBlock.getType());
-      expect(firstBlock.getText()).toBe('');
-
-      const secondBlock = resultContent
-        .getBlockMap()
-        .skip(1)
-        .first();
-      assertAtomicBlock(secondBlock);
-
-      const thirdBlock = resultContent
-        .getBlockMap()
-        .skip(2)
-        .first();
-      expect(thirdBlock.getType()).toBe(originalFirstBlock.getType());
-      expect(thirdBlock.getText()).toBe(originalFirstBlock.getText().slice(2));
-    });
-
-    it('must insert atomic within a block', () => {
-      const targetSelection = selectionState.merge({
+test('must insert atomic within a block', () => {
+  assertInsertAtomicBlock(
+    EditorState.forceSelection(
+      editorState,
+      selectionState.merge({
         anchorOffset: 1,
         focusOffset: 2,
-      });
-      const targetEditor = EditorState.forceSelection(
-        editorState,
-        targetSelection,
-      );
+      }),
+    ),
+  );
+});
 
-      const resultEditor = insertAtomicBlock(
-        targetEditor,
-        entityKey,
-        character,
-      );
-      const resultContent = resultEditor.getCurrentContent();
-
-      const firstBlock = resultContent.getBlockMap().first();
-      expect(firstBlock.getType()).toBe(originalFirstBlock.getType());
-      expect(firstBlock.getText()).toBe(
-        originalFirstBlock.getText().slice(0, 1),
-      );
-
-      const secondBlock = resultContent
-        .getBlockMap()
-        .skip(1)
-        .first();
-      assertAtomicBlock(secondBlock);
-
-      const thirdBlock = resultContent
-        .getBlockMap()
-        .skip(2)
-        .first();
-      expect(thirdBlock.getType()).toBe(originalFirstBlock.getType());
-      expect(thirdBlock.getText()).toBe(originalFirstBlock.getText().slice(2));
-    });
-
-    it('must insert atomic at end of block', () => {
-      const origLength = originalFirstBlock.getLength();
-      const targetSelection = selectionState.merge({
+test('must insert atomic at end of block', () => {
+  const origLength = initialBlock.getLength();
+  assertInsertAtomicBlock(
+    EditorState.forceSelection(
+      editorState,
+      selectionState.merge({
         anchorOffset: origLength - 2,
         focusOffset: origLength,
-      });
-      const targetEditor = EditorState.forceSelection(
-        editorState,
-        targetSelection,
-      );
+      }),
+    ),
+  );
+});
 
-      const resultEditor = insertAtomicBlock(
-        targetEditor,
-        entityKey,
-        character,
-      );
-      const resultContent = resultEditor.getCurrentContent();
-
-      const firstBlock = resultContent.getBlockMap().first();
-      expect(firstBlock.getType()).toBe(originalFirstBlock.getType());
-      expect(firstBlock.getText()).toBe(
-        originalFirstBlock.getText().slice(0, origLength - 2),
-      );
-
-      const secondBlock = resultContent
-        .getBlockMap()
-        .skip(1)
-        .first();
-      assertAtomicBlock(secondBlock);
-
-      const thirdBlock = resultContent
-        .getBlockMap()
-        .skip(2)
-        .first();
-      expect(thirdBlock.getType()).toBe(originalFirstBlock.getType());
-      expect(thirdBlock.getText()).toBe('');
-    });
-
-    it('must insert atomic for cross-block selection', () => {
-      const originalThirdBlock = contentState
-        .getBlockMap()
-        .skip(2)
-        .first();
-
-      const targetSelection = selectionState.merge({
+test('must insert atomic for cross-block selection', () => {
+  const originalThirdBlock = contentState
+    .getBlockMap()
+    .skip(2)
+    .first();
+  assertInsertAtomicBlock(
+    EditorState.forceSelection(
+      editorState,
+      selectionState.merge({
         anchorOffset: 2,
         focusKey: originalThirdBlock.getKey(),
         focusOffset: 2,
-      });
-      const targetEditor = EditorState.forceSelection(
-        editorState,
-        targetSelection,
-      );
+      }),
+    ),
+  );
+});
 
-      const resultEditor = insertAtomicBlock(
-        targetEditor,
-        entityKey,
-        character,
-      );
-      const resultContent = resultEditor.getCurrentContent();
+test('must move atomic at start of block', () => {
+  // Insert atomic block at the first position
+  const resultEditor = assertInsertAtomicBlock();
+  const resultContent = resultEditor.getCurrentContent();
+  const atomicBlock = resultContent
+    .getBlockMap()
+    .skip(1)
+    .first();
+  const lastBlock = resultContent.getBlockMap().last();
 
-      const firstBlock = resultContent.getBlockMap().first();
-      expect(firstBlock.getType()).toBe(originalFirstBlock.getType());
-      expect(firstBlock.getText()).toBe(
-        originalFirstBlock.getText().slice(0, 2),
-      );
+  // Move atomic block at start of the last block
+  assertMoveAtomicBlock(
+    atomicBlock,
+    new SelectionState({
+      anchorKey: lastBlock.getKey(),
+      anchorOffset: 0,
+      focusKey: lastBlock.getKey(),
+      focusOffset: 2,
+    }),
+    resultEditor,
+  );
+});
 
-      const secondBlock = resultContent
-        .getBlockMap()
-        .skip(1)
-        .first();
-      assertAtomicBlock(secondBlock);
+test('must move atomic at end of block', () => {
+  // Insert atomic block at the first position
+  const resultEditor = assertInsertAtomicBlock();
+  const resultContent = resultEditor.getCurrentContent();
+  const atomicBlock = resultContent
+    .getBlockMap()
+    .skip(1)
+    .first();
+  const lastBlock = resultContent.getBlockMap().last();
 
-      // Third block gets original first block's type, but sliced text from
-      // original second block.
-      const thirdBlock = resultContent
-        .getBlockMap()
-        .skip(2)
-        .first();
-      expect(thirdBlock.getType()).toBe(originalFirstBlock.getType());
-      expect(thirdBlock.getText()).toBe(originalThirdBlock.getText().slice(2));
-    });
+  // Move atomic block at end of the last block
+  assertMoveAtomicBlock(
+    atomicBlock,
+    new SelectionState({
+      anchorKey: lastBlock.getKey(),
+      anchorOffset: lastBlock.getLength() - 2,
+      focusKey: lastBlock.getKey(),
+      focusOffset: lastBlock.getLength(),
+    }),
+    resultEditor,
+  );
+});
 
-    it('must move atomic at start of block', () => {
-      // Insert atomic block at the first position
-      const resultEditor = insertAtomicBlock(editorState, entityKey, character);
-      const resultContent = resultEditor.getCurrentContent();
+test('must move atomic inbetween block', () => {
+  // Insert atomic block at the first position
+  const resultEditor = assertInsertAtomicBlock();
+  const resultContent = resultEditor.getCurrentContent();
+  const atomicBlock = resultContent
+    .getBlockMap()
+    .skip(1)
+    .first();
+  const thirdBlock = resultContent
+    .getBlockMap()
+    .skip(2)
+    .first();
 
-      const atomicBlock = resultContent
-        .getBlockMap()
-        .skip(1)
-        .first();
-      const lastBlock = resultContent.getBlockMap().last();
+  // Move atomic block inbetween the splitted parts of the third block
+  assertMoveAtomicBlock(
+    atomicBlock,
+    new SelectionState({
+      anchorKey: thirdBlock.getKey(),
+      anchorOffset: 1,
+      focusKey: thirdBlock.getKey(),
+      focusOffset: 2,
+    }),
+    resultEditor,
+  );
+});
 
-      assertAtomicBlock(atomicBlock);
+test('must move atomic before block', () => {
+  // Insert atomic block at the first position
+  const resultEditor = assertInsertAtomicBlock();
+  const resultContent = resultEditor.getCurrentContent();
+  const firstBlock = resultContent.getBlockMap().first();
+  const atomicBlock = resultContent
+    .getBlockMap()
+    .skip(1)
+    .first();
+  const lastBlock = resultContent.getBlockMap().last();
 
-      // Move atomic block at start of the last block
-      const atomicResultEditor = moveAtomicBlock(
-        resultEditor,
-        atomicBlock,
-        new SelectionState({
-          anchorKey: lastBlock.getKey(),
-          anchorOffset: 0,
-          focusKey: lastBlock.getKey(),
-          focusOffset: 2,
-        }),
-      );
-      const atomicResultContent = atomicResultEditor.getCurrentContent();
+  // Move atomic block before the first block
+  assertMoveAtomicBlock(
+    atomicBlock,
+    new SelectionState({
+      anchorKey: firstBlock.getKey(),
+      anchorOffset: 2,
+      focusKey: lastBlock.getKey(),
+      focusOffset: 2,
+    }),
+    resultEditor,
+    'before',
+  );
+});
 
-      expect(atomicResultEditor.getLastChangeType()).toBe('move-block');
+test('must move atomic after block', () => {
+  // Insert atomic block at the first position
+  const resultEditor = assertInsertAtomicBlock();
+  const resultContent = resultEditor.getCurrentContent();
+  const firstBlock = resultContent.getBlockMap().first();
+  const atomicBlock = resultContent
+    .getBlockMap()
+    .skip(1)
+    .first();
+  const lastBlock = resultContent.getBlockMap().last();
 
-      // Atomic block must be on the second last position now
-      const atomicResultSecondLastBlock = atomicResultContent
-        .getBlockMap()
-        .reverse()
-        .skip(1)
-        .first();
-      const atomicResultLastBlock = atomicResultContent.getBlockMap().last();
+  // Move atomic block after the last block
+  assertMoveAtomicBlock(
+    atomicBlock,
+    new SelectionState({
+      anchorKey: firstBlock.getKey(),
+      anchorOffset: 2,
+      focusKey: lastBlock.getKey(),
+      focusOffset: 2,
+    }),
+    resultEditor,
+    'after',
+  );
+});
 
-      assertAtomicBlock(atomicResultSecondLastBlock);
-      expect(atomicResultLastBlock.getText()).toBe('arlie');
-    });
+test("mustn't move atomic next to itself", () => {
+  // Insert atomic block at the second position
+  const resultEditor = assertInsertAtomicBlock(
+    EditorState.forceSelection(
+      editorState,
+      selectionState.merge({
+        anchorOffset: initialBlock.getLength(),
+        focusOffset: initialBlock.getLength(),
+      }),
+    ),
+  );
+  const resultContent = resultEditor.getCurrentContent();
+  const beforeAtomicBlock = resultContent.getBlockMap().first();
+  const atomicBlock = resultContent
+    .getBlockMap()
+    .skip(1)
+    .first();
+  const afterAtomicBlock = resultContent
+    .getBlockMap()
+    .skip(2)
+    .first();
 
-    it('must move atomic at end of block', () => {
-      // Insert atomic block at the first position
-      const resultEditor = insertAtomicBlock(editorState, entityKey, character);
-      const resultContent = resultEditor.getCurrentContent();
+  // Move atomic block above itself by moving it after preceeding block by
+  // replacement
+  expect(() => {
+    moveAtomicBlock(
+      resultEditor,
+      atomicBlock,
+      new SelectionState({
+        anchorKey: beforeAtomicBlock.getKey(),
+        anchorOffset: beforeAtomicBlock.getLength() - 2,
+        focusKey: beforeAtomicBlock.getKey(),
+        focusOffset: beforeAtomicBlock.getLength(),
+      }),
+    );
+  }).toThrow(new Error('Block cannot be moved next to itself.'));
 
-      const atomicBlock = resultContent
-        .getBlockMap()
-        .skip(1)
-        .first();
-      const lastBlock = resultContent.getBlockMap().last();
-
-      assertAtomicBlock(atomicBlock);
-
-      // Move atomic block at end of the last block
-      const atomicResultEditor = moveAtomicBlock(
-        resultEditor,
-        atomicBlock,
-        new SelectionState({
-          anchorKey: lastBlock.getKey(),
-          anchorOffset: lastBlock.getLength() - 2,
-          focusKey: lastBlock.getKey(),
-          focusOffset: lastBlock.getLength(),
-        }),
-      );
-      const atomicResultContent = atomicResultEditor.getCurrentContent();
-
-      expect(atomicResultEditor.getLastChangeType()).toBe('move-block');
-
-      // Atomic block must be on the last position now
-      const atomicResultSecondLastBlock = atomicResultContent
-        .getBlockMap()
-        .reverse()
-        .skip(1)
-        .first();
-      const atomicResultLastBlock = atomicResultContent.getBlockMap().last();
-
-      expect(atomicResultSecondLastBlock.getText()).toBe('Charl');
-      assertAtomicBlock(atomicResultLastBlock);
-    });
-
-    it('must move atomic inbetween block', () => {
-      // Insert atomic block at the first position
-      const resultEditor = insertAtomicBlock(editorState, entityKey, character);
-      const resultContent = resultEditor.getCurrentContent();
-
-      const atomicBlock = resultContent
-        .getBlockMap()
-        .skip(1)
-        .first();
-      const thirdBlock = resultContent
-        .getBlockMap()
-        .skip(2)
-        .first();
-
-      assertAtomicBlock(atomicBlock);
-
-      // Move atomic block inbetween the splitted parts of the third block
-      const atomicResultEditor = moveAtomicBlock(
-        resultEditor,
-        atomicBlock,
-        new SelectionState({
-          anchorKey: thirdBlock.getKey(),
-          anchorOffset: 1,
-          focusKey: thirdBlock.getKey(),
-          focusOffset: 2,
-        }),
-      );
-      const atomicResultContent = atomicResultEditor.getCurrentContent();
-
-      expect(atomicResultEditor.getLastChangeType()).toBe('move-block');
-
-      // Atomic block must be inbetween the splitted block
-      const atomicResultSecondBlock = atomicResultContent
-        .getBlockMap()
-        .skip(1)
-        .first();
-      const atomicResultThirdBlock = atomicResultContent
-        .getBlockMap()
-        .skip(2)
-        .first();
-      const atomicResultFourthBlock = atomicResultContent
-        .getBlockMap()
-        .skip(3)
-        .first();
-
-      expect(atomicResultSecondBlock.getText()).toBe('A');
-      assertAtomicBlock(atomicResultThirdBlock);
-      expect(atomicResultFourthBlock.getText()).toBe('pha');
-    });
-
-    it('must move atomic before block', () => {
-      // Insert atomic block at the first position
-      const resultEditor = insertAtomicBlock(editorState, entityKey, character);
-      const resultContent = resultEditor.getCurrentContent();
-
-      const firstBlock = resultContent.getBlockMap().first();
-      const atomicBlock = resultContent
-        .getBlockMap()
-        .skip(1)
-        .first();
-      const lastBlock = resultContent.getBlockMap().last();
-
-      assertAtomicBlock(atomicBlock);
-
-      // Move atomic block before the first block
-      const atomicResultEditor = moveAtomicBlock(
-        resultEditor,
-        atomicBlock,
-        new SelectionState({
-          anchorKey: firstBlock.getKey(),
-          anchorOffset: 2,
-          focusKey: lastBlock.getKey(),
-          focusOffset: 2,
-        }),
-        'before',
-      );
-      const atomicResultContent = atomicResultEditor.getCurrentContent();
-
-      expect(atomicResultEditor.getLastChangeType()).toBe('move-block');
-
-      // Atomic block must be on the first position now
-      const atomicResultFirstBlock = atomicResultContent.getBlockMap().first();
-      assertAtomicBlock(atomicResultFirstBlock);
-    });
-
-    it('must move atomic after block', () => {
-      // Insert atomic block at the first position
-      const resultEditor = insertAtomicBlock(editorState, entityKey, character);
-      const resultContent = resultEditor.getCurrentContent();
-
-      const firstBlock = resultContent.getBlockMap().first();
-      const atomicBlock = resultContent
-        .getBlockMap()
-        .skip(1)
-        .first();
-      const lastBlock = resultContent.getBlockMap().last();
-
-      assertAtomicBlock(atomicBlock);
-
-      // Move atomic block after the last block
-      const atomicResultEditor = moveAtomicBlock(
-        resultEditor,
-        atomicBlock,
-        new SelectionState({
-          anchorKey: firstBlock.getKey(),
-          anchorOffset: 2,
-          focusKey: lastBlock.getKey(),
-          focusOffset: 2,
-        }),
-        'after',
-      );
-      const atomicResultContent = atomicResultEditor.getCurrentContent();
-
-      expect(atomicResultEditor.getLastChangeType()).toBe('move-block');
-
-      // Atomic block must be on the last position now
-      const atomicResultLastBlock = atomicResultContent.getBlockMap().last();
-      assertAtomicBlock(atomicResultLastBlock);
-    });
-
-    it("mustn't move atomic next to itself", () => {
-      const targetSelection = selectionState.merge({
-        anchorOffset: originalFirstBlock.getLength(),
-        focusOffset: originalFirstBlock.getLength(),
-      });
-      const targetEditor = EditorState.forceSelection(
-        editorState,
-        targetSelection,
-      );
-
-      // Insert atomic block at the second position
-      const resultEditor = insertAtomicBlock(
-        targetEditor,
-        entityKey,
-        character,
-      );
-      const resultContent = resultEditor.getCurrentContent();
-
-      const beforeAtomicBlock = resultContent.getBlockMap().first();
-      const atomicBlock = resultContent
-        .getBlockMap()
-        .skip(1)
-        .first();
-      const afterAtomicBlock = resultContent
-        .getBlockMap()
-        .skip(2)
-        .first();
-
-      assertAtomicBlock(atomicBlock);
-
-      // Move atomic block above itself by moving it after preceeding block by
-      // replacement
-      expect(function() {
-        moveAtomicBlock(
-          resultEditor,
-          atomicBlock,
-          new SelectionState({
-            anchorKey: beforeAtomicBlock.getKey(),
-            anchorOffset: beforeAtomicBlock.getLength() - 2,
-            focusKey: beforeAtomicBlock.getKey(),
-            focusOffset: beforeAtomicBlock.getLength(),
-          }),
-        );
-      }).toThrow(new Error('Block cannot be moved next to itself.'));
-
-      // Move atomic block below itself by moving it before following block by
-      // replacement
-      expect(function() {
-        moveAtomicBlock(
-          resultEditor,
-          atomicBlock,
-          new SelectionState({
-            anchorKey: afterAtomicBlock.getKey(),
-            anchorOffset: 0,
-            focusKey: afterAtomicBlock.getKey(),
-            focusOffset: 2,
-          }),
-        );
-      }).toThrow(new Error('Block cannot be moved next to itself.'));
-    });
-  });
+  // Move atomic block below itself by moving it before following block by
+  // replacement
+  expect(() => {
+    moveAtomicBlock(
+      resultEditor,
+      atomicBlock,
+      new SelectionState({
+        anchorKey: afterAtomicBlock.getKey(),
+        anchorOffset: 0,
+        focusKey: afterAtomicBlock.getKey(),
+        focusOffset: 2,
+      }),
+    );
+  }).toThrow(new Error('Block cannot be moved next to itself.'));
 });

--- a/src/model/modifier/__tests__/DraftRemovableWord-test.js
+++ b/src/model/modifier/__tests__/DraftRemovableWord-test.js
@@ -14,128 +14,120 @@
 
 jest.disableAutomock();
 
-var DraftRemovableWord = require('DraftRemovableWord');
+const DraftRemovableWord = require('DraftRemovableWord');
 
-describe('DraftRemovableWord', function() {
-  var forward;
-  var backward;
+let forward;
+let backward;
 
-  var english = 'the animals';
-  var accents = 'th\u00e9 f\u00e0bregas';
-  var arabic = '\u0637\u0638\u0639 \u063A\u063B\u063C';
-  var japanese = '\u4f1a\u8b70\u4e2d \u30cf\u30c3\u30b7\u30e5';
-  var korean = '\ud2b8\uc704\ud130 \ud2b8\uc704\ud130';
-  var halfWidthHangul = '\uffa3\uffa6\uffb0 \uffa1\uffa2\uffb2';
-  var cyrillic = '\u0430\u0448\u043e\u043a \u0431\u0414\u0416\u0426';
-  var withNumbers = 'f14 tomcat';
+const accents = 'th\u00e9 f\u00e0bregas';
+const arabic = '\u0637\u0638\u0639 \u063A\u063B\u063C';
+const cyrillic = '\u0430\u0448\u043e\u043a \u0431\u0414\u0416\u0426';
+const english = 'the animals';
+const halfWidthHangul = '\uffa3\uffa6\uffb0 \uffa1\uffa2\uffb2';
+const japanese = '\u4f1a\u8b70\u4e2d \u30cf\u30c3\u30b7\u30e5';
+const korean = '\ud2b8\uc704\ud130 \ud2b8\uc704\ud130';
+const withNumbers = 'f14 tomcat';
 
-  beforeEach(function() {
-    jest.resetModules();
-    forward = DraftRemovableWord.getForward;
-    backward = DraftRemovableWord.getBackward;
-  });
+beforeEach(() => {
+  jest.resetModules();
+  forward = DraftRemovableWord.getForward;
+  backward = DraftRemovableWord.getBackward;
+});
 
-  it('must identify words looking forward', function() {
-    expect(forward(english)).toBe(english.split(' ')[0]);
-    expect(forward(accents)).toBe(accents.split(' ')[0]);
-    expect(forward(arabic)).toBe(arabic.split(' ')[0]);
-    expect(forward(japanese)).toBe(japanese.split(' ')[0]);
-    expect(forward(korean)).toBe(korean.split(' ')[0]);
-    expect(forward(halfWidthHangul)).toBe(halfWidthHangul.split(' ')[0]);
-    expect(forward(cyrillic)).toBe(cyrillic.split(' ')[0]);
-    expect(forward(withNumbers)).toBe(withNumbers.split(' ')[0]);
-  });
+test('must identify words looking forward', () => {
+  expect(forward(english)).toMatchSnapshot();
+  expect(forward(accents)).toMatchSnapshot();
+  expect(forward(arabic)).toMatchSnapshot();
+  expect(forward(japanese)).toMatchSnapshot();
+  expect(forward(korean)).toMatchSnapshot();
+  expect(forward(halfWidthHangul)).toMatchSnapshot();
+  expect(forward(cyrillic)).toMatchSnapshot();
+  expect(forward(withNumbers)).toMatchSnapshot();
+});
 
-  it('must identify words with apostrophes looking forward', function() {
-    expect(forward("you're correct.")).toBe("you're");
-  });
+test('must identify words with apostrophes looking forward', () => {
+  expect(forward("you're correct.")).toMatchSnapshot();
+});
 
-  it('must identify words with curly quotes looking forward', function() {
-    expect(forward('you\u2019re correct.')).toBe('you\u2019re');
-  });
+test('must identify words with curly quotes looking forward', () => {
+  expect(forward('you\u2019re correct.')).toMatchSnapshot();
+});
 
-  it('must identify punctuation with apostrophes', function() {
-    expect(forward("'hello'")).toBe("'hello");
-    expect(backward("'hello'")).toBe("hello'");
-    expect(forward('\u2018hello\u2019')).toBe('\u2018hello');
-    expect(backward('\u2018hello\u2019')).toBe('hello\u2019');
+test('must identify punctuation with apostrophes', () => {
+  expect(forward("'hello'")).toMatchSnapshot();
+  expect(backward("'hello'")).toMatchSnapshot();
+  expect(forward('\u2018hello\u2019')).toMatchSnapshot();
+  expect(backward('\u2018hello\u2019')).toMatchSnapshot();
 
-    expect(forward("('hello')")).toBe("('hello");
-    expect(backward("('hello')")).toBe("hello')");
-    expect(forward(".'.")).toBe(".'.");
-    expect(backward(".'.")).toBe(".'.");
-  });
+  expect(forward("('hello')")).toMatchSnapshot();
+  expect(backward("('hello')")).toMatchSnapshot();
+  expect(forward(".'.")).toMatchSnapshot();
+  expect(backward(".'.")).toMatchSnapshot();
+});
 
-  it('must identify words with underscores', () => {
-    expect(forward('under_score hey')).toBe('under_score');
-    expect(backward('hey under_score')).toBe('under_score');
-  });
+test('must identify words with underscores', () => {
+  expect(forward('under_score hey')).toMatchSnapshot();
+  expect(backward('hey under_score')).toMatchSnapshot();
+});
 
-  it('must identify words led by spaces looking forward', function() {
-    expect(forward('  ' + english)).toBe('  ' + english.split(' ')[0]);
-    expect(forward('    ' + accents)).toBe('    ' + accents.split(' ')[0]);
-    expect(forward('      ' + arabic)).toBe('      ' + arabic.split(' ')[0]);
-  });
+test('must identify words led by spaces looking forward', () => {
+  expect(forward('  ' + english)).toMatchSnapshot();
+  expect(forward('    ' + accents)).toMatchSnapshot();
+  expect(forward('      ' + arabic)).toMatchSnapshot();
+});
 
-  it('must identify words led by punctuation looking forward', function() {
-    var match = english.split(' ')[0];
-    expect(forward('.' + english)).toBe('.' + match);
-    expect(forward('|' + english)).toBe('|' + match);
-    expect(forward('^' + english)).toBe('^' + match);
-    expect(forward('\u060d\uFD3e\uFD3F' + english)).toBe(
-      '\u060d\uFD3e\uFD3F' + match,
-    );
-    expect(forward('.. .. ..' + english)).toBe('.. .. ..' + match);
-  });
+test('must identify words led by punctuation looking forward', () => {
+  expect(forward('.' + english)).toMatchSnapshot();
+  expect(forward('|' + english)).toMatchSnapshot();
+  expect(forward('^' + english)).toMatchSnapshot();
+  expect(forward('\u060d\uFD3e\uFD3F' + english)).toMatchSnapshot();
+  expect(forward('.. .. ..' + english)).toMatchSnapshot();
+});
 
-  it('must identify punct/whitespace strings looking forward', function() {
-    expect(forward('    ')).toBe('    ');
-    expect(forward('\u060d\uFD3e\uFD3F')).toBe('\u060d\uFD3e\uFD3F');
-    expect(forward('. . . . .')).toBe('. . . . .');
-    expect(forward('   !!!???   ')).toBe('   !!!???   ');
-  });
+test('must identify punct/whitespace strings looking forward', () => {
+  expect(forward('    ')).toMatchSnapshot();
+  expect(forward('\u060d\uFD3e\uFD3F')).toMatchSnapshot();
+  expect(forward('. . . . .')).toMatchSnapshot();
+  expect(forward('   !!!???   ')).toMatchSnapshot();
+});
 
-  it('must identify words looking backward', function() {
-    expect(backward(english)).toBe(english.split(' ')[1]);
-    expect(backward(accents)).toBe(accents.split(' ')[1]);
-    expect(backward(arabic)).toBe(arabic.split(' ')[1]);
-    expect(backward(japanese)).toBe(japanese.split(' ')[1]);
-    expect(backward(korean)).toBe(korean.split(' ')[1]);
-    expect(backward(halfWidthHangul)).toBe(halfWidthHangul.split(' ')[1]);
-    expect(backward(cyrillic)).toBe(cyrillic.split(' ')[1]);
-    expect(backward(withNumbers)).toBe(withNumbers.split(' ')[1]);
-  });
+test('must identify words looking backward', () => {
+  expect(backward(english)).toMatchSnapshot();
+  expect(backward(accents)).toMatchSnapshot();
+  expect(backward(arabic)).toMatchSnapshot();
+  expect(backward(japanese)).toMatchSnapshot();
+  expect(backward(korean)).toMatchSnapshot();
+  expect(backward(halfWidthHangul)).toMatchSnapshot();
+  expect(backward(cyrillic)).toMatchSnapshot();
+  expect(backward(withNumbers)).toMatchSnapshot();
+});
 
-  it('must identify words with apostrophes looking backward', function() {
-    expect(backward("you don't")).toBe("don't");
-  });
+test('must identify words with apostrophes looking backward', () => {
+  expect(backward("you don't")).toMatchSnapshot();
+});
 
-  it('must identify words ended by spaces looking backward', function() {
-    expect(backward(english + '  ')).toBe(english.split(' ')[1] + '  ');
-    expect(backward(accents + '    ')).toBe(accents.split(' ')[1] + '    ');
-    expect(backward(arabic + '      ')).toBe(arabic.split(' ')[1] + '      ');
-  });
+test('must identify words ended by spaces looking backward', () => {
+  expect(backward(english + '  ')).toMatchSnapshot();
+  expect(backward(accents + '    ')).toMatchSnapshot();
+  expect(backward(arabic + '      ')).toMatchSnapshot();
+});
 
-  it('must identify words ended by punctuation looking backward', function() {
-    var match = english.split(' ')[1];
-    expect(backward(english + '.')).toBe(match + '.');
-    expect(backward(english + '|')).toBe(match + '|');
-    expect(backward(english + '^')).toBe(match + '^');
-    expect(backward(english + '\u060d\uFD3e\uFD3F')).toBe(
-      match + '\u060d\uFD3e\uFD3F',
-    );
-    expect(backward(english + '.. .. ..')).toBe(match + '.. .. ..');
-  });
+test('must identify words ended by punctuation looking backward', () => {
+  expect(backward(english + '.')).toMatchSnapshot();
+  expect(backward(english + '|')).toMatchSnapshot();
+  expect(backward(english + '^')).toMatchSnapshot();
+  expect(backward(english + '\u060d\uFD3e\uFD3F')).toMatchSnapshot();
+  expect(backward(english + '.. .. ..')).toMatchSnapshot();
+});
 
-  it('must identify punct/whitespace strings looking backward', function() {
-    expect(backward('    ')).toBe('    ');
-    expect(backward('\u060d\uFD3e\uFD3F')).toBe('\u060d\uFD3e\uFD3F');
-    expect(backward('. . . . .')).toBe('. . . . .');
-    expect(backward('   !!!???   ')).toBe('   !!!???   ');
-  });
+test('must identify punct/whitespace strings looking backward', () => {
+  expect(backward('    ')).toMatchSnapshot();
+  expect(backward('\u060d\uFD3e\uFD3F')).toMatchSnapshot();
+  expect(backward('. . . . .')).toMatchSnapshot();
+  expect(backward('   !!!???   ')).toMatchSnapshot();
+});
 
-  it('must identify nothing in an empty string', function() {
-    expect(forward('')).toBe('');
-    expect(backward('')).toBe('');
-  });
+test('must identify nothing in an empty string', () => {
+  expect(forward('')).toMatchSnapshot();
+  expect(backward('')).toMatchSnapshot();
 });

--- a/src/model/modifier/__tests__/RichTextEditorUtil-test.js
+++ b/src/model/modifier/__tests__/RichTextEditorUtil-test.js
@@ -20,165 +20,152 @@ const SelectionState = require('SelectionState');
 
 const getSampleStateForTesting = require('getSampleStateForTesting');
 
-describe('RichTextEditorUtil', () => {
-  const {editorState, selectionState} = getSampleStateForTesting();
+const {editorState, selectionState} = getSampleStateForTesting();
+const {onBackspace, onDelete, tryToRemoveBlockStyle} = RichTextEditorUtil;
 
-  function insertAtomicBlock(targetEditorState) {
-    const entityKey = targetEditorState
-      .getCurrentContent()
-      .createEntity('TEST', 'IMMUTABLE', null)
-      .getLastCreatedEntityKey();
-    const character = ' ';
-    const movedSelection = EditorState.moveSelectionToEnd(targetEditorState);
-    return AtomicBlockUtils.insertAtomicBlock(
-      movedSelection,
-      entityKey,
-      character,
-    );
-  }
+const insertAtomicBlock = targetEditorState => {
+  const entityKey = targetEditorState
+    .getCurrentContent()
+    .createEntity('TEST', 'IMMUTABLE', null)
+    .getLastCreatedEntityKey();
+  const character = ' ';
+  const movedSelection = EditorState.moveSelectionToEnd(targetEditorState);
+  return AtomicBlockUtils.insertAtomicBlock(
+    movedSelection,
+    entityKey,
+    character,
+  );
+};
 
-  describe('onBackspace', () => {
-    const {onBackspace} = RichTextEditorUtil;
+test('onBackspace does not handle non-zero-offset or non-collapsed selections', () => {
+  const nonZero = selectionState.merge({anchorOffset: 2, focusOffset: 2});
+  expect(
+    onBackspace(EditorState.forceSelection(editorState, nonZero)),
+  ).toMatchSnapshot();
 
-    it('does not handle non-zero-offset or non-collapsed selections', () => {
-      const nonZero = selectionState.merge({anchorOffset: 2, focusOffset: 2});
-      expect(
-        onBackspace(EditorState.forceSelection(editorState, nonZero)),
-      ).toBe(null);
+  const nonCollapsed = nonZero.merge({anchorOffset: 0});
+  expect(
+    onBackspace(EditorState.forceSelection(editorState, nonCollapsed)),
+  ).toMatchSnapshot();
+});
 
-      const nonCollapsed = nonZero.merge({anchorOffset: 0});
-      expect(
-        onBackspace(EditorState.forceSelection(editorState, nonCollapsed)),
-      ).toBe(null);
-    });
+test('onBackspace resets the current block type if empty', () => {
+  const contentState = editorState.getCurrentContent();
+  const lastBlock = contentState.getLastBlock();
+  const lastBlockKey = lastBlock.getKey();
 
-    it('resets the current block type if empty', () => {
-      const contentState = editorState.getCurrentContent();
-      const lastBlock = contentState.getLastBlock();
-      const lastBlockKey = lastBlock.getKey();
+  // Remove the current text from the blockquote.
+  const resetBlockquote = DraftModifier.removeRange(
+    contentState,
+    new SelectionState({
+      anchorKey: lastBlockKey,
+      anchorOffset: 0,
+      focusKey: lastBlockKey,
+      focusOffset: lastBlock.getLength(),
+    }),
+    'backward',
+  );
 
-      // Remove the current text from the blockquote.
-      const resetBlockquote = DraftModifier.removeRange(
-        contentState,
-        new SelectionState({
-          anchorKey: lastBlockKey,
-          anchorOffset: 0,
-          focusKey: lastBlockKey,
-          focusOffset: lastBlock.getLength(),
-        }),
-        'backward',
-      );
+  const withEmptyBlockquote = EditorState.push(
+    editorState,
+    resetBlockquote,
+    'remove-range',
+  );
 
-      const withEmptyBlockquote = EditorState.push(
-        editorState,
-        resetBlockquote,
-        'remove-range',
-      );
+  const afterBackspace = onBackspace(withEmptyBlockquote);
+  const lastBlockNow = afterBackspace.getCurrentContent().getLastBlock();
 
-      const afterBackspace = onBackspace(withEmptyBlockquote);
-      const lastBlockNow = afterBackspace.getCurrentContent().getLastBlock();
+  expect(lastBlockNow).toMatchSnapshot();
+});
 
-      expect(lastBlockNow.getType()).toBe('unstyled');
-      expect(lastBlockNow.getText()).toBe('');
-    });
+test('onBackspace resets the current block type at the start of the first block', () => {
+  const contentState = editorState.getCurrentContent();
 
-    it('resets the current block type at the start of the first block', () => {
-      const contentState = editorState.getCurrentContent();
+  const setListItem = DraftModifier.setBlockType(
+    contentState,
+    selectionState,
+    'unordered-list-item',
+  );
 
-      const setListItem = DraftModifier.setBlockType(
-        contentState,
-        selectionState,
-        'unordered-list-item',
-      );
+  const withListItem = EditorState.push(
+    editorState,
+    setListItem,
+    'change-block-type',
+  );
 
-      const withListItem = EditorState.push(
-        editorState,
-        setListItem,
-        'change-block-type',
-      );
+  const afterBackspace = onBackspace(withListItem);
+  const firstBlockNow = afterBackspace.getCurrentContent().getFirstBlock();
 
-      const afterBackspace = onBackspace(withListItem);
-      const firstBlockNow = afterBackspace.getCurrentContent().getFirstBlock();
+  expect(firstBlockNow).toMatchSnapshot();
+});
 
-      expect(firstBlockNow.getType()).toBe('unstyled');
-    });
+test('onBackspace removes a preceding atomic block', () => {
+  const blockSizeBeforeRemove = editorState.getCurrentContent().getBlockMap()
+    .size;
+  const withAtomicBlock = insertAtomicBlock(editorState);
+  const afterBackspace = onBackspace(withAtomicBlock);
+  const contentState = afterBackspace.getCurrentContent();
+  const blockMap = contentState.getBlockMap();
+  expect(blockMap.size === blockSizeBeforeRemove + 1).toMatchSnapshot();
+  expect(
+    blockMap.some(block => block.getType() === 'atomic'),
+  ).toMatchSnapshot();
+});
 
-    it('removes a preceding atomic block', () => {
-      const blockSizeBeforeRemove = editorState
-        .getCurrentContent()
-        .getBlockMap().size;
-      const withAtomicBlock = insertAtomicBlock(editorState);
-      const afterBackspace = onBackspace(withAtomicBlock);
-      const contentState = afterBackspace.getCurrentContent();
-      const blockMap = contentState.getBlockMap();
-      expect(blockMap.size).toBe(blockSizeBeforeRemove + 1);
-      expect(blockMap.some(block => block.getType() === 'atomic')).toBe(false);
-    });
-  });
+test('onDelete does not handle non-block-end or non-collapsed selections', () => {
+  const nonZero = selectionState.merge({anchorOffset: 2, focusOffset: 2});
+  expect(
+    onDelete(EditorState.forceSelection(editorState, nonZero)) === null,
+  ).toMatchSnapshot();
 
-  describe('onDelete', () => {
-    const {onDelete} = RichTextEditorUtil;
+  const nonCollapsed = nonZero.merge({anchorOffset: 0});
+  expect(
+    onDelete(EditorState.forceSelection(editorState, nonCollapsed)) === null,
+  ).toMatchSnapshot();
+});
 
-    it('does not handle non-block-end or non-collapsed selections', () => {
-      const nonZero = selectionState.merge({anchorOffset: 2, focusOffset: 2});
-      expect(onDelete(EditorState.forceSelection(editorState, nonZero))).toBe(
-        null,
-      );
+test('onDelete removes a following atomic block', () => {
+  const blockSizeBeforeRemove = editorState.getCurrentContent().getBlockMap()
+    .size;
+  const withAtomicBlock = insertAtomicBlock(editorState);
+  const content = withAtomicBlock.getCurrentContent();
+  const atomicKey = content
+    .getBlockMap()
+    .find(block => block.getType() === 'atomic')
+    .getKey();
 
-      const nonCollapsed = nonZero.merge({anchorOffset: 0});
-      expect(
-        onDelete(EditorState.forceSelection(editorState, nonCollapsed)),
-      ).toBe(null);
-    });
+  const blockBefore = content.getBlockBefore(atomicKey);
+  const keyBefore = blockBefore.getKey();
+  const lengthBefore = blockBefore.getLength();
 
-    it('removes a following atomic block', () => {
-      const blockSizeBeforeRemove = editorState
-        .getCurrentContent()
-        .getBlockMap().size;
-      const withAtomicBlock = insertAtomicBlock(editorState);
-      const content = withAtomicBlock.getCurrentContent();
-      const atomicKey = content
-        .getBlockMap()
-        .find(block => block.getType() === 'atomic')
-        .getKey();
+  const withSelectionAboveAtomic = EditorState.forceSelection(
+    withAtomicBlock,
+    new SelectionState({
+      anchorKey: keyBefore,
+      anchorOffset: lengthBefore,
+      focusKey: keyBefore,
+      focusOffset: lengthBefore,
+    }),
+  );
 
-      const blockBefore = content.getBlockBefore(atomicKey);
-      const keyBefore = blockBefore.getKey();
-      const lengthBefore = blockBefore.getLength();
+  const afterDelete = onDelete(withSelectionAboveAtomic);
+  const blockMapAfterDelete = afterDelete.getCurrentContent().getBlockMap();
 
-      const withSelectionAboveAtomic = EditorState.forceSelection(
-        withAtomicBlock,
-        new SelectionState({
-          anchorKey: keyBefore,
-          anchorOffset: lengthBefore,
-          focusKey: keyBefore,
-          focusOffset: lengthBefore,
-        }),
-      );
+  expect(
+    blockMapAfterDelete.some(block => block.getType() === 'atomic'),
+  ).toMatchSnapshot();
 
-      const afterDelete = onDelete(withSelectionAboveAtomic);
-      const blockMapAfterDelete = afterDelete.getCurrentContent().getBlockMap();
+  expect(
+    blockMapAfterDelete.size === blockSizeBeforeRemove + 1,
+  ).toMatchSnapshot();
+});
 
-      expect(
-        blockMapAfterDelete.some(block => block.getType() === 'atomic'),
-      ).toBe(false);
+test('tryToRemoveBlockStyleonDelete breaks out of code block on enter two blank lines', () => {
+  const blankLine = selectionState.merge({anchorKey: 'e', focusKey: 'e'});
+  const withBlankLine = EditorState.forceSelection(editorState, blankLine);
 
-      expect(blockMapAfterDelete.size).toBe(blockSizeBeforeRemove + 1);
-    });
-  });
+  const afterEnter = tryToRemoveBlockStyle(withBlankLine);
+  const lastBlock = afterEnter.getLastBlock();
 
-  describe('tryToRemoveBlockStyle', () => {
-    const {tryToRemoveBlockStyle} = RichTextEditorUtil;
-
-    it('breaks out of code block on enter two blank lines', () => {
-      const blankLine = selectionState.merge({anchorKey: 'e', focusKey: 'e'});
-      const withBlankLine = EditorState.forceSelection(editorState, blankLine);
-
-      const afterEnter = tryToRemoveBlockStyle(withBlankLine);
-      const lastBlock = afterEnter.getLastBlock();
-
-      expect(lastBlock.getType()).toBe('blockquote');
-      expect(lastBlock.getText()).toBe('Charlie');
-    });
-  });
+  expect(lastBlock).toMatchSnapshot();
 });

--- a/src/model/modifier/__tests__/__snapshots__/AtomicBlockUtils-test.js.snap
+++ b/src/model/modifier/__tests__/__snapshots__/AtomicBlockUtils-test.js.snap
@@ -1,0 +1,1306 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must insert atomic after a block with collapsed selection 1`] = `
+Array [
+  Object {
+    "key": "a",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "key8",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "key": "key11",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
+`;
+
+exports[`must insert atomic at end of block 1`] = `
+Array [
+  Object {
+    "key": "a",
+    "text": "Alp",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "key45",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "key": "key48",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
+`;
+
+exports[`must insert atomic at start of block 1`] = `
+Array [
+  Object {
+    "key": "a",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "key37",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "key": "key40",
+    "text": "pha",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
+`;
+
+exports[`must insert atomic at start of block with collapsed seletion 1`] = `
+Array [
+  Object {
+    "key": "a",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "key0",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "key": "key3",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
+`;
+
+exports[`must insert atomic for cross-block selection 1`] = `
+Array [
+  Object {
+    "key": "a",
+    "text": "Al",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "key49",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "key": "key52",
+    "text": "st",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
+`;
+
+exports[`must insert atomic within a block 1`] = `
+Array [
+  Object {
+    "key": "a",
+    "text": "A",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "key41",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "key": "key44",
+    "text": "pha",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
+`;
+
+exports[`must insert atomic within a block, via split with collapsed selection 1`] = `
+Array [
+  Object {
+    "key": "a",
+    "text": "Al",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "key4",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "key": "key7",
+    "text": "pha",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
+`;
+
+exports[`must move atomic after block 1`] = `
+Array [
+  Object {
+    "key": "a",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "key70",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "key": "key73",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
+`;
+
+exports[`must move atomic after block 2`] = `
+Array [
+  Object {
+    "key": "a",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "key73",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+  Object {
+    "key": "key70",
+    "text": " ",
+    "type": "atomic",
+  },
+]
+`;
+
+exports[`must move atomic after block with collapsed selection 1`] = `
+Array [
+  Object {
+    "key": "a",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "key29",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "key": "key32",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
+`;
+
+exports[`must move atomic after block with collapsed selection 2`] = `
+Array [
+  Object {
+    "key": "a",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "key32",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+  Object {
+    "key": "key29",
+    "text": " ",
+    "type": "atomic",
+  },
+]
+`;
+
+exports[`must move atomic at end of block 1`] = `
+Array [
+  Object {
+    "key": "a",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "key57",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "key": "key60",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
+`;
+
+exports[`must move atomic at end of block 2`] = `
+Array [
+  Object {
+    "key": "a",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "key60",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "f",
+    "text": "Charl",
+    "type": "blockquote",
+  },
+  Object {
+    "key": "key57",
+    "text": " ",
+    "type": "atomic",
+  },
+]
+`;
+
+exports[`must move atomic at end of block with collapsed selection 1`] = `
+Array [
+  Object {
+    "key": "a",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "key16",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "key": "key19",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
+`;
+
+exports[`must move atomic at end of block with collapsed selection 2`] = `
+Array [
+  Object {
+    "key": "a",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "key19",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+  Object {
+    "key": "key16",
+    "text": " ",
+    "type": "atomic",
+  },
+]
+`;
+
+exports[`must move atomic at start of block 1`] = `
+Array [
+  Object {
+    "key": "a",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "key53",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "key": "key56",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
+`;
+
+exports[`must move atomic at start of block 2`] = `
+Array [
+  Object {
+    "key": "a",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "key56",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "key53",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "key": "f",
+    "text": "arlie",
+    "type": "blockquote",
+  },
+]
+`;
+
+exports[`must move atomic at start of block with collapsed selection 1`] = `
+Array [
+  Object {
+    "key": "a",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "key12",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "key": "key15",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
+`;
+
+exports[`must move atomic at start of block with collapsed selection 2`] = `
+Array [
+  Object {
+    "key": "key12",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "key": "a",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "key15",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
+`;
+
+exports[`must move atomic before block 1`] = `
+Array [
+  Object {
+    "key": "a",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "key66",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "key": "key69",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
+`;
+
+exports[`must move atomic before block 2`] = `
+Array [
+  Object {
+    "key": "key66",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "key": "a",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "key69",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
+`;
+
+exports[`must move atomic before block with collapsed selection 1`] = `
+Array [
+  Object {
+    "key": "a",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "key25",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "key": "key28",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
+`;
+
+exports[`must move atomic before block with collapsed selection 2`] = `
+Array [
+  Object {
+    "key": "key25",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "key": "a",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "key28",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
+`;
+
+exports[`must move atomic inbetween block 1`] = `
+Array [
+  Object {
+    "key": "a",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "key61",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "key": "key64",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
+`;
+
+exports[`must move atomic inbetween block 2`] = `
+Array [
+  Object {
+    "key": "a",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "key64",
+    "text": "A",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "key61",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "key": "key65",
+    "text": "pha",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
+`;
+
+exports[`must move atomic inbetween block with collapsed selection 1`] = `
+Array [
+  Object {
+    "key": "a",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "key20",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "key": "key23",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
+`;
+
+exports[`must move atomic inbetween block with collapsed selection 2`] = `
+Array [
+  Object {
+    "key": "a",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "key23",
+    "text": "Al",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "key20",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "key": "key24",
+    "text": "pha",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
+`;
+
+exports[`mustn't move atomic next to itself 1`] = `
+Array [
+  Object {
+    "key": "a",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "key74",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "key": "key77",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
+`;
+
+exports[`mustn't move atomic next to itself with collapsed selection 1`] = `
+Array [
+  Object {
+    "key": "a",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "key33",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "key": "key36",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
+`;

--- a/src/model/modifier/__tests__/__snapshots__/DraftRemovableWord-test.js.snap
+++ b/src/model/modifier/__tests__/__snapshots__/DraftRemovableWord-test.js.snap
@@ -1,0 +1,111 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must identify nothing in an empty string 1`] = `""`;
+
+exports[`must identify nothing in an empty string 2`] = `""`;
+
+exports[`must identify punct/whitespace strings looking backward 1`] = `"    "`;
+
+exports[`must identify punct/whitespace strings looking backward 2`] = `"؍﴾﴿"`;
+
+exports[`must identify punct/whitespace strings looking backward 3`] = `". . . . ."`;
+
+exports[`must identify punct/whitespace strings looking backward 4`] = `"   !!!???   "`;
+
+exports[`must identify punct/whitespace strings looking forward 1`] = `"    "`;
+
+exports[`must identify punct/whitespace strings looking forward 2`] = `"؍﴾﴿"`;
+
+exports[`must identify punct/whitespace strings looking forward 3`] = `". . . . ."`;
+
+exports[`must identify punct/whitespace strings looking forward 4`] = `"   !!!???   "`;
+
+exports[`must identify punctuation with apostrophes 1`] = `"'hello"`;
+
+exports[`must identify punctuation with apostrophes 2`] = `"hello'"`;
+
+exports[`must identify punctuation with apostrophes 3`] = `"‘hello"`;
+
+exports[`must identify punctuation with apostrophes 4`] = `"hello’"`;
+
+exports[`must identify punctuation with apostrophes 5`] = `"('hello"`;
+
+exports[`must identify punctuation with apostrophes 6`] = `"hello')"`;
+
+exports[`must identify punctuation with apostrophes 7`] = `".'."`;
+
+exports[`must identify punctuation with apostrophes 8`] = `".'."`;
+
+exports[`must identify words ended by punctuation looking backward 1`] = `"animals."`;
+
+exports[`must identify words ended by punctuation looking backward 2`] = `"animals|"`;
+
+exports[`must identify words ended by punctuation looking backward 3`] = `"animals^"`;
+
+exports[`must identify words ended by punctuation looking backward 4`] = `"animals؍﴾﴿"`;
+
+exports[`must identify words ended by punctuation looking backward 5`] = `"animals.. .. .."`;
+
+exports[`must identify words ended by spaces looking backward 1`] = `"animals  "`;
+
+exports[`must identify words ended by spaces looking backward 2`] = `"fàbregas    "`;
+
+exports[`must identify words ended by spaces looking backward 3`] = `"غػؼ      "`;
+
+exports[`must identify words led by punctuation looking forward 1`] = `".the"`;
+
+exports[`must identify words led by punctuation looking forward 2`] = `"|the"`;
+
+exports[`must identify words led by punctuation looking forward 3`] = `"^the"`;
+
+exports[`must identify words led by punctuation looking forward 4`] = `"؍﴾﴿the"`;
+
+exports[`must identify words led by punctuation looking forward 5`] = `".. .. ..the"`;
+
+exports[`must identify words led by spaces looking forward 1`] = `"  the"`;
+
+exports[`must identify words led by spaces looking forward 2`] = `"    thé"`;
+
+exports[`must identify words led by spaces looking forward 3`] = `"      طظع"`;
+
+exports[`must identify words looking backward 1`] = `"animals"`;
+
+exports[`must identify words looking backward 2`] = `"fàbregas"`;
+
+exports[`must identify words looking backward 3`] = `"غػؼ"`;
+
+exports[`must identify words looking backward 4`] = `"ハッシュ"`;
+
+exports[`must identify words looking backward 5`] = `"트위터"`;
+
+exports[`must identify words looking backward 6`] = `"ﾡﾢﾲ"`;
+
+exports[`must identify words looking backward 7`] = `"бДЖЦ"`;
+
+exports[`must identify words looking backward 8`] = `"tomcat"`;
+
+exports[`must identify words looking forward 1`] = `"the"`;
+
+exports[`must identify words looking forward 2`] = `"thé"`;
+
+exports[`must identify words looking forward 3`] = `"طظع"`;
+
+exports[`must identify words looking forward 4`] = `"会議中"`;
+
+exports[`must identify words looking forward 5`] = `"트위터"`;
+
+exports[`must identify words looking forward 6`] = `"ﾣﾦﾰ"`;
+
+exports[`must identify words looking forward 7`] = `"ашок"`;
+
+exports[`must identify words looking forward 8`] = `"f14"`;
+
+exports[`must identify words with apostrophes looking backward 1`] = `"don't"`;
+
+exports[`must identify words with apostrophes looking forward 1`] = `"you're"`;
+
+exports[`must identify words with curly quotes looking forward 1`] = `"you’re"`;
+
+exports[`must identify words with underscores 1`] = `"under_score"`;
+
+exports[`must identify words with underscores 2`] = `"under_score"`;

--- a/src/model/modifier/__tests__/__snapshots__/RichTextEditorUtil-test.js.snap
+++ b/src/model/modifier/__tests__/__snapshots__/RichTextEditorUtil-test.js.snap
@@ -1,0 +1,114 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`onBackspace does not handle non-zero-offset or non-collapsed selections 1`] = `null`;
+
+exports[`onBackspace does not handle non-zero-offset or non-collapsed selections 2`] = `null`;
+
+exports[`onBackspace removes a preceding atomic block 1`] = `true`;
+
+exports[`onBackspace removes a preceding atomic block 2`] = `false`;
+
+exports[`onBackspace resets the current block type at the start of the first block 1`] = `
+Immutable.Record {
+  "key": "a",
+  "type": "unstyled",
+  "text": "Alpha",
+  "characterList": Immutable.List [
+    Immutable.Record {
+      "style": Immutable.OrderedSet [],
+      "entity": null,
+    },
+    Immutable.Record {
+      "style": Immutable.OrderedSet [],
+      "entity": null,
+    },
+    Immutable.Record {
+      "style": Immutable.OrderedSet [],
+      "entity": null,
+    },
+    Immutable.Record {
+      "style": Immutable.OrderedSet [],
+      "entity": null,
+    },
+    Immutable.Record {
+      "style": Immutable.OrderedSet [],
+      "entity": null,
+    },
+  ],
+  "depth": 0,
+  "data": Immutable.Map {},
+}
+`;
+
+exports[`onBackspace resets the current block type if empty 1`] = `
+Immutable.Record {
+  "key": "f",
+  "type": "unstyled",
+  "text": "",
+  "characterList": Immutable.List [],
+  "depth": 0,
+  "data": Immutable.Map {},
+}
+`;
+
+exports[`onDelete does not handle non-block-end or non-collapsed selections 1`] = `true`;
+
+exports[`onDelete does not handle non-block-end or non-collapsed selections 2`] = `true`;
+
+exports[`onDelete removes a following atomic block 1`] = `false`;
+
+exports[`onDelete removes a following atomic block 2`] = `true`;
+
+exports[`tryToRemoveBlockStyleonDelete breaks out of code block on enter two blank lines 1`] = `
+Immutable.Record {
+  "key": "f",
+  "type": "blockquote",
+  "text": "Charlie",
+  "characterList": Immutable.List [
+    Immutable.Record {
+      "style": Immutable.OrderedSet [
+        "ITALIC",
+      ],
+      "entity": null,
+    },
+    Immutable.Record {
+      "style": Immutable.OrderedSet [
+        "ITALIC",
+      ],
+      "entity": null,
+    },
+    Immutable.Record {
+      "style": Immutable.OrderedSet [
+        "ITALIC",
+      ],
+      "entity": null,
+    },
+    Immutable.Record {
+      "style": Immutable.OrderedSet [
+        "ITALIC",
+      ],
+      "entity": null,
+    },
+    Immutable.Record {
+      "style": Immutable.OrderedSet [
+        "ITALIC",
+      ],
+      "entity": null,
+    },
+    Immutable.Record {
+      "style": Immutable.OrderedSet [
+        "ITALIC",
+      ],
+      "entity": null,
+    },
+    Immutable.Record {
+      "style": Immutable.OrderedSet [
+        "ITALIC",
+      ],
+      "entity": null,
+    },
+  ],
+  "depth": 0,
+  "data": Immutable.Map {},
+}
+`;

--- a/src/model/paste/__tests__/DraftPasteProcessor-test.js
+++ b/src/model/paste/__tests__/DraftPasteProcessor-test.js
@@ -92,17 +92,17 @@ test('must collapse nested blocks to the topmost level', () => {
 });
 
 /**
-   * todo: azelenskiy
-   * Changes to the mocked DOM appear to have broken this.
-   *
-   * test('must suppress blocks nested inside other blocks', () => {
-   *   const html = '<p><h2>Some text here</h2> more text here </p>';
-   *   const output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
-   *   assertBlockTypes(output, [
-   *   'unstyled',
-   *   ]);
-   * });
-   */
+ * todo: azelenskiy
+ * Changes to the mocked DOM appear to have broken this.
+ *
+ * test('must suppress blocks nested inside other blocks', () => {
+ *   const html = '<p><h2>Some text here</h2> more text here </p>';
+ *   const output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+ *   assertBlockTypes(output, [
+ *   'unstyled',
+ *   ]);
+ * });
+ */
 
 test('must detect two touching blocks', () => {
   assertDraftPasteProcessorProcessHTML(`
@@ -136,10 +136,9 @@ test('must not generate fake blocks on heavy nesting', () => {
 });
 
 test('must preserve spaces', () => {
-  assertDraftPasteProcessorProcessHTML(`
-    <span>hello</span> 
-    <span>hi</span>
-  `);
+  assertDraftPasteProcessorProcessHTML(`<span>hello</span> <span>hi</span>`);
+  assertDraftPasteProcessorProcessHTML(`<span>hello </span><span>hi</span>`);
+  assertDraftPasteProcessorProcessHTML(`<span>hello</span><span> hi</span>`);
 });
 
 test('must treat divs as Ps when we do not have semantic markup', () => {

--- a/src/model/paste/__tests__/DraftPasteProcessor-test.js
+++ b/src/model/paste/__tests__/DraftPasteProcessor-test.js
@@ -14,9 +14,12 @@
 
 jest.disableAutomock();
 
-var DraftPasteProcessor = require('DraftPasteProcessor');
-var Immutable = require('immutable');
-var CUSTOM_BLOCK_MAP = Immutable.Map({
+jest.mock('generateRandomKey');
+
+const DraftPasteProcessor = require('DraftPasteProcessor');
+const Immutable = require('immutable');
+
+const CUSTOM_BLOCK_MAP = Immutable.Map({
   'header-one': {
     element: 'h1',
   },
@@ -46,422 +49,236 @@ var CUSTOM_BLOCK_MAP = Immutable.Map({
   },
 });
 
-describe('DraftPasteProcessor', function() {
-  function assertInlineStyles(block, comparison) {
-    var styles = block.getCharacterList().map(c => c.getStyle());
-    expect(styles.toJS()).toEqual(comparison);
-  }
+const assertDraftPasteProcessorProcessHTML = (
+  html,
+  blockMap = CUSTOM_BLOCK_MAP,
+) => {
+  const {contentBlocks} = DraftPasteProcessor.processHTML(html, blockMap);
+  expect(contentBlocks).toMatchSnapshot();
+};
 
-  // Don't want to couple this to a specific way of generating entity IDs so
-  // just checking their existence
-  function assertEntities(block, comparison) {
-    var entities = block.getCharacterList().map(c => c.getEntity());
-    entities.toJS().forEach((entity, ii) => {
-      expect(comparison[ii]).toBe(!!entity);
-    });
-  }
+test('must identify italics text', () => {
+  assertDraftPasteProcessorProcessHTML(`
+    <i>hello</i> hi
+  `);
+});
 
-  function assertDepths(blocks, comparison) {
-    expect(blocks.map(b => b.getDepth())).toEqual(comparison);
-  }
+test('must identify overlapping inline styles', () => {
+  assertDraftPasteProcessorProcessHTML(`
+    <i>
+      <b>he</b>
+      hi
+    </i>
+  `);
+});
 
-  function assertBlockTypes(blocks, comparison) {
-    expect(blocks.map(b => b.getType())).toEqual(comparison);
-  }
+test('must identify block styles', () => {
+  assertDraftPasteProcessorProcessHTML(`
+    <ol>
+      <li>hi</li>
+      <li>there</li>
+    </ol>
+  `);
+});
 
-  it('must identify italics text', function() {
-    var html = '<i>hello</i> hi';
-    var {contentBlocks: output} = DraftPasteProcessor.processHTML(
-      html,
-      CUSTOM_BLOCK_MAP,
-    );
-    var block = output[0];
-    expect(block.getType()).toBe('unstyled');
-    assertInlineStyles(block, [
-      ['ITALIC'],
-      ['ITALIC'],
-      ['ITALIC'],
-      ['ITALIC'],
-      ['ITALIC'],
-      [],
-      [],
-      [],
-    ]);
-    expect(block.getText()).toBe('hello hi');
-  });
+test('must collapse nested blocks to the topmost level', () => {
+  assertDraftPasteProcessorProcessHTML(`
+    <ul>
+      <li>
+        <h2>what</h2>
+      </li>
+    </ul>
+  `);
+});
 
-  it('must identify overlapping inline styles', function() {
-    var html = '<i><b>he</b>hi</i>';
-    var {contentBlocks: output} = DraftPasteProcessor.processHTML(
-      html,
-      CUSTOM_BLOCK_MAP,
-    );
-    var block = output[0];
-    expect(block.getType()).toBe('unstyled');
-    assertInlineStyles(block, [
-      ['ITALIC', 'BOLD'],
-      ['ITALIC', 'BOLD'],
-      ['ITALIC'],
-      ['ITALIC'],
-    ]);
-    expect(block.getText()).toBe('hehi');
-  });
-
-  it('must identify block styles', function() {
-    var html = '<ol><li>hi</li><li>there</li></ol>';
-    var {contentBlocks: output} = DraftPasteProcessor.processHTML(
-      html,
-      CUSTOM_BLOCK_MAP,
-    );
-    assertBlockTypes(output, ['ordered-list-item', 'ordered-list-item']);
-  });
-
-  it('must collapse nested blocks to the topmost level', function() {
-    var html = '<ul><li><h2>what</h2></li></ul>';
-    var {contentBlocks: output} = DraftPasteProcessor.processHTML(
-      html,
-      CUSTOM_BLOCK_MAP,
-    );
-    assertBlockTypes(output, ['unordered-list-item']);
-  });
-
-  /**
+/**
    * todo: azelenskiy
    * Changes to the mocked DOM appear to have broken this.
    *
-   * it('must suppress blocks nested inside other blocks', function() {
-   *   var html = '<p><h2>Some text here</h2> more text here </p>';
-   *   var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
+   * test('must suppress blocks nested inside other blocks', () => {
+   *   const html = '<p><h2>Some text here</h2> more text here </p>';
+   *   const output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
    *   assertBlockTypes(output, [
    *   'unstyled',
    *   ]);
    * });
    */
 
-  it('must detect two touching blocks', function() {
-    var html = '<h1>hi</h1>    <h2>hi</h2>';
-    var {contentBlocks: output} = DraftPasteProcessor.processHTML(
-      html,
-      CUSTOM_BLOCK_MAP,
-    );
-    assertBlockTypes(output, ['header-one', 'header-two']);
-  });
+test('must detect two touching blocks', () => {
+  assertDraftPasteProcessorProcessHTML(`
+    <h1>hi</h1>    
+    <h2>hi</h2>
+  `);
+});
 
-  it('must insert a block when needed', function() {
-    var html = ' <h1> hi </h1><h1> </h1><span> whatever </span> <h2>hi </h2> ';
-    var {contentBlocks: output} = DraftPasteProcessor.processHTML(
-      html,
-      CUSTOM_BLOCK_MAP,
-    );
-    assertBlockTypes(output, ['header-one', 'unstyled', 'header-two']);
-  });
+test('must insert a block when needed', () => {
+  assertDraftPasteProcessorProcessHTML(`
+    <h1> hi </h1>
+    <h1> </h1>
+    <span> whatever </span> 
+    <h2>hi </h2> 
+  `);
+});
 
-  it('must not generate fake blocks on heavy nesting', function() {
-    var html =
-      '<p><span><span><span>Word</span></span></span>' +
-      '<span><span>,</span></span></p>';
-    var {contentBlocks: output} = DraftPasteProcessor.processHTML(
-      html,
-      CUSTOM_BLOCK_MAP,
-    );
-    assertBlockTypes(output, ['paragraph']);
-  });
+test('must not generate fake blocks on heavy nesting', () => {
+  assertDraftPasteProcessorProcessHTML(`
+    <p>
+      <span>
+        <span>
+          <span>Word</span>
+        </span>
+      </span>
+      <span>
+        <span>,</span>
+      </span>
+    </p>
+  `);
+});
 
-  it('must preserve spaces', function() {
-    var html, output;
+test('must preserve spaces', () => {
+  assertDraftPasteProcessorProcessHTML(`
+    <span>hello</span> 
+    <span>hi</span>
+  `);
+});
 
-    html = '<span>hello</span> <span>hi</span>';
-    output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
-    expect(output.contentBlocks.length).toEqual(1);
-    assertBlockTypes(output.contentBlocks, ['unstyled']);
-    var block = output.contentBlocks[0];
-    expect(block.getText()).toBe('hello hi');
+test('must treat divs as Ps when we do not have semantic markup', () => {
+  assertDraftPasteProcessorProcessHTML(`
+    <div>hi</div>
+    <div>hello</div>
+  `);
+});
 
-    html = '<span>hello </span><span>hi</span>';
-    output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
-    expect(output.contentBlocks[0].getText()).toBe('hello hi');
+test('must NOT treat divs as Ps when we pave Ps', () => {
+  assertDraftPasteProcessorProcessHTML(`
+    <div>
+      <p>hi</p>
+      <p>hello</p>
+    </div>
+  `);
+});
 
-    html = '<span>hello</span><span> hi</span>';
-    output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
-    expect(output.contentBlocks[0].getText()).toEqual('hello hi');
-  });
+test('must replace br tags with soft newlines', () => {
+  assertDraftPasteProcessorProcessHTML(`
+    hi<br>hello
+  `);
+});
 
-  it('must treat divs as Ps when we do not have semantic markup', function() {
-    var html = '<div>hi</div><div>hello</div>';
-    var {contentBlocks: output} = DraftPasteProcessor.processHTML(
-      html,
-      CUSTOM_BLOCK_MAP,
-    );
-    assertBlockTypes(output, ['unstyled', 'unstyled']);
-  });
+test('must strip xml carriages and zero width spaces', () => {
+  assertDraftPasteProcessorProcessHTML(`
+    hi&#13;&#8203;hello
+  `);
+});
 
-  it('must NOT treat divs as Ps when we pave Ps', function() {
-    var html = '<div><p>hi</p><p>hello</p></div>';
-    var {contentBlocks: output} = DraftPasteProcessor.processHTML(
-      html,
-      CUSTOM_BLOCK_MAP,
-    );
-    assertBlockTypes(output, ['paragraph', 'paragraph']);
-  });
+test('must split unstyled blocks on two br tags', () => {
+  assertDraftPasteProcessorProcessHTML(`
+    hi<br><br>hello
+  `);
+});
 
-  it('must replace br tags with soft newlines', function() {
-    var html = 'hi<br>hello';
-    var {contentBlocks: output} = DraftPasteProcessor.processHTML(
-      html,
-      CUSTOM_BLOCK_MAP,
-    );
-    expect(output[0].getText()).toBe('hi\nhello');
-  });
+test('must NOT split unstyled blocks inside a styled block', () => {
+  assertDraftPasteProcessorProcessHTML(`
+    <pre>
+      hi<br><br>hello
+    </pre>
+  `);
+});
 
-  it('must strip xml carriages and zero width spaces', function() {
-    var html = 'hi&#13;&#8203;hello';
-    var {contentBlocks: output} = DraftPasteProcessor.processHTML(
-      html,
-      CUSTOM_BLOCK_MAP,
-    );
-    expect(output[0].getText()).toBe('hihello');
-  });
+test('must replace newlines in regular tags', () => {
+  assertDraftPasteProcessorProcessHTML(`
+    <div>
+      hello\nthere
+    </div>
+  `);
+});
 
-  it('must split unstyled blocks on two br tags', function() {
-    var html = 'hi<br><br>hello';
-    var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
-    assertBlockTypes(output.contentBlocks, ['unstyled', 'unstyled']);
-    html = '<div>hi<br><br>hello</div>';
-    output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
-    assertBlockTypes(output.contentBlocks, ['unstyled', 'unstyled']);
-  });
+test('must preserve newlines in pre tags', () => {
+  assertDraftPasteProcessorProcessHTML(`
+    <pre>
+      hello\nthere
+    </pre>
+  `);
+});
 
-  it('must NOT split unstyled blocks inside a styled block', function() {
-    var html = '<pre>hi<br><br>hello</pre>';
-    var {contentBlocks: output} = DraftPasteProcessor.processHTML(
-      html,
-      CUSTOM_BLOCK_MAP,
-    );
-    assertBlockTypes(output, ['code-block']);
-  });
+test('must preserve newlines in whitespace in pre tags', () => {
+  assertDraftPasteProcessorProcessHTML(`
+    <pre>
+      <span>hello</span>\n<span>there</span>
+    </pre>
+  `);
+});
 
-  it('must split unstyled blocks on two br tags', function() {
-    var html = 'hi<br><br>hello';
-    var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
-    expect(output.contentBlocks[0].getText().length).toBe(3);
-    expect(output.contentBlocks[1].getText()).toBe('hello');
-    assertBlockTypes(output.contentBlocks, ['unstyled', 'unstyled']);
-  });
+test('must parse based on style attribute', () => {
+  assertDraftPasteProcessorProcessHTML(`
+    <span style="font-weight: bold;">
+      Bold <span style="font-style: italic;">Italic </span>
+    </span>.
+  `);
+});
 
-  it('must replace newlines in regular tags', function() {
-    var html = '<div>hello\nthere</div>';
-    var {contentBlocks: output} = DraftPasteProcessor.processHTML(
-      html,
-      CUSTOM_BLOCK_MAP,
-    );
-    expect(output[0].getText()).toBe('hello there');
-  });
+test('must detect links in pasted content', () => {
+  assertDraftPasteProcessorProcessHTML(`
+    This is a <a href="http://www.facebook.com">link</a>, yep.
+  `);
+});
 
-  it('must preserve newlines in pre tags', function() {
-    var html = '<pre>hello\nthere</pre>';
-    var {contentBlocks: output} = DraftPasteProcessor.processHTML(
-      html,
-      CUSTOM_BLOCK_MAP,
-    );
-    expect(output[0].getText()).toBe('hello\nthere');
-  });
+test('must preserve styles inside links in a good way', () => {
+  assertDraftPasteProcessorProcessHTML(`
+    A <a href="http://www.facebook.com"><i>cool</i> link</a>, yep.
+  `);
+});
 
-  it('must preserve newlines in whitespace in pre tags', function() {
-    var html = '<pre><span>hello</span>\n<span>there</span></pre>';
-    var {contentBlocks: output} = DraftPasteProcessor.processHTML(
-      html,
-      CUSTOM_BLOCK_MAP,
-    );
-    expect(output[0].getText()).toBe('hello\nthere');
-    assertBlockTypes(output, ['code-block']);
-  });
+test('must ignore links that do not actually link anywhere', () => {
+  assertDraftPasteProcessorProcessHTML(`
+    This is a <a>link</a>, yep.
+  `);
+});
 
-  it('must parse based on style attribute', function() {
-    var html =
-      '<span style="font-weight: bold;">Bold ' +
-      '<span style="font-style: italic;">Italic</span></span>.';
-    var {contentBlocks: output} = DraftPasteProcessor.processHTML(
-      html,
-      CUSTOM_BLOCK_MAP,
-    );
-    assertBlockTypes(output, ['unstyled']);
-    assertInlineStyles(output[0], [
-      ['BOLD'],
-      ['BOLD'],
-      ['BOLD'],
-      ['BOLD'],
-      ['BOLD'],
-      ['BOLD', 'ITALIC'],
-      ['BOLD', 'ITALIC'],
-      ['BOLD', 'ITALIC'],
-      ['BOLD', 'ITALIC'],
-      ['BOLD', 'ITALIC'],
-      ['BOLD', 'ITALIC'],
-      [],
-    ]);
-    expect(output[0].getText()).toBe('Bold Italic.');
-  });
+test('must ignore javascript: links', () => {
+  assertDraftPasteProcessorProcessHTML(`
+    This is a <a href="javascript:void(0)">link</a>, yep.
+  `);
+});
 
-  it('must detect links in pasted content', function() {
-    var html = 'This is a <a href="http://www.facebook.com">link</a>, yep.';
-    var {contentBlocks: output, entityMap} = DraftPasteProcessor.processHTML(
-      html,
-      CUSTOM_BLOCK_MAP,
-    );
-    assertBlockTypes(output, ['unstyled']);
-    assertEntities(
-      output[0],
-      Array(10)
-        .fill(false)
-        .concat(Array(4).fill(true), Array(6).fill(false)),
-    );
-    expect(output[0].getText()).toBe('This is a link, yep.');
-    var entityId = output[0]
-      .getCharacterList()
-      .get(12)
-      .getEntity();
-    var entity = entityMap.__get(entityId);
-    expect(entity.getData().url).toBe('http://www.facebook.com/');
-  });
+test('must preserve mailto: links', () => {
+  assertDraftPasteProcessorProcessHTML(`
+    This is a <a href="mailto:example@example.com">link</a>, yep.
+  `);
+});
 
-  it('must preserve styles inside links in a good way', function() {
-    var html = 'A <a href="http://www.facebook.com"><i>cool</i> link</a>, yep.';
-    var {contentBlocks: output} = DraftPasteProcessor.processHTML(
-      html,
-      CUSTOM_BLOCK_MAP,
-    );
-    assertBlockTypes(output, ['unstyled']);
-    assertInlineStyles(
-      output[0],
-      Array(2)
-        .fill([])
-        .concat(Array(4).fill(['ITALIC']), Array(11).fill([])),
-    );
-    assertEntities(
-      output[0],
-      Array(2)
-        .fill(false)
-        .concat(Array(9).fill(true), Array(6).fill(false)),
-    );
-    expect(output[0].getText()).toBe('A cool link, yep.');
-  });
+test('Tolerate doule BR tags separated by whitespace', () => {
+  assertDraftPasteProcessorProcessHTML(`
+    hi<br>  <br>hello
+  `);
+});
 
-  it('must ignore links that do not actually link anywhere', function() {
-    var html = 'This is a <a>link</a>, yep.';
-    var {contentBlocks: output} = DraftPasteProcessor.processHTML(
-      html,
-      CUSTOM_BLOCK_MAP,
-    );
-    assertBlockTypes(output, ['unstyled']);
-    assertEntities(output[0], Array(20).fill(false));
-    expect(output[0].getText()).toBe('This is a link, yep.');
-  });
+test('Strip whitespace after block dividers', () => {
+  assertDraftPasteProcessorProcessHTML(`
+    <p>hello</p> <p> what</p>
+  `);
+});
 
-  it('must ignore javascript: links', function() {
-    var html = 'This is a <a href="javascript:void(0)">link</a>, yep.';
-    var {contentBlocks: output} = DraftPasteProcessor.processHTML(
-      html,
-      CUSTOM_BLOCK_MAP,
-    );
-    assertBlockTypes(output, ['unstyled']);
-    assertEntities(output[0], Array(20).fill(false));
-    expect(output[0].getText()).toBe('This is a link, yep.');
-  });
+test('Should detect when somthing is un-styled in a child', () => {
+  assertDraftPasteProcessorProcessHTML(`
+    <b>
+      hello<span style="font-weight:400;">there</span>
+    </b>
+  `);
 
-  it('must preserve mailto: links', function() {
-    var html = 'This is a <a href="mailto:example@example.com">link</a>, yep.';
-    var {contentBlocks: output, entityMap} = DraftPasteProcessor.processHTML(
-      html,
-      CUSTOM_BLOCK_MAP,
-    );
-    assertBlockTypes(output, ['unstyled']);
-    assertEntities(
-      output[0],
-      Array(10)
-        .fill(false)
-        .concat(Array(4).fill(true), Array(6).fill(false)),
-    );
-    expect(output[0].getText()).toBe('This is a link, yep.');
-    var entityId = output[0]
-      .getCharacterList()
-      .get(12)
-      .getEntity();
-    var entity = entityMap.__get(entityId);
-    expect(entity.getData().url).toBe('mailto:example@example.com');
-  });
+  assertDraftPasteProcessorProcessHTML(`
+    <i>
+      hello<span style="font-style:normal;">there</span>
+    </i>
+  `);
 
-  it('Tolerate doule BR tags separated by whitespace', function() {
-    var html = 'hi<br>  <br>hello';
-    var output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
-    assertBlockTypes(output.contentBlocks, ['unstyled', 'unstyled']);
-    html = '<div>hi<br> <br>hello</div>';
-    output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
-    assertBlockTypes(output.contentBlocks, ['unstyled', 'unstyled']);
+  // nothing to remove. make sure we don't throw an error
+  assertDraftPasteProcessorProcessHTML(`
+    <span>hello<span style="font-style:normal;">there</span></span>
+  `);
+});
 
-    html = '<div>hi<br> good stuff here <br>hello</div>';
-    output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
-    assertBlockTypes(output.contentBlocks, ['unstyled']);
-  });
-
-  it('Strip whitespace after block dividers', function() {
-    var html = '<p>hello</p> <p> what</p>';
-    var {contentBlocks: output} = DraftPasteProcessor.processHTML(
-      html,
-      CUSTOM_BLOCK_MAP,
-    );
-    expect(output[1].getText()).toBe('what');
-  });
-
-  it('Should detect when somthing is un-styled in a child', function() {
-    let html = '<b>hello<span style="font-weight:400;">there</span></b>';
-    let output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
-    assertInlineStyles(output.contentBlocks[0], [
-      ['BOLD'],
-      ['BOLD'],
-      ['BOLD'],
-      ['BOLD'],
-      ['BOLD'],
-      [],
-      [],
-      [],
-      [],
-      [],
-    ]);
-
-    html = '<i>hello<span style="font-style:normal;">there</span></i>';
-    output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
-    assertInlineStyles(output.contentBlocks[0], [
-      ['ITALIC'],
-      ['ITALIC'],
-      ['ITALIC'],
-      ['ITALIC'],
-      ['ITALIC'],
-      [],
-      [],
-      [],
-      [],
-      [],
-    ]);
-
-    // nothing to remove. make sure we don't throw an error
-    html = '<span>hello<span style="font-style:normal;">there</span></span>';
-    output = DraftPasteProcessor.processHTML(html, CUSTOM_BLOCK_MAP);
-    assertInlineStyles(output.contentBlocks[0], [
-      [],
-      [],
-      [],
-      [],
-      [],
-      [],
-      [],
-      [],
-      [],
-      [],
-    ]);
-  });
-
-  it('must preserve list formatting', function() {
-    var html = `
+test('must preserve list formatting', () => {
+  assertDraftPasteProcessorProcessHTML(`
     what
     <ul>
       <li>what</li>
@@ -474,19 +291,5 @@ describe('DraftPasteProcessor', function() {
       </li>
       <li>what</li>
     </ul>
-    `;
-    var {contentBlocks: output} = DraftPasteProcessor.processHTML(
-      html,
-      CUSTOM_BLOCK_MAP,
-    );
-    assertBlockTypes(output, [
-      'unstyled',
-      'unordered-list-item',
-      'unordered-list-item',
-      'ordered-list-item',
-      'ordered-list-item',
-      'unordered-list-item',
-    ]);
-    assertDepths(output, [0, 0, 0, 1, 1, 0]);
-  });
+  `);
 });

--- a/src/model/paste/__tests__/__snapshots__/DraftPasteProcessor-test.js.snap
+++ b/src/model/paste/__tests__/__snapshots__/DraftPasteProcessor-test.js.snap
@@ -3,7 +3,7 @@
 exports[`Should detect when somthing is un-styled in a child 1`] = `
 Array [
   Immutable.Record {
-    "key": "key37",
+    "key": "key39",
     "type": "unstyled",
     "text": "       hellothere ",
     "characterList": Immutable.List [
@@ -113,7 +113,7 @@ Array [
 exports[`Should detect when somthing is un-styled in a child 2`] = `
 Array [
   Immutable.Record {
-    "key": "key38",
+    "key": "key40",
     "type": "unstyled",
     "text": "       hellothere ",
     "characterList": Immutable.List [
@@ -223,7 +223,7 @@ Array [
 exports[`Should detect when somthing is un-styled in a child 3`] = `
 Array [
   Immutable.Record {
-    "key": "key39",
+    "key": "key41",
     "type": "unstyled",
     "text": "hellothere",
     "characterList": Immutable.List [
@@ -277,7 +277,7 @@ Array [
 exports[`Strip whitespace after block dividers 1`] = `
 Array [
   Immutable.Record {
-    "key": "key35",
+    "key": "key37",
     "type": "paragraph",
     "text": "hello",
     "characterList": Immutable.List [
@@ -306,7 +306,7 @@ Array [
     "data": Immutable.Map {},
   },
   Immutable.Record {
-    "key": "key36",
+    "key": "key38",
     "type": "paragraph",
     "text": "what",
     "characterList": Immutable.List [
@@ -336,7 +336,7 @@ Array [
 exports[`Tolerate doule BR tags separated by whitespace 1`] = `
 Array [
   Immutable.Record {
-    "key": "key33",
+    "key": "key35",
     "type": "unstyled",
     "text": "hi
  ",
@@ -362,7 +362,7 @@ Array [
     "data": Immutable.Map {},
   },
   Immutable.Record {
-    "key": "key34",
+    "key": "key36",
     "type": "unstyled",
     "text": "hello",
     "characterList": Immutable.List [
@@ -396,7 +396,7 @@ Array [
 exports[`must NOT split unstyled blocks inside a styled block 1`] = `
 Array [
   Immutable.Record {
-    "key": "key23",
+    "key": "key25",
     "type": "code-block",
     "text": "     hi
 
@@ -489,7 +489,7 @@ hello
 exports[`must NOT treat divs as Ps when we pave Ps 1`] = `
 Array [
   Immutable.Record {
-    "key": "key16",
+    "key": "key18",
     "type": "unstyled",
     "text": " ",
     "characterList": Immutable.List [
@@ -502,7 +502,7 @@ Array [
     "data": Immutable.Map {},
   },
   Immutable.Record {
-    "key": "key17",
+    "key": "key19",
     "type": "paragraph",
     "text": "hi",
     "characterList": Immutable.List [
@@ -519,7 +519,7 @@ Array [
     "data": Immutable.Map {},
   },
   Immutable.Record {
-    "key": "key18",
+    "key": "key20",
     "type": "paragraph",
     "text": "hello",
     "characterList": Immutable.List [
@@ -605,7 +605,7 @@ Array [
 exports[`must detect links in pasted content 1`] = `
 Array [
   Immutable.Record {
-    "key": "key28",
+    "key": "key30",
     "type": "unstyled",
     "text": "This is a link, yep.",
     "characterList": Immutable.List [
@@ -974,7 +974,7 @@ Array [
 exports[`must ignore javascript: links 1`] = `
 Array [
   Immutable.Record {
-    "key": "key31",
+    "key": "key33",
     "type": "unstyled",
     "text": "This is a link, yep.",
     "characterList": Immutable.List [
@@ -1068,7 +1068,7 @@ Array [
 exports[`must ignore links that do not actually link anywhere 1`] = `
 Array [
   Immutable.Record {
-    "key": "key30",
+    "key": "key32",
     "type": "unstyled",
     "text": "This is a link, yep.",
     "characterList": Immutable.List [
@@ -1320,7 +1320,7 @@ Array [
 exports[`must parse based on style attribute 1`] = `
 Array [
   Immutable.Record {
-    "key": "key27",
+    "key": "key29",
     "type": "unstyled",
     "text": "       Bold Italic  .",
     "characterList": Immutable.List [
@@ -1463,7 +1463,7 @@ Array [
 exports[`must preserve list formatting 1`] = `
 Array [
   Immutable.Record {
-    "key": "key40",
+    "key": "key42",
     "type": "unstyled",
     "text": "what      ",
     "characterList": Immutable.List [
@@ -1512,7 +1512,7 @@ Array [
     "data": Immutable.Map {},
   },
   Immutable.Record {
-    "key": "key41",
+    "key": "key43",
     "type": "unordered-list-item",
     "text": "what",
     "characterList": Immutable.List [
@@ -1537,7 +1537,7 @@ Array [
     "data": Immutable.Map {},
   },
   Immutable.Record {
-    "key": "key42",
+    "key": "key44",
     "type": "unordered-list-item",
     "text": "        what          ",
     "characterList": Immutable.List [
@@ -1634,7 +1634,7 @@ Array [
     "data": Immutable.Map {},
   },
   Immutable.Record {
-    "key": "key43",
+    "key": "key45",
     "type": "ordered-list-item",
     "text": "one",
     "characterList": Immutable.List [
@@ -1655,7 +1655,7 @@ Array [
     "data": Immutable.Map {},
   },
   Immutable.Record {
-    "key": "key44",
+    "key": "key46",
     "type": "ordered-list-item",
     "text": "two",
     "characterList": Immutable.List [
@@ -1676,7 +1676,7 @@ Array [
     "data": Immutable.Map {},
   },
   Immutable.Record {
-    "key": "key45",
+    "key": "key47",
     "type": "unordered-list-item",
     "text": "what",
     "characterList": Immutable.List [
@@ -1706,7 +1706,7 @@ Array [
 exports[`must preserve mailto: links 1`] = `
 Array [
   Immutable.Record {
-    "key": "key32",
+    "key": "key34",
     "type": "unstyled",
     "text": "This is a link, yep.",
     "characterList": Immutable.List [
@@ -1800,7 +1800,7 @@ Array [
 exports[`must preserve newlines in pre tags 1`] = `
 Array [
   Immutable.Record {
-    "key": "key25",
+    "key": "key27",
     "type": "code-block",
     "text": "     hello
 there
@@ -1900,7 +1900,7 @@ there
 exports[`must preserve newlines in whitespace in pre tags 1`] = `
 Array [
   Immutable.Record {
-    "key": "key26",
+    "key": "key28",
     "type": "code-block",
     "text": "     hello
 there
@@ -2043,10 +2043,102 @@ Array [
 ]
 `;
 
+exports[`must preserve spaces 2`] = `
+Array [
+  Immutable.Record {
+    "key": "key14",
+    "type": "unstyled",
+    "text": "hello hi",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must preserve spaces 3`] = `
+Array [
+  Immutable.Record {
+    "key": "key15",
+    "type": "unstyled",
+    "text": "hello hi",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
 exports[`must preserve styles inside links in a good way 1`] = `
 Array [
   Immutable.Record {
-    "key": "key29",
+    "key": "key31",
     "type": "unstyled",
     "text": "A cool link, yep.",
     "characterList": Immutable.List [
@@ -2136,7 +2228,7 @@ Array [
 exports[`must replace br tags with soft newlines 1`] = `
 Array [
   Immutable.Record {
-    "key": "key19",
+    "key": "key21",
     "type": "unstyled",
     "text": "hi
 hello",
@@ -2183,7 +2275,7 @@ hello",
 exports[`must replace newlines in regular tags 1`] = `
 Array [
   Immutable.Record {
-    "key": "key24",
+    "key": "key26",
     "type": "unstyled",
     "text": "      hello there     ",
     "characterList": Immutable.List [
@@ -2285,7 +2377,7 @@ Array [
 exports[`must split unstyled blocks on two br tags 1`] = `
 Array [
   Immutable.Record {
-    "key": "key21",
+    "key": "key23",
     "type": "unstyled",
     "text": "hi
 ",
@@ -2307,7 +2399,7 @@ Array [
     "data": Immutable.Map {},
   },
   Immutable.Record {
-    "key": "key22",
+    "key": "key24",
     "type": "unstyled",
     "text": "hello",
     "characterList": Immutable.List [
@@ -2341,7 +2433,7 @@ Array [
 exports[`must strip xml carriages and zero width spaces 1`] = `
 Array [
   Immutable.Record {
-    "key": "key20",
+    "key": "key22",
     "type": "unstyled",
     "text": "hihello",
     "characterList": Immutable.List [
@@ -2383,7 +2475,7 @@ Array [
 exports[`must treat divs as Ps when we do not have semantic markup 1`] = `
 Array [
   Immutable.Record {
-    "key": "key14",
+    "key": "key16",
     "type": "unstyled",
     "text": "hi",
     "characterList": Immutable.List [
@@ -2400,7 +2492,7 @@ Array [
     "data": Immutable.Map {},
   },
   Immutable.Record {
-    "key": "key15",
+    "key": "key17",
     "type": "unstyled",
     "text": "hello",
     "characterList": Immutable.List [

--- a/src/model/paste/__tests__/__snapshots__/DraftPasteProcessor-test.js.snap
+++ b/src/model/paste/__tests__/__snapshots__/DraftPasteProcessor-test.js.snap
@@ -1,0 +1,2432 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Should detect when somthing is un-styled in a child 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key37",
+    "type": "unstyled",
+    "text": "       hellothere ",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`Should detect when somthing is un-styled in a child 2`] = `
+Array [
+  Immutable.Record {
+    "key": "key38",
+    "type": "unstyled",
+    "text": "       hellothere ",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`Should detect when somthing is un-styled in a child 3`] = `
+Array [
+  Immutable.Record {
+    "key": "key39",
+    "type": "unstyled",
+    "text": "hellothere",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`Strip whitespace after block dividers 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key35",
+    "type": "paragraph",
+    "text": "hello",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  Immutable.Record {
+    "key": "key36",
+    "type": "paragraph",
+    "text": "what",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`Tolerate doule BR tags separated by whitespace 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key33",
+    "type": "unstyled",
+    "text": "hi
+ ",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  Immutable.Record {
+    "key": "key34",
+    "type": "unstyled",
+    "text": "hello",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must NOT split unstyled blocks inside a styled block 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key23",
+    "type": "code-block",
+    "text": "     hi
+
+hello
+    ",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must NOT treat divs as Ps when we pave Ps 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key16",
+    "type": "unstyled",
+    "text": " ",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  Immutable.Record {
+    "key": "key17",
+    "type": "paragraph",
+    "text": "hi",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  Immutable.Record {
+    "key": "key18",
+    "type": "paragraph",
+    "text": "hello",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must collapse nested blocks to the topmost level 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key5",
+    "type": "unstyled",
+    "text": " ",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  Immutable.Record {
+    "key": "key6",
+    "type": "unordered-list-item",
+    "text": "what
+ ",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must detect links in pasted content 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key28",
+    "type": "unstyled",
+    "text": "This is a link, yep.",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": "1",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": "1",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": "1",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": "1",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must detect two touching blocks 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key7",
+    "type": "header-one",
+    "text": "hi",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  Immutable.Record {
+    "key": "key8",
+    "type": "header-two",
+    "text": "hi",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must identify block styles 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key2",
+    "type": "unstyled",
+    "text": " ",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  Immutable.Record {
+    "key": "key3",
+    "type": "ordered-list-item",
+    "text": "hi",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  Immutable.Record {
+    "key": "key4",
+    "type": "ordered-list-item",
+    "text": "there",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must identify italics text 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key0",
+    "type": "unstyled",
+    "text": "hello hi",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must identify overlapping inline styles 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key1",
+    "type": "unstyled",
+    "text": " he       hi     ",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must ignore javascript: links 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key31",
+    "type": "unstyled",
+    "text": "This is a link, yep.",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must ignore links that do not actually link anywhere 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key30",
+    "type": "unstyled",
+    "text": "This is a link, yep.",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must insert a block when needed 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key9",
+    "type": "header-one",
+    "text": "hi ",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  Immutable.Record {
+    "key": "key10",
+    "type": "unstyled",
+    "text": "whatever  ",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  Immutable.Record {
+    "key": "key11",
+    "type": "header-two",
+    "text": "hi ",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must not generate fake blocks on heavy nesting 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key12",
+    "type": "paragraph",
+    "text": " Word    ,  ",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must parse based on style attribute 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key27",
+    "type": "unstyled",
+    "text": "       Bold Italic  .",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must preserve list formatting 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key40",
+    "type": "unstyled",
+    "text": "what      ",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  Immutable.Record {
+    "key": "key41",
+    "type": "unordered-list-item",
+    "text": "what",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  Immutable.Record {
+    "key": "key42",
+    "type": "unordered-list-item",
+    "text": "        what          ",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  Immutable.Record {
+    "key": "key43",
+    "type": "ordered-list-item",
+    "text": "one",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 1,
+    "data": Immutable.Map {},
+  },
+  Immutable.Record {
+    "key": "key44",
+    "type": "ordered-list-item",
+    "text": "two",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 1,
+    "data": Immutable.Map {},
+  },
+  Immutable.Record {
+    "key": "key45",
+    "type": "unordered-list-item",
+    "text": "what",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must preserve mailto: links 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key32",
+    "type": "unstyled",
+    "text": "This is a link, yep.",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": "3",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": "3",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": "3",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": "3",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must preserve newlines in pre tags 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key25",
+    "type": "code-block",
+    "text": "     hello
+there
+    ",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must preserve newlines in whitespace in pre tags 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key26",
+    "type": "code-block",
+    "text": "     hello
+there
+    ",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must preserve spaces 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key13",
+    "type": "unstyled",
+    "text": "hello hi",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must preserve styles inside links in a good way 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key29",
+    "type": "unstyled",
+    "text": "A cool link, yep.",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": "2",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": "2",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": "2",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": "2",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": "2",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": "2",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": "2",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": "2",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": "2",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must replace br tags with soft newlines 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key19",
+    "type": "unstyled",
+    "text": "hi
+hello",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must replace newlines in regular tags 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key24",
+    "type": "unstyled",
+    "text": "      hello there     ",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must split unstyled blocks on two br tags 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key21",
+    "type": "unstyled",
+    "text": "hi
+",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  Immutable.Record {
+    "key": "key22",
+    "type": "unstyled",
+    "text": "hello",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must strip xml carriages and zero width spaces 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key20",
+    "type": "unstyled",
+    "text": "hihello",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;
+
+exports[`must treat divs as Ps when we do not have semantic markup 1`] = `
+Array [
+  Immutable.Record {
+    "key": "key14",
+    "type": "unstyled",
+    "text": "hi",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  Immutable.Record {
+    "key": "key15",
+    "type": "unstyled",
+    "text": "hello",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+]
+`;

--- a/src/model/transaction/__tests__/ContentStateInlineStyle-test.js
+++ b/src/model/transaction/__tests__/ContentStateInlineStyle-test.js
@@ -15,86 +15,87 @@
 jest.disableAutomock();
 
 const ContentStateInlineStyle = require('ContentStateInlineStyle');
-const {List, Repeat} = require('immutable');
 
 const getSampleStateForTesting = require('getSampleStateForTesting');
 
-describe('ContentStateInlineStyle', () => {
-  const {contentState, selectionState} = getSampleStateForTesting();
+const {contentState, selectionState} = getSampleStateForTesting();
 
-  function getStyles(block) {
-    return block
-      .getCharacterList()
-      .map(c => c.getStyle())
-      .flatten()
-      .toJS();
-  }
+const initialSelection = selectionState.set(
+  'focusOffset',
+  contentState.getBlockForKey(selectionState.getStartKey()).getLength(),
+);
 
-  describe('Within a single block', () => {
-    const blockKey = selectionState.getStartKey();
-    const length = contentState.getBlockForKey(blockKey).getLength();
-    const target = selectionState.set('focusOffset', length);
+const assertAddContentStateInlineStyle = (
+  inlineStyle,
+  selection = selectionState,
+  content = contentState,
+) => {
+  const newContentState = ContentStateInlineStyle.add(
+    content,
+    selection,
+    inlineStyle,
+  );
 
-    it('must add styles', () => {
-      let modified = ContentStateInlineStyle.add(contentState, target, 'BOLD');
-      expect(getStyles(modified.getBlockForKey(blockKey))).toEqual(
-        Repeat('BOLD', length).toJS(),
-      );
+  expect(newContentState.getBlockMap()).toMatchSnapshot();
 
-      const nextTarget = target.set('focusOffset', 2);
-      modified = ContentStateInlineStyle.add(modified, nextTarget, 'ITALIC');
-      expect(getStyles(modified.getBlockForKey(blockKey))).toEqual(
-        List(['BOLD', 'ITALIC', 'BOLD', 'ITALIC'])
-          .concat(List(Repeat('BOLD', 3)))
-          .toJS(),
-      );
-    });
+  return newContentState;
+};
 
-    it('must remove styles', () => {
-      // Go ahead and add some styles that we'll then remove.
-      let modified = ContentStateInlineStyle.add(contentState, target, 'BOLD');
-      modified = ContentStateInlineStyle.add(modified, target, 'ITALIC');
-      modified = ContentStateInlineStyle.remove(modified, target, 'BOLD');
-      expect(getStyles(modified.getBlockForKey(blockKey))).toEqual(
-        Repeat('ITALIC', length).toJS(),
-      );
+const assertRemoveContentStateInlineStyle = (
+  inlineStyle,
+  selection = selectionState,
+  content = contentState,
+) => {
+  const newContentState = ContentStateInlineStyle.remove(
+    content,
+    selection,
+    inlineStyle,
+  );
 
-      const nextTarget = target.set('focusOffset', 2);
-      modified = ContentStateInlineStyle.remove(modified, nextTarget, 'ITALIC');
-      expect(getStyles(modified.getBlockForKey(blockKey))).toEqual(
-        List(Repeat('ITALIC', 3)).toJS(),
-      );
-    });
+  expect(newContentState.getBlockMap()).toMatchSnapshot();
+
+  return newContentState;
+};
+
+test('must add styles', () => {
+  let modified = assertAddContentStateInlineStyle('BOLD', initialSelection);
+
+  assertAddContentStateInlineStyle(
+    'ITALIC',
+    selectionState.set('focusOffset', 2),
+    modified,
+  );
+});
+
+test('must remove styles', () => {
+  // Go ahead and add some styles that we'll then remove.
+  let modified = assertAddContentStateInlineStyle('BOLD', initialSelection);
+  modified = assertAddContentStateInlineStyle(
+    'ITALIC',
+    initialSelection,
+    modified,
+  );
+
+  // we then remove the added styles
+  modified = assertRemoveContentStateInlineStyle(
+    'BOLD',
+    initialSelection,
+    modified,
+  );
+  assertRemoveContentStateInlineStyle(
+    'ITALIC',
+    initialSelection.set('focusOffset', 2),
+    modified,
+  );
+});
+
+test('must add and remove styles accross multiple blocks', () => {
+  const nextBlock = contentState.getBlockAfter(selectionState.getStartKey());
+  const selection = selectionState.merge({
+    focusKey: nextBlock.getKey(),
+    focusOffset: nextBlock.getLength(),
   });
 
-  describe('Across multiple blocks', () => {
-    const nextBlock = contentState.getBlockAfter(selectionState.getStartKey());
-    const target = selectionState.merge({
-      focusKey: nextBlock.getKey(),
-      focusOffset: nextBlock.getLength(),
-    });
-
-    it('must add and remove styles', () => {
-      let modified = ContentStateInlineStyle.add(contentState, target, 'BOLD');
-      const start = contentState.getBlockForKey(target.getStartKey());
-
-      expect(getStyles(modified.getBlockForKey(target.getStartKey()))).toEqual(
-        Repeat('BOLD', start.getLength()).toJS(),
-      );
-
-      expect(getStyles(modified.getBlockForKey(nextBlock.getKey()))).toEqual(
-        Repeat('BOLD', nextBlock.getLength()).toJS(),
-      );
-
-      modified = ContentStateInlineStyle.remove(contentState, target, 'BOLD');
-
-      expect(
-        getStyles(modified.getBlockForKey(target.getStartKey())).length,
-      ).toEqual(0);
-
-      expect(
-        getStyles(modified.getBlockForKey(nextBlock.getKey())).length,
-      ).toEqual(0);
-    });
-  });
+  const modified = assertAddContentStateInlineStyle('BOLD', selection);
+  assertRemoveContentStateInlineStyle('BOLD', selection, modified);
 });

--- a/src/model/transaction/__tests__/__snapshots__/ContentStateInlineStyle-test.js.snap
+++ b/src/model/transaction/__tests__/__snapshots__/ContentStateInlineStyle-test.js.snap
@@ -1,0 +1,1384 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must add and remove styles accross multiple blocks 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alpha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must add and remove styles accross multiple blocks 2`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alpha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must add styles 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alpha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must add styles 2`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alpha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must remove styles 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alpha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must remove styles 2`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alpha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must remove styles 3`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alpha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must remove styles 4`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alpha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;

--- a/src/model/transaction/__tests__/__snapshots__/ContentStateInlineStyle-test.js.snap
+++ b/src/model/transaction/__tests__/__snapshots__/ContentStateInlineStyle-test.js.snap
@@ -50,31 +50,31 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,
@@ -213,23 +213,23 @@ Immutable.OrderedMap {
     "characterList": Immutable.List [
       Immutable.Record {
         "style": Immutable.OrderedSet [],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,
@@ -380,31 +380,31 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,
@@ -557,31 +557,31 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,
@@ -732,31 +732,31 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,
@@ -912,31 +912,31 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,
@@ -1087,31 +1087,31 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,
@@ -1258,31 +1258,31 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,

--- a/src/model/transaction/__tests__/__snapshots__/applyEntityToContentBlock-test.js.snap
+++ b/src/model/transaction/__tests__/__snapshots__/applyEntityToContentBlock-test.js.snap
@@ -1,129 +1,129 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`must apply at the end 1`] = `
-Immutable.Record {
-  "key": "a",
-  "type": "unstyled",
-  "text": "Hello",
-  "characterList": Immutable.List [
-    Immutable.Record {
-      "style": Immutable.OrderedSet [],
+Object {
+  "characterList": Array [
+    Object {
       "entity": null,
+      "style": Array [],
     },
-    Immutable.Record {
-      "style": Immutable.OrderedSet [],
+    Object {
       "entity": null,
+      "style": Array [],
     },
-    Immutable.Record {
-      "style": Immutable.OrderedSet [],
+    Object {
       "entity": null,
+      "style": Array [],
     },
-    Immutable.Record {
-      "style": Immutable.OrderedSet [],
+    Object {
       "entity": "x",
+      "style": Array [],
     },
-    Immutable.Record {
-      "style": Immutable.OrderedSet [],
+    Object {
       "entity": "x",
+      "style": Array [],
     },
   ],
+  "data": Object {},
   "depth": 0,
-  "data": Immutable.Map {},
+  "key": "a",
+  "text": "Hello",
+  "type": "unstyled",
 }
 `;
 
 exports[`must apply from the start 1`] = `
-Immutable.Record {
-  "key": "a",
-  "type": "unstyled",
-  "text": "Hello",
-  "characterList": Immutable.List [
-    Immutable.Record {
-      "style": Immutable.OrderedSet [],
+Object {
+  "characterList": Array [
+    Object {
       "entity": "x",
+      "style": Array [],
     },
-    Immutable.Record {
-      "style": Immutable.OrderedSet [],
+    Object {
       "entity": "x",
+      "style": Array [],
     },
-    Immutable.Record {
-      "style": Immutable.OrderedSet [],
+    Object {
       "entity": null,
+      "style": Array [],
     },
-    Immutable.Record {
-      "style": Immutable.OrderedSet [],
+    Object {
       "entity": null,
+      "style": Array [],
     },
-    Immutable.Record {
-      "style": Immutable.OrderedSet [],
+    Object {
       "entity": null,
+      "style": Array [],
     },
   ],
+  "data": Object {},
   "depth": 0,
-  "data": Immutable.Map {},
+  "key": "a",
+  "text": "Hello",
+  "type": "unstyled",
 }
 `;
 
 exports[`must apply to the entire text 1`] = `
-Immutable.Record {
-  "key": "a",
-  "type": "unstyled",
-  "text": "Hello",
-  "characterList": Immutable.List [
-    Immutable.Record {
-      "style": Immutable.OrderedSet [],
+Object {
+  "characterList": Array [
+    Object {
       "entity": "x",
+      "style": Array [],
     },
-    Immutable.Record {
-      "style": Immutable.OrderedSet [],
+    Object {
       "entity": "x",
+      "style": Array [],
     },
-    Immutable.Record {
-      "style": Immutable.OrderedSet [],
+    Object {
       "entity": "x",
+      "style": Array [],
     },
-    Immutable.Record {
-      "style": Immutable.OrderedSet [],
+    Object {
       "entity": "x",
+      "style": Array [],
     },
-    Immutable.Record {
-      "style": Immutable.OrderedSet [],
+    Object {
       "entity": "x",
+      "style": Array [],
     },
   ],
+  "data": Object {},
   "depth": 0,
-  "data": Immutable.Map {},
+  "key": "a",
+  "text": "Hello",
+  "type": "unstyled",
 }
 `;
 
 exports[`must apply within 1`] = `
-Immutable.Record {
-  "key": "a",
-  "type": "unstyled",
-  "text": "Hello",
-  "characterList": Immutable.List [
-    Immutable.Record {
-      "style": Immutable.OrderedSet [],
+Object {
+  "characterList": Array [
+    Object {
       "entity": null,
+      "style": Array [],
     },
-    Immutable.Record {
-      "style": Immutable.OrderedSet [],
+    Object {
       "entity": "x",
+      "style": Array [],
     },
-    Immutable.Record {
-      "style": Immutable.OrderedSet [],
+    Object {
       "entity": "x",
+      "style": Array [],
     },
-    Immutable.Record {
-      "style": Immutable.OrderedSet [],
+    Object {
       "entity": "x",
+      "style": Array [],
     },
-    Immutable.Record {
-      "style": Immutable.OrderedSet [],
+    Object {
       "entity": null,
+      "style": Array [],
     },
   ],
+  "data": Object {},
   "depth": 0,
-  "data": Immutable.Map {},
+  "key": "a",
+  "text": "Hello",
+  "type": "unstyled",
 }
 `;

--- a/src/model/transaction/__tests__/__snapshots__/applyEntityToContentBlock-test.js.snap
+++ b/src/model/transaction/__tests__/__snapshots__/applyEntityToContentBlock-test.js.snap
@@ -1,0 +1,129 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must apply at the end 1`] = `
+Immutable.Record {
+  "key": "a",
+  "type": "unstyled",
+  "text": "Hello",
+  "characterList": Immutable.List [
+    Immutable.Record {
+      "style": Immutable.OrderedSet [],
+      "entity": null,
+    },
+    Immutable.Record {
+      "style": Immutable.OrderedSet [],
+      "entity": null,
+    },
+    Immutable.Record {
+      "style": Immutable.OrderedSet [],
+      "entity": null,
+    },
+    Immutable.Record {
+      "style": Immutable.OrderedSet [],
+      "entity": "x",
+    },
+    Immutable.Record {
+      "style": Immutable.OrderedSet [],
+      "entity": "x",
+    },
+  ],
+  "depth": 0,
+  "data": Immutable.Map {},
+}
+`;
+
+exports[`must apply from the start 1`] = `
+Immutable.Record {
+  "key": "a",
+  "type": "unstyled",
+  "text": "Hello",
+  "characterList": Immutable.List [
+    Immutable.Record {
+      "style": Immutable.OrderedSet [],
+      "entity": "x",
+    },
+    Immutable.Record {
+      "style": Immutable.OrderedSet [],
+      "entity": "x",
+    },
+    Immutable.Record {
+      "style": Immutable.OrderedSet [],
+      "entity": null,
+    },
+    Immutable.Record {
+      "style": Immutable.OrderedSet [],
+      "entity": null,
+    },
+    Immutable.Record {
+      "style": Immutable.OrderedSet [],
+      "entity": null,
+    },
+  ],
+  "depth": 0,
+  "data": Immutable.Map {},
+}
+`;
+
+exports[`must apply to the entire text 1`] = `
+Immutable.Record {
+  "key": "a",
+  "type": "unstyled",
+  "text": "Hello",
+  "characterList": Immutable.List [
+    Immutable.Record {
+      "style": Immutable.OrderedSet [],
+      "entity": "x",
+    },
+    Immutable.Record {
+      "style": Immutable.OrderedSet [],
+      "entity": "x",
+    },
+    Immutable.Record {
+      "style": Immutable.OrderedSet [],
+      "entity": "x",
+    },
+    Immutable.Record {
+      "style": Immutable.OrderedSet [],
+      "entity": "x",
+    },
+    Immutable.Record {
+      "style": Immutable.OrderedSet [],
+      "entity": "x",
+    },
+  ],
+  "depth": 0,
+  "data": Immutable.Map {},
+}
+`;
+
+exports[`must apply within 1`] = `
+Immutable.Record {
+  "key": "a",
+  "type": "unstyled",
+  "text": "Hello",
+  "characterList": Immutable.List [
+    Immutable.Record {
+      "style": Immutable.OrderedSet [],
+      "entity": null,
+    },
+    Immutable.Record {
+      "style": Immutable.OrderedSet [],
+      "entity": "x",
+    },
+    Immutable.Record {
+      "style": Immutable.OrderedSet [],
+      "entity": "x",
+    },
+    Immutable.Record {
+      "style": Immutable.OrderedSet [],
+      "entity": "x",
+    },
+    Immutable.Record {
+      "style": Immutable.OrderedSet [],
+      "entity": null,
+    },
+  ],
+  "depth": 0,
+  "data": Immutable.Map {},
+}
+`;

--- a/src/model/transaction/__tests__/__snapshots__/applyEntityToContentState-test.js.snap
+++ b/src/model/transaction/__tests__/__snapshots__/applyEntityToContentState-test.js.snap
@@ -1,0 +1,661 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must apply entity key 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alpha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": "x",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": "x",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": "x",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": "x",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": "x",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must apply entity key accross multiple blocks 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alpha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": "x",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": "x",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": "x",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": "x",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": "x",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "x",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "x",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "x",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "x",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "x",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must apply null entity 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alpha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must apply null entity key accross multiple blocks 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alpha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;

--- a/src/model/transaction/__tests__/__snapshots__/applyEntityToContentState-test.js.snap
+++ b/src/model/transaction/__tests__/__snapshots__/applyEntityToContentState-test.js.snap
@@ -40,31 +40,31 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,
@@ -370,31 +370,31 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,

--- a/src/model/transaction/__tests__/__snapshots__/insertFragmentIntoContentState-test.js.snap
+++ b/src/model/transaction/__tests__/__snapshots__/insertFragmentIntoContentState-test.js.snap
@@ -1,0 +1,796 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must apply fragment at the end 1`] = `
+Immutable.Record {
+  "entityMap": Immutable.OrderedMap {},
+  "blockMap": Immutable.OrderedMap {
+    "a": Immutable.Record {
+      "key": "a",
+      "type": "unstyled",
+      "text": "Alphaxx",
+      "characterList": Immutable.List [
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+      ],
+      "depth": 0,
+      "data": Immutable.Map {
+        "a": 1,
+      },
+    },
+    "b": Immutable.Record {
+      "key": "b",
+      "type": "unordered-list-item",
+      "text": "Bravo",
+      "characterList": Immutable.List [
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "BOLD",
+          ],
+          "entity": "123",
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "BOLD",
+          ],
+          "entity": "123",
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "BOLD",
+          ],
+          "entity": "123",
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "BOLD",
+          ],
+          "entity": "123",
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "BOLD",
+          ],
+          "entity": "123",
+        },
+      ],
+      "depth": 0,
+      "data": Immutable.Map {},
+    },
+    "c": Immutable.Record {
+      "key": "c",
+      "type": "code-block",
+      "text": "Test",
+      "characterList": Immutable.List [
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+      ],
+      "depth": 0,
+      "data": Immutable.Map {},
+    },
+    "d": Immutable.Record {
+      "key": "d",
+      "type": "code-block",
+      "text": "",
+      "characterList": Immutable.List [],
+      "depth": 0,
+      "data": Immutable.Map {},
+    },
+    "e": Immutable.Record {
+      "key": "e",
+      "type": "code-block",
+      "text": "",
+      "characterList": Immutable.List [],
+      "depth": 0,
+      "data": Immutable.Map {},
+    },
+    "f": Immutable.Record {
+      "key": "f",
+      "type": "blockquote",
+      "text": "Charlie",
+      "characterList": Immutable.List [
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "ITALIC",
+          ],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "ITALIC",
+          ],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "ITALIC",
+          ],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "ITALIC",
+          ],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "ITALIC",
+          ],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "ITALIC",
+          ],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "ITALIC",
+          ],
+          "entity": null,
+        },
+      ],
+      "depth": 0,
+      "data": Immutable.Map {},
+    },
+  },
+  "selectionBefore": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 5,
+    "focusKey": "a",
+    "focusOffset": 5,
+    "isBackward": false,
+    "hasFocus": true,
+  },
+  "selectionAfter": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 7,
+    "focusKey": "a",
+    "focusOffset": 7,
+    "isBackward": false,
+    "hasFocus": true,
+  },
+}
+`;
+
+exports[`must apply fragment to the start 1`] = `
+Immutable.Record {
+  "entityMap": Immutable.OrderedMap {},
+  "blockMap": Immutable.OrderedMap {
+    "a": Immutable.Record {
+      "key": "a",
+      "type": "unstyled",
+      "text": "xxAlpha",
+      "characterList": Immutable.List [
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+      ],
+      "depth": 0,
+      "data": Immutable.Map {
+        "a": 1,
+      },
+    },
+    "b": Immutable.Record {
+      "key": "b",
+      "type": "unordered-list-item",
+      "text": "Bravo",
+      "characterList": Immutable.List [
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "BOLD",
+          ],
+          "entity": "123",
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "BOLD",
+          ],
+          "entity": "123",
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "BOLD",
+          ],
+          "entity": "123",
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "BOLD",
+          ],
+          "entity": "123",
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "BOLD",
+          ],
+          "entity": "123",
+        },
+      ],
+      "depth": 0,
+      "data": Immutable.Map {},
+    },
+    "c": Immutable.Record {
+      "key": "c",
+      "type": "code-block",
+      "text": "Test",
+      "characterList": Immutable.List [
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+      ],
+      "depth": 0,
+      "data": Immutable.Map {},
+    },
+    "d": Immutable.Record {
+      "key": "d",
+      "type": "code-block",
+      "text": "",
+      "characterList": Immutable.List [],
+      "depth": 0,
+      "data": Immutable.Map {},
+    },
+    "e": Immutable.Record {
+      "key": "e",
+      "type": "code-block",
+      "text": "",
+      "characterList": Immutable.List [],
+      "depth": 0,
+      "data": Immutable.Map {},
+    },
+    "f": Immutable.Record {
+      "key": "f",
+      "type": "blockquote",
+      "text": "Charlie",
+      "characterList": Immutable.List [
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "ITALIC",
+          ],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "ITALIC",
+          ],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "ITALIC",
+          ],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "ITALIC",
+          ],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "ITALIC",
+          ],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "ITALIC",
+          ],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "ITALIC",
+          ],
+          "entity": null,
+        },
+      ],
+      "depth": 0,
+      "data": Immutable.Map {},
+    },
+  },
+  "selectionBefore": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 0,
+    "focusKey": "a",
+    "focusOffset": 0,
+    "isBackward": false,
+    "hasFocus": true,
+  },
+  "selectionAfter": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 2,
+    "focusKey": "a",
+    "focusOffset": 2,
+    "isBackward": false,
+    "hasFocus": true,
+  },
+}
+`;
+
+exports[`must apply fragment to within block 1`] = `
+Immutable.Record {
+  "entityMap": Immutable.OrderedMap {},
+  "blockMap": Immutable.OrderedMap {
+    "a": Immutable.Record {
+      "key": "a",
+      "type": "unstyled",
+      "text": "Alxxpha",
+      "characterList": Immutable.List [
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+      ],
+      "depth": 0,
+      "data": Immutable.Map {
+        "a": 1,
+      },
+    },
+    "b": Immutable.Record {
+      "key": "b",
+      "type": "unordered-list-item",
+      "text": "Bravo",
+      "characterList": Immutable.List [
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "BOLD",
+          ],
+          "entity": "123",
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "BOLD",
+          ],
+          "entity": "123",
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "BOLD",
+          ],
+          "entity": "123",
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "BOLD",
+          ],
+          "entity": "123",
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "BOLD",
+          ],
+          "entity": "123",
+        },
+      ],
+      "depth": 0,
+      "data": Immutable.Map {},
+    },
+    "c": Immutable.Record {
+      "key": "c",
+      "type": "code-block",
+      "text": "Test",
+      "characterList": Immutable.List [
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+      ],
+      "depth": 0,
+      "data": Immutable.Map {},
+    },
+    "d": Immutable.Record {
+      "key": "d",
+      "type": "code-block",
+      "text": "",
+      "characterList": Immutable.List [],
+      "depth": 0,
+      "data": Immutable.Map {},
+    },
+    "e": Immutable.Record {
+      "key": "e",
+      "type": "code-block",
+      "text": "",
+      "characterList": Immutable.List [],
+      "depth": 0,
+      "data": Immutable.Map {},
+    },
+    "f": Immutable.Record {
+      "key": "f",
+      "type": "blockquote",
+      "text": "Charlie",
+      "characterList": Immutable.List [
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "ITALIC",
+          ],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "ITALIC",
+          ],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "ITALIC",
+          ],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "ITALIC",
+          ],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "ITALIC",
+          ],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "ITALIC",
+          ],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "ITALIC",
+          ],
+          "entity": null,
+        },
+      ],
+      "depth": 0,
+      "data": Immutable.Map {},
+    },
+  },
+  "selectionBefore": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 2,
+    "focusKey": "a",
+    "focusOffset": 2,
+    "isBackward": false,
+    "hasFocus": true,
+  },
+  "selectionAfter": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 4,
+    "focusKey": "a",
+    "focusOffset": 4,
+    "isBackward": false,
+    "hasFocus": true,
+  },
+}
+`;
+
+exports[`must apply multiblock fragments 1`] = `
+Immutable.Record {
+  "entityMap": Immutable.OrderedMap {},
+  "blockMap": Immutable.OrderedMap {
+    "a": Immutable.Record {
+      "key": "a",
+      "type": "unstyled",
+      "text": "xx",
+      "characterList": Immutable.List [
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+      ],
+      "depth": 0,
+      "data": Immutable.Map {
+        "a": 1,
+      },
+    },
+    "key0": Immutable.Record {
+      "key": "key0",
+      "type": "unstyled",
+      "text": "yyAlpha",
+      "characterList": Immutable.List [
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+      ],
+      "depth": 0,
+      "data": Immutable.Map {
+        "b": 2,
+      },
+    },
+    "b": Immutable.Record {
+      "key": "b",
+      "type": "unordered-list-item",
+      "text": "Bravo",
+      "characterList": Immutable.List [
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "BOLD",
+          ],
+          "entity": "123",
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "BOLD",
+          ],
+          "entity": "123",
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "BOLD",
+          ],
+          "entity": "123",
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "BOLD",
+          ],
+          "entity": "123",
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "BOLD",
+          ],
+          "entity": "123",
+        },
+      ],
+      "depth": 0,
+      "data": Immutable.Map {},
+    },
+    "c": Immutable.Record {
+      "key": "c",
+      "type": "code-block",
+      "text": "Test",
+      "characterList": Immutable.List [
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [],
+          "entity": null,
+        },
+      ],
+      "depth": 0,
+      "data": Immutable.Map {},
+    },
+    "d": Immutable.Record {
+      "key": "d",
+      "type": "code-block",
+      "text": "",
+      "characterList": Immutable.List [],
+      "depth": 0,
+      "data": Immutable.Map {},
+    },
+    "e": Immutable.Record {
+      "key": "e",
+      "type": "code-block",
+      "text": "",
+      "characterList": Immutable.List [],
+      "depth": 0,
+      "data": Immutable.Map {},
+    },
+    "f": Immutable.Record {
+      "key": "f",
+      "type": "blockquote",
+      "text": "Charlie",
+      "characterList": Immutable.List [
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "ITALIC",
+          ],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "ITALIC",
+          ],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "ITALIC",
+          ],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "ITALIC",
+          ],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "ITALIC",
+          ],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "ITALIC",
+          ],
+          "entity": null,
+        },
+        Immutable.Record {
+          "style": Immutable.OrderedSet [
+            "ITALIC",
+          ],
+          "entity": null,
+        },
+      ],
+      "depth": 0,
+      "data": Immutable.Map {},
+    },
+  },
+  "selectionBefore": Immutable.Record {
+    "anchorKey": "a",
+    "anchorOffset": 0,
+    "focusKey": "a",
+    "focusOffset": 0,
+    "isBackward": false,
+    "hasFocus": true,
+  },
+  "selectionAfter": Immutable.Record {
+    "anchorKey": "key0",
+    "anchorOffset": 2,
+    "focusKey": "key0",
+    "focusOffset": 2,
+    "isBackward": false,
+    "hasFocus": true,
+  },
+}
+`;

--- a/src/model/transaction/__tests__/__snapshots__/insertFragmentIntoContentState-test.js.snap
+++ b/src/model/transaction/__tests__/__snapshots__/insertFragmentIntoContentState-test.js.snap
@@ -52,31 +52,31 @@ Immutable.Record {
           "style": Immutable.OrderedSet [
             "BOLD",
           ],
-          "entity": "123",
+          "entity": "1",
         },
         Immutable.Record {
           "style": Immutable.OrderedSet [
             "BOLD",
           ],
-          "entity": "123",
+          "entity": "1",
         },
         Immutable.Record {
           "style": Immutable.OrderedSet [
             "BOLD",
           ],
-          "entity": "123",
+          "entity": "1",
         },
         Immutable.Record {
           "style": Immutable.OrderedSet [
             "BOLD",
           ],
-          "entity": "123",
+          "entity": "1",
         },
         Immutable.Record {
           "style": Immutable.OrderedSet [
             "BOLD",
           ],
-          "entity": "123",
+          "entity": "1",
         },
       ],
       "depth": 0,
@@ -246,31 +246,31 @@ Immutable.Record {
           "style": Immutable.OrderedSet [
             "BOLD",
           ],
-          "entity": "123",
+          "entity": "1",
         },
         Immutable.Record {
           "style": Immutable.OrderedSet [
             "BOLD",
           ],
-          "entity": "123",
+          "entity": "1",
         },
         Immutable.Record {
           "style": Immutable.OrderedSet [
             "BOLD",
           ],
-          "entity": "123",
+          "entity": "1",
         },
         Immutable.Record {
           "style": Immutable.OrderedSet [
             "BOLD",
           ],
-          "entity": "123",
+          "entity": "1",
         },
         Immutable.Record {
           "style": Immutable.OrderedSet [
             "BOLD",
           ],
-          "entity": "123",
+          "entity": "1",
         },
       ],
       "depth": 0,
@@ -440,31 +440,31 @@ Immutable.Record {
           "style": Immutable.OrderedSet [
             "BOLD",
           ],
-          "entity": "123",
+          "entity": "1",
         },
         Immutable.Record {
           "style": Immutable.OrderedSet [
             "BOLD",
           ],
-          "entity": "123",
+          "entity": "1",
         },
         Immutable.Record {
           "style": Immutable.OrderedSet [
             "BOLD",
           ],
-          "entity": "123",
+          "entity": "1",
         },
         Immutable.Record {
           "style": Immutable.OrderedSet [
             "BOLD",
           ],
-          "entity": "123",
+          "entity": "1",
         },
         Immutable.Record {
           "style": Immutable.OrderedSet [
             "BOLD",
           ],
-          "entity": "123",
+          "entity": "1",
         },
       ],
       "depth": 0,
@@ -653,31 +653,31 @@ Immutable.Record {
           "style": Immutable.OrderedSet [
             "BOLD",
           ],
-          "entity": "123",
+          "entity": "1",
         },
         Immutable.Record {
           "style": Immutable.OrderedSet [
             "BOLD",
           ],
-          "entity": "123",
+          "entity": "1",
         },
         Immutable.Record {
           "style": Immutable.OrderedSet [
             "BOLD",
           ],
-          "entity": "123",
+          "entity": "1",
         },
         Immutable.Record {
           "style": Immutable.OrderedSet [
             "BOLD",
           ],
-          "entity": "123",
+          "entity": "1",
         },
         Immutable.Record {
           "style": Immutable.OrderedSet [
             "BOLD",
           ],
-          "entity": "123",
+          "entity": "1",
         },
       ],
       "depth": 0,

--- a/src/model/transaction/__tests__/__snapshots__/insertIntoList-test.js.snap
+++ b/src/model/transaction/__tests__/__snapshots__/insertIntoList-test.js.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must insert at beginning of list 1`] = `
+Immutable.List [
+  100,
+  101,
+  102,
+  0,
+  1,
+  2,
+  3,
+  4,
+]
+`;
+
+exports[`must insert at end of list 1`] = `
+Immutable.List [
+  0,
+  1,
+  2,
+  3,
+  4,
+  100,
+  101,
+  102,
+]
+`;
+
+exports[`must insert within a list 1`] = `
+Immutable.List [
+  0,
+  1,
+  2,
+  100,
+  101,
+  102,
+  3,
+  4,
+]
+`;

--- a/src/model/transaction/__tests__/__snapshots__/insertTextIntoContentState-test.js.snap
+++ b/src/model/transaction/__tests__/__snapshots__/insertTextIntoContentState-test.js.snap
@@ -1,0 +1,697 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must insert at the end 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alphaxx",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must insert at the start 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "xxAlpha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must insert within block 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alxxpha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must return early if no text is provided 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alpha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;

--- a/src/model/transaction/__tests__/__snapshots__/insertTextIntoContentState-test.js.snap
+++ b/src/model/transaction/__tests__/__snapshots__/insertTextIntoContentState-test.js.snap
@@ -52,31 +52,31 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,
@@ -229,31 +229,31 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,
@@ -406,31 +406,31 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,
@@ -571,31 +571,31 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,

--- a/src/model/transaction/__tests__/__snapshots__/removeEntitiesAtEdges-test.js.snap
+++ b/src/model/transaction/__tests__/__snapshots__/removeEntitiesAtEdges-test.js.snap
@@ -1,0 +1,2146 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must ignore an entity that is entirely within the selection 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alpha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must not affect blockMap if there are no entities 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alpha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must not remove if cursor is at end of entity 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alpha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must not remove if cursor is at start of entity 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alpha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must not remove mutable entities 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alpha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must remove entities at both ends of selection 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alpha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must remove entity at end of selection 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alpha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must remove entity at start of selection 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alpha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must remove for non-collapsed cursor on multiple entities 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alpha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must remove for non-collapsed cursor within a single entity 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alpha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must remove if cursor is within entity 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alpha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must remove immutable entities 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alpha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must remove segmented entities 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alpha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;

--- a/src/model/transaction/__tests__/__snapshots__/removeEntitiesAtEdges-test.js.snap
+++ b/src/model/transaction/__tests__/__snapshots__/removeEntitiesAtEdges-test.js.snap
@@ -46,19 +46,19 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
@@ -205,31 +205,31 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,
@@ -370,31 +370,31 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,
@@ -535,31 +535,31 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,
@@ -700,31 +700,31 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,

--- a/src/model/transaction/__tests__/__snapshots__/removeRangeFromContentState-test.js.snap
+++ b/src/model/transaction/__tests__/__snapshots__/removeRangeFromContentState-test.js.snap
@@ -1,0 +1,1966 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must remove blocks entirely within the selection 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alpt",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must remove from the beginning of the block 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "ha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must remove from the end of A to the end of B 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "AlphaBravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must remove from the end of A to the start of B 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "AlphaBravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must remove from the end of A to within B 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alphavo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must remove from the start of A to the end of B 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must remove from the start of A to the start of B 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must remove from the start of A to within B 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "vo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must remove from within A to the end of B 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alp",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must remove from within A to the start of B 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "AlpBravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must remove from within A to within B 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alpvo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must remove from within the block 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Ala",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must remove to the end of the block 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alp",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must return the input ContentState if selection is collapsed 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alpha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;

--- a/src/model/transaction/__tests__/__snapshots__/removeRangeFromContentState-test.js.snap
+++ b/src/model/transaction/__tests__/__snapshots__/removeRangeFromContentState-test.js.snap
@@ -255,7 +255,7 @@ Immutable.OrderedMap {
   "a": Immutable.Record {
     "key": "a",
     "type": "unstyled",
-    "text": "AlphaBravo",
+    "text": "Alpha",
     "characterList": Immutable.List [
       Immutable.Record {
         "style": Immutable.OrderedSet [],
@@ -276,36 +276,6 @@ Immutable.OrderedMap {
       Immutable.Record {
         "style": Immutable.OrderedSet [],
         "entity": null,
-      },
-      Immutable.Record {
-        "style": Immutable.OrderedSet [
-          "BOLD",
-        ],
-        "entity": "1",
-      },
-      Immutable.Record {
-        "style": Immutable.OrderedSet [
-          "BOLD",
-        ],
-        "entity": "1",
-      },
-      Immutable.Record {
-        "style": Immutable.OrderedSet [
-          "BOLD",
-        ],
-        "entity": "1",
-      },
-      Immutable.Record {
-        "style": Immutable.OrderedSet [
-          "BOLD",
-        ],
-        "entity": "1",
-      },
-      Immutable.Record {
-        "style": Immutable.OrderedSet [
-          "BOLD",
-        ],
-        "entity": "1",
       },
     ],
     "depth": 0,
@@ -705,39 +675,8 @@ Immutable.OrderedMap {
   "a": Immutable.Record {
     "key": "a",
     "type": "unstyled",
-    "text": "Bravo",
-    "characterList": Immutable.List [
-      Immutable.Record {
-        "style": Immutable.OrderedSet [
-          "BOLD",
-        ],
-        "entity": "1",
-      },
-      Immutable.Record {
-        "style": Immutable.OrderedSet [
-          "BOLD",
-        ],
-        "entity": "1",
-      },
-      Immutable.Record {
-        "style": Immutable.OrderedSet [
-          "BOLD",
-        ],
-        "entity": "1",
-      },
-      Immutable.Record {
-        "style": Immutable.OrderedSet [
-          "BOLD",
-        ],
-        "entity": "1",
-      },
-      Immutable.Record {
-        "style": Immutable.OrderedSet [
-          "BOLD",
-        ],
-        "entity": "1",
-      },
-    ],
+    "text": "",
+    "characterList": Immutable.List [],
     "depth": 0,
     "data": Immutable.Map {},
   },

--- a/src/model/transaction/__tests__/__snapshots__/removeRangeFromContentState-test.js.snap
+++ b/src/model/transaction/__tests__/__snapshots__/removeRangeFromContentState-test.js.snap
@@ -125,31 +125,31 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,
@@ -281,31 +281,31 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,
@@ -437,31 +437,31 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,
@@ -593,13 +593,13 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,
@@ -711,31 +711,31 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,
@@ -847,31 +847,31 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,
@@ -983,13 +983,13 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,
@@ -1231,31 +1231,31 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,
@@ -1379,13 +1379,13 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,
@@ -1518,31 +1518,31 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,
@@ -1675,31 +1675,31 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,
@@ -1840,31 +1840,31 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,

--- a/src/model/transaction/__tests__/__snapshots__/splitBlockInContentState-test.js.snap
+++ b/src/model/transaction/__tests__/__snapshots__/splitBlockInContentState-test.js.snap
@@ -48,31 +48,31 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,
@@ -221,31 +221,31 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,
@@ -395,31 +395,31 @@ Immutable.OrderedMap {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
       Immutable.Record {
         "style": Immutable.OrderedSet [
           "BOLD",
         ],
-        "entity": "123",
+        "entity": "1",
       },
     ],
     "depth": 0,

--- a/src/model/transaction/__tests__/__snapshots__/splitBlockInContentState-test.js.snap
+++ b/src/model/transaction/__tests__/__snapshots__/splitBlockInContentState-test.js.snap
@@ -1,0 +1,521 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must split at the beginning of a block 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "key1": Immutable.Record {
+    "key": "key1",
+    "type": "unstyled",
+    "text": "Alpha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must split at the end of a block 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alpha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "key3": Immutable.Record {
+    "key": "key3",
+    "type": "unstyled",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;
+
+exports[`must split within a block 1`] = `
+Immutable.OrderedMap {
+  "a": Immutable.Record {
+    "key": "a",
+    "type": "unstyled",
+    "text": "Alp",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "key2": Immutable.Record {
+    "key": "key2",
+    "type": "unstyled",
+    "text": "ha",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "b": Immutable.Record {
+    "key": "b",
+    "type": "unordered-list-item",
+    "text": "Bravo",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "BOLD",
+        ],
+        "entity": "123",
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "c": Immutable.Record {
+    "key": "c",
+    "type": "code-block",
+    "text": "Test",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "d": Immutable.Record {
+    "key": "d",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "e": Immutable.Record {
+    "key": "e",
+    "type": "code-block",
+    "text": "",
+    "characterList": Immutable.List [],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+  "f": Immutable.Record {
+    "key": "f",
+    "type": "blockquote",
+    "text": "Charlie",
+    "characterList": Immutable.List [
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+      Immutable.Record {
+        "style": Immutable.OrderedSet [
+          "ITALIC",
+        ],
+        "entity": null,
+      },
+    ],
+    "depth": 0,
+    "data": Immutable.Map {},
+  },
+}
+`;

--- a/src/model/transaction/__tests__/applyEntityToContentBlock-test.js
+++ b/src/model/transaction/__tests__/applyEntityToContentBlock-test.js
@@ -14,43 +14,38 @@
 
 jest.disableAutomock();
 
-var CharacterMetadata = require('CharacterMetadata');
-var ContentBlock = require('ContentBlock');
-var {List, Repeat} = require('immutable');
+const ContentBlock = require('ContentBlock');
 
-var applyEntityToContentBlock = require('applyEntityToContentBlock');
+const applyEntityToContentBlock = require('applyEntityToContentBlock');
 
-describe('applyEntityToContentBlock', () => {
-  var block = new ContentBlock({
-    key: 'a',
-    text: 'Hello',
-    characterList: List(Repeat(CharacterMetadata.EMPTY, 5)),
-  });
+const sampleBlock = new ContentBlock({
+  key: 'a',
+  text: 'Hello',
+});
 
-  function getEntities(block) {
-    return block
-      .getCharacterList()
-      .map(c => c.getEntity())
-      .toJS();
-  }
+const assertApplyEntityToContentBlock = (
+  start,
+  end,
+  entityKey = 'x',
+  contentBlock = sampleBlock,
+) => {
+  expect(
+    applyEntityToContentBlock(contentBlock, start, end, entityKey),
+  ).toMatchSnapshot();
+};
 
-  it('must apply from the start', () => {
-    var modified = applyEntityToContentBlock(block, 0, 2, 'x');
-    expect(getEntities(modified)).toEqual(['x', 'x', null, null, null]);
-  });
+test('must apply from the start', () => {
+  assertApplyEntityToContentBlock(0, 2);
+});
 
-  it('must apply within', () => {
-    var modified = applyEntityToContentBlock(block, 1, 4, 'x');
-    expect(getEntities(modified)).toEqual([null, 'x', 'x', 'x', null]);
-  });
+test('must apply within', () => {
+  assertApplyEntityToContentBlock(1, 4);
+});
 
-  it('must apply at the end', () => {
-    var modified = applyEntityToContentBlock(block, 3, 5, 'x');
-    expect(getEntities(modified)).toEqual([null, null, null, 'x', 'x']);
-  });
+test('must apply at the end', () => {
+  assertApplyEntityToContentBlock(3, 5);
+});
 
-  it('must apply to the entire text', () => {
-    var modified = applyEntityToContentBlock(block, 0, 5, 'x');
-    expect(getEntities(modified)).toEqual(['x', 'x', 'x', 'x', 'x']);
-  });
+test('must apply to the entire text', () => {
+  assertApplyEntityToContentBlock(0, 5);
 });

--- a/src/model/transaction/__tests__/applyEntityToContentBlock-test.js
+++ b/src/model/transaction/__tests__/applyEntityToContentBlock-test.js
@@ -30,7 +30,7 @@ const assertApplyEntityToContentBlock = (
   contentBlock = sampleBlock,
 ) => {
   expect(
-    applyEntityToContentBlock(contentBlock, start, end, entityKey),
+    applyEntityToContentBlock(contentBlock, start, end, entityKey).toJS(),
   ).toMatchSnapshot();
 };
 

--- a/src/model/transaction/__tests__/applyEntityToContentState-test.js
+++ b/src/model/transaction/__tests__/applyEntityToContentState-test.js
@@ -14,95 +14,52 @@
 
 jest.disableAutomock();
 
-var Immutable = require('immutable');
-var SelectionState = require('SelectionState');
+const SelectionState = require('SelectionState');
 
-var applyEntityToContentState = require('applyEntityToContentState');
-var getSampleStateForTesting = require('getSampleStateForTesting');
+const applyEntityToContentState = require('applyEntityToContentState');
+const getSampleStateForTesting = require('getSampleStateForTesting');
 
-describe('applyEntityToContentState', () => {
-  var {contentState} = getSampleStateForTesting();
+const {contentState, selectionState} = getSampleStateForTesting();
 
-  function checkForCharacterList(block) {
-    expect(Immutable.List.isList(block.getCharacterList())).toBe(true);
-  }
+const initialBlock = contentState.getBlockMap().first();
+const secondBlock = contentState.getBlockAfter(initialBlock.getKey());
 
-  function getEntities(block) {
-    return block
-      .getCharacterList()
-      .map(c => c.getEntity())
-      .toJS();
-  }
+const selectBlock = new SelectionState({
+  anchorKey: initialBlock.getKey(),
+  anchorOffset: 0,
+  focusKey: initialBlock.getKey(),
+  focusOffset: initialBlock.getLength(),
+});
 
-  describe('Apply entity within single block', () => {
-    var target = contentState.getBlockMap().first();
-    var targetSelection = new SelectionState({
-      anchorKey: target.getKey(),
-      anchorOffset: 0,
-      focusKey: target.getKey(),
-      focusOffset: target.getLength(),
-    });
+const selectAdjacentBlocks = new SelectionState({
+  anchorKey: initialBlock.getKey(),
+  anchorOffset: 0,
+  focusKey: secondBlock.getKey(),
+  focusOffset: secondBlock.getLength(),
+});
 
-    function applyAndCheck(entityKey) {
-      var withNewEntity = applyEntityToContentState(
-        contentState,
-        targetSelection,
-        entityKey,
-      );
-      var first = withNewEntity.getBlockMap().first();
+const assertApplyEntityToContentState = (
+  entityKey,
+  selection = selectionState,
+  content = contentState,
+) => {
+  expect(
+    applyEntityToContentState(content, selection, entityKey).getBlockMap(),
+  ).toMatchSnapshot();
+};
 
-      checkForCharacterList(first);
-      expect(getEntities(first)).toEqual(
-        Immutable.Repeat(entityKey, first.getLength()).toArray(),
-      );
-    }
+test('must apply entity key', () => {
+  assertApplyEntityToContentState('x', selectBlock);
+});
 
-    it('must apply entity key', () => {
-      applyAndCheck('x');
-    });
+test('must apply null entity', () => {
+  assertApplyEntityToContentState(null, selectBlock);
+});
 
-    it('must apply null entity', () => {
-      applyAndCheck(null);
-    });
-  });
+test('must apply entity key accross multiple blocks', () => {
+  assertApplyEntityToContentState('x', selectAdjacentBlocks);
+});
 
-  describe('Apply entity across multiple blocks', () => {
-    var blockMap = contentState.getBlockMap();
-    var first = blockMap.first();
-    var last = contentState.getBlockAfter(first.getKey());
-
-    var targetSelection = new SelectionState({
-      anchorKey: first.getKey(),
-      anchorOffset: 0,
-      focusKey: last.getKey(),
-      focusOffset: last.getLength(),
-    });
-
-    function applyAndCheck(entityKey) {
-      var withNewEntity = applyEntityToContentState(
-        contentState,
-        targetSelection,
-        entityKey,
-      );
-      var first = withNewEntity.getBlockMap().first();
-      var last = withNewEntity.getBlockAfter(first.getKey());
-
-      checkForCharacterList(first);
-      expect(getEntities(first)).toEqual(
-        Immutable.Repeat(entityKey, first.getLength()).toArray(),
-      );
-      checkForCharacterList(last);
-      expect(getEntities(last)).toEqual(
-        Immutable.Repeat(entityKey, last.getLength()).toArray(),
-      );
-    }
-
-    it('must apply entity key', () => {
-      applyAndCheck('x');
-    });
-
-    it('must apply null entity', () => {
-      applyAndCheck(null);
-    });
-  });
+test('must apply null entity key accross multiple blocks', () => {
+  assertApplyEntityToContentState(null, selectAdjacentBlocks);
 });

--- a/src/model/transaction/__tests__/insertFragmentIntoContentState-test.js
+++ b/src/model/transaction/__tests__/insertFragmentIntoContentState-test.js
@@ -14,120 +14,96 @@
 
 jest.disableAutomock();
 
-var BlockMapBuilder = require('BlockMapBuilder');
-var CharacterMetadata = require('CharacterMetadata');
-var ContentBlock = require('ContentBlock');
-var Immutable = require('immutable');
+jest.mock('generateRandomKey');
 
-var getSampleStateForTesting = require('getSampleStateForTesting');
-var insertFragmentIntoContentState = require('insertFragmentIntoContentState');
+const BlockMapBuilder = require('BlockMapBuilder');
+const CharacterMetadata = require('CharacterMetadata');
+const ContentBlock = require('ContentBlock');
+const Immutable = require('immutable');
 
+const getSampleStateForTesting = require('getSampleStateForTesting');
+const insertFragmentIntoContentState = require('insertFragmentIntoContentState');
+
+const {contentState, selectionState} = getSampleStateForTesting();
 const {EMPTY} = CharacterMetadata;
 const {List, Map} = Immutable;
 
-describe('insertFragmentIntoContentState', () => {
-  var sample = getSampleStateForTesting();
-  var content = sample.contentState;
-  var selection = sample.selectionState;
+const DEFAULT_BLOCK_CONFIG = {
+  key: 'j',
+  type: 'unstyled',
+  text: 'xx',
+  characterList: List.of(EMPTY, EMPTY),
+  data: new Map({a: 1}),
+};
 
-  var block = content.getBlockMap().first();
-  var data = new Map({a: 1});
-  var secondData = new Map({b: 2});
+const initialBlock = contentState.getBlockMap().first();
 
-  function createFragment() {
-    var fragmentArray = [
-      new ContentBlock({
-        key: 'j',
-        type: 'unstyled',
-        text: 'xx',
-        characterList: List.of(EMPTY, EMPTY),
-        data,
-      }),
-    ];
-    return BlockMapBuilder.createFromArray(fragmentArray);
-  }
+const createFragment = (fragment = {}) => {
+  fragment = Array.isArray(fragment) ? fragment : [fragment];
 
-  function createMultiblockFragment() {
-    var fragmentArray = [
-      new ContentBlock({
-        key: 'j',
-        type: 'unstyled',
-        text: 'xx',
-        characterList: List.of(EMPTY, EMPTY),
-        data,
-      }),
-      new ContentBlock({
-        key: 'k',
-        type: 'unstyled',
-        text: 'yy',
-        characterList: List.of(EMPTY, EMPTY),
-        data: secondData,
-      }),
-    ];
-    return BlockMapBuilder.createFromArray(fragmentArray);
-  }
+  return BlockMapBuilder.createFromArray(
+    fragment.map(
+      config =>
+        new ContentBlock({
+          ...DEFAULT_BLOCK_CONFIG,
+          ...config,
+        }),
+    ),
+  );
+};
 
-  it('must throw if no fragment is provided', () => {
-    var fragment = BlockMapBuilder.createFromArray([]);
-    expect(() => {
-      insertFragmentIntoContentState(content, selection, fragment);
-    }).toThrow();
-  });
+const assertInsertFragmentIntoContentState = (
+  fragment,
+  selection = selectionState,
+  content = contentState,
+) => {
+  expect(
+    insertFragmentIntoContentState(content, selection, fragment),
+  ).toMatchSnapshot();
+};
 
-  it('must apply fragment to the start', () => {
-    var fragment = createFragment();
-    var modified = insertFragmentIntoContentState(content, selection, fragment);
+test('must throw if no fragment is provided', () => {
+  const fragment = BlockMapBuilder.createFromArray([]);
+  expect(() => {
+    insertFragmentIntoContentState(contentState, selectionState, fragment);
+  }).toThrow();
+});
 
-    var newBlock = modified.getBlockMap().first();
+test('must apply fragment to the start', () => {
+  assertInsertFragmentIntoContentState(createFragment());
+});
 
-    expect(newBlock.getText().slice(0, 2)).toBe('xx');
-    expect(newBlock.getData()).toBe(data);
-  });
-
-  it('must apply fragment to within block', () => {
-    var target = selection.merge({
+test('must apply fragment to within block', () => {
+  assertInsertFragmentIntoContentState(
+    createFragment(),
+    selectionState.merge({
       focusOffset: 2,
       anchorOffset: 2,
       isBackward: false,
-    });
+    }),
+  );
+});
 
-    var fragment = createFragment();
-
-    var modified = insertFragmentIntoContentState(content, target, fragment);
-
-    var newBlock = modified.getBlockMap().first();
-
-    expect(newBlock.getText().slice(2, 4)).toBe('xx');
-    expect(newBlock.getData()).toBe(data);
-  });
-
-  it('must apply fragment at the end', () => {
-    var length = block.getLength();
-    var target = selection.merge({
-      focusOffset: length,
-      anchorOffset: length,
+test('must apply fragment at the end', () => {
+  assertInsertFragmentIntoContentState(
+    createFragment(),
+    selectionState.merge({
+      focusOffset: initialBlock.getLength(),
+      anchorOffset: initialBlock.getLength(),
       isBackward: false,
-    });
+    }),
+  );
+});
 
-    var fragment = createFragment();
-    var modified = insertFragmentIntoContentState(content, target, fragment);
-
-    var newBlock = modified.getBlockMap().first();
-
-    expect(newBlock.getText().slice(length, length + 2)).toBe('xx');
-    expect(newBlock.getData()).toBe(data);
-  });
-
-  it('must apply multiblock fragments', () => {
-    var fragment = createMultiblockFragment();
-    var modified = insertFragmentIntoContentState(content, selection, fragment);
-
-    var newBlock = modified.getBlockMap().first();
-    var secondBlock = modified.getBlockMap().toArray()[1];
-
-    expect(newBlock.getText()).toBe('xx');
-    expect(newBlock.getData()).toBe(data);
-    expect(secondBlock.getText().slice(0, 2)).toBe('yy');
-    expect(secondBlock.getData()).toBe(secondData);
-  });
+test('must apply multiblock fragments', () => {
+  assertInsertFragmentIntoContentState(
+    createFragment([
+      DEFAULT_BLOCK_CONFIG,
+      {
+        key: 'k',
+        text: 'yy',
+        data: new Map({b: 2}),
+      },
+    ]),
+  );
 });

--- a/src/model/transaction/__tests__/insertIntoList-test.js
+++ b/src/model/transaction/__tests__/insertIntoList-test.js
@@ -14,32 +14,28 @@
 
 jest.disableAutomock();
 
-var Immutable = require('immutable');
+const Immutable = require('immutable');
 
-var insertIntoList = require('insertIntoList');
+const insertIntoList = require('insertIntoList');
 
-describe('insertIntoList', () => {
-  var list = Immutable.List.of(0, 1, 2, 3, 4);
+const SAMPLE_LIST = Immutable.List.of(0, 1, 2, 3, 4);
 
-  it('must insert at end of list', () => {
-    var result = insertIntoList(
-      list,
-      Immutable.List.of(100, 101, 102),
-      list.size,
-    );
-    expect(result.size).toBe(8);
-    expect(result.toJS()).toEqual([0, 1, 2, 3, 4, 100, 101, 102]);
-  });
+const assertAssertInsertIntoList = (
+  toInsert,
+  offset = SAMPLE_LIST.size,
+  targetList = SAMPLE_LIST,
+) => {
+  expect(insertIntoList(targetList, toInsert, offset)).toMatchSnapshot();
+};
 
-  it('must insert at beginning of list', () => {
-    var result = insertIntoList(list, Immutable.List.of(100, 101, 102), 0);
-    expect(result.size).toBe(8);
-    expect(result.toJS()).toEqual([100, 101, 102, 0, 1, 2, 3, 4]);
-  });
+test('must insert at end of list', () => {
+  assertAssertInsertIntoList(Immutable.List.of(100, 101, 102));
+});
 
-  it('must insert within a list', () => {
-    var result = insertIntoList(list, Immutable.List.of(100, 101, 102), 3);
-    expect(result.size).toBe(8);
-    expect(result.toJS()).toEqual([0, 1, 2, 100, 101, 102, 3, 4]);
-  });
+test('must insert at beginning of list', () => {
+  assertAssertInsertIntoList(Immutable.List.of(100, 101, 102), 0);
+});
+
+test('must insert within a list', () => {
+  assertAssertInsertIntoList(Immutable.List.of(100, 101, 102), 3);
 });

--- a/src/model/transaction/__tests__/insertTextIntoContentState-test.js
+++ b/src/model/transaction/__tests__/insertTextIntoContentState-test.js
@@ -14,120 +14,73 @@
 
 jest.disableAutomock();
 
-var CharacterMetadata = require('CharacterMetadata');
-var Immutable = require('immutable');
-var {BOLD} = require('SampleDraftInlineStyle');
+const CharacterMetadata = require('CharacterMetadata');
+const {BOLD} = require('SampleDraftInlineStyle');
+const getSampleStateForTesting = require('getSampleStateForTesting');
+const insertTextIntoContentState = require('insertTextIntoContentState');
 
-var getSampleStateForTesting = require('getSampleStateForTesting');
-var insertTextIntoContentState = require('insertTextIntoContentState');
+const {contentState, selectionState} = getSampleStateForTesting();
 
-describe('insertTextIntoContentState', () => {
-  var sample = getSampleStateForTesting();
-  var content = sample.contentState;
-  var selection = sample.selectionState;
+const EMPTY = CharacterMetadata.EMPTY;
+const initialBlock = contentState.getBlockMap().first();
 
-  var EMPTY = CharacterMetadata.EMPTY;
-
-  var block = content.getBlockMap().first();
-
-  it('must throw if selection is not collapsed', () => {
-    var target = selection.set('focusOffset', 2);
-    expect(() => {
-      insertTextIntoContentState(content, target, 'hey', EMPTY);
-    }).toThrow();
-  });
-
-  it('must return early if no text is provided', () => {
-    var modified = insertTextIntoContentState(content, selection, '', EMPTY);
-    expect(modified).toBe(content);
-  });
-
-  it('must insert at the start', () => {
-    var character = CharacterMetadata.create({style: BOLD});
-    var modified = insertTextIntoContentState(
-      content,
+const assertInsertTextIntoContentState = (
+  text,
+  characterMetadata,
+  selection = selectionState,
+) => {
+  expect(
+    insertTextIntoContentState(
+      contentState,
       selection,
-      'xx',
-      character,
+      text,
+      characterMetadata,
+    ).getBlockMap(),
+  ).toMatchSnapshot();
+};
+
+test('must throw if selection is not collapsed', () => {
+  expect(() => {
+    insertTextIntoContentState(
+      contentState,
+      selectionState.set('focusOffset', 2),
+      'hey',
+      EMPTY,
     );
+  }).toThrow();
+});
 
-    var newBlock = modified.getBlockMap().first();
-    expect(newBlock.getText().slice(0, 2)).toBe('xx');
-    expect(newBlock.getText().slice(2)).toBe(block.getText());
+test('must return early if no text is provided', () => {
+  assertInsertTextIntoContentState('', EMPTY);
+});
 
-    expect(
-      Immutable.is(
-        Immutable.List.of(
-          character,
-          character,
-          EMPTY,
-          EMPTY,
-          EMPTY,
-          EMPTY,
-          EMPTY,
-        ),
-        newBlock.getCharacterList(),
-      ),
-    ).toBe(true);
-  });
+test('must insert at the start', () => {
+  assertInsertTextIntoContentState(
+    'xx',
+    CharacterMetadata.create({style: BOLD}),
+  );
+});
 
-  it('must insert within block', () => {
-    var target = selection.merge({
+test('must insert within block', () => {
+  assertInsertTextIntoContentState(
+    'xx',
+    CharacterMetadata.create({style: BOLD}),
+    selectionState.merge({
       focusOffset: 2,
       anchorOffset: 2,
       isBackward: false,
-    });
-    var character = CharacterMetadata.create({style: BOLD});
-    var modified = insertTextIntoContentState(content, target, 'xx', character);
-    var newBlock = modified.getBlockMap().first();
+    }),
+  );
+});
 
-    expect(newBlock.getText().slice(2, 4)).toBe('xx');
-    expect(newBlock.getText().slice(0, 2)).toBe(block.getText().slice(0, 2));
-    expect(newBlock.getText().slice(4, 7)).toBe(block.getText().slice(2, 5));
-
-    expect(
-      Immutable.is(
-        newBlock.getCharacterList(),
-        Immutable.List([
-          EMPTY,
-          EMPTY,
-          character,
-          character,
-          EMPTY,
-          EMPTY,
-          EMPTY,
-        ]),
-      ),
-    ).toBe(true);
-  });
-
-  it('must insert at the end', () => {
-    var target = selection.merge({
-      focusOffset: block.getLength(),
-      anchorOffset: block.getLength(),
+test('must insert at the end', () => {
+  assertInsertTextIntoContentState(
+    'xx',
+    CharacterMetadata.create({style: BOLD}),
+    selectionState.merge({
+      focusOffset: initialBlock.getLength(),
+      anchorOffset: initialBlock.getLength(),
       isBackward: false,
-    });
-
-    var character = CharacterMetadata.create({style: BOLD});
-    var modified = insertTextIntoContentState(content, target, 'xx', character);
-
-    var newBlock = modified.getBlockMap().first();
-    expect(newBlock.getText().slice(5, 7)).toBe('xx');
-    expect(newBlock.getText().slice(0, 5)).toBe(block.getText());
-
-    expect(
-      Immutable.is(
-        newBlock.getCharacterList(),
-        Immutable.List([
-          EMPTY,
-          EMPTY,
-          EMPTY,
-          EMPTY,
-          EMPTY,
-          character,
-          character,
-        ]),
-      ),
-    ).toBe(true);
-  });
+    }),
+  );
 });

--- a/src/model/transaction/__tests__/removeEntitiesAtEdges-test.js
+++ b/src/model/transaction/__tests__/removeEntitiesAtEdges-test.js
@@ -14,187 +14,152 @@
 
 jest.disableAutomock();
 
-var Immutable = require('immutable');
+const applyEntityToContentBlock = require('applyEntityToContentBlock');
+const getSampleStateForTesting = require('getSampleStateForTesting');
+const removeEntitiesAtEdges = require('removeEntitiesAtEdges');
 
-var applyEntityToContentBlock = require('applyEntityToContentBlock');
-var getSampleStateForTesting = require('getSampleStateForTesting');
-var removeEntitiesAtEdges = require('removeEntitiesAtEdges');
+const {contentState, selectionState} = getSampleStateForTesting();
 
-describe('removeEntitiesAtEdges', () => {
-  var {List, Repeat} = Immutable;
+const selectionOnEntity = selectionState.merge({
+  anchorKey: 'b',
+  anchorOffset: 2,
+  focusKey: 'b',
+  focusOffset: 2,
+});
 
-  var {contentState, selectionState} = getSampleStateForTesting();
-
-  var selectionOnEntity = selectionState.merge({
-    anchorKey: 'b',
-    anchorOffset: 2,
-    focusKey: 'b',
-    focusOffset: 2,
+const setEntityMutability = (mutability, content = contentState) => {
+  content.getEntityMap().__get = () => ({
+    getMutability: () => mutability,
   });
+};
 
-  function getEntities(block) {
-    return block
-      .getCharacterList()
-      .map(c => c.getEntity())
-      .toJS();
-  }
+const assertRemoveEntitiesAtEdges = (
+  selection,
+  mutability = 'IMMUTABLE',
+  content = contentState,
+) => {
+  setEntityMutability(mutability, content);
+  expect(
+    removeEntitiesAtEdges(content, selection).getBlockMap(),
+  ).toMatchSnapshot();
+};
 
-  function expectSameBlockMap(before, after) {
-    expect(before.getBlockMap()).toBe(after.getBlockMap());
-  }
+test('must not affect blockMap if there are no entities', () => {
+  assertRemoveEntitiesAtEdges(selectionState);
+});
 
-  function expectNullEntities(block) {
-    expect(getEntities(block)).toEqual(
-      List(Repeat(null, block.getLength())).toJS(),
-    );
-  }
+test('must not remove mutable entities', () => {
+  assertRemoveEntitiesAtEdges(selectionOnEntity, 'MUTABLE');
+});
 
-  function setEntityMutability(mutability) {
-    contentState.getEntityMap().__get = () => ({
-      getMutability: () => mutability,
-    });
-  }
+test('must remove immutable entities', () => {
+  assertRemoveEntitiesAtEdges(selectionOnEntity);
+});
 
-  describe('Within a single block', () => {
-    it('must not affect blockMap if there are no entities', () => {
-      var result = removeEntitiesAtEdges(contentState, selectionState);
-      expectSameBlockMap(contentState, result);
-    });
+test('must remove segmented entities', () => {
+  assertRemoveEntitiesAtEdges(selectionOnEntity, 'SEGMENTED');
+});
 
-    describe('Handling different mutability types', () => {
-      it('must not remove mutable entities', () => {
-        setEntityMutability('MUTABLE');
-        var result = removeEntitiesAtEdges(contentState, selectionOnEntity);
-        expectSameBlockMap(contentState, result);
-      });
+test('must not remove if cursor is at start of entity', () => {
+  assertRemoveEntitiesAtEdges(
+    selectionOnEntity.merge({
+      anchorOffset: 0,
+      focusOffset: 0,
+    }),
+  );
+});
 
-      it('must remove immutable entities', () => {
-        setEntityMutability('IMMUTABLE');
-        var result = removeEntitiesAtEdges(contentState, selectionOnEntity);
-        expect(result.getBlockMap()).not.toBe(contentState.getBlockMap());
-        expectNullEntities(result.getBlockForKey('b'));
-      });
+test('must remove if cursor is within entity', () => {
+  assertRemoveEntitiesAtEdges(selectionOnEntity);
+});
 
-      it('must remove segmented entities', () => {
-        setEntityMutability('SEGMENTED');
-        var result = removeEntitiesAtEdges(contentState, selectionOnEntity);
-        expect(result.getBlockMap()).not.toBe(contentState.getBlockMap());
-        expectNullEntities(result.getBlockForKey('b'));
-      });
-    });
+test('must not remove if cursor is at end of entity', () => {
+  const length = contentState.getBlockForKey('b').getLength();
+  assertRemoveEntitiesAtEdges(
+    selectionOnEntity.merge({
+      anchorOffset: length,
+      focusOffset: length,
+    }),
+  );
+});
 
-    describe('Removal for a collapsed cursor', () => {
-      setEntityMutability('IMMUTABLE');
+test('must remove for non-collapsed cursor within a single entity', () => {
+  assertRemoveEntitiesAtEdges(selectionOnEntity.set('anchorOffset', 1));
+});
 
-      it('must not remove if cursor is at start of entity', () => {
-        var selection = selectionOnEntity.merge({
-          anchorOffset: 0,
-          focusOffset: 0,
-        });
-        var result = removeEntitiesAtEdges(contentState, selection);
-        expectSameBlockMap(contentState, result);
-      });
+test('must remove for non-collapsed cursor on multiple entities', () => {
+  const block = contentState.getBlockForKey('b');
+  const newBlock = applyEntityToContentBlock(block, 3, 5, '456');
+  const newBlockMap = contentState.getBlockMap().set('b', newBlock);
+  const newContent = contentState.set('blockMap', newBlockMap);
 
-      it('must remove if cursor is within entity', () => {
-        var result = removeEntitiesAtEdges(contentState, selectionOnEntity);
-        expectNullEntities(result.getBlockForKey('b'));
-      });
+  assertRemoveEntitiesAtEdges(
+    selectionOnEntity.merge({
+      anchorOffset: 1,
+      focusOffset: 4,
+    }),
+    'IMMUTABLE',
+    newContent,
+  );
+});
 
-      it('must not remove if cursor is at end of entity', () => {
-        var length = contentState.getBlockForKey('b').getLength();
-        var selection = selectionOnEntity.merge({
-          anchorOffset: length,
-          focusOffset: length,
-        });
-        var result = removeEntitiesAtEdges(contentState, selection);
-        expectSameBlockMap(contentState, result);
-      });
-    });
+test('must ignore an entity that is entirely within the selection', () => {
+  const block = contentState.getBlockForKey('b');
 
-    describe('Removal for a non-collapsed cursor', () => {
-      setEntityMutability('IMMUTABLE');
+  // Remove entity from beginning and end of block.
+  let newBlock = applyEntityToContentBlock(block, 0, 1, null);
+  newBlock = applyEntityToContentBlock(newBlock, 4, 5, null);
 
-      it('must remove for non-collapsed cursor within a single entity', () => {
-        setEntityMutability('IMMUTABLE');
-        var selection = selectionOnEntity.set('anchorOffset', 1);
-        var result = removeEntitiesAtEdges(contentState, selection);
-        expectNullEntities(result.getBlockForKey('b'));
-      });
+  const newBlockMap = contentState.getBlockMap().set('b', newBlock);
+  const newContent = contentState.set('blockMap', newBlockMap);
 
-      it('must remove for non-collapsed cursor on multiple entities', () => {
-        var block = contentState.getBlockForKey('b');
-        var newBlock = applyEntityToContentBlock(block, 3, 5, '456');
-        var newBlockMap = contentState.getBlockMap().set('b', newBlock);
-        var newContent = contentState.set('blockMap', newBlockMap);
-        var selection = selectionOnEntity.merge({
-          anchorOffset: 1,
-          focusOffset: 4,
-        });
-        var result = removeEntitiesAtEdges(newContent, selection);
-        expectNullEntities(result.getBlockForKey('b'));
-      });
+  assertRemoveEntitiesAtEdges(
+    selectionOnEntity.merge({
+      anchorOffset: 0,
+      focusOffset: 5,
+    }),
+    'IMMUTABLE',
+    newContent,
+  );
+});
 
-      it('must ignore an entity that is entirely within the selection', () => {
-        var block = contentState.getBlockForKey('b');
+test('must remove entity at start of selection', () => {
+  assertRemoveEntitiesAtEdges(
+    selectionState.merge({
+      anchorKey: 'b',
+      anchorOffset: 3,
+      focusKey: 'c',
+      focusOffset: 3,
+    }),
+  );
+});
 
-        // Remove entity from beginning and end of block.
-        var newBlock = applyEntityToContentBlock(block, 0, 1, null);
-        newBlock = applyEntityToContentBlock(newBlock, 4, 5, null);
+test('must remove entity at end of selection', () => {
+  assertRemoveEntitiesAtEdges(
+    selectionState.merge({
+      anchorKey: 'a',
+      anchorOffset: 3,
+      focusKey: 'b',
+      focusOffset: 3,
+    }),
+  );
+});
 
-        var newBlockMap = contentState.getBlockMap().set('b', newBlock);
-        var newContent = contentState.set('blockMap', newBlockMap);
-        var selection = selectionOnEntity.merge({
-          anchorOffset: 0,
-          focusOffset: 5,
-        });
-        var result = removeEntitiesAtEdges(newContent, selection);
-        expectSameBlockMap(newContent, result);
-      });
-    });
-  });
+test('must remove entities at both ends of selection', () => {
+  const cBlock = contentState.getBlockForKey('c');
+  const len = cBlock.getLength();
+  const modifiedC = applyEntityToContentBlock(cBlock, 0, len, '456');
+  const newBlockMap = contentState.getBlockMap().set('c', modifiedC);
+  const newContent = contentState.set('blockMap', newBlockMap);
 
-  describe('Across multiple blocks', () => {
-    setEntityMutability('IMMUTABLE');
-
-    it('must remove entity at start of selection', () => {
-      var selection = selectionState.merge({
-        anchorKey: 'b',
-        anchorOffset: 3,
-        focusKey: 'c',
-        focusOffset: 3,
-      });
-      var result = removeEntitiesAtEdges(contentState, selection);
-      expectNullEntities(result.getBlockForKey('b'));
-      expectNullEntities(result.getBlockForKey('c'));
-    });
-
-    it('must remove entity at end of selection', () => {
-      var selection = selectionState.merge({
-        anchorKey: 'a',
-        anchorOffset: 3,
-        focusKey: 'b',
-        focusOffset: 3,
-      });
-      var result = removeEntitiesAtEdges(contentState, selection);
-      expectNullEntities(result.getBlockForKey('a'));
-      expectNullEntities(result.getBlockForKey('b'));
-    });
-
-    it('must remove entities at both ends of selection', () => {
-      var cBlock = contentState.getBlockForKey('c');
-      var len = cBlock.getLength();
-      var modifiedC = applyEntityToContentBlock(cBlock, 0, len, '456');
-      var newBlockMap = contentState.getBlockMap().set('c', modifiedC);
-      var newContent = contentState.set('blockMap', newBlockMap);
-      var selection = selectionState.merge({
-        anchorKey: 'b',
-        anchorOffset: 3,
-        focusKey: 'c',
-        focusOffset: 3,
-      });
-      var result = removeEntitiesAtEdges(newContent, selection);
-      expectNullEntities(result.getBlockForKey('b'));
-      expectNullEntities(result.getBlockForKey('c'));
-    });
-  });
+  assertRemoveEntitiesAtEdges(
+    selectionState.merge({
+      anchorKey: 'b',
+      anchorOffset: 3,
+      focusKey: 'c',
+      focusOffset: 3,
+    }),
+    'IMMUTABLE',
+    newContent,
+  );
 });

--- a/src/model/transaction/__tests__/removeEntitiesAtEdges-test.js
+++ b/src/model/transaction/__tests__/removeEntitiesAtEdges-test.js
@@ -53,7 +53,7 @@ test('must not remove mutable entities', () => {
 });
 
 test('must remove immutable entities', () => {
-  assertRemoveEntitiesAtEdges(selectionOnEntity);
+  assertRemoveEntitiesAtEdges(selectionOnEntity, 'IMMUTABLE');
 });
 
 test('must remove segmented entities', () => {

--- a/src/model/transaction/__tests__/removeRangeFromContentState-test.js
+++ b/src/model/transaction/__tests__/removeRangeFromContentState-test.js
@@ -26,6 +26,10 @@ const assertRemoveRangeFromContentState = selection => {
 };
 
 const initialBlock = contentState.getBlockMap().first();
+const secondBlock = contentState
+  .getBlockMap()
+  .skip(1)
+  .first();
 const selectionWithinA = selectionState.set('anchorOffset', 3);
 const selectionFromEndOfA = selectionState.merge({
   anchorOffset: initialBlock.getLength(),
@@ -86,10 +90,7 @@ test('must remove from the start of A to the end of B', () => {
   assertRemoveRangeFromContentState(
     selectionState.merge({
       focusKey: 'b',
-      focusOffset: contentState
-        .getBlockMap()
-        .skip(1)
-        .first(),
+      focusOffset: secondBlock.getLength(),
     }),
   );
 });
@@ -111,11 +112,7 @@ test('must remove from within A to the end of B', () => {
   assertRemoveRangeFromContentState(
     selectionWithinA.merge({
       focusKey: 'b',
-      focusOffset: contentState
-        .getBlockMap()
-        .skip(1)
-        .first()
-        .getLength(),
+      focusOffset: secondBlock.getLength(),
     }),
   );
 });
@@ -142,10 +139,7 @@ test('must remove from the end of A to the end of B', () => {
   assertRemoveRangeFromContentState(
     selectionFromEndOfA.merge({
       focusKey: 'b',
-      focusOffset: contentState
-        .getBlockMap()
-        .skip(1)
-        .first(),
+      focusOffset: secondBlock.getLength(),
     }),
   );
 });

--- a/src/model/transaction/__tests__/removeRangeFromContentState-test.js
+++ b/src/model/transaction/__tests__/removeRangeFromContentState-test.js
@@ -14,444 +14,148 @@
 
 jest.disableAutomock();
 
-var ContentBlock = require('ContentBlock');
-var Immutable = require('immutable');
+const getSampleStateForTesting = require('getSampleStateForTesting');
+const removeRangeFromContentState = require('removeRangeFromContentState');
 
-var getSampleStateForTesting = require('getSampleStateForTesting');
-var removeRangeFromContentState = require('removeRangeFromContentState');
+const {contentState, selectionState} = getSampleStateForTesting();
 
-describe('removeRangeFromContentState', () => {
-  var {contentState, selectionState} = getSampleStateForTesting();
-  const blockSizeBeforeRemoval = contentState.getBlockMap().size;
+const assertRemoveRangeFromContentState = selection => {
+  expect(
+    removeRangeFromContentState(contentState, selection).getBlockMap(),
+  ).toMatchSnapshot();
+};
 
-  function checkForCharacterList(block) {
-    expect(Immutable.List.isList(block.getCharacterList())).toBe(true);
-  }
+const initialBlock = contentState.getBlockMap().first();
+const selectionWithinA = selectionState.set('anchorOffset', 3);
+const selectionFromEndOfA = selectionState.merge({
+  anchorOffset: initialBlock.getLength(),
+  focusOffset: initialBlock.getLength(),
+});
 
-  function getInlineStyles(block) {
-    return block
-      .getCharacterList()
-      .map(c => c.getStyle())
-      .toJS();
-  }
+test('must return the input ContentState if selection is collapsed', () => {
+  assertRemoveRangeFromContentState(selectionState);
+});
 
-  function getEntities(block) {
-    return block
-      .getCharacterList()
-      .map(c => c.getEntity())
-      .toJS();
-  }
+test('must remove from the beginning of the block', () => {
+  // Remove from 0 to 3.
+  assertRemoveRangeFromContentState(selectionState.set('focusOffset', 3));
+});
 
-  function expectBlockToBeSlice(block, comparison, start, end) {
-    expect(block.getType()).toBe(comparison.getType());
-    expect(block.getText()).toBe(comparison.getText().slice(start, end));
-    expect(getInlineStyles(block)).toEqual(
-      getInlineStyles(comparison).slice(start, end),
-    );
-    expect(getEntities(block)).toEqual(
-      getEntities(comparison).slice(start, end),
-    );
-    checkForCharacterList(block);
-  }
+test('must remove from within the block', () => {
+  // Remove from 2 to 4.
+  assertRemoveRangeFromContentState(
+    selectionState.merge({
+      anchorOffset: 2,
+      focusOffset: 4,
+    }),
+  );
+});
 
-  it('must return the input ContentState if selection is collapsed', () => {
-    expect(removeRangeFromContentState(contentState, selectionState)).toBe(
-      contentState,
-    );
-  });
+test('must remove to the end of the block', () => {
+  // Remove from 3 to end.
+  assertRemoveRangeFromContentState(
+    selectionState.merge({
+      anchorOffset: 3,
+      focusOffset: contentState
+        .getBlockMap()
+        .first()
+        .getLength(),
+    }),
+  );
+});
 
-  describe('Removal within a single block', () => {
-    it('must remove from the beginning of the block', () => {
-      // Remove from 0 to 3.
-      var selection = selectionState.set('focusOffset', 3);
-      var afterRemoval = removeRangeFromContentState(contentState, selection);
-      var afterBlockMap = afterRemoval.getBlockMap();
-      var alteredBlock = afterBlockMap.first();
-      var originalBlock = contentState.getBlockMap().first();
+test('must remove from the start of A to the start of B', () => {
+  // Block B is removed. Its contents replace the contents of block A,
+  // while the `type` of block A is preserved.
+  assertRemoveRangeFromContentState(selectionState.set('focusKey', 'b'));
+});
 
-      expectBlockToBeSlice(alteredBlock, originalBlock, 3);
-    });
+test('must remove from the start of A to within B', () => {
+  // A slice of block B contents replace the contents of block A,
+  // while the `type` of block A is preserved. Block B is removed.
+  assertRemoveRangeFromContentState(
+    selectionState.merge({
+      focusKey: 'b',
+      focusOffset: 3,
+    }),
+  );
+});
 
-    it('must remove from within the block', () => {
-      // Remove from 2 to 4.
-      var selection = selectionState.merge({
-        anchorOffset: 2,
-        focusOffset: 4,
-      });
-      var afterRemoval = removeRangeFromContentState(contentState, selection);
-      var afterBlockMap = afterRemoval.getBlockMap();
-      var alteredBlock = afterBlockMap.first();
-      var originalBlock = contentState.getBlockMap().first();
+test('must remove from the start of A to the end of B', () => {
+  // Block A is effectively just emptied out, while block B is removed.
+  assertRemoveRangeFromContentState(
+    selectionState.merge({
+      focusKey: 'b',
+      focusOffset: contentState
+        .getBlockMap()
+        .skip(1)
+        .first(),
+    }),
+  );
+});
 
-      expect(alteredBlock).not.toBe(originalBlock);
-      expect(alteredBlock.getType()).toBe(originalBlock.getType());
-      expect(alteredBlock.getText()).toBe(
-        originalBlock.getText().slice(0, 2) + originalBlock.getText().slice(4),
-      );
+test('must remove from within A to the start of B', () => {
+  assertRemoveRangeFromContentState(selectionWithinA.set('focusKey', 'b'));
+});
 
-      var stylesToJS = getInlineStyles(originalBlock);
-      expect(getInlineStyles(alteredBlock)).toEqual(
-        stylesToJS.slice(0, 2).concat(stylesToJS.slice(4)),
-      );
-      var entitiesToJS = getEntities(originalBlock);
-      expect(getEntities(alteredBlock)).toEqual(
-        entitiesToJS.slice(0, 2).concat(entitiesToJS.slice(4)),
-      );
-    });
+test('must remove from within A to within B', () => {
+  assertRemoveRangeFromContentState(
+    selectionWithinA.merge({
+      focusKey: 'b',
+      focusOffset: 3,
+    }),
+  );
+});
 
-    it('nust remove to the end of the block', () => {
-      // Remove from 3 to end.
-      var originalBlock = contentState.getBlockMap().first();
-      var selection = selectionState.merge({
-        anchorOffset: 3,
-        focusOffset: originalBlock.getLength(),
-      });
-      var afterRemoval = removeRangeFromContentState(contentState, selection);
-      var afterBlockMap = afterRemoval.getBlockMap();
-      var alteredBlock = afterBlockMap.first();
+test('must remove from within A to the end of B', () => {
+  assertRemoveRangeFromContentState(
+    selectionWithinA.merge({
+      focusKey: 'b',
+      focusOffset: contentState
+        .getBlockMap()
+        .skip(1)
+        .first()
+        .getLength(),
+    }),
+  );
+});
 
-      expectBlockToBeSlice(alteredBlock, originalBlock, 0, 3);
-    });
-  });
+test('must remove from the end of A to the start of B', () => {
+  assertRemoveRangeFromContentState(
+    selectionFromEndOfA.merge({
+      focusKey: 'b',
+      focusOffset: 0,
+    }),
+  );
+});
 
-  describe('Removal across two blocks', () => {
-    describe('Removal from the start of A', () => {
-      it('must remove from the start of A to the start of B', () => {
-        var selection = selectionState.set('focusKey', 'b');
-        var afterRemoval = removeRangeFromContentState(contentState, selection);
-        var afterBlockMap = afterRemoval.getBlockMap();
-        expect(afterBlockMap.size).toBe(blockSizeBeforeRemoval - 1);
-        var alteredBlock = afterBlockMap.first();
+test('must remove from the end of A to within B', () => {
+  assertRemoveRangeFromContentState(
+    selectionFromEndOfA.merge({
+      focusKey: 'b',
+      focusOffset: 3,
+    }),
+  );
+});
 
-        // Block B is removed. Its contents replace the contents of block A,
-        // while the `type` of block A is preserved.
-        var blockB = contentState
-          .getBlockMap()
-          .skip(1)
-          .first();
-        var sameContentDifferentType = blockB.set(
-          'type',
-          contentState
-            .getBlockMap()
-            .first()
-            .getType(),
-        );
+test('must remove from the end of A to the end of B', () => {
+  assertRemoveRangeFromContentState(
+    selectionFromEndOfA.merge({
+      focusKey: 'b',
+      focusOffset: contentState
+        .getBlockMap()
+        .skip(1)
+        .first(),
+    }),
+  );
+});
 
-        expectBlockToBeSlice(alteredBlock, sameContentDifferentType, 0);
-      });
-
-      it('must remove from the start of A to within B', () => {
-        var selection = selectionState.merge({
-          focusKey: 'b',
-          focusOffset: 3,
-        });
-
-        var afterRemoval = removeRangeFromContentState(contentState, selection);
-        var afterBlockMap = afterRemoval.getBlockMap();
-        expect(afterBlockMap.size).toBe(blockSizeBeforeRemoval - 1);
-        var alteredBlock = afterBlockMap.first();
-
-        // A slice of block B contents replace the contents of block A,
-        // while the `type` of block A is preserved. Block B is removed.
-        var blockB = contentState
-          .getBlockMap()
-          .skip(1)
-          .first();
-        var sameContentDifferentType = blockB.set(
-          'type',
-          contentState
-            .getBlockMap()
-            .first()
-            .getType(),
-        );
-
-        expectBlockToBeSlice(alteredBlock, sameContentDifferentType, 3);
-      });
-
-      it('must remove from the start of A to the end of B', () => {
-        var blockB = contentState
-          .getBlockMap()
-          .skip(1)
-          .first();
-        var selection = selectionState.merge({
-          focusKey: 'b',
-          focusOffset: blockB.getLength(),
-        });
-
-        var afterRemoval = removeRangeFromContentState(contentState, selection);
-        var afterBlockMap = afterRemoval.getBlockMap();
-        expect(afterBlockMap.size).toBe(blockSizeBeforeRemoval - 1);
-        var alteredBlock = afterBlockMap.first();
-
-        // Block A is effectively just emptied out, while block B is removed.
-        var emptyBlock = new ContentBlock({
-          text: '',
-          type: contentState
-            .getBlockMap()
-            .first()
-            .getType(),
-          characterList: Immutable.List(),
-        });
-
-        expectBlockToBeSlice(alteredBlock, emptyBlock);
-      });
-    });
-
-    describe('Removal from within A', () => {
-      var selectionWithinA = selectionState.set('anchorOffset', 3);
-
-      it('must remove from within A to the start of B', () => {
-        var selection = selectionWithinA.set('focusKey', 'b');
-
-        var originalBlockA = contentState.getBlockMap().first();
-        var originalBlockB = contentState
-          .getBlockMap()
-          .skip(1)
-          .first();
-        var afterRemoval = removeRangeFromContentState(contentState, selection);
-        var afterBlockMap = afterRemoval.getBlockMap();
-        expect(afterBlockMap.size).toBe(blockSizeBeforeRemoval - 1);
-        var alteredBlock = afterBlockMap.first();
-
-        expect(alteredBlock).not.toBe(originalBlockA);
-        expect(alteredBlock).not.toBe(originalBlockB);
-        expect(alteredBlock.getType()).toBe(originalBlockA.getType());
-        expect(alteredBlock.getText()).toBe(
-          originalBlockA.getText().slice(0, 3) + originalBlockB.getText(),
-        );
-
-        var stylesToJS = getInlineStyles(originalBlockA);
-        expect(getInlineStyles(alteredBlock)).toEqual(
-          stylesToJS.slice(0, 3).concat(getInlineStyles(originalBlockB)),
-        );
-        var entitiesToJS = getEntities(originalBlockA);
-        expect(getEntities(alteredBlock)).toEqual(
-          entitiesToJS.slice(0, 3).concat(getEntities(originalBlockB)),
-        );
-
-        checkForCharacterList(alteredBlock);
-      });
-
-      it('must remove from within A to within B', () => {
-        var selection = selectionWithinA.merge({
-          focusKey: 'b',
-          focusOffset: 3,
-        });
-
-        var originalBlockA = contentState.getBlockMap().first();
-        var originalBlockB = contentState
-          .getBlockMap()
-          .skip(1)
-          .first();
-        var afterRemoval = removeRangeFromContentState(contentState, selection);
-        var afterBlockMap = afterRemoval.getBlockMap();
-        expect(afterBlockMap.size).toBe(blockSizeBeforeRemoval - 1);
-        var alteredBlock = afterBlockMap.first();
-
-        expect(alteredBlock).not.toBe(originalBlockA);
-        expect(alteredBlock).not.toBe(originalBlockB);
-        expect(alteredBlock.getType()).toBe(originalBlockA.getType());
-        expect(alteredBlock.getText()).toBe(
-          originalBlockA.getText().slice(0, 3) +
-            originalBlockB.getText().slice(3),
-        );
-
-        var stylesToJS = getInlineStyles(originalBlockA);
-        expect(getInlineStyles(alteredBlock)).toEqual(
-          stylesToJS
-            .slice(0, 3)
-            .concat(getInlineStyles(originalBlockB).slice(3)),
-        );
-        var entitiesToJS = getEntities(originalBlockA);
-        expect(getEntities(alteredBlock)).toEqual(
-          entitiesToJS.slice(0, 3).concat(getEntities(originalBlockB).slice(3)),
-        );
-
-        checkForCharacterList(alteredBlock);
-      });
-
-      it('must remove from within A to the end of B', () => {
-        var blockB = contentState
-          .getBlockMap()
-          .skip(1)
-          .first();
-        var selection = selectionWithinA.merge({
-          focusKey: 'b',
-          focusOffset: blockB.getLength(),
-        });
-
-        var originalBlockA = contentState.getBlockMap().first();
-        var originalBlockB = contentState
-          .getBlockMap()
-          .skip(1)
-          .first();
-        var afterRemoval = removeRangeFromContentState(contentState, selection);
-        var afterBlockMap = afterRemoval.getBlockMap();
-        expect(afterBlockMap.size).toBe(blockSizeBeforeRemoval - 1);
-        var alteredBlock = afterBlockMap.first();
-
-        expect(alteredBlock).not.toBe(originalBlockA);
-        expect(alteredBlock).not.toBe(originalBlockB);
-        expect(alteredBlock.getType()).toBe(originalBlockA.getType());
-        expect(alteredBlock.getText()).toBe(
-          originalBlockA.getText().slice(0, 3),
-        );
-
-        var stylesToJS = getInlineStyles(originalBlockA);
-        expect(getInlineStyles(alteredBlock)).toEqual(stylesToJS.slice(0, 3));
-        var entitiesToJS = getEntities(originalBlockA);
-        expect(getEntities(alteredBlock)).toEqual(entitiesToJS.slice(0, 3));
-
-        checkForCharacterList(alteredBlock);
-      });
-    });
-
-    describe('Removal from the end of A', () => {
-      var initialBlock = contentState.getBlockMap().first();
-      var selectionFromEndOfA = selectionState.merge({
-        anchorOffset: initialBlock.getLength(),
-        focusOffset: initialBlock.getLength(),
-      });
-
-      it('must remove from the end of A to the start of B', () => {
-        var selection = selectionFromEndOfA.merge({
-          focusKey: 'b',
-          focusOffset: 0,
-        });
-
-        var originalBlockA = contentState.getBlockMap().first();
-        var originalBlockB = contentState
-          .getBlockMap()
-          .skip(1)
-          .first();
-        var afterRemoval = removeRangeFromContentState(contentState, selection);
-        var afterBlockMap = afterRemoval.getBlockMap();
-        expect(afterBlockMap.size).toBe(blockSizeBeforeRemoval - 1);
-        var alteredBlock = afterBlockMap.first();
-
-        expect(alteredBlock).not.toBe(originalBlockA);
-        expect(alteredBlock).not.toBe(originalBlockB);
-        expect(alteredBlock.getType()).toBe(originalBlockA.getType());
-        expect(alteredBlock.getText()).toBe(
-          originalBlockA.getText() + originalBlockB.getText(),
-        );
-
-        var stylesToJS = getInlineStyles(originalBlockA);
-        expect(getInlineStyles(alteredBlock)).toEqual(
-          stylesToJS.concat(getInlineStyles(originalBlockB)),
-        );
-        var entitiesToJS = getEntities(originalBlockA);
-        expect(getEntities(alteredBlock)).toEqual(
-          entitiesToJS.concat(getEntities(originalBlockB)),
-        );
-
-        checkForCharacterList(alteredBlock);
-      });
-
-      it('must remove from the end of A to within B', () => {
-        var selection = selectionFromEndOfA.merge({
-          focusKey: 'b',
-          focusOffset: 3,
-        });
-
-        var originalBlockA = contentState.getBlockMap().first();
-        var originalBlockB = contentState
-          .getBlockMap()
-          .skip(1)
-          .first();
-        var afterRemoval = removeRangeFromContentState(contentState, selection);
-        var afterBlockMap = afterRemoval.getBlockMap();
-        expect(afterBlockMap.size).toBe(blockSizeBeforeRemoval - 1);
-        var alteredBlock = afterBlockMap.first();
-
-        expect(alteredBlock).not.toBe(originalBlockA);
-        expect(alteredBlock).not.toBe(originalBlockB);
-        expect(alteredBlock.getType()).toBe(originalBlockA.getType());
-        expect(alteredBlock.getText()).toBe(
-          originalBlockA.getText() + originalBlockB.getText().slice(3),
-        );
-
-        var stylesToJS = getInlineStyles(originalBlockA);
-        expect(getInlineStyles(alteredBlock)).toEqual(
-          stylesToJS.concat(getInlineStyles(originalBlockB).slice(3)),
-        );
-        var entitiesToJS = getEntities(originalBlockA);
-        expect(getEntities(alteredBlock)).toEqual(
-          entitiesToJS.concat(getEntities(originalBlockB).slice(3)),
-        );
-        checkForCharacterList(alteredBlock);
-      });
-
-      it('must remove from the end of A to the end of B', () => {
-        var originalBlockA = contentState.getBlockMap().first();
-        var originalBlockB = contentState
-          .getBlockMap()
-          .skip(1)
-          .first();
-
-        var selection = selectionFromEndOfA.merge({
-          focusKey: 'b',
-          focusOffset: originalBlockB.getLength(),
-        });
-
-        var afterRemoval = removeRangeFromContentState(contentState, selection);
-        var afterBlockMap = afterRemoval.getBlockMap();
-        expect(afterBlockMap.size).toBe(blockSizeBeforeRemoval - 1);
-        var alteredBlock = afterBlockMap.first();
-
-        // no-op for the first block, since no new content is appended.
-        expect(alteredBlock).toBe(originalBlockA);
-        expect(alteredBlock).not.toBe(originalBlockB);
-        expect(alteredBlock.getType()).toBe(originalBlockA.getType());
-
-        expectBlockToBeSlice(alteredBlock, originalBlockA);
-        checkForCharacterList(alteredBlock);
-      });
-    });
-  });
-
-  describe('Removal across more than two blocks', () => {
-    var selection = selectionState.merge({
+test('must remove blocks entirely within the selection', () => {
+  assertRemoveRangeFromContentState(
+    selectionState.merge({
       anchorOffset: 3,
       focusKey: 'c',
       focusOffset: 3,
-    });
-
-    it('must remove blocks entirely within the selection', () => {
-      var originalBlockA = contentState.getBlockMap().first();
-      var originalBlockB = contentState
-        .getBlockMap()
-        .skip(1)
-        .first();
-      var originalBlockC = contentState
-        .getBlockMap()
-        .skip(2)
-        .first();
-
-      var afterRemoval = removeRangeFromContentState(contentState, selection);
-      var afterBlockMap = afterRemoval.getBlockMap();
-      expect(afterBlockMap.size).toBe(blockSizeBeforeRemoval - 2);
-      var alteredBlock = afterBlockMap.first();
-
-      expect(alteredBlock).not.toBe(originalBlockA);
-      expect(alteredBlock).not.toBe(originalBlockB);
-      expect(alteredBlock).not.toBe(originalBlockC);
-      expect(alteredBlock.getType()).toBe(originalBlockA.getType());
-      expect(alteredBlock.getText()).toBe(
-        originalBlockA.getText().slice(0, 3) +
-          originalBlockC.getText().slice(3),
-      );
-
-      var stylesToJS = getInlineStyles(originalBlockA);
-      expect(getInlineStyles(alteredBlock)).toEqual(
-        stylesToJS.slice(0, 3).concat(getInlineStyles(originalBlockC).slice(3)),
-      );
-      var entitiesToJS = getEntities(originalBlockA);
-      expect(getEntities(alteredBlock)).toEqual(
-        entitiesToJS.slice(0, 3).concat(getEntities(originalBlockC).slice(3)),
-      );
-
-      checkForCharacterList(alteredBlock);
-    });
-  });
+    }),
+  );
 });

--- a/src/model/transaction/__tests__/splitBlockInContentState-test.js
+++ b/src/model/transaction/__tests__/splitBlockInContentState-test.js
@@ -14,153 +14,55 @@
 
 jest.disableAutomock();
 
-var Immutable = require('immutable');
+jest.mock('generateRandomKey');
 
-var getSampleStateForTesting = require('getSampleStateForTesting');
-var splitBlockInContentState = require('splitBlockInContentState');
+const getSampleStateForTesting = require('getSampleStateForTesting');
+const splitBlockInContentState = require('splitBlockInContentState');
 
-const {List} = Immutable;
+const {contentState, selectionState} = getSampleStateForTesting();
 
-describe('splitBlockInContentState', () => {
-  var {contentState, selectionState} = getSampleStateForTesting();
-  const blockSizeBeforeSplit = contentState.getBlockMap().size;
+const assertSplitBlockInContentState = selection => {
+  expect(
+    splitBlockInContentState(contentState, selection).getBlockMap(),
+  ).toMatchSnapshot();
+};
 
-  function checkForCharacterList(block) {
-    expect(List.isList(block.getCharacterList())).toBe(true);
-  }
+test('must be restricted to collapsed selections', () => {
+  expect(() => {
+    const nonCollapsed = selectionState.set('focusOffset', 1);
+    return splitBlockInContentState(contentState, nonCollapsed);
+  }).toThrow();
 
-  function getInlineStyles(block) {
-    return block
-      .getCharacterList()
-      .map(c => c.getStyle())
-      .toJS();
-  }
+  expect(() => {
+    return splitBlockInContentState(contentState, selectionState);
+  }).not.toThrow();
+});
 
-  function getEntities(block) {
-    return block
-      .getCharacterList()
-      .map(c => c.getEntity())
-      .toJS();
-  }
+test('must split at the beginning of a block', () => {
+  assertSplitBlockInContentState(selectionState);
+});
 
-  it('must be restricted to collapsed selections', () => {
-    expect(() => {
-      var nonCollapsed = selectionState.set('focusOffset', 1);
-      return splitBlockInContentState(contentState, nonCollapsed);
-    }).toThrow();
+test('must split within a block', () => {
+  const SPLIT_OFFSET = 3;
 
-    expect(() => {
-      return splitBlockInContentState(contentState, selectionState);
-    }).not.toThrow();
-  });
-
-  it('must split at the beginning of a block', () => {
-    const blockSizeBeforeInsert = contentState.getBlockMap().size;
-    var initialBlock = contentState.getBlockMap().first();
-    var afterSplit = splitBlockInContentState(contentState, selectionState);
-    var afterBlockMap = afterSplit.getBlockMap();
-    expect(afterBlockMap.size).toBe(blockSizeBeforeInsert + 1);
-
-    var preSplitBlock = afterBlockMap.first();
-
-    expect(preSplitBlock.getKey()).toBe(initialBlock.getKey());
-    expect(preSplitBlock.getText()).toBe('');
-    expect(getInlineStyles(preSplitBlock)).toEqual([]);
-    expect(getEntities(preSplitBlock)).toEqual([]);
-
-    var postSplitBlock = afterBlockMap.skip(1).first();
-    expect(preSplitBlock.getKey()).not.toBe(postSplitBlock.getKey());
-    expect(preSplitBlock.getType()).toBe(postSplitBlock.getType());
-
-    expect(postSplitBlock.getKey()).not.toBe(initialBlock.getKey());
-    expect(postSplitBlock.getType()).toBe(initialBlock.getType());
-    expect(postSplitBlock.getText()).toBe(initialBlock.getText());
-    expect(getInlineStyles(initialBlock)).toEqual(
-      getInlineStyles(postSplitBlock),
-    );
-    expect(getEntities(postSplitBlock)).toEqual(getEntities(initialBlock));
-
-    checkForCharacterList(preSplitBlock);
-    checkForCharacterList(postSplitBlock);
-  });
-
-  it('must split within a block', () => {
-    var initialBlock = contentState.getBlockMap().first();
-    var SPLIT_OFFSET = 3;
-    var selection = selectionState.merge({
+  assertSplitBlockInContentState(
+    selectionState.merge({
       anchorOffset: SPLIT_OFFSET,
       focusOffset: SPLIT_OFFSET,
-    });
+    }),
+  );
+});
 
-    var afterSplit = splitBlockInContentState(contentState, selection);
-    var afterBlockMap = afterSplit.getBlockMap();
-    expect(afterBlockMap.size).toBe(blockSizeBeforeSplit + 1);
+test('must split at the end of a block', () => {
+  const SPLIT_OFFSET = contentState
+    .getBlockMap()
+    .first()
+    .getLength();
 
-    var preSplitBlock = afterBlockMap.first();
-    var postSplitBlock = afterBlockMap.skip(1).first();
-
-    expect(preSplitBlock.getKey()).toBe(initialBlock.getKey());
-    expect(preSplitBlock.getText()).toBe(
-      initialBlock.getText().slice(0, SPLIT_OFFSET),
-    );
-    expect(getInlineStyles(preSplitBlock)).toEqual(
-      getInlineStyles(initialBlock).slice(0, SPLIT_OFFSET),
-    );
-    expect(getEntities(preSplitBlock)).toEqual(
-      getEntities(initialBlock).slice(0, SPLIT_OFFSET),
-    );
-
-    expect(preSplitBlock.getKey()).not.toBe(postSplitBlock.getKey());
-    expect(preSplitBlock.getType()).toBe(postSplitBlock.getType());
-
-    expect(postSplitBlock.getKey()).not.toBe(initialBlock.getKey());
-    expect(postSplitBlock.getType()).toBe(initialBlock.getType());
-    expect(postSplitBlock.getText()).toBe(
-      initialBlock.getText().slice(SPLIT_OFFSET),
-    );
-    expect(getInlineStyles(postSplitBlock)).toEqual(
-      getInlineStyles(initialBlock).slice(SPLIT_OFFSET),
-    );
-    expect(getEntities(postSplitBlock)).toEqual(
-      getEntities(initialBlock).slice(SPLIT_OFFSET),
-    );
-
-    checkForCharacterList(preSplitBlock);
-    checkForCharacterList(postSplitBlock);
-  });
-
-  it('must split at the end of a block', () => {
-    var initialBlock = contentState.getBlockMap().first();
-    var end = initialBlock.getLength();
-    var selection = selectionState.merge({
-      anchorOffset: end,
-      focusOffset: end,
-    });
-
-    var afterSplit = splitBlockInContentState(contentState, selection);
-    var afterBlockMap = afterSplit.getBlockMap();
-    expect(afterBlockMap.size).toBe(blockSizeBeforeSplit + 1);
-
-    var preSplitBlock = afterBlockMap.first();
-    var postSplitBlock = afterBlockMap.skip(1).first();
-
-    expect(preSplitBlock.getKey()).toBe(initialBlock.getKey());
-
-    expect(preSplitBlock.getKey()).not.toBe(postSplitBlock.getKey());
-    expect(preSplitBlock.getType()).toBe(postSplitBlock.getType());
-    expect(preSplitBlock.getText()).toBe(initialBlock.getText());
-    expect(getInlineStyles(preSplitBlock)).toEqual(
-      getInlineStyles(initialBlock),
-    );
-    expect(getEntities(preSplitBlock)).toEqual(getEntities(initialBlock));
-
-    expect(postSplitBlock.getKey()).not.toBe(initialBlock.getKey());
-    expect(postSplitBlock.getType()).toBe(initialBlock.getType());
-    expect(postSplitBlock.getText()).toBe('');
-    expect(getInlineStyles(postSplitBlock)).toEqual([]);
-    expect(getEntities(postSplitBlock)).toEqual([]);
-
-    checkForCharacterList(preSplitBlock);
-    checkForCharacterList(postSplitBlock);
-  });
+  assertSplitBlockInContentState(
+    selectionState.merge({
+      anchorOffset: SPLIT_OFFSET,
+      focusOffset: SPLIT_OFFSET,
+    }),
+  );
 });


### PR DESCRIPTION
This PR aim on refactoring our existing tests and moving towards jest snapshot testing.

Snapshot testing will not only allow us to move faster but also reduce the barrier for contributors to be able to contribute to draft.

tldr:

- moved to jest snapshots
- refactored tests to remove duplication
- removed nested describes in favor of plain 'test' to increase readability

***

I suggest we review this internally in phabricator as it may be tricky to do that on github. Also once this is merged should be pretty easy to update tests or add some new ones.

