### PR TITLE
Exploration - Feature tree / Serializing Draft state to tree data structure

### DIFF
--- a/src/model/encoding/RawDraftContentBlock.js
+++ b/src/model/encoding/RawDraftContentBlock.js
@@ -29,4 +29,5 @@ export type RawDraftContentBlock = {
   inlineStyleRanges: ?Array<InlineStyleRange>,
   entityRanges: ?Array<EntityRange>,
   data?: Object,
+  children?: Array<RawDraftContentBlock>,
 };

--- a/src/model/encoding/__tests__/__snapshots__/convertFromDraftStateToRaw-test.js.snap
+++ b/src/model/encoding/__tests__/__snapshots__/convertFromDraftStateToRaw-test.js.snap
@@ -1,0 +1,91 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must be able to convert from draft state with ContentBlock to raw 1`] = `
+Object {
+  "blocks": Array [
+    Object {
+      "data": Object {},
+      "depth": 0,
+      "entityRanges": Array [],
+      "inlineStyleRanges": Array [],
+      "key": "a",
+      "text": "Alpha",
+      "type": "unstyled",
+    },
+    Object {
+      "data": Object {},
+      "depth": 0,
+      "entityRanges": Array [
+        Object {
+          "key": 0,
+          "length": 5,
+          "offset": 0,
+        },
+      ],
+      "inlineStyleRanges": Array [
+        Object {
+          "length": 5,
+          "offset": 0,
+          "style": "BOLD",
+        },
+      ],
+      "key": "b",
+      "text": "Bravo",
+      "type": "unordered-list-item",
+    },
+    Object {
+      "data": Object {},
+      "depth": 0,
+      "entityRanges": Array [],
+      "inlineStyleRanges": Array [],
+      "key": "c",
+      "text": "Test",
+      "type": "code-block",
+    },
+    Object {
+      "data": Object {},
+      "depth": 0,
+      "entityRanges": Array [],
+      "inlineStyleRanges": Array [],
+      "key": "d",
+      "text": "",
+      "type": "code-block",
+    },
+    Object {
+      "data": Object {},
+      "depth": 0,
+      "entityRanges": Array [],
+      "inlineStyleRanges": Array [],
+      "key": "e",
+      "text": "",
+      "type": "code-block",
+    },
+    Object {
+      "data": Object {},
+      "depth": 0,
+      "entityRanges": Array [],
+      "inlineStyleRanges": Array [
+        Object {
+          "length": 7,
+          "offset": 0,
+          "style": "ITALIC",
+        },
+      ],
+      "key": "f",
+      "text": "Charlie",
+      "type": "blockquote",
+    },
+  ],
+  "entityMap": Object {
+    "0": Object {
+      "data": Object {},
+      "mutability": undefined,
+      "type": Object {
+        "data": null,
+        "mutability": "IMMUTABLE",
+        "type": "IMAGE",
+      },
+    },
+  },
+}
+`;

--- a/src/model/encoding/__tests__/__snapshots__/convertFromDraftStateToRaw-test.js.snap
+++ b/src/model/encoding/__tests__/__snapshots__/convertFromDraftStateToRaw-test.js.snap
@@ -89,3 +89,63 @@ Object {
   },
 }
 `;
+
+exports[`must be able to convert from draft state with ContentBlockNode to raw 1`] = `
+Object {
+  "blocks": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "data": Object {},
+              "depth": 0,
+              "entityRanges": Array [],
+              "inlineStyleRanges": Array [],
+              "key": "C",
+              "text": "left block",
+              "type": "unstyled",
+            },
+            Object {
+              "children": Array [],
+              "data": Object {},
+              "depth": 0,
+              "entityRanges": Array [],
+              "inlineStyleRanges": Array [],
+              "key": "D",
+              "text": "right block",
+              "type": "unstyled",
+            },
+          ],
+          "data": Object {},
+          "depth": 0,
+          "entityRanges": Array [],
+          "inlineStyleRanges": Array [],
+          "key": "B",
+          "text": "",
+          "type": "unstyled",
+        },
+        Object {
+          "children": Array [],
+          "data": Object {},
+          "depth": 0,
+          "entityRanges": Array [],
+          "inlineStyleRanges": Array [],
+          "key": "E",
+          "text": "This is a tree based document!",
+          "type": "header-one",
+        },
+      ],
+      "data": Object {},
+      "depth": 0,
+      "entityRanges": Array [],
+      "inlineStyleRanges": Array [],
+      "key": "A",
+      "text": "",
+      "type": "unstyled",
+    },
+  ],
+  "entityMap": Object {},
+}
+`;

--- a/src/model/encoding/__tests__/convertFromDraftStateToRaw-test.js
+++ b/src/model/encoding/__tests__/convertFromDraftStateToRaw-test.js
@@ -57,12 +57,12 @@ const treeContentState = contentState.set(
   ]),
 );
 
-const assertConvertFromDraftStateToRaw = (content = contentState) => {
+const assertConvertFromDraftStateToRaw = content => {
   expect(convertFromDraftStateToRaw(content)).toMatchSnapshot();
 };
 
 test('must be able to convert from draft state with ContentBlock to raw', () => {
-  assertConvertFromDraftStateToRaw();
+  assertConvertFromDraftStateToRaw(contentState);
 });
 
 test('must be able to convert from draft state with ContentBlockNode to raw', () => {

--- a/src/model/encoding/__tests__/convertFromDraftStateToRaw-test.js
+++ b/src/model/encoding/__tests__/convertFromDraftStateToRaw-test.js
@@ -14,10 +14,48 @@
 
 jest.disableAutomock();
 
+const ContentBlockNode = require('ContentBlockNode');
+const BlockMapBuilder = require('BlockMapBuilder');
 const getSampleStateForTesting = require('getSampleStateForTesting');
 const convertFromDraftStateToRaw = require('convertFromDraftStateToRaw');
+const Immutable = require('immutable');
 
 const {contentState} = getSampleStateForTesting();
+
+const treeContentState = contentState.set(
+  'blockMap',
+  BlockMapBuilder.createFromArray([
+    new ContentBlockNode({
+      key: 'A',
+      children: Immutable.List.of('B', 'E'),
+    }),
+    new ContentBlockNode({
+      parent: 'A',
+      key: 'B',
+      nextSibling: 'C',
+      children: Immutable.List.of('C', 'D'),
+    }),
+    new ContentBlockNode({
+      parent: 'B',
+      key: 'C',
+      text: 'left block',
+      nextSibling: 'D',
+    }),
+    new ContentBlockNode({
+      parent: 'B',
+      key: 'D',
+      text: 'right block',
+      prevSibling: 'C',
+    }),
+    new ContentBlockNode({
+      parent: 'A',
+      key: 'E',
+      text: 'This is a tree based document!',
+      type: 'header-one',
+      prevSibling: 'B',
+    }),
+  ]),
+);
 
 const assertConvertFromDraftStateToRaw = (content = contentState) => {
   expect(convertFromDraftStateToRaw(content)).toMatchSnapshot();
@@ -25,4 +63,8 @@ const assertConvertFromDraftStateToRaw = (content = contentState) => {
 
 test('must be able to convert from draft state with ContentBlock to raw', () => {
   assertConvertFromDraftStateToRaw();
+});
+
+test('must be able to convert from draft state with ContentBlockNode to raw', () => {
+  assertConvertFromDraftStateToRaw(treeContentState);
 });

--- a/src/model/encoding/__tests__/convertFromDraftStateToRaw-test.js
+++ b/src/model/encoding/__tests__/convertFromDraftStateToRaw-test.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+ui_infra
+ * @format
+ */
+
+'use strict';
+
+jest.disableAutomock();
+
+const getSampleStateForTesting = require('getSampleStateForTesting');
+const convertFromDraftStateToRaw = require('convertFromDraftStateToRaw');
+
+const {contentState} = getSampleStateForTesting();
+
+const assertConvertFromDraftStateToRaw = (content = contentState) => {
+  expect(convertFromDraftStateToRaw(content)).toMatchSnapshot();
+};
+
+test('must be able to convert from draft state with ContentBlock to raw', () => {
+  assertConvertFromDraftStateToRaw();
+});

--- a/src/model/encoding/__tests__/encodeInlineStyleRanges-test.js
+++ b/src/model/encoding/__tests__/encodeInlineStyleRanges-test.js
@@ -91,13 +91,13 @@ describe('encodeInlineStyleRanges', () => {
 
   it('must encode custom styles', () => {
     const custom = List([FOO, FOO, FOO_BAR, FOO_BAR, BOLD, BOLD]);
-    expect(
-      encodeInlineStyleRanges(createBlock(' '.repeat(6), custom)),
-    ).toEqual([
-      {offset: 0, length: 4, style: 'foo'},
-      {offset: 2, length: 2, style: 'bar'},
-      {offset: 4, length: 2, style: 'BOLD'},
-    ]);
+    expect(encodeInlineStyleRanges(createBlock(' '.repeat(6), custom))).toEqual(
+      [
+        {offset: 0, length: 4, style: 'foo'},
+        {offset: 2, length: 2, style: 'bar'},
+        {offset: 4, length: 2, style: 'BOLD'},
+      ],
+    );
   });
 
   it('must encode for a complex styled document', () => {

--- a/src/model/encoding/convertFromDraftStateToRaw.js
+++ b/src/model/encoding/convertFromDraftStateToRaw.js
@@ -150,7 +150,7 @@ const convertFromDraftStateToRaw = (
   // add blocks
   rawDraftContentState = encodeRawBlocks(contentState, rawDraftContentState);
 
-  // add entity
+  // add entities
   rawDraftContentState = encodeRawEntityMap(contentState, rawDraftContentState);
 
   return rawDraftContentState;

--- a/src/model/encoding/convertFromDraftStateToRaw.js
+++ b/src/model/encoding/convertFromDraftStateToRaw.js
@@ -13,7 +13,9 @@
 
 'use strict';
 
+import type {BlockNodeRecord} from 'BlockNodeRecord';
 import type ContentState from 'ContentState';
+import type {RawDraftContentBlock} from 'RawDraftContentBlock';
 import type {RawDraftContentState} from 'RawDraftContentState';
 
 const DraftStringKey = require('DraftStringKey');
@@ -25,7 +27,7 @@ const ContentBlock = require('ContentBlock');
 const ContentBlockNode = require('ContentBlockNode');
 const invariant = require('invariant');
 
-const createRawBlock = (block, entityStorageMap) => {
+const createRawBlock = (block: BlockNodeRecord, entityStorageMap: *) => {
   return {
     key: block.getKey(),
     text: block.getText(),
@@ -37,7 +39,12 @@ const createRawBlock = (block, entityStorageMap) => {
   };
 };
 
-const insertRawBlock = (block, entityMap, rawBlocks, blockCacheRef) => {
+const insertRawBlock = (
+  block: BlockNodeRecord,
+  entityMap: *,
+  rawBlocks: Array<RawDraftContentBlock>,
+  blockCacheRef: *,
+) => {
   if (block instanceof ContentBlock) {
     rawBlocks.push(createRawBlock(block, entityMap));
     return;
@@ -60,10 +67,10 @@ const insertRawBlock = (block, entityMap, rawBlocks, blockCacheRef) => {
 };
 
 const insertRawEntity = (
-  entityStorageKey,
-  entityKey,
-  entityMap,
-  entityCacheRef,
+  entityStorageKey: number,
+  entityKey: mixed,
+  entityMap: *,
+  entityCacheRef: *,
 ) => {
   // Stringify to maintain order of otherwise numeric keys.
   const stringifiedEntityKey = DraftStringKey.stringify(entityKey);

--- a/src/model/encoding/convertFromDraftStateToRaw.js
+++ b/src/model/encoding/convertFromDraftStateToRaw.js
@@ -21,7 +21,11 @@ const DraftStringKey = require('DraftStringKey');
 const encodeEntityRanges = require('encodeEntityRanges');
 const encodeInlineStyleRanges = require('encodeInlineStyleRanges');
 
-const encodeBlock = (block, entityStorageMap) => {
+const ContentBlock = require('ContentBlock');
+const ContentBlockNode = require('ContentBlockNode');
+const invariant = require('invariant');
+
+const createRawBlock = (block, entityStorageMap) => {
   return {
     key: block.getKey(),
     text: block.getText(),
@@ -33,37 +37,96 @@ const encodeBlock = (block, entityStorageMap) => {
   };
 };
 
-const convertFromDraftStateToRaw = (
+const insertRawBlock = (block, entityMap, rawBlocks, blockCacheRef) => {
+  if (block instanceof ContentBlock) {
+    rawBlocks.push(createRawBlock(block, entityMap));
+    return;
+  }
+
+  invariant(block instanceof ContentBlockNode, 'block is not a BlockNode');
+
+  const parentKey = block.getParentKey();
+  const rawBlock = (blockCacheRef[block.getKey()] = {
+    ...createRawBlock(block, entityMap),
+    children: [],
+  });
+
+  if (parentKey) {
+    blockCacheRef[parentKey].children.push(rawBlock);
+    return;
+  }
+
+  rawBlocks.push(rawBlock);
+};
+
+const insertRawEntity = (
+  entityStorageKey,
+  entityKey,
+  entityMap,
+  entityCacheRef,
+) => {
+  // Stringify to maintain order of otherwise numeric keys.
+  const stringifiedEntityKey = DraftStringKey.stringify(entityKey);
+
+  if (entityCacheRef[stringifiedEntityKey]) {
+    return;
+  }
+
+  entityCacheRef[stringifiedEntityKey] = entityKey;
+
+  // we need the `any` casting here since this is a temporary state
+  // where we will later on flip the entity map and populate it with
+  // real entity, at this stage we just need to map back the entity
+  // key used by the BlockNode
+  entityMap[stringifiedEntityKey] = (`${entityStorageKey}`: any);
+};
+
+const encodeRawBlocks = (
   contentState: ContentState,
+  rawState: RawDraftContentState,
 ): RawDraftContentState => {
-  let entityStorageKey = 0;
-  const entityStorageMap = {};
+  const {entityMap} = rawState;
+
   const rawBlocks = [];
+
+  const blockCacheRef = {};
+  const entityCacheRef = {};
+  let entityStorageKey = 0;
 
   contentState.getBlockMap().forEach(block => {
     block.findEntityRanges(
       character => character.getEntity() !== null,
-      start => {
-        // Stringify to maintain order of otherwise numeric keys.
-        const stringifiedEntityKey = DraftStringKey.stringify(
+      start =>
+        insertRawEntity(
+          entityStorageKey++,
           block.getEntityAt(start),
-        );
-        if (!entityStorageMap.hasOwnProperty(stringifiedEntityKey)) {
-          entityStorageMap[stringifiedEntityKey] = '' + entityStorageKey++;
-        }
-      },
+          entityMap,
+          entityCacheRef,
+        ),
     );
 
-    rawBlocks.push(encodeBlock(block, entityStorageMap));
+    insertRawBlock(block, entityMap, rawBlocks, blockCacheRef);
   });
 
-  // Flip storage map so that our storage keys map to global
-  // DraftEntity keys.
-  const entityKeys = Object.keys(entityStorageMap);
-  const flippedStorageMap = {};
-  entityKeys.forEach((key, jj) => {
+  return {
+    blocks: rawBlocks,
+    entityMap,
+  };
+};
+
+// Flip storage map so that our storage keys map to global
+// DraftEntity keys.
+const encodeRawEntityMap = (
+  contentState: ContentState,
+  rawState: RawDraftContentState,
+): RawDraftContentState => {
+  const {blocks, entityMap} = rawState;
+
+  const rawEntityMap = {};
+
+  Object.keys(entityMap).forEach((key, index) => {
     const entity = contentState.getEntity(DraftStringKey.unstringify(key));
-    flippedStorageMap[jj] = {
+    rawEntityMap[index] = {
       type: entity.getType(),
       mutability: entity.getMutability(),
       data: entity.getData(),
@@ -71,9 +134,26 @@ const convertFromDraftStateToRaw = (
   });
 
   return {
-    entityMap: flippedStorageMap,
-    blocks: rawBlocks,
+    blocks,
+    entityMap: rawEntityMap,
   };
+};
+
+const convertFromDraftStateToRaw = (
+  contentState: ContentState,
+): RawDraftContentState => {
+  let rawDraftContentState = {
+    entityMap: {},
+    blocks: [],
+  };
+
+  // add blocks
+  rawDraftContentState = encodeRawBlocks(contentState, rawDraftContentState);
+
+  // add entity
+  rawDraftContentState = encodeRawEntityMap(contentState, rawDraftContentState);
+
+  return rawDraftContentState;
 };
 
 module.exports = convertFromDraftStateToRaw;

--- a/src/model/entity/__tests__/getEntityKeyForSelection-test.js
+++ b/src/model/entity/__tests__/getEntityKeyForSelection-test.js
@@ -42,7 +42,7 @@ describe('getEntityKeyForSelection', () => {
     it('must return key if mutable', () => {
       setEntityMutability('MUTABLE');
       var key = getEntityKeyForSelection(contentState, collapsed);
-      expect(key).toBe('123');
+      expect(key).toBe('1');
     });
 
     it('must not return key if immutable', () => {
@@ -76,7 +76,7 @@ describe('getEntityKeyForSelection', () => {
     it('must return key if mutable', () => {
       setEntityMutability('MUTABLE');
       var key = getEntityKeyForSelection(contentState, nonCollapsed);
-      expect(key).toBe('123');
+      expect(key).toBe('1');
     });
 
     it('must not return key if immutable', () => {

--- a/src/model/transaction/getSampleStateForTesting.js
+++ b/src/model/transaction/getSampleStateForTesting.js
@@ -98,8 +98,8 @@ const contentState = new ContentState({
 let editorState = EditorState.createWithContent(contentState);
 editorState = EditorState.forceSelection(editorState, selectionState);
 
-function getSampleStateForTesting(): Object {
+const getSampleStateForTesting = (): Object => {
   return {editorState, contentState, selectionState};
-}
+};
 
 module.exports = getSampleStateForTesting;

--- a/src/model/transaction/getSampleStateForTesting.js
+++ b/src/model/transaction/getSampleStateForTesting.js
@@ -13,19 +13,19 @@
 
 'use strict';
 
-var BlockMapBuilder = require('BlockMapBuilder');
-var CharacterMetadata = require('CharacterMetadata');
-var ContentBlock = require('ContentBlock');
-var ContentState = require('ContentState');
-var EditorState = require('EditorState');
-var Immutable = require('immutable');
-var SampleDraftInlineStyle = require('SampleDraftInlineStyle');
-var SelectionState = require('SelectionState');
+const BlockMapBuilder = require('BlockMapBuilder');
+const CharacterMetadata = require('CharacterMetadata');
+const ContentBlock = require('ContentBlock');
+const ContentState = require('ContentState');
+const EditorState = require('EditorState');
+const Immutable = require('immutable');
+const SampleDraftInlineStyle = require('SampleDraftInlineStyle');
+const SelectionState = require('SelectionState');
 
-var {BOLD, ITALIC} = SampleDraftInlineStyle;
-var ENTITY_KEY = '123';
+const {BOLD, ITALIC} = SampleDraftInlineStyle;
+const ENTITY_KEY = '1';
 
-var BLOCKS = [
+const BLOCKS = [
   new ContentBlock({
     key: 'a',
     type: 'unstyled',
@@ -74,7 +74,7 @@ var BLOCKS = [
   }),
 ];
 
-var selectionState = new SelectionState({
+const selectionState = new SelectionState({
   anchorKey: 'a',
   anchorOffset: 0,
   focusKey: 'a',
@@ -83,15 +83,19 @@ var selectionState = new SelectionState({
   hasFocus: true,
 });
 
-var blockMap = BlockMapBuilder.createFromArray(BLOCKS);
-var contentState = new ContentState({
+const blockMap = BlockMapBuilder.createFromArray(BLOCKS);
+const contentState = new ContentState({
   blockMap,
   entityMap: Immutable.OrderedMap(),
   selectionBefore: selectionState,
   selectionAfter: selectionState,
+}).createEntity({
+  type: 'IMAGE',
+  mutability: 'IMMUTABLE',
+  data: null,
 });
 
-var editorState = EditorState.createWithContent(contentState);
+let editorState = EditorState.createWithContent(contentState);
 editorState = EditorState.forceSelection(editorState, selectionState);
 
 function getSampleStateForTesting(): Object {


### PR DESCRIPTION
### Context

This PR is part of a series of PR's that will be exploring **tree data block support** in Draft.


**Serializing Draft state to tree data structure**

This PR will make sure that we can serialize existing draft state into a tree data block structure for ContentBlockNode and flat data structure for the existing ContentBlock

***

**Note:**
This is unstable and not part of the public API and should not be used by
production systems.
