### PR TITLE
While prettier is still outdated internally we should downgrade linting to warning

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,7 +16,7 @@ module.exports = {
     'prettier/standard',
   ],
   rules: {
-    'prettier/prettier': ['error', 'fb'],
+    'prettier/prettier': [1, 'fb'],
   },
   plugins: ['prettier'],
   overrides: [


### PR DESCRIPTION
We have been getting some builds failing due to incompatible prettier versions, to avoid this we will downgrade prettier linting from error to warning. Once we have prettier internal version being bumped we will then use a `yarn.lock` to lock the prettier version on draft.js to match the internal and bump again the linting rules to `error`