### PR TITLE
Exploration - Feature tree / Tree adapter transformer

### DIFF
--- a/src/component/utils/exploration/DraftTreeAdapter.js
+++ b/src/component/utils/exploration/DraftTreeAdapter.js
@@ -26,11 +26,12 @@ const traverseInDepthOrder = (
   let stack = [...blocks].reverse();
   while (stack.length) {
     const block = stack.pop();
+
+    fn(block);
+
     const children = block.children;
 
     invariant(Array.isArray(children), 'Invalid tree raw block');
-
-    fn(block);
 
     stack = stack.concat([...children.reverse()]);
   }

--- a/src/component/utils/exploration/DraftTreeAdapter.js
+++ b/src/component/utils/exploration/DraftTreeAdapter.js
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule DraftTreeAdapter
+ * @format
+ * @flow
+ *
+ * This is unstable and not part of the public API and should not be used by
+ * production systems. This file may be update/removed without notice.
+ */
+
+const invariant = require('invariant');
+
+import type {RawDraftContentBlock} from 'RawDraftContentBlock';
+import type {RawDraftContentState} from 'RawDraftContentState';
+
+const traverseInDepthOrder = (
+  blocks: Array<RawDraftContentBlock>,
+  fn: (block: RawDraftContentBlock) => void,
+) => {
+  let stack = [...blocks].reverse();
+  while (stack.length) {
+    const block = stack.pop();
+    const children = block.children;
+
+    invariant(Array.isArray(children), 'Invalid tree raw block');
+
+    fn(block);
+
+    stack = stack.concat([...children.reverse()]);
+  }
+};
+
+const isListBlock = (block?: RawDraftContentBlock): boolean => {
+  if (!(block && block.type)) {
+    return false;
+  }
+  const {type} = block;
+  return type === 'unordered-list-item' || type === 'ordered-list-item';
+};
+
+const addDepthToChildren = (block: RawDraftContentBlock) => {
+  if (Array.isArray(block.children)) {
+    block.children = block.children.map(
+      child =>
+        child.type === block.type
+          ? {...child, depth: (block.depth || 0) + 1}
+          : child,
+    );
+  }
+};
+
+/**
+ * This adapter is intended to be be used as an adapter to draft tree data
+ *
+ * draft state <=====> draft tree state
+ */
+const DraftTreeAdapter = {
+  /**
+   * Converts from a tree raw state back to  draft raw state
+   */
+  fromRawTreeStateToRawState(
+    draftTreeState: RawDraftContentState,
+  ): RawDraftContentState {
+    const {blocks} = draftTreeState;
+    const transformedBlocks = [];
+
+    invariant(Array.isArray(blocks), 'Invalid raw state');
+
+    if (!Array.isArray(blocks) || !blocks.length) {
+      return draftTreeState;
+    }
+
+    traverseInDepthOrder(blocks, block => {
+      const newBlock = {
+        ...block,
+      };
+
+      if (isListBlock(block)) {
+        newBlock.depth = newBlock.depth || 0;
+        addDepthToChildren(block);
+      }
+
+      delete newBlock.children;
+
+      transformedBlocks.push(newBlock);
+    });
+
+    draftTreeState.blocks = transformedBlocks;
+
+    return {
+      ...draftTreeState,
+      blocks: transformedBlocks,
+    };
+  },
+
+  /**
+   * Converts from draft raw state to tree draft state
+   */
+  fromRawStateToRawTreeState(
+    draftState: RawDraftContentState,
+  ): RawDraftContentState {
+    let lastListDepthCacheRef = {};
+    const transformedBlocks = [];
+
+    draftState.blocks.forEach(block => {
+      const isList = isListBlock(block);
+      const depth = block.depth || 0;
+      const treeBlock = {
+        ...block,
+        children: [],
+      };
+
+      if (!isList) {
+        // reset the cache path
+        lastListDepthCacheRef = {};
+        transformedBlocks.push(treeBlock);
+        return;
+      }
+
+      // update our depth cache reference path
+      lastListDepthCacheRef[depth] = treeBlock;
+
+      // if we are greater than zero we must have seen a parent already
+      if (depth > 0) {
+        const parent = lastListDepthCacheRef[depth - 1];
+
+        invariant(parent, 'Invalid depth for RawDraftContentBlock');
+
+        // push nested list blocks
+        parent.children.push(treeBlock);
+        return;
+      }
+
+      // push root list blocks
+      transformedBlocks.push(treeBlock);
+    });
+
+    return {
+      ...draftState,
+      blocks: transformedBlocks,
+    };
+  },
+};
+
+module.exports = DraftTreeAdapter;

--- a/src/component/utils/exploration/__tests__/DraftTreeAdapter-test.js
+++ b/src/component/utils/exploration/__tests__/DraftTreeAdapter-test.js
@@ -1,0 +1,232 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+ui_infra
+ * @format
+ */
+
+'use strict';
+
+jest.disableAutomock();
+
+const DraftTreeAdapter = require('DraftTreeAdapter');
+
+const assertFromRawTreeStateToRawState = rawState => {
+  expect(DraftTreeAdapter.fromRawTreeStateToRawState(rawState)).toMatchSnapshot();
+};
+
+const assertFromRawStateToRawTreeState = rawState => {
+  expect(
+    DraftTreeAdapter.fromRawStateToRawTreeState(rawState),
+  ).toMatchSnapshot();
+};
+
+test('must be able to convert from tree raw state with only root blocks to raw state', () => {
+  const rawState = {
+    blocks: [
+      {
+        key: 'A',
+        text: 'Alpha',
+        children: [],
+      },
+      {
+        key: 'B',
+        text: 'Beta',
+        children: [],
+      },
+    ],
+    entityMap: {},
+  };
+
+  assertFromRawTreeStateToRawState(rawState);
+});
+
+test('must be able to convert from tree raw state with nested blocks to raw state', () => {
+  const rawState = {
+    blocks: [
+      {
+        key: 'A',
+        type: 'blockquote',
+        text: '',
+        children: [
+          {
+            key: 'B',
+            text: 'Beta',
+            type: 'header-one',
+            children: [],
+          },
+          {
+            key: 'C',
+            text: 'Charlie',
+            type: 'header-two',
+            children: [],
+          },
+        ],
+      },
+    ],
+    entityMap: {},
+  };
+
+  assertFromRawTreeStateToRawState(rawState);
+});
+
+test('must be able to convert from tree raw state with nested list blocks to raw state preserving lists depth', () => {
+  const rawState = {
+    blocks: [
+      {
+        key: 'A',
+        type: 'ordered-list-item',
+        text: 'Alpha',
+        children: [
+          {
+            key: 'B',
+            text: 'Beta',
+            type: 'ordered-list-item',
+            children: [
+              {
+                key: 'C',
+                text: 'Charlie',
+                type: 'ordered-list-item',
+                children: [],
+              },
+            ],
+          },
+          {
+            key: 'D',
+            text: 'Delta',
+            type: 'ordered-list-item',
+            children: [],
+          },
+        ],
+      },
+    ],
+    entityMap: {},
+  };
+
+  assertFromRawTreeStateToRawState(rawState);
+});
+
+test('must be able to convert from tree raw state with nested list blocks to raw state preserving lists depth only if type matches', () => {
+  const rawState = {
+    blocks: [
+      {
+        key: 'A',
+        type: 'ordered-list-item',
+        text: 'Alpha',
+        children: [
+          {
+            key: 'B',
+            text: 'Beta',
+            type: 'ordered-list-item',
+            children: [
+              {
+                key: 'C',
+                text: 'Charlie',
+                type: 'unordered-list-item',
+                children: [],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    entityMap: {},
+  };
+
+  assertFromRawTreeStateToRawState(rawState);
+});
+
+test('must be able to convert from raw state to raw tree state', () => {
+  const rawState = {
+    blocks: [
+      {
+        key: 'A',
+        text: 'Alpha',
+      },
+      {
+        key: 'B',
+        text: 'Beta',
+      },
+      {
+        key: 'C',
+        text: 'Charlie',
+      },
+    ],
+    entityMap: {},
+  };
+
+  assertFromRawStateToRawTreeState(rawState);
+});
+
+test('must be able to convert from raw state to raw tree state with nested trees based on lists depth', () => {
+  const rawState = {
+    blocks: [
+      {
+        key: 'A',
+        text: 'Alpha',
+        type: 'ordered-list-item',
+        depth: 0,
+      },
+      {
+        key: 'B',
+        text: 'Beta',
+        type: 'ordered-list-item',
+        depth: 1,
+      },
+      {
+        key: 'C',
+        text: 'Charlie',
+        type: 'ordered-list-item',
+        depth: 2,
+      },
+      {
+        key: 'D',
+        text: 'Delta',
+        type: 'ordered-list-item',
+        depth: 1,
+      },
+    ],
+    entityMap: {},
+  };
+
+  assertFromRawStateToRawTreeState(rawState);
+});
+
+test('must be able to convert from raw state to raw tree state with nested trees based on lists depth and attach nested blocks to closest depth parent', () => {
+  const rawState = {
+    blocks: [
+      {
+        key: 'A',
+        text: 'Alpha',
+        type: 'ordered-list-item',
+        depth: 0,
+      },
+      {
+        key: 'B',
+        text: 'Beta',
+        type: 'ordered-list-item',
+        depth: 1,
+      },
+      {
+        key: 'C',
+        text: 'Charlie',
+        type: 'ordered-list-item',
+        depth: 1,
+      },
+      {
+        key: 'D',
+        text: 'Delta',
+        type: 'ordered-list-item',
+        depth: 2,
+      },
+    ],
+    entityMap: {},
+  };
+
+  assertFromRawStateToRawTreeState(rawState);
+});

--- a/src/component/utils/exploration/__tests__/__snapshots__/DraftTreeAdapter-test.js.snap
+++ b/src/component/utils/exploration/__tests__/__snapshots__/DraftTreeAdapter-test.js.snap
@@ -132,19 +132,19 @@ Object {
       "type": "ordered-list-item",
     },
     Object {
-      "depth": 0,
+      "depth": 1,
       "key": "B",
       "text": "Beta",
       "type": "ordered-list-item",
     },
     Object {
-      "depth": 0,
+      "depth": 2,
       "key": "C",
       "text": "Charlie",
       "type": "ordered-list-item",
     },
     Object {
-      "depth": 0,
+      "depth": 1,
       "key": "D",
       "text": "Delta",
       "type": "ordered-list-item",
@@ -164,7 +164,7 @@ Object {
       "type": "ordered-list-item",
     },
     Object {
-      "depth": 0,
+      "depth": 1,
       "key": "B",
       "text": "Beta",
       "type": "ordered-list-item",

--- a/src/component/utils/exploration/__tests__/__snapshots__/DraftTreeAdapter-test.js.snap
+++ b/src/component/utils/exploration/__tests__/__snapshots__/DraftTreeAdapter-test.js.snap
@@ -1,0 +1,197 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must be able to convert from raw state to raw tree state 1`] = `
+Object {
+  "blocks": Array [
+    Object {
+      "children": Array [],
+      "key": "A",
+      "text": "Alpha",
+    },
+    Object {
+      "children": Array [],
+      "key": "B",
+      "text": "Beta",
+    },
+    Object {
+      "children": Array [],
+      "key": "C",
+      "text": "Charlie",
+    },
+  ],
+  "entityMap": Object {},
+}
+`;
+
+exports[`must be able to convert from raw state to raw tree state with nested trees based on lists depth 1`] = `
+Object {
+  "blocks": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "depth": 2,
+              "key": "C",
+              "text": "Charlie",
+              "type": "ordered-list-item",
+            },
+          ],
+          "depth": 1,
+          "key": "B",
+          "text": "Beta",
+          "type": "ordered-list-item",
+        },
+        Object {
+          "children": Array [],
+          "depth": 1,
+          "key": "D",
+          "text": "Delta",
+          "type": "ordered-list-item",
+        },
+      ],
+      "depth": 0,
+      "key": "A",
+      "text": "Alpha",
+      "type": "ordered-list-item",
+    },
+  ],
+  "entityMap": Object {},
+}
+`;
+
+exports[`must be able to convert from raw state to raw tree state with nested trees based on lists depth and attach nested blocks to closest depth parent 1`] = `
+Object {
+  "blocks": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "depth": 1,
+          "key": "B",
+          "text": "Beta",
+          "type": "ordered-list-item",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "depth": 2,
+              "key": "D",
+              "text": "Delta",
+              "type": "ordered-list-item",
+            },
+          ],
+          "depth": 1,
+          "key": "C",
+          "text": "Charlie",
+          "type": "ordered-list-item",
+        },
+      ],
+      "depth": 0,
+      "key": "A",
+      "text": "Alpha",
+      "type": "ordered-list-item",
+    },
+  ],
+  "entityMap": Object {},
+}
+`;
+
+exports[`must be able to convert from tree raw state with nested blocks to raw state 1`] = `
+Object {
+  "blocks": Array [
+    Object {
+      "key": "A",
+      "text": "",
+      "type": "blockquote",
+    },
+    Object {
+      "key": "B",
+      "text": "Beta",
+      "type": "header-one",
+    },
+    Object {
+      "key": "C",
+      "text": "Charlie",
+      "type": "header-two",
+    },
+  ],
+  "entityMap": Object {},
+}
+`;
+
+exports[`must be able to convert from tree raw state with nested list blocks to raw state preserving lists depth 1`] = `
+Object {
+  "blocks": Array [
+    Object {
+      "depth": 0,
+      "key": "A",
+      "text": "Alpha",
+      "type": "ordered-list-item",
+    },
+    Object {
+      "depth": 0,
+      "key": "B",
+      "text": "Beta",
+      "type": "ordered-list-item",
+    },
+    Object {
+      "depth": 0,
+      "key": "C",
+      "text": "Charlie",
+      "type": "ordered-list-item",
+    },
+    Object {
+      "depth": 0,
+      "key": "D",
+      "text": "Delta",
+      "type": "ordered-list-item",
+    },
+  ],
+  "entityMap": Object {},
+}
+`;
+
+exports[`must be able to convert from tree raw state with nested list blocks to raw state preserving lists depth only if type matches 1`] = `
+Object {
+  "blocks": Array [
+    Object {
+      "depth": 0,
+      "key": "A",
+      "text": "Alpha",
+      "type": "ordered-list-item",
+    },
+    Object {
+      "depth": 0,
+      "key": "B",
+      "text": "Beta",
+      "type": "ordered-list-item",
+    },
+    Object {
+      "depth": 0,
+      "key": "C",
+      "text": "Charlie",
+      "type": "unordered-list-item",
+    },
+  ],
+  "entityMap": Object {},
+}
+`;
+
+exports[`must be able to convert from tree raw state with only root blocks to raw state 1`] = `
+Object {
+  "blocks": Array [
+    Object {
+      "key": "A",
+      "text": "Alpha",
+    },
+    Object {
+      "key": "B",
+      "text": "Beta",
+    },
+  ],
+  "entityMap": Object {},
+}
+`;

--- a/src/model/encoding/__tests__/convertFromRawToDraftState-test.js
+++ b/src/model/encoding/__tests__/convertFromRawToDraftState-test.js
@@ -16,7 +16,7 @@ jest.disableAutomock();
 
 const convertFromRawToDraftState = require('convertFromRawToDraftState');
 
-const assertDraftState = (rawState, expected) => {
+const assertDraftState = rawState => {
   expect(
     convertFromRawToDraftState(rawState)
       .getBlockMap()


### PR DESCRIPTION
### Context

This PR is part of a series of PR's that will be exploring **tree data block support** in Draft.


**Tree adapter to transformer**

This creates a raw tree data adapter to transform back and forth between raw tree and draft raw data

***

**Note:**
This is unstable and not part of the public API and should not be used by
production systems.
