### PR TITLE
Mark props that have defaults as required

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eslint-plugin-react": "^7.3.0",
     "eslint-plugin-relay": "^0.0.8",
     "fbjs-scripts": "^0.8.0",
-    "flow-bin": "^0.53.1",
+    "flow-bin": "^0.59.0",
     "gulp": "^3.9.0",
     "gulp-babel": "^6.1.2",
     "gulp-browserify-thin": "^0.1.5",

--- a/src/.flowconfig
+++ b/src/.flowconfig
@@ -27,4 +27,4 @@ suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(2[0-8]\\|1[
 module.name_mapper='ReactDOM' -> 'react-dom'
 
 [version]
-^0.53.1
+^0.59.0

--- a/src/component/base/DraftEditorProps.js
+++ b/src/component/base/DraftEditorProps.js
@@ -60,10 +60,10 @@ export type DraftEditorProps = {
   // For a given `ContentBlock` object, return an object that specifies
   // a custom block component and/or props. If no object is returned,
   // the default `DraftEditorBlock` is used.
-  blockRendererFn?: (block: BlockNodeRecord) => ?Object,
+  blockRendererFn: (block: BlockNodeRecord) => ?Object,
 
   // Function that returns a cx map corresponding to block-level styles.
-  blockStyleFn?: (block: BlockNodeRecord) => string,
+  blockStyleFn: (block: BlockNodeRecord) => string,
 
   // A function that accepts a synthetic key event and returns
   // the matching DraftEditorCommand constant, or a custom string,
@@ -73,16 +73,16 @@ export type DraftEditorProps = {
   // Set whether the `DraftEditor` component should be editable. Useful for
   // temporarily disabling edit behavior or allowing `DraftEditor` rendering
   // to be used for consumption purposes.
-  readOnly?: boolean,
+  readOnly: boolean,
 
   // Note: spellcheck is always disabled for IE. If enabled in Safari, OSX
   // autocorrect is enabled as well.
-  spellCheck?: boolean,
+  spellCheck: boolean,
 
   // Set whether to remove all style information from pasted content. If your
   // use case should not have any block or inline styles, it is recommended
   // that you set this to `true`.
-  stripPastedStyles?: boolean,
+  stripPastedStyles: boolean,
 
   tabIndex?: number,
 


### PR DESCRIPTION
Fixes facebook/draft-js#1514

**Summary**

According to the [Flow documentation](https://flow.org/en/docs/react/components/#toc-using-default-props), when using default props, the prop should be marked as required, as "Flow will make sure that [the prop] is optional if you have a default prop for [it]."

This fixes Flow errors that would occur when using Draft.js in a project with Flow. Flow would complain that `blockRendererFn` and `blockStyleFn` could potentially be `undefined` when passed to `DraftEditorContents`, even though these two properties have default values, so they will never be undefined.

This commit also upgrades Flow to 0.59.0, since there weren't any additional Flow errors between the version of Flow that was being used (0.53.1) and the latest version of Flow (0.59.0).

**Test Plan**

 * Flow check passes
 * A sample project, such as https://github.com/bjohn465/draft-and-flow-errors, does not produce Flow errors when using Draft.js