### PR TITLE
Exploration - Feature tree / Adding support for nested block selection

### DIFF
--- a/src/component/selection/__tests__/__snapshots__/getDraftEditorSelection-test.js.snap
+++ b/src/component/selection/__tests__/__snapshots__/getDraftEditorSelection-test.js.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`begins at nested text node zero, ends at end of nested block 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 0,
+    "focusKey": "b",
+    "focusOffset": 4,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
 exports[`begins at text node zero, ends at end of block 1`] = `
 Object {
   "needsRecovery": true,
@@ -8,6 +22,20 @@ Object {
     "anchorOffset": 0,
     "focusKey": "a",
     "focusOffset": 19,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
+exports[`begins within nested text node, ends at end of nested block 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 2,
+    "focusKey": "b",
+    "focusOffset": 4,
     "hasFocus": false,
     "isBackward": false,
   },
@@ -42,6 +70,20 @@ Object {
 }
 `;
 
+exports[`contains an entire nested leaf 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "d",
+    "anchorOffset": 0,
+    "focusKey": "d",
+    "focusOffset": 5,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
 exports[`does the crazy stuff described above 1`] = `
 Object {
   "needsRecovery": true,
@@ -50,6 +92,34 @@ Object {
     "anchorOffset": 0,
     "focusKey": "c",
     "focusOffset": 12,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
+exports[`does the crazy stuff described above with nested blocks 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 0,
+    "focusKey": "d",
+    "focusOffset": 5,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
+exports[`extends from head of one nested node to end of another nested node 1`] = `
+Object {
+  "needsRecovery": false,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 0,
+    "focusKey": "d",
+    "focusOffset": 5,
     "hasFocus": false,
     "isBackward": false,
   },
@@ -98,6 +168,48 @@ Object {
 }
 `;
 
+exports[`from start of one nestd block to end of other nested block 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 0,
+    "focusKey": "d",
+    "focusOffset": 5,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
+exports[`from start of one nested block to start of another 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 0,
+    "focusKey": "d",
+    "focusOffset": 0,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
+exports[`goes from end of one nested block to end of other nested block 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 4,
+    "focusKey": "d",
+    "focusOffset": 5,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
 exports[`goes from end of one to end of other block 1`] = `
 Object {
   "needsRecovery": true,
@@ -140,6 +252,34 @@ Object {
 }
 `;
 
+exports[`goes from start of one nested block to end of other nested block 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 0,
+    "focusKey": "d",
+    "focusOffset": 5,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
+exports[`goes from start of one nested block to start of other 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 0,
+    "focusKey": "d",
+    "focusOffset": 0,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
 exports[`goes from within one block to within another block 1`] = `
 Object {
   "needsRecovery": true,
@@ -148,6 +288,48 @@ Object {
     "anchorOffset": 19,
     "focusKey": "c",
     "focusOffset": 7,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
+exports[`goes from within one nested block to within another nested block 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 4,
+    "focusKey": "d",
+    "focusOffset": 5,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
+exports[`is a reversed nested text-to-leaf selection 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "d",
+    "anchorOffset": 0,
+    "focusKey": "b",
+    "focusOffset": 2,
+    "hasFocus": false,
+    "isBackward": true,
+  },
+}
+`;
+
+exports[`is a reversed selection across multiple nested text nodes 1`] = `
+Object {
+  "needsRecovery": false,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 2,
+    "focusKey": "d",
+    "focusOffset": 3,
     "hasFocus": false,
     "isBackward": false,
   },
@@ -196,6 +378,34 @@ Object {
 }
 `;
 
+exports[`is a reversed text-to-leaf-child selection of nested node 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "d",
+    "anchorOffset": 0,
+    "focusKey": "b",
+    "focusOffset": 4,
+    "hasFocus": false,
+    "isBackward": true,
+  },
+}
+`;
+
+exports[`is collapsed at end at nested single block 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 4,
+    "focusKey": "b",
+    "focusOffset": 4,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
 exports[`is collapsed at end at single block 1`] = `
 Object {
   "needsRecovery": true,
@@ -204,6 +414,20 @@ Object {
     "anchorOffset": 19,
     "focusKey": "a",
     "focusOffset": 19,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
+exports[`is collapsed at end of nested single span 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 4,
+    "focusKey": "b",
+    "focusOffset": 4,
     "hasFocus": false,
     "isBackward": false,
   },
@@ -238,6 +462,34 @@ Object {
 }
 `;
 
+exports[`is collapsed at end with full selection with nested blocks 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "d",
+    "anchorOffset": 5,
+    "focusKey": "d",
+    "focusOffset": 5,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
+exports[`is collapsed at start at nested single block 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 0,
+    "focusKey": "b",
+    "focusOffset": 0,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
 exports[`is collapsed at start at single block 1`] = `
 Object {
   "needsRecovery": true,
@@ -245,6 +497,20 @@ Object {
     "anchorKey": "a",
     "anchorOffset": 0,
     "focusKey": "a",
+    "focusOffset": 0,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
+exports[`is collapsed at start of nested single span 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 0,
+    "focusKey": "b",
     "focusOffset": 0,
     "hasFocus": false,
     "isBackward": false,
@@ -280,6 +546,20 @@ Object {
 }
 `;
 
+exports[`is collapsed at start with full selection with nested blocks 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "a",
+    "anchorOffset": 0,
+    "focusKey": "a",
+    "focusOffset": 0,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
 exports[`is collapsed at the end of a child 1`] = `
 Object {
   "needsRecovery": true,
@@ -294,7 +574,35 @@ Object {
 }
 `;
 
+exports[`is collapsed at the end of a nested child 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 4,
+    "focusKey": "b",
+    "focusOffset": 4,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
 exports[`is collapsed at the start of the contents 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "a",
+    "anchorOffset": 0,
+    "focusKey": "a",
+    "focusOffset": 0,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
+exports[`is collapsed at the start of the contents with nesting blocks 1`] = `
 Object {
   "needsRecovery": true,
   "selectionState": Object {
@@ -322,6 +630,20 @@ Object {
 }
 `;
 
+exports[`is completely selected with nested blocks 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "a",
+    "anchorOffset": 0,
+    "focusKey": "d",
+    "focusOffset": 5,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
 exports[`is contains multiple children 1`] = `
 Object {
   "needsRecovery": true,
@@ -330,6 +652,20 @@ Object {
     "anchorOffset": 0,
     "focusKey": "c",
     "focusOffset": 12,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
+exports[`is contains multiple nested children 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "a",
+    "anchorOffset": 0,
+    "focusKey": "d",
+    "focusOffset": 5,
     "hasFocus": false,
     "isBackward": false,
   },
@@ -350,12 +686,40 @@ Object {
 }
 `;
 
+exports[`is entirely selected with nested blocks 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 0,
+    "focusKey": "b",
+    "focusOffset": 4,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
 exports[`is reversed from above 1`] = `
 Object {
   "needsRecovery": true,
   "selectionState": Object {
     "anchorKey": "c",
     "anchorOffset": 12,
+    "focusKey": "a",
+    "focusOffset": 0,
+    "hasFocus": false,
+    "isBackward": true,
+  },
+}
+`;
+
+exports[`is reversed from above nested blocks 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "d",
+    "anchorOffset": 5,
     "focusKey": "a",
     "focusOffset": 0,
     "hasFocus": false,
@@ -378,6 +742,20 @@ Object {
 }
 `;
 
+exports[`is reversed from the first nested case 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 4,
+    "focusKey": "b",
+    "focusOffset": 0,
+    "hasFocus": false,
+    "isBackward": true,
+  },
+}
+`;
+
 exports[`is reversed on entire leaf 1`] = `
 Object {
   "needsRecovery": true,
@@ -386,6 +764,34 @@ Object {
     "anchorOffset": 7,
     "focusKey": "c",
     "focusOffset": 0,
+    "hasFocus": false,
+    "isBackward": true,
+  },
+}
+`;
+
+exports[`is reversed on nested entire leaf 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "d",
+    "anchorOffset": 5,
+    "focusKey": "d",
+    "focusOffset": 0,
+    "hasFocus": false,
+    "isBackward": true,
+  },
+}
+`;
+
+exports[`is the same as above but nested and reversed 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "d",
+    "anchorOffset": 5,
+    "focusKey": "b",
+    "focusOffset": 4,
     "hasFocus": false,
     "isBackward": true,
   },
@@ -420,6 +826,20 @@ Object {
 }
 `;
 
+exports[`must find offsets for non-collapsed selection of nested node 1`] = `
+Object {
+  "needsRecovery": false,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 1,
+    "focusKey": "b",
+    "focusOffset": 2,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
 exports[`must find offsets for reversed selection 1`] = `
 Object {
   "needsRecovery": false,
@@ -427,6 +847,20 @@ Object {
     "anchorKey": "a",
     "anchorOffset": 6,
     "focusKey": "a",
+    "focusOffset": 1,
+    "hasFocus": false,
+    "isBackward": true,
+  },
+}
+`;
+
+exports[`must find offsets for reversed selection of nested node 1`] = `
+Object {
+  "needsRecovery": false,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 2,
+    "focusKey": "b",
     "focusOffset": 1,
     "hasFocus": false,
     "isBackward": true,
@@ -448,6 +882,20 @@ Object {
 }
 `;
 
+exports[`must find offsets for selection on entire text node of nested node 1`] = `
+Object {
+  "needsRecovery": false,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 0,
+    "focusKey": "b",
+    "focusOffset": 4,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
 exports[`must find offsets when collapsed at end 1`] = `
 Object {
   "needsRecovery": false,
@@ -462,6 +910,20 @@ Object {
 }
 `;
 
+exports[`must find offsets when collapsed at end of nested node 1`] = `
+Object {
+  "needsRecovery": false,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 4,
+    "focusKey": "b",
+    "focusOffset": 4,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
 exports[`must find offsets when collapsed at start 1`] = `
 Object {
   "needsRecovery": false,
@@ -469,6 +931,20 @@ Object {
     "anchorKey": "a",
     "anchorOffset": 0,
     "focusKey": "a",
+    "focusOffset": 0,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
+exports[`must find offsets when collapsed at start of nested node 1`] = `
+Object {
+  "needsRecovery": false,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 0,
+    "focusKey": "b",
     "focusOffset": 0,
     "hasFocus": false,
     "isBackward": false,
@@ -490,6 +966,20 @@ Object {
 }
 `;
 
+exports[`occupies a single child of the contents with nested blocks 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "a",
+    "anchorOffset": 0,
+    "focusKey": "b",
+    "focusOffset": 4,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
 exports[`reversed leaf to leaf 1`] = `
 Object {
   "needsRecovery": true,
@@ -500,6 +990,90 @@ Object {
     "focusOffset": 0,
     "hasFocus": false,
     "isBackward": true,
+  },
+}
+`;
+
+exports[`reversed leaf to nested leaf 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "d",
+    "anchorOffset": 5,
+    "focusKey": "b",
+    "focusOffset": 0,
+    "hasFocus": false,
+    "isBackward": true,
+  },
+}
+`;
+
+exports[`starts at head of a nested text node, ends at head of leaf child of another nested node 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 0,
+    "focusKey": "d",
+    "focusOffset": 0,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
+exports[`starts at head of nested text node, ends at end of nested leaf child 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 0,
+    "focusKey": "d",
+    "focusOffset": 5,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
+exports[`starts at head of nested text node, ends at end of nested leaf span 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 0,
+    "focusKey": "d",
+    "focusOffset": 5,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
+exports[`starts at head of nested text node, ends at head of nested leaf span 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 0,
+    "focusKey": "d",
+    "focusOffset": 0,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
+exports[`starts at head of one nested node and ends at head of another nested node 1`] = `
+Object {
+  "needsRecovery": false,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 0,
+    "focusKey": "d",
+    "focusOffset": 0,
+    "hasFocus": false,
+    "isBackward": false,
   },
 }
 `;
@@ -568,6 +1142,76 @@ Object {
     "anchorOffset": 0,
     "focusKey": "c",
     "focusOffset": 0,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
+exports[`starts within nested text node, ends at end of nested leaf child 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 2,
+    "focusKey": "d",
+    "focusOffset": 5,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
+exports[`starts within nested text node, ends at end of nested leaf span 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 2,
+    "focusKey": "d",
+    "focusOffset": 5,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
+exports[`starts within nested text node, ends at start of nested leaf child 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 2,
+    "focusKey": "d",
+    "focusOffset": 0,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
+exports[`starts within nested text node, ends at start of nested leaf span 1`] = `
+Object {
+  "needsRecovery": true,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 2,
+    "focusKey": "d",
+    "focusOffset": 0,
+    "hasFocus": false,
+    "isBackward": false,
+  },
+}
+`;
+
+exports[`starts within one nested text node and ends within another nested block 1`] = `
+Object {
+  "needsRecovery": false,
+  "selectionState": Object {
+    "anchorKey": "b",
+    "anchorOffset": 2,
+    "focusKey": "d",
+    "focusOffset": 3,
     "hasFocus": false,
     "isBackward": false,
   },

--- a/src/component/selection/__tests__/getDraftEditorSelection-test.js
+++ b/src/component/selection/__tests__/getDraftEditorSelection-test.js
@@ -15,28 +15,47 @@
 
 jest.disableAutomock();
 
-const CharacterMetadata = require('CharacterMetadata');
-const ContentBlock = require('ContentBlock');
-const ContentState = require('ContentState');
-const EditorState = require('EditorState');
-const Immutable = require('immutable');
-const {BOLD} = require('SampleDraftInlineStyle');
-const {EMPTY} = CharacterMetadata;
-
+const getSampleSelectionMocksForTesting = require('getSampleSelectionMocksForTesting');
+const getSampleSelectionMocksForTestingNestedBlocks = require('getSampleSelectionMocksForTestingNestedBlocks');
 const getDraftEditorSelection = require('getDraftEditorSelection');
 
-let editorState;
-let root;
-let contents;
-let blocks;
-let decorators;
-let leafs;
-let leafChildren;
-let textNodes;
+let editorState = null;
+let root = null;
+let contents = null;
+let blocks = null;
+let leafs = null;
+let leafChildren = null;
+let textNodes = null;
+
+const resetRootNodeMocks = () => {
+  ({
+    editorState,
+    root,
+    contents,
+    blocks,
+    leafs,
+    leafChildren,
+    textNodes,
+  } = getSampleSelectionMocksForTesting());
+};
+
+const resetNestedNodeMocks = () => {
+  ({
+    editorState,
+    root,
+    contents,
+    blocks,
+    leafs,
+    leafChildren,
+    textNodes,
+  } = getSampleSelectionMocksForTestingNestedBlocks());
+};
 
 const assertGetDraftEditorSelection = getSelectionReturnValue => {
+  document.selection = null;
+  window.getSelection = jest.fn();
   window.getSelection.mockReturnValueOnce(getSelectionReturnValue);
-  const selection = getDraftEditorSelection(editorState, root);
+  let selection = getDraftEditorSelection(editorState, root);
   expect({
     ...selection,
     selectionState: selection.selectionState.toJS(),
@@ -44,102 +63,7 @@ const assertGetDraftEditorSelection = getSelectionReturnValue => {
 };
 
 beforeEach(() => {
-  window.getSelection = jest.fn();
-  root = document.createElement('div');
-  contents = document.createElement('div');
-  contents.setAttribute('data-contents', 'true');
-  root.appendChild(contents);
-
-  const text = [
-    'Washington',
-    'Jefferson',
-    'Lincoln',
-    'Roosevelt',
-    'Kennedy',
-    'Obama',
-  ];
-
-  const textA = text[0] + text[1];
-  const textB = text[2] + text[3];
-  const textC = text[4] + text[5];
-
-  const boldChar = CharacterMetadata.create({style: BOLD});
-  const aChars = Immutable.List(
-    Immutable.Repeat(EMPTY, text[0].length).concat(
-      Immutable.Repeat(boldChar, text[1].length),
-    ),
-  );
-  const bChars = Immutable.List(
-    Immutable.Repeat(EMPTY, text[2].length).concat(
-      Immutable.Repeat(boldChar, text[3].length),
-    ),
-  );
-  const cChars = Immutable.List(
-    Immutable.Repeat(EMPTY, text[4].length).concat(
-      Immutable.Repeat(boldChar, text[5].length),
-    ),
-  );
-
-  const contentBlocks = [
-    new ContentBlock({
-      key: 'a',
-      type: 'unstyled',
-      text: textA,
-      characterList: aChars,
-    }),
-    new ContentBlock({
-      key: 'b',
-      type: 'unstyled',
-      text: textB,
-      characterList: bChars,
-    }),
-    new ContentBlock({
-      key: 'c',
-      type: 'unstyled',
-      text: textC,
-      characterList: cChars,
-    }),
-  ];
-
-  const contentState = ContentState.createFromBlockArray(contentBlocks);
-  editorState = EditorState.createWithContent(contentState);
-
-  textNodes = text.map(function(text) {
-    return document.createTextNode(text);
-  });
-  leafChildren = textNodes.map(function(textNode) {
-    const span = document.createElement('span');
-    span.appendChild(textNode);
-    return span;
-  });
-  leafs = ['a-0-0', 'a-0-1', 'b-0-0', 'b-0-1', 'c-0-0', 'c-0-1'].map(function(
-    blockKey,
-    ii,
-  ) {
-    const span = document.createElement('span');
-    span.setAttribute('data-offset-key', '' + blockKey);
-    span.appendChild(leafChildren[ii]);
-    return span;
-  });
-  decorators = ['a-0-0', 'b-0-0', 'c-0-0'].map(function(decoratorKey, ii) {
-    const span = document.createElement('span');
-    // Decorators may not have `data-offset-key` attribute
-    span.setAttribute('decorator-key', '' + decoratorKey);
-    span.appendChild(leafs[ii * 2]);
-    span.appendChild(leafs[ii * 2 + 1]);
-    return span;
-  });
-  blocks = ['a-0-0', 'b-0-0', 'c-0-0'].map(function(blockKey, ii) {
-    const blockElement = document.createElement('div');
-    blockElement.setAttribute('data-offset-key', '' + blockKey);
-    blockElement.appendChild(decorators[ii]);
-    return blockElement;
-  });
-  blocks.forEach(function(blockElem) {
-    contents.appendChild(blockElem);
-  });
-
-  document.selection = null;
+  resetRootNodeMocks();
 });
 
 /**
@@ -155,8 +79,20 @@ test('must find offsets when collapsed at start', () => {
   assertGetDraftEditorSelection({
     rangeCount: 1,
     anchorNode: textNode,
-    anchorOffset: 0,
     focusNode: textNode,
+    anchorOffset: 0,
+    focusOffset: 0,
+  });
+});
+
+test('must find offsets when collapsed at start of nested node', () => {
+  resetNestedNodeMocks();
+  const textNode = textNodes[1];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNode,
+    focusNode: textNode,
+    anchorOffset: 0,
     focusOffset: 0,
   });
 });
@@ -166,8 +102,20 @@ test('must find offsets when collapsed at end', () => {
   assertGetDraftEditorSelection({
     rangeCount: 1,
     anchorNode: textNode,
-    anchorOffset: textNode.length,
     focusNode: textNode,
+    anchorOffset: textNode.length,
+    focusOffset: textNode.length,
+  });
+});
+
+test('must find offsets when collapsed at end of nested node', () => {
+  resetNestedNodeMocks();
+  const textNode = textNodes[1];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNode,
+    focusNode: textNode,
+    anchorOffset: textNode.length,
     focusOffset: textNode.length,
   });
 });
@@ -183,6 +131,18 @@ test('must find offsets for non-collapsed selection', () => {
   });
 });
 
+test('must find offsets for non-collapsed selection of nested node', () => {
+  resetNestedNodeMocks();
+  const textNode = textNodes[1];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNode,
+    anchorOffset: 1,
+    focusNode: textNode,
+    focusOffset: 2,
+  });
+});
+
 test('must find offsets for reversed selection', () => {
   const textNode = textNodes[0];
   assertGetDraftEditorSelection({
@@ -194,8 +154,32 @@ test('must find offsets for reversed selection', () => {
   });
 });
 
+test('must find offsets for reversed selection of nested node', () => {
+  resetNestedNodeMocks();
+  const textNode = textNodes[1];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNode,
+    anchorOffset: 2,
+    focusNode: textNode,
+    focusOffset: 1,
+  });
+});
+
 test('must find offsets for selection on entire text node', () => {
   const textNode = textNodes[0];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNode,
+    anchorOffset: 0,
+    focusNode: textNode,
+    focusOffset: textNode.length,
+  });
+});
+
+test('must find offsets for selection on entire text node of nested node', () => {
+  resetNestedNodeMocks();
+  const textNode = textNodes[1];
   assertGetDraftEditorSelection({
     rangeCount: 1,
     anchorNode: textNode,
@@ -215,6 +199,17 @@ test('starts at head of one node and ends at head of another', () => {
   });
 });
 
+test('starts at head of one nested node and ends at head of another nested node', () => {
+  resetNestedNodeMocks();
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNodes[1],
+    anchorOffset: 0,
+    focusNode: textNodes[3],
+    focusOffset: 0,
+  });
+});
+
 test('extends from head of one node to end of another', () => {
   assertGetDraftEditorSelection({
     rangeCount: 1,
@@ -222,6 +217,17 @@ test('extends from head of one node to end of another', () => {
     anchorOffset: 0,
     focusNode: textNodes[2],
     focusOffset: textNodes[2].textContent.length,
+  });
+});
+
+test('extends from head of one nested node to end of another nested node', () => {
+  resetNestedNodeMocks();
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNodes[1],
+    anchorOffset: 0,
+    focusNode: textNodes[3],
+    focusOffset: textNodes[3].textContent.length,
   });
 });
 
@@ -235,6 +241,17 @@ test('starts within one text node and ends within another block', () => {
   });
 });
 
+test('starts within one nested text node and ends within another nested block', () => {
+  resetNestedNodeMocks();
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNodes[1],
+    anchorOffset: 2,
+    focusNode: textNodes[3],
+    focusOffset: 3,
+  });
+});
+
 test('is a reversed selection across multiple text nodes', () => {
   assertGetDraftEditorSelection({
     rangeCount: 1,
@@ -242,6 +259,17 @@ test('is a reversed selection across multiple text nodes', () => {
     anchorOffset: 4,
     focusNode: textNodes[0],
     focusOffset: 6,
+  });
+});
+
+test('is a reversed selection across multiple nested text nodes', () => {
+  resetNestedNodeMocks();
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNodes[1],
+    anchorOffset: 2,
+    focusNode: textNodes[3],
+    focusOffset: 3,
   });
 });
 
@@ -256,11 +284,34 @@ test('starts at head of text node, ends at head of leaf child', () => {
   });
 });
 
+test('starts at head of a nested text node, ends at head of leaf child of another nested node', () => {
+  resetNestedNodeMocks();
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNodes[1],
+    anchorOffset: 0,
+    focusNode: leafChildren[3],
+    focusOffset: 0,
+  });
+});
+
 test('starts at head of text node, ends at end of leaf child', () => {
   const leaf = leafChildren[4];
   assertGetDraftEditorSelection({
     rangeCount: 1,
     anchorNode: textNodes[0],
+    anchorOffset: 0,
+    focusNode: leaf,
+    focusOffset: leaf.childNodes.length,
+  });
+});
+
+test('starts at head of nested text node, ends at end of nested leaf child', () => {
+  resetNestedNodeMocks();
+  const leaf = leafChildren[3];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNodes[1],
     anchorOffset: 0,
     focusNode: leaf,
     focusOffset: leaf.childNodes.length,
@@ -278,12 +329,36 @@ test('starts within text node, ends at start of leaf child', () => {
   });
 });
 
+test('starts within nested text node, ends at start of nested leaf child', () => {
+  resetNestedNodeMocks();
+  const leaf = leafChildren[3];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNodes[1],
+    anchorOffset: 2,
+    focusNode: leaf,
+    focusOffset: 0,
+  });
+});
+
 test('starts within text node, ends at end of leaf child', () => {
   const leaf = leafChildren[4];
   assertGetDraftEditorSelection({
     rangeCount: 1,
     anchorNode: textNodes[0],
     anchorOffset: 4,
+    focusNode: leaf,
+    focusOffset: leaf.childNodes.length,
+  });
+});
+
+test('starts within nested text node, ends at end of nested leaf child', () => {
+  resetNestedNodeMocks();
+  const leaf = leafChildren[3];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNodes[1],
+    anchorOffset: 2,
     focusNode: leaf,
     focusOffset: leaf.childNodes.length,
   });
@@ -300,6 +375,18 @@ test('is a reversed text-to-leaf-child selection', () => {
   });
 });
 
+test('is a reversed text-to-leaf-child selection of nested node', () => {
+  resetNestedNodeMocks();
+  const leaf = leafChildren[3];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: leaf,
+    anchorOffset: 0,
+    focusNode: textNodes[1],
+    focusOffset: 4,
+  });
+});
+
 test('starts at head of text node, ends at head of leaf span', () => {
   assertGetDraftEditorSelection({
     rangeCount: 1,
@@ -310,11 +397,34 @@ test('starts at head of text node, ends at head of leaf span', () => {
   });
 });
 
+test('starts at head of nested text node, ends at head of nested leaf span', () => {
+  resetNestedNodeMocks();
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNodes[1],
+    anchorOffset: 0,
+    focusNode: leafs[3],
+    focusOffset: 0,
+  });
+});
+
 test('starts at head of text node, ends at end of leaf span', () => {
   const leaf = leafs[4];
   assertGetDraftEditorSelection({
     rangeCount: 1,
     anchorNode: textNodes[0],
+    anchorOffset: 0,
+    focusNode: leaf,
+    focusOffset: leaf.childNodes.length,
+  });
+});
+
+test('starts at head of nested text node, ends at end of nested leaf span', () => {
+  resetNestedNodeMocks();
+  const leaf = leafs[3];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNodes[1],
     anchorOffset: 0,
     focusNode: leaf,
     focusOffset: leaf.childNodes.length,
@@ -332,12 +442,36 @@ test('starts within text node, ends at start of leaf span', () => {
   });
 });
 
+test('starts within nested text node, ends at start of nested leaf span', () => {
+  resetNestedNodeMocks();
+  const leaf = leafs[3];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNodes[1],
+    anchorOffset: 2,
+    focusNode: leaf,
+    focusOffset: 0,
+  });
+});
+
 test('starts within text node, ends at end of leaf span', () => {
   const leaf = leafs[4];
   assertGetDraftEditorSelection({
     rangeCount: 1,
     anchorNode: textNodes[0],
     anchorOffset: 4,
+    focusNode: leaf,
+    focusOffset: leaf.childNodes.length,
+  });
+});
+
+test('starts within nested text node, ends at end of nested leaf span', () => {
+  resetNestedNodeMocks();
+  const leaf = leafs[3];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNodes[1],
+    anchorOffset: 2,
     focusNode: leaf,
     focusOffset: leaf.childNodes.length,
   });
@@ -354,8 +488,32 @@ test('is a reversed text-to-leaf selection', () => {
   });
 });
 
+test('is a reversed nested text-to-leaf selection', () => {
+  resetNestedNodeMocks();
+  const leaf = leafs[3];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: leaf,
+    anchorOffset: 0,
+    focusNode: textNodes[1],
+    focusOffset: 2,
+  });
+});
+
 test('is collapsed at start of single span', () => {
   const leaf = leafs[0];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: leaf,
+    anchorOffset: 0,
+    focusNode: leaf,
+    focusOffset: 0,
+  });
+});
+
+test('is collapsed at start of nested single span', () => {
+  resetNestedNodeMocks();
+  const leaf = leafs[1];
   assertGetDraftEditorSelection({
     rangeCount: 1,
     anchorNode: leaf,
@@ -376,8 +534,32 @@ test('is collapsed at end of single span', () => {
   });
 });
 
+test('is collapsed at end of nested single span', () => {
+  resetNestedNodeMocks();
+  const leaf = leafs[1];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: leaf,
+    anchorOffset: leaf.childNodes.length,
+    focusNode: leaf,
+    focusOffset: leaf.childNodes.length,
+  });
+});
+
 test('contains an entire leaf', () => {
   const leaf = leafs[4];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: leaf,
+    anchorOffset: 0,
+    focusNode: leaf,
+    focusOffset: leaf.childNodes.length,
+  });
+});
+
+test('contains an entire nested leaf', () => {
+  resetNestedNodeMocks();
+  const leaf = leafs[3];
   assertGetDraftEditorSelection({
     rangeCount: 1,
     anchorNode: leaf,
@@ -398,12 +580,35 @@ test('is reversed on entire leaf', () => {
   });
 });
 
+test('is reversed on nested entire leaf', () => {
+  resetNestedNodeMocks();
+  const leaf = leafs[3];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: leaf,
+    anchorOffset: leaf.childNodes.length,
+    focusNode: leaf,
+    focusOffset: 0,
+  });
+});
+
 test('from start of one block to start of another', () => {
   assertGetDraftEditorSelection({
     rangeCount: 1,
     anchorNode: leafs[0],
     anchorOffset: 0,
     focusNode: leafs[4],
+    focusOffset: 0,
+  });
+});
+
+test('from start of one nested block to start of another', () => {
+  resetNestedNodeMocks();
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: leafs[1],
+    anchorOffset: 0,
+    focusNode: leafs[3],
     focusOffset: 0,
   });
 });
@@ -418,6 +623,17 @@ test('from start of one block to end of other block', () => {
   });
 });
 
+test('from start of one nestd block to end of other nested block', () => {
+  resetNestedNodeMocks();
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: leafs[1],
+    anchorOffset: 0,
+    focusNode: leafs[3],
+    focusOffset: leafs[3].childNodes.length,
+  });
+});
+
 test('reversed leaf to leaf', () => {
   assertGetDraftEditorSelection({
     rangeCount: 1,
@@ -428,8 +644,31 @@ test('reversed leaf to leaf', () => {
   });
 });
 
+test('reversed leaf to nested leaf', () => {
+  resetNestedNodeMocks();
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: leafs[3],
+    anchorOffset: leafs[3].childNodes.length,
+    focusNode: leafs[1],
+    focusOffset: 0,
+  });
+});
+
 test('is collapsed at start at single block', () => {
   const block = blocks[0];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: block,
+    anchorOffset: 0,
+    focusNode: block,
+    focusOffset: 0,
+  });
+});
+
+test('is collapsed at start at nested single block', () => {
+  resetNestedNodeMocks();
+  const block = blocks[1];
   assertGetDraftEditorSelection({
     rangeCount: 1,
     anchorNode: block,
@@ -451,8 +690,34 @@ test('is collapsed at end at single block', () => {
   });
 });
 
+test('is collapsed at end at nested single block', () => {
+  resetNestedNodeMocks();
+  const block = blocks[1];
+  const decorators = block.childNodes;
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: block,
+    anchorOffset: decorators.length,
+    focusNode: block,
+    focusOffset: decorators.length,
+  });
+});
+
 test('is entirely selected', () => {
   const block = blocks[0];
+  const decorators = block.childNodes;
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: block,
+    anchorOffset: 0,
+    focusNode: block,
+    focusOffset: decorators.length,
+  });
+});
+
+test('is entirely selected with nested blocks', () => {
+  resetNestedNodeMocks();
+  const block = blocks[1];
   const decorators = block.childNodes;
   assertGetDraftEditorSelection({
     rangeCount: 1,
@@ -480,6 +745,19 @@ test('begins at text node zero, ends at end of block', () => {
   });
 });
 
+test('begins at nested text node zero, ends at end of nested block', () => {
+  resetNestedNodeMocks();
+  const textNode = textNodes[1];
+  const block = blocks[1];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNode,
+    anchorOffset: 0,
+    focusNode: block,
+    focusOffset: block.childNodes.length,
+  });
+});
+
 // No idea if this is possible.
 test('begins within text node, ends at end of block', () => {
   const textNode = textNodes[0];
@@ -493,10 +771,36 @@ test('begins within text node, ends at end of block', () => {
   });
 });
 
+test('begins within nested text node, ends at end of nested block', () => {
+  resetNestedNodeMocks();
+  const textNode = textNodes[1];
+  const block = blocks[1];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNode,
+    anchorOffset: 2,
+    focusNode: block,
+    focusOffset: block.childNodes.length,
+  });
+});
+
 // No idea if this is possible.
 test('is reversed from the first case', () => {
   const textNode = textNodes[0];
   const block = blocks[0];
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: block,
+    anchorOffset: block.childNodes.length,
+    focusNode: textNode,
+    focusOffset: 0,
+  });
+});
+
+test('is reversed from the first nested case', () => {
+  resetNestedNodeMocks();
+  const textNode = textNodes[1];
+  const block = blocks[1];
   assertGetDraftEditorSelection({
     rangeCount: 1,
     anchorNode: block,
@@ -516,12 +820,34 @@ test('goes from start of one block to end of other block', () => {
   });
 });
 
+test('goes from start of one nested block to end of other nested block', () => {
+  resetNestedNodeMocks();
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: blocks[1],
+    anchorOffset: 0,
+    focusNode: blocks[3],
+    focusOffset: blocks[3].childNodes.length,
+  });
+});
+
 test('goes from start of one block to start of other', () => {
   assertGetDraftEditorSelection({
     rangeCount: 1,
     anchorNode: blocks[0],
     anchorOffset: 0,
     focusNode: blocks[2],
+    focusOffset: 0,
+  });
+});
+
+test('goes from start of one nested block to start of other', () => {
+  resetNestedNodeMocks();
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: blocks[1],
+    anchorOffset: 0,
+    focusNode: blocks[3],
     focusOffset: 0,
   });
 });
@@ -536,12 +862,34 @@ test('goes from end of one to end of other block', () => {
   });
 });
 
+test('goes from end of one nested block to end of other nested block', () => {
+  resetNestedNodeMocks();
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: blocks[1],
+    anchorOffset: blocks[1].childNodes.length,
+    focusNode: blocks[3],
+    focusOffset: blocks[3].childNodes.length,
+  });
+});
+
 test('goes from within one block to within another block', () => {
   assertGetDraftEditorSelection({
     rangeCount: 1,
     anchorNode: blocks[0],
     anchorOffset: 1,
-    focusNode: blocks[2].firstChild,
+    focusNode: blocks[2].firstChild.firstChild,
+    focusOffset: 1,
+  });
+});
+
+test('goes from within one nested block to within another nested block', () => {
+  resetNestedNodeMocks();
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: blocks[1],
+    anchorOffset: 1,
+    focusNode: blocks[3].firstChild.firstChild,
     focusOffset: 1,
   });
 });
@@ -549,14 +897,36 @@ test('goes from within one block to within another block', () => {
 test('is the same as above but reversed', () => {
   assertGetDraftEditorSelection({
     rangeCount: 1,
-    anchorNode: blocks[2].firstChild,
+    anchorNode: blocks[2].firstChild.firstChild,
     anchorOffset: 1,
     focusNode: blocks[0],
     focusOffset: 1,
   });
 });
 
+test('is the same as above but nested and reversed', () => {
+  resetNestedNodeMocks();
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: blocks[3].firstChild.firstChild,
+    anchorOffset: 1,
+    focusNode: blocks[1],
+    focusOffset: 1,
+  });
+});
+
 test('is collapsed at the start of the contents', () => {
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: contents,
+    anchorOffset: 0,
+    focusNode: contents,
+    focusOffset: 0,
+  });
+});
+
+test('is collapsed at the start of the contents with nesting blocks', () => {
+  resetNestedNodeMocks();
   assertGetDraftEditorSelection({
     rangeCount: 1,
     anchorNode: contents,
@@ -576,7 +946,29 @@ test('occupies a single child of the contents', () => {
   });
 });
 
+test('occupies a single child of the contents with nested blocks', () => {
+  resetNestedNodeMocks();
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: contents,
+    anchorOffset: 0,
+    focusNode: contents,
+    focusOffset: 1,
+  });
+});
+
 test('is collapsed at the end of a child', () => {
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: contents,
+    anchorOffset: 1,
+    focusNode: contents,
+    focusOffset: 1,
+  });
+});
+
+test('is collapsed at the end of a nested child', () => {
+  resetNestedNodeMocks();
   assertGetDraftEditorSelection({
     rangeCount: 1,
     anchorNode: contents,
@@ -596,10 +988,32 @@ test('is contains multiple children', () => {
   });
 });
 
+test('is contains multiple nested children', () => {
+  resetNestedNodeMocks();
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: contents,
+    anchorOffset: 0,
+    focusNode: contents,
+    focusOffset: 2,
+  });
+});
+
 /**
  * In some scenarios, the entire editor may be selected by command-A.
  */
 test('is collapsed at start with full selection', () => {
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: root,
+    anchorOffset: 0,
+    focusNode: root,
+    focusOffset: 0,
+  });
+});
+
+test('is collapsed at start with full selection with nested blocks', () => {
+  resetNestedNodeMocks();
   assertGetDraftEditorSelection({
     rangeCount: 1,
     anchorNode: root,
@@ -619,7 +1033,29 @@ test('is collapsed at end with full selection', () => {
   });
 });
 
+test('is collapsed at end with full selection with nested blocks', () => {
+  resetNestedNodeMocks();
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: root,
+    anchorOffset: root.childNodes.length,
+    focusNode: root,
+    focusOffset: root.childNodes.length,
+  });
+});
+
 test('is completely selected', () => {
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: root,
+    anchorOffset: 0,
+    focusNode: root,
+    focusOffset: root.childNodes.length,
+  });
+});
+
+test('is completely selected with nested blocks', () => {
+  resetNestedNodeMocks();
   assertGetDraftEditorSelection({
     rangeCount: 1,
     anchorNode: root,
@@ -639,6 +1075,17 @@ test('is reversed from above', () => {
   });
 });
 
+test('is reversed from above nested blocks', () => {
+  resetNestedNodeMocks();
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: root,
+    anchorOffset: root.childNodes.length,
+    focusNode: root,
+    focusOffset: 0,
+  });
+});
+
 /**
  * A selection possibility that defies logic. In IE11, triple clicking a
  * block leads to the text node being selected as the anchor, and the
@@ -648,6 +1095,17 @@ test('does the crazy stuff described above', () => {
   assertGetDraftEditorSelection({
     rangeCount: 1,
     anchorNode: textNodes[0],
+    anchorOffset: 0,
+    focusNode: root,
+    focusOffset: root.childNodes.length,
+  });
+});
+
+test('does the crazy stuff described above with nested blocks', () => {
+  resetNestedNodeMocks();
+  assertGetDraftEditorSelection({
+    rangeCount: 1,
+    anchorNode: textNodes[1],
     anchorOffset: 0,
     focusNode: root,
     focusOffset: root.childNodes.length,

--- a/src/component/selection/getDraftEditorSelectionWithNodes.js
+++ b/src/component/selection/getDraftEditorSelectionWithNodes.js
@@ -121,8 +121,14 @@ function getDraftEditorSelectionWithNodes(
 /**
  * Identify the first leaf descendant for the given node.
  */
-function getFirstLeaf(node: Node): Node {
-  while (node.firstChild && getSelectionOffsetKeyForNode(node.firstChild)) {
+function getFirstLeaf(node: any): Node {
+  while (
+    node.firstChild &&
+    // data-blocks has no offset
+    ((node.firstChild instanceof Element &&
+      node.firstChild.getAttribute('data-blocks') === 'true') ||
+      getSelectionOffsetKeyForNode(node.firstChild))
+  ) {
     node = node.firstChild;
   }
   return node;
@@ -131,8 +137,14 @@ function getFirstLeaf(node: Node): Node {
 /**
  * Identify the last leaf descendant for the given node.
  */
-function getLastLeaf(node: Node): Node {
-  while (node.lastChild && getSelectionOffsetKeyForNode(node.lastChild)) {
+function getLastLeaf(node: any): Node {
+  while (
+    node.lastChild &&
+    // data-blocks has no offset
+    ((node.lastChild instanceof Element &&
+      node.lastChild.getAttribute('data-blocks') === 'true') ||
+      getSelectionOffsetKeyForNode(node.lastChild))
+  ) {
     node = node.lastChild;
   }
   return node;

--- a/src/component/selection/getSampleSelectionMocksForTesting.js
+++ b/src/component/selection/getSampleSelectionMocksForTesting.js
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule getSampleSelectionMocksForTesting
+ */
+
+'use strict';
+
+const CharacterMetadata = require('CharacterMetadata');
+const ContentBlock = require('ContentBlock');
+const ContentState = require('ContentState');
+const EditorState = require('EditorState');
+const Immutable = require('immutable');
+
+const {BOLD} = require('SampleDraftInlineStyle');
+const {EMPTY} = CharacterMetadata;
+
+const getSampleSelectionMocksForTesting = (): Object => {
+  const root = document.createElement('div');
+  const contents = document.createElement('div');
+
+  contents.setAttribute('data-contents', 'true');
+  root.appendChild(contents);
+
+  const text = [
+    'Washington',
+    'Jefferson',
+    'Lincoln',
+    'Roosevelt',
+    'Kennedy',
+    'Obama',
+  ];
+
+  const textA = text[0] + text[1];
+  const textB = text[2] + text[3];
+  const textC = text[4] + text[5];
+
+  const boldChar = CharacterMetadata.create({
+    style: BOLD,
+  });
+
+  const aChars = Immutable.List(
+    Immutable.Repeat(EMPTY, text[0].length).concat(
+      Immutable.Repeat(boldChar, text[1].length),
+    ),
+  );
+
+  const bChars = Immutable.List(
+    Immutable.Repeat(EMPTY, text[2].length).concat(
+      Immutable.Repeat(boldChar, text[3].length),
+    ),
+  );
+
+  const cChars = Immutable.List(
+    Immutable.Repeat(EMPTY, text[4].length).concat(
+      Immutable.Repeat(boldChar, text[5].length),
+    ),
+  );
+
+  const contentBlocks = [
+    new ContentBlock({
+      key: 'a',
+      type: 'unstyled',
+      text: textA,
+      characterList: aChars,
+    }),
+    new ContentBlock({
+      key: 'b',
+      type: 'unstyled',
+      text: textB,
+      characterList: bChars,
+    }),
+    new ContentBlock({
+      key: 'c',
+      type: 'unstyled',
+      text: textC,
+      characterList: cChars,
+    }),
+  ];
+
+  const contentState = ContentState.createFromBlockArray(contentBlocks);
+  const editorState = EditorState.createWithContent(contentState);
+
+  const textNodes = text.map(text => {
+    return document.createTextNode(text);
+  });
+
+  const leafChildren = textNodes.map(textNode => {
+    const span = document.createElement('span');
+    span.appendChild(textNode);
+    return span;
+  });
+
+  const leafs = ['a-0-0', 'a-0-1', 'b-0-0', 'b-0-1', 'c-0-0', 'c-0-1'].map(
+    (blockKey, index) => {
+      const span = document.createElement('span');
+      span.setAttribute('data-offset-key', '' + blockKey);
+      span.appendChild(leafChildren[index]);
+      return span;
+    },
+  );
+
+  const decorators = ['a-0-0', 'b-0-0', 'c-0-0'].map((decoratorKey, index) => {
+    const span = document.createElement('span');
+    span.setAttribute('data-offset-key', '' + decoratorKey);
+    span.appendChild(leafs[index * 2]);
+    span.appendChild(leafs[index * 2 + 1]);
+    return span;
+  });
+
+  const blocks = ['a-0-0', 'b-0-0', 'c-0-0'].map((blockKey, index) => {
+    const outerBlockElement = document.createElement('div');
+    const innerBlockElement = document.createElement('div');
+
+    innerBlockElement.setAttribute('data-offset-key', '' + blockKey);
+    innerBlockElement.appendChild(decorators[index]);
+
+    outerBlockElement.setAttribute('data-offset-key', '' + blockKey);
+    outerBlockElement.setAttribute('data-block', 'true');
+    outerBlockElement.appendChild(innerBlockElement);
+
+    return outerBlockElement;
+  });
+
+  blocks.forEach(blockElem => {
+    contents.appendChild(blockElem);
+  });
+
+  return {
+    editorState,
+    root,
+    contents,
+    blocks,
+    decorators,
+    leafs,
+    leafChildren,
+    textNodes,
+  };
+};
+
+module.exports = getSampleSelectionMocksForTesting;

--- a/src/component/selection/getSampleSelectionMocksForTestingNestedBlocks.js
+++ b/src/component/selection/getSampleSelectionMocksForTestingNestedBlocks.js
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule getSampleSelectionMocksForTestingNestedBlocks
+ */
+
+'use strict';
+
+const ContentBlockNode = require('ContentBlockNode');
+const ContentState = require('ContentState');
+const EditorState = require('EditorState');
+const Immutable = require('immutable');
+
+const getSampleSelectionMocksForTestingNestedBlocks = (): Object => {
+  const root = document.createElement('div');
+  const contents = document.createElement('div');
+
+  contents.setAttribute('data-contents', 'true');
+  root.appendChild(contents);
+
+  const text = [null, 'beta', null, 'delta'];
+  const offsetKeys = ['a-0-0', 'b-0-0', 'c-0-0', 'd-0-0'];
+
+  const contentBlocks = [
+    new ContentBlockNode({
+      key: 'a',
+      nextSibling: 'c',
+      children: Immutable.List.of('b'),
+    }),
+    new ContentBlockNode({
+      key: 'b',
+      parent: 'a',
+      text: text[1],
+    }),
+    new ContentBlockNode({
+      key: 'c',
+      prevSibling: 'a',
+      children: Immutable.List.of('d'),
+    }),
+    new ContentBlockNode({
+      key: 'd',
+      parent: 'c',
+      text: text[3],
+    }),
+  ];
+
+  const contentState = ContentState.createFromBlockArray(contentBlocks);
+  const editorState = EditorState.createWithContent(contentState);
+
+  const textNodes = text.map(text => {
+    if (!text) {
+      return null;
+    }
+    return document.createTextNode(text);
+  });
+
+  const leafChildren = textNodes.map(textNode => {
+    if (!textNode) {
+      return null;
+    }
+    const span = document.createElement('span');
+    span.appendChild(textNode);
+    return span;
+  });
+
+  const leafs = leafChildren.map((leafChild, index) => {
+    if (!leafChild) {
+      return null;
+    }
+    const blockKey = offsetKeys[index];
+    const span = document.createElement('span');
+    span.setAttribute('data-offset-key', blockKey);
+    span.appendChild(leafChild);
+    return span;
+  });
+
+  const decorators = leafs.map((leaf, index) => {
+    if (!leaf) {
+      return null;
+    }
+    const blockKey = offsetKeys[index];
+    const span = document.createElement('span');
+    span.setAttribute('data-offset-key', blockKey);
+    span.appendChild(leaf);
+    return span;
+  });
+
+  const blocks = offsetKeys.map((blockKey, index) => {
+    const outerBlockElement = document.createElement('div');
+    const innerBlockElement = document.createElement('div');
+
+    innerBlockElement.setAttribute('data-offset-key', blockKey);
+    outerBlockElement.setAttribute('data-offset-key', blockKey);
+    outerBlockElement.setAttribute('data-block', 'true');
+
+    const decorator = decorators[index];
+
+    // only leaf nodes can have text
+    if (decorator) {
+      innerBlockElement.appendChild(decorator);
+    }
+
+    outerBlockElement.appendChild(innerBlockElement);
+
+    return outerBlockElement;
+  });
+
+  const blockCacheRef = {};
+  blocks.forEach((blockElem, index) => {
+    const currentBlock = contentBlocks[index];
+    const parentKey = currentBlock.getParentKey();
+
+    // add this block reference to the cache lookup ref
+    blockCacheRef[currentBlock.getKey()] = blockElem;
+
+    // root nodes get appended directly to the contents block
+    if (!parentKey) {
+      contents.appendChild(blockElem);
+      return;
+    }
+
+    // append to to the innerBlockElement of the parent block
+    blockCacheRef[parentKey].firstChild.appendChild(blockElem);
+  });
+
+  return {
+    editorState,
+    root,
+    contents,
+    blocks,
+    decorators,
+    leafs,
+    leafChildren,
+    textNodes,
+  };
+};
+
+module.exports = getSampleSelectionMocksForTestingNestedBlocks;


### PR DESCRIPTION
### Context

This PR is part of a series of PR's that will be exploring **tree data block support** in Draft.


**Adding support for nested block selection**

This PR adds support for dealing with nested blocks selections and also add some tests to make sure we cover all the previous use cases when dealing with nested blocks.

***

**Note:**
This is unstable and not part of the public API and should not be used by
production systems.
