### PR TITLE
Exploration - Feature tree / Adding regression tests

### DIFF
--- a/src/model/encoding/__tests__/__snapshots__/convertFromHTMLToContentBlocks-test.js.snap
+++ b/src/model/encoding/__tests__/__snapshots__/convertFromHTMLToContentBlocks-test.js.snap
@@ -403,9 +403,230 @@ Array [
 ]
 `;
 
+exports[`does not convert deeply nested html blocks when experimentalTreeDataSupport is disabled 1`] = `false`;
+
+exports[`does not convert deeply nested html blocks when experimentalTreeDataSupport is disabled 2`] = `
+Array [
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
+    "text": " ",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "text": "Some quote",
+    "type": "ordered-list-item",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key2",
+    "text": "Hello World!
+ lorem ipsum
+ 
+ ",
+    "type": "ordered-list-item",
+  },
+]
+`;
+
 exports[`img with data protocol should be correctly parsed 1`] = `"📷"`;
 
 exports[`img with http protocol should have camera emoji content 1`] = `"📷"`;
+
+exports[`must convert root ContentBlockNodes to matching ContentBlock nodes for <blockquote /> 1`] = `true`;
+
+exports[`must convert root ContentBlockNodes to matching ContentBlock nodes for <div /> 1`] = `true`;
+
+exports[`must convert root ContentBlockNodes to matching ContentBlock nodes for <figure /> 1`] = `true`;
+
+exports[`must convert root ContentBlockNodes to matching ContentBlock nodes for <h1 /> 1`] = `true`;
+
+exports[`must convert root ContentBlockNodes to matching ContentBlock nodes for <h2 /> 1`] = `true`;
+
+exports[`must convert root ContentBlockNodes to matching ContentBlock nodes for <h3 /> 1`] = `true`;
+
+exports[`must convert root ContentBlockNodes to matching ContentBlock nodes for <h4 /> 1`] = `true`;
+
+exports[`must convert root ContentBlockNodes to matching ContentBlock nodes for <h5 /> 1`] = `true`;
+
+exports[`must convert root ContentBlockNodes to matching ContentBlock nodes for <h6 /> 1`] = `true`;
+
+exports[`must convert root ContentBlockNodes to matching ContentBlock nodes for <li /> 1`] = `true`;
+
+exports[`must convert root ContentBlockNodes to matching ContentBlock nodes for <p /> 1`] = `true`;
+
+exports[`must convert root ContentBlockNodes to matching ContentBlock nodes for <pre /> 1`] = `true`;
 
 exports[`must not merge tags when converting adjacent <blockquote /> 1`] = `
 Array [

--- a/src/model/encoding/__tests__/convertFromHTMLToContentBlocks-test.js
+++ b/src/model/encoding/__tests__/convertFromHTMLToContentBlocks-test.js
@@ -47,12 +47,12 @@ const SUPPORTED_TAGS = [
 ];
 
 const normalizeBlock = block => {
-  const {type, depth, textBlock, characterList} = block;
+  const {type, depth, text, characterList} = block;
 
   return {
     type,
     depth,
-    textBlock,
+    text,
     characterList,
   };
 };
@@ -69,7 +69,7 @@ beforeEach(() => {
   jest.resetModules();
 });
 
-const assertConvertFromHTMLToContentBlocks = (html_string, config = {}) => {
+const convertFromHTML = (html_string, config) => {
   const options = {
     ...DEFAULT_CONFIG,
     ...config,
@@ -77,14 +77,34 @@ const assertConvertFromHTMLToContentBlocks = (html_string, config = {}) => {
 
   const {DOMBuilder, blockRenderMap, experimentalTreeDataSupport} = options;
 
+  jest.resetModules();
   toggleExperimentalTreeDataSupport(experimentalTreeDataSupport);
+  return convertFromHTMLToContentBlocks(
+    html_string,
+    DOMBuilder,
+    blockRenderMap,
+  );
+};
 
+const AreTreeBlockNodesEquivalent = (html_string, config = {}) => {
+  const treeEnabled = convertFromHTML(html_string, {
+    ...config,
+    experimentalTreeDataSupport: true,
+  }).contentBlocks.map(block => normalizeBlock(block.toJS()));
+
+  const treeDisabled = convertFromHTML(html_string, {
+    ...config,
+    experimentalTreeDataSupport: false,
+  }).contentBlocks.map(block => normalizeBlock(block.toJS()));
+
+  return JSON.stringify(treeEnabled) === JSON.stringify(treeDisabled);
+};
+
+const assertConvertFromHTMLToContentBlocks = (html_string, config = {}) => {
   expect(
-    convertFromHTMLToContentBlocks(
-      html_string,
-      DOMBuilder,
-      blockRenderMap,
-    ).contentBlocks.map(block => block.toJS()),
+    convertFromHTML(html_string, config).contentBlocks.map(block =>
+      block.toJS(),
+    ),
   ).toMatchSnapshot();
 };
 
@@ -108,25 +128,12 @@ const testConvertingAdjacentHtmlElementsToContentBlocks = (
 const testConvertingHtmlElementsToContentBlocksAndRootContentBlockNodesMatch = (
   tag: string,
 ) => {
-  test(`must convert root ContentBlockNodes to matching ContentBlock nodes for <${tag} />`, () => {
-    const {DOMBuilder, blockRenderMap} = DEFAULT_CONFIG;
-    const html_string = `<${tag}>a</${tag}> `;
-
-    toggleExperimentalTreeDataSupport(false);
-    const contentBlocks = convertFromHTMLToContentBlocks(
-      html_string,
-      DOMBuilder,
-      blockRenderMap,
-    ).contentBlocks.map(block => normalizeBlock(block.toJS()));
-
-    toggleExperimentalTreeDataSupport(true);
-    const contentBlockNodes = convertFromHTMLToContentBlocks(
-      html_string,
-      DOMBuilder,
-      blockRenderMap,
-    ).contentBlocks.map(block => normalizeBlock(block.toJS()));
-
-    expect(contentBlocks).toEqual(contentBlockNodes);
+  test(`must convert root ContentBlockNodes to matching ContentBlock nodes for <${
+    tag
+  } />`, () => {
+    expect(
+      AreTreeBlockNodesEquivalent(`<${tag}>a</${tag}> `),
+    ).toMatchSnapshot();
   });
 };
 
@@ -176,6 +183,25 @@ test('converts deeply nested html blocks when experimentalTreeDataSupport is ena
 
   assertConvertFromHTMLToContentBlocks(html_string, {
     experimentalTreeDataSupport: true,
+  });
+});
+
+test('does not convert deeply nested html blocks when experimentalTreeDataSupport is disabled', () => {
+  const html_string = `
+    <ol>
+      <li>Some quote</li>
+      <li>
+        <blockquote>
+          <h1>Hello World!</h1>
+          <p>lorem ipsum</p>
+        </blockquote>
+      </li>
+    </ol>
+  `;
+
+  expect(AreTreeBlockNodesEquivalent(html_string)).toMatchSnapshot();
+  assertConvertFromHTMLToContentBlocks(html_string, {
+    experimentalTreeDataSupport: false,
   });
 });
 


### PR DESCRIPTION
### Context

This PR is part of a series of PR's that will be exploring **tree data block support** in Draft.


**Adding regression tests**

This PR adds regression tests to make sure we do not enable experimental features unless the dark feature flag is enabled

***

**Note:**
This is unstable and not part of the public API and should not be used by
production systems.
