### PR TITLE
Exploration - Feature tree / Fixing shouldComponentUpdate lifcycle for ContentBlockNode

### DIFF
--- a/src/component/contents/exploration/DraftEditorBlockNode.react.js
+++ b/src/component/contents/exploration/DraftEditorBlockNode.react.js
@@ -204,7 +204,7 @@ const getElementPropsConfig = (
 class DraftEditorBlockNode extends React.Component<Props> {
   shouldComponentUpdate(nextProps: Props): boolean {
     const {block, direction, tree} = this.props;
-    const isContainerNode = !block.getChildKeys.isEmpty();
+    const isContainerNode = !block.getChildKeys().isEmpty();
     const blockHasChanged =
       block !== nextProps.block ||
       tree !== nextProps.tree ||


### PR DESCRIPTION
### Context

This PR is part of a series of PR's that will be exploring **tree data block support** in Draft.

**Fixing component lifcycle for ContentBlockNode**

`block.getChildKeys` is not a property it is meant to be a function call
***

**Note:**
This is unstable and not part of the public API and should not be used by
production systems.
