### PR TITLE
Exploration - Feature tree / Wiring up BlockNode interface

### DIFF
--- a/src/component/base/DraftEditorProps.js
+++ b/src/component/base/DraftEditorProps.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-import type ContentBlock from 'ContentBlock';
+import type {BlockNode} from 'BlockNode';
 import type {DraftBlockRenderMap} from 'DraftBlockRenderMap';
 import type {DraftDragType} from 'DraftDragType';
 import type {DraftEditorCommand} from 'DraftEditorCommand';
@@ -60,10 +60,10 @@ export type DraftEditorProps = {
   // For a given `ContentBlock` object, return an object that specifies
   // a custom block component and/or props. If no object is returned,
   // the default `DraftEditorBlock` is used.
-  blockRendererFn?: (block: ContentBlock) => ?Object,
+  blockRendererFn?: (block: BlockNode) => ?Object,
 
   // Function that returns a cx map corresponding to block-level styles.
-  blockStyleFn?: (block: ContentBlock) => string,
+  blockStyleFn?: (block: BlockNode) => string,
 
   // A function that accepts a synthetic key event and returns
   // the matching DraftEditorCommand constant, or a custom string,
@@ -170,7 +170,7 @@ export type DraftEditorProps = {
 
   // Provide a function that will construct CSS style objects given inline
   // style names.
-  customStyleFn?: (style: DraftInlineStyle, block: ContentBlock) => ?Object,
+  customStyleFn?: (style: DraftInlineStyle, block: BlockNode) => ?Object,
 
   // Provide a map of block rendering configurations. Each block type maps to
   // an element tag and an optional react element wrapper. This configuration
@@ -180,8 +180,8 @@ export type DraftEditorProps = {
 
 export type DraftEditorDefaultProps = {
   blockRenderMap: DraftBlockRenderMap,
-  blockRendererFn: (block: ContentBlock) => ?Object,
-  blockStyleFn: (block: ContentBlock) => string,
+  blockRendererFn: (block: BlockNode) => ?Object,
+  blockStyleFn: (block: BlockNode) => string,
   keyBindingFn: (e: SyntheticKeyboardEvent<>) => ?string,
   readOnly: boolean,
   spellCheck: boolean,

--- a/src/component/contents/DraftEditorBlock.react.js
+++ b/src/component/contents/DraftEditorBlock.react.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-import type ContentBlock from 'ContentBlock';
+import type {BlockNode} from 'BlockNode';
 import type ContentState from 'ContentState';
 import type {DraftDecoratorType} from 'DraftDecoratorType';
 import type SelectionState from 'SelectionState';
@@ -40,7 +40,7 @@ const SCROLL_BUFFER = 10;
 
 type Props = {
   contentState: ContentState,
-  block: ContentBlock,
+  block: BlockNode,
   customStyleMap: Object,
   customStyleFn: Function,
   tree: List<any>,

--- a/src/component/contents/DraftEditorContents.react.js
+++ b/src/component/contents/DraftEditorContents.react.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-import type ContentBlock from 'ContentBlock';
+import type {BlockNode} from 'BlockNode';
 import type {BidiDirection} from 'UnicodeBidiDirection';
 
 const DraftEditorBlock = require('DraftEditorBlock.react');
@@ -27,7 +27,7 @@ const nullthrows = require('nullthrows');
 
 type Props = {
   blockRendererFn: Function,
-  blockStyleFn: (block: ContentBlock) => string,
+  blockStyleFn: (block: BlockNode) => string,
   editorState: EditorState,
   textDirectionality?: BidiDirection,
 };

--- a/src/component/contents/DraftEditorLeaf.react.js
+++ b/src/component/contents/DraftEditorLeaf.react.js
@@ -15,8 +15,8 @@
 
 import type {DraftInlineStyle} from 'DraftInlineStyle';
 import type SelectionState from 'SelectionState';
+import type {BlockNode} from 'BlockNode';
 
-var ContentBlock = require('ContentBlock');
 const DraftEditorTextNode = require('DraftEditorTextNode.react');
 var React = require('React');
 var ReactDOM = require('ReactDOM');
@@ -26,7 +26,7 @@ var setDraftEditorSelection = require('setDraftEditorSelection');
 
 type Props = {
   // The block that contains this leaf.
-  block: ContentBlock,
+  block: BlockNode,
 
   // Mapping of style names to CSS declarations.
   customStyleMap: Object,

--- a/src/model/decorators/CompositeDraftDecorator.js
+++ b/src/model/decorators/CompositeDraftDecorator.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-import type ContentBlock from 'ContentBlock';
+import type {BlockNode} from 'BlockNode';
 import type ContentState from 'ContentState';
 import type {DraftDecorator} from 'DraftDecorator';
 
@@ -52,10 +52,7 @@ class CompositeDraftDecorator {
     this._decorators = decorators.slice();
   }
 
-  getDecorations(
-    block: ContentBlock,
-    contentState: ContentState,
-  ): List<?string> {
+  getDecorations(block: BlockNode, contentState: ContentState): List<?string> {
     var decorations = Array(block.getText().length).fill(null);
 
     this._decorators.forEach((/*object*/ decorator, /*number*/ ii) => {

--- a/src/model/decorators/DraftDecorator.js
+++ b/src/model/decorators/DraftDecorator.js
@@ -13,11 +13,11 @@
 
 'use strict';
 
-import type ContentBlock from 'ContentBlock';
+import type {BlockNode} from 'BlockNode';
 import type ContentState from 'ContentState';
 
 export type DraftDecoratorStrategy = (
-  block: ContentBlock,
+  block: BlockNode,
   callback: (start: number, end: number) => void,
   contentState: ContentState,
 ) => void;

--- a/src/model/decorators/DraftDecoratorType.js
+++ b/src/model/decorators/DraftDecoratorType.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-import type ContentBlock from 'ContentBlock';
+import type {BlockNode} from 'BlockNode';
 import type ContentState from 'ContentState';
 import type {List} from 'immutable';
 
@@ -27,10 +27,7 @@ export type DraftDecoratorType = {
   /**
    * Given a `ContentBlock`, return an immutable List of decorator keys.
    */
-  getDecorations(
-    block: ContentBlock,
-    contentState: ContentState,
-  ): List<?string>,
+  getDecorations(block: BlockNode, contentState: ContentState): List<?string>,
 
   /**
    * Given a decorator key, return the component to use when rendering

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -13,6 +13,7 @@
 
 'use strict';
 
+import type {BlockNode} from 'BlockNode';
 import type {DraftBlockRenderConfig} from 'DraftBlockRenderConfig';
 import type {DraftBlockRenderMap} from 'DraftBlockRenderMap';
 import type {DraftBlockType} from 'DraftBlockType';
@@ -569,7 +570,7 @@ function convertFromHTMLtoContentBlocks(
   html: string,
   DOMBuilder: Function = getSafeBodyFromHTML,
   blockRenderMap?: DraftBlockRenderMap = DefaultDraftBlockRenderMap,
-): ?{contentBlocks: ?Array<ContentBlock>, entityMap: EntityMap} {
+): ?{contentBlocks: ?Array<BlockNode>, entityMap: EntityMap} {
   // Be ABSOLUTELY SURE that the dom builder you pass here won't execute
   // arbitrary code in whatever environment you're running this in. For an
   // example of how we try to do this in-browser, see getSafeBodyFromHTML.

--- a/src/model/encoding/encodeEntityRanges.js
+++ b/src/model/encoding/encodeEntityRanges.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-import type ContentBlock from 'ContentBlock';
+import type {BlockNode} from 'BlockNode';
 import type {EntityRange} from 'EntityRange';
 
 var DraftStringKey = require('DraftStringKey');
@@ -25,7 +25,7 @@ var {strlen} = UnicodeUtils;
  * Convert to UTF-8 character counts for storage.
  */
 function encodeEntityRanges(
-  block: ContentBlock,
+  block: BlockNode,
   storageMap: Object,
 ): Array<EntityRange> {
   var encoded = [];

--- a/src/model/encoding/encodeInlineStyleRanges.js
+++ b/src/model/encoding/encodeInlineStyleRanges.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-import type ContentBlock from 'ContentBlock';
+import type {BlockNode} from 'BlockNode';
 import type {DraftInlineStyle} from 'DraftInlineStyle';
 import type {InlineStyleRange} from 'InlineStyleRange';
 import type {List} from 'immutable';
@@ -31,7 +31,7 @@ var EMPTY_ARRAY = [];
  * to UTF-8 character counts for storage.
  */
 function getEncodedInlinesForType(
-  block: ContentBlock,
+  block: BlockNode,
   styleList: List<DraftInlineStyle>,
   styleToEncode: string,
 ): Array<InlineStyleRange> {
@@ -64,7 +64,7 @@ function getEncodedInlinesForType(
  * Retrieve the encoded arrays of inline styles, with each individual style
  * treated separately.
  */
-function encodeInlineStyleRanges(block: ContentBlock): Array<InlineStyleRange> {
+function encodeInlineStyleRanges(block: BlockNode): Array<InlineStyleRange> {
   var styleList = block
     .getCharacterList()
     .map(c => c.getStyle())

--- a/src/model/entity/getTextAfterNearestEntity.js
+++ b/src/model/entity/getTextAfterNearestEntity.js
@@ -13,16 +13,13 @@
 
 'use strict';
 
-import type ContentBlock from 'ContentBlock';
+import type {BlockNode} from 'BlockNode';
 
 /**
  * Find the string of text between the previous entity and the specified
  * offset. This allows us to narrow down search areas for regex matching.
  */
-function getTextAfterNearestEntity(
-  block: ContentBlock,
-  offset: number,
-): string {
+function getTextAfterNearestEntity(block: BlockNode, offset: number): string {
   var start = offset;
 
   // Get start based on where the last entity ended.

--- a/src/model/immutable/BlockMap.js
+++ b/src/model/immutable/BlockMap.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-import type ContentBlock from 'ContentBlock';
+import type {BlockNode} from 'BlockNode';
 import type {OrderedMap} from 'immutable';
 
-export type BlockMap = OrderedMap<string, ContentBlock>;
+export type BlockMap = OrderedMap<string, BlockNode>;

--- a/src/model/immutable/BlockMapBuilder.js
+++ b/src/model/immutable/BlockMapBuilder.js
@@ -14,14 +14,14 @@
 'use strict';
 
 import type {BlockMap} from 'BlockMap';
-import type ContentBlock from 'ContentBlock';
+import type {BlockNode} from 'BlockNode';
 
 var Immutable = require('immutable');
 
 var {OrderedMap} = Immutable;
 
 var BlockMapBuilder = {
-  createFromArray: function(blocks: Array<ContentBlock>): BlockMap {
+  createFromArray: function(blocks: Array<BlockNode>): BlockMap {
     return OrderedMap(blocks.map(block => [block.getKey(), block]));
   },
 };

--- a/src/model/immutable/BlockNode.js
+++ b/src/model/immutable/BlockNode.js
@@ -16,7 +16,7 @@
 import type CharacterMetadata from 'CharacterMetadata';
 import type {DraftBlockType} from 'DraftBlockType';
 import type {DraftInlineStyle} from 'DraftInlineStyle';
-import type {List, Map} from 'immutable';
+import type {List, Map, Record} from 'immutable';
 
 export type BlockNodeKey = string;
 
@@ -31,7 +31,7 @@ export type BlockNodeConfig = {
 
 // https://github.com/facebook/draft-js/issues/1492
 // prettier-ignore
-export interface BlockNode {
+export interface BlockNode extends Record {
   findEntityRanges(
     filterFn: (value: CharacterMetadata) => boolean,
     callback: (start: number, end: number) => void,

--- a/src/model/immutable/BlockTree.js
+++ b/src/model/immutable/BlockTree.js
@@ -14,7 +14,7 @@
 'use strict';
 
 import type CharacterMetadata from 'CharacterMetadata';
-import type ContentBlock from 'ContentBlock';
+import type {BlockNode} from 'BlockNode';
 import type ContentState from 'ContentState';
 import type {DraftDecoratorType} from 'DraftDecoratorType';
 
@@ -59,7 +59,7 @@ var BlockTree = {
    */
   generate: function(
     contentState: ContentState,
-    block: ContentBlock,
+    block: BlockNode,
     decorator: ?DraftDecoratorType,
   ): List<DecoratorRange> {
     var textLength = block.getLength();

--- a/src/model/immutable/ContentState.js
+++ b/src/model/immutable/ContentState.js
@@ -13,6 +13,7 @@
 
 'use strict';
 
+import type {BlockNode} from 'BlockNode';
 import type {BlockMap} from 'BlockMap';
 import type DraftEntityInstance from 'DraftEntityInstance';
 import type {DraftEntityMutability} from 'DraftEntityMutability';
@@ -62,8 +63,8 @@ class ContentState extends ContentStateRecord {
     return this.get('selectionAfter');
   }
 
-  getBlockForKey(key: string): ContentBlock {
-    var block: ContentBlock = this.getBlockMap().get(key);
+  getBlockForKey(key: string): BlockNode {
+    var block: BlockNode = this.getBlockMap().get(key);
     return block;
   }
 
@@ -84,14 +85,14 @@ class ContentState extends ContentStateRecord {
       .first();
   }
 
-  getBlockAfter(key: string): ?ContentBlock {
+  getBlockAfter(key: string): ?BlockNode {
     return this.getBlockMap()
       .skipUntil((_, k) => k === key)
       .skip(1)
       .first();
   }
 
-  getBlockBefore(key: string): ?ContentBlock {
+  getBlockBefore(key: string): ?BlockNode {
     return this.getBlockMap()
       .reverse()
       .skipUntil((_, k) => k === key)
@@ -99,15 +100,15 @@ class ContentState extends ContentStateRecord {
       .first();
   }
 
-  getBlocksAsArray(): Array<ContentBlock> {
+  getBlocksAsArray(): Array<BlockNode> {
     return this.getBlockMap().toArray();
   }
 
-  getFirstBlock(): ContentBlock {
+  getFirstBlock(): BlockNode {
     return this.getBlockMap().first();
   }
 
-  getLastBlock(): ContentBlock {
+  getLastBlock(): BlockNode {
     return this.getBlockMap().last();
   }
 
@@ -164,7 +165,7 @@ class ContentState extends ContentStateRecord {
 
   static createFromBlockArray(
     // TODO: update flow type when we completely deprecate the old entity API
-    blocks: Array<ContentBlock> | {contentBlocks: Array<ContentBlock>},
+    blocks: Array<BlockNode> | {contentBlocks: Array<BlockNode>},
     entityMap: ?any,
   ): ContentState {
     // TODO: remove this when we completely deprecate the old entity API

--- a/src/model/modifier/AtomicBlockUtils.js
+++ b/src/model/modifier/AtomicBlockUtils.js
@@ -13,6 +13,7 @@
 
 'use strict';
 
+import type {BlockNode} from 'BlockNode';
 import type {DraftInsertionType} from 'DraftInsertionType';
 
 const BlockMapBuilder = require('BlockMapBuilder');
@@ -88,7 +89,7 @@ const AtomicBlockUtils = {
 
   moveAtomicBlock: function(
     editorState: EditorState,
-    atomicBlock: ContentBlock,
+    atomicBlock: BlockNode,
     targetRange: SelectionState,
     insertionMode?: DraftInsertionType,
   ): EditorState {

--- a/src/model/modifier/getCharacterRemovalRange.js
+++ b/src/model/modifier/getCharacterRemovalRange.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-import type ContentBlock from 'ContentBlock';
+import type {BlockNode} from 'BlockNode';
 import type {DraftRemovalDirection} from 'DraftRemovalDirection';
 import type {EntityMap} from 'EntityMap';
 import type SelectionState from 'SelectionState';
@@ -34,8 +34,8 @@ var invariant = require('invariant');
  */
 function getCharacterRemovalRange(
   entityMap: EntityMap,
-  startBlock: ContentBlock,
-  endBlock: ContentBlock,
+  startBlock: BlockNode,
+  endBlock: BlockNode,
   selectionState: SelectionState,
   direction: DraftRemovalDirection,
 ): SelectionState {
@@ -115,7 +115,7 @@ function getCharacterRemovalRange(
 
 function getEntityRemovalRange(
   entityMap: EntityMap,
-  block: ContentBlock,
+  block: BlockNode,
   selectionState: SelectionState,
   direction: DraftRemovalDirection,
   entityKey: string,

--- a/src/model/modifier/getRangesForDraftEntity.js
+++ b/src/model/modifier/getRangesForDraftEntity.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-import type ContentBlock from 'ContentBlock';
+import type {BlockNode} from 'BlockNode';
 import type {DraftRange} from 'DraftRange';
 
 var invariant = require('invariant');
@@ -27,7 +27,7 @@ var invariant = require('invariant');
  * the subsequent range.
  */
 function getRangesForDraftEntity(
-  block: ContentBlock,
+  block: BlockNode,
   key: string,
 ): Array<DraftRange> {
   var ranges = [];

--- a/src/model/paste/DraftPasteProcessor.js
+++ b/src/model/paste/DraftPasteProcessor.js
@@ -13,6 +13,7 @@
 
 'use strict';
 
+import type {BlockNode} from 'BlockNode';
 import type {DraftBlockRenderMap} from 'DraftBlockRenderMap';
 import type {DraftBlockType} from 'DraftBlockType';
 import type {EntityMap} from 'EntityMap';
@@ -32,7 +33,7 @@ const DraftPasteProcessor = {
   processHTML(
     html: string,
     blockRenderMap?: DraftBlockRenderMap,
-  ): ?{contentBlocks: ?Array<ContentBlock>, entityMap: EntityMap} {
+  ): ?{contentBlocks: ?Array<BlockNode>, entityMap: EntityMap} {
     return convertFromHTMLtoContentBlocks(
       html,
       getSafeBodyFromHTML,
@@ -44,7 +45,7 @@ const DraftPasteProcessor = {
     textBlocks: Array<string>,
     character: CharacterMetadata,
     type: DraftBlockType,
-  ): Array<ContentBlock> {
+  ): Array<BlockNode> {
     return textBlocks.map(textLine => {
       textLine = sanitizeDraftText(textLine);
       return new ContentBlock({

--- a/src/model/transaction/applyEntityToContentBlock.js
+++ b/src/model/transaction/applyEntityToContentBlock.js
@@ -13,16 +13,16 @@
 
 'use strict';
 
-import type ContentBlock from 'ContentBlock';
+import type {BlockNode} from 'BlockNode';
 
 var CharacterMetadata = require('CharacterMetadata');
 
 function applyEntityToContentBlock(
-  contentBlock: ContentBlock,
+  contentBlock: BlockNode,
   start: number,
   end: number,
   entityKey: ?string,
-): ContentBlock {
+): BlockNode {
   var characterList = contentBlock.getCharacterList();
   while (start < end) {
     characterList = characterList.set(

--- a/src/model/transaction/modifyBlockForContentState.js
+++ b/src/model/transaction/modifyBlockForContentState.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-import type ContentBlock from 'ContentBlock';
+import type {BlockNode} from 'BlockNode';
 import type ContentState from 'ContentState';
 import type SelectionState from 'SelectionState';
 
@@ -24,7 +24,7 @@ const {Map} = Immutable;
 function modifyBlockForContentState(
   contentState: ContentState,
   selectionState: SelectionState,
-  operation: (block: ContentBlock) => ContentBlock,
+  operation: (block: BlockNode) => BlockNode,
 ): ContentState {
   var startKey = selectionState.getStartKey();
   var endKey = selectionState.getEndKey();

--- a/src/model/transaction/moveBlockInContentState.js
+++ b/src/model/transaction/moveBlockInContentState.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-import type ContentBlock from 'ContentBlock';
+import type {BlockNode} from 'BlockNode';
 import type ContentState from 'ContentState';
 import type {DraftInsertionType} from 'DraftInsertionType';
 
@@ -21,8 +21,8 @@ const invariant = require('invariant');
 
 function moveBlockInContentState(
   contentState: ContentState,
-  blockToBeMoved: ContentBlock,
-  targetBlock: ContentBlock,
+  blockToBeMoved: BlockNode,
+  targetBlock: BlockNode,
   insertionMode: DraftInsertionType,
 ): ContentState {
   invariant(

--- a/src/model/transaction/removeEntitiesAtEdges.js
+++ b/src/model/transaction/removeEntitiesAtEdges.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-import type ContentBlock from 'ContentBlock';
+import type {BlockNode} from 'BlockNode';
 import type ContentState from 'ContentState';
 import type {EntityMap} from 'EntityMap';
 import type SelectionState from 'SelectionState';
@@ -90,9 +90,9 @@ function getRemovalRange(
 
 function removeForBlock(
   entityMap: EntityMap,
-  block: ContentBlock,
+  block: BlockNode,
   offset: number,
-): ContentBlock {
+): BlockNode {
   var chars = block.getCharacterList();
   var charBefore = offset > 0 ? chars.get(offset - 1) : undefined;
   var charAfter = offset < chars.count() ? chars.get(offset) : undefined;


### PR DESCRIPTION
### Context

This PR is part of a series of PR's that will be exploring **tree data block support** in Draft.


**Wiring up BlockNode interface**

This PR will make sure that ContentBlock references are now referencing the BlockNode interface in order for us to be able to support both ContentBlock and ContentBlockNode operations


***

**Note:**
This is unstable and not part of the public API and should not be used by
production systems.
