### PR TITLE
Bugfix - Making sure empty spaces leading prior to ul/ol are not

### DIFF
--- a/src/model/encoding/__tests__/__snapshots__/convertFromHTMLToContentBlocks-test.js.snap
+++ b/src/model/encoding/__tests__/__snapshots__/convertFromHTMLToContentBlocks-test.js.snap
@@ -1,9 +1,91 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`converts deeply nested html blocks when experimentalTreeDataSupport is enabled 1`] = `
+exports[`Should not create empty container blocks around ol and their list items 1`] = `
 Array [
   Object {
     "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "text": "something",
+    "type": "ordered-list-item",
+  },
+]
+`;
+
+exports[`Should not create empty container blocks around ol and their list items when nesting enabled 1`] = `
+Array [
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
       Object {
         "entity": null,
         "style": Array [],
@@ -12,19 +94,124 @@ Array [
     "children": Array [],
     "data": Object {},
     "depth": 0,
-    "key": "key5",
+    "key": "key0",
     "nextSibling": null,
-    "parent": undefined,
+    "parent": null,
     "prevSibling": null,
-    "text": " ",
-    "type": "unstyled",
+    "text": "something",
+    "type": "ordered-list-item",
   },
+]
+`;
+
+exports[`Should not create empty container blocks around ul and their list items 1`] = `
+Array [
   Object {
     "characterList": Array [
       Object {
         "entity": null,
         "style": Array [],
       },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "text": "something",
+    "type": "unordered-list-item",
+  },
+]
+`;
+
+exports[`Should not create empty container blocks around ul and their list items when nesting enabled 1`] = `
+Array [
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": null,
+    "text": "something",
+    "type": "unordered-list-item",
+  },
+]
+`;
+
+exports[`converts deeply nested html blocks when experimentalTreeDataSupport is enabled 1`] = `
+Array [
+  Object {
+    "characterList": Array [
       Object {
         "entity": null,
         "style": Array [],
@@ -73,7 +260,7 @@ Array [
     "nextSibling": "key1",
     "parent": null,
     "prevSibling": null,
-    "text": "Some quote ",
+    "text": "Some quote",
     "type": "ordered-list-item",
   },
   Object {
@@ -228,10 +415,6 @@ Array [
         "entity": null,
         "style": Array [],
       },
-      Object {
-        "entity": null,
-        "style": Array [],
-      },
     ],
     "children": Array [],
     "data": Object {},
@@ -241,7 +424,7 @@ Array [
     "parent": "key2",
     "prevSibling": "key3",
     "text": "lorem ipsum 
-  ",
+ ",
     "type": "unstyled",
   },
 ]
@@ -407,19 +590,6 @@ exports[`does not convert deeply nested html blocks when experimentalTreeDataSup
 
 exports[`does not convert deeply nested html blocks when experimentalTreeDataSupport is disabled 2`] = `
 Array [
-  Object {
-    "characterList": Array [
-      Object {
-        "entity": null,
-        "style": Array [],
-      },
-    ],
-    "data": Object {},
-    "depth": 0,
-    "key": "key4",
-    "text": " ",
-    "type": "unstyled",
-  },
   Object {
     "characterList": Array [
       Object {

--- a/src/model/encoding/__tests__/convertFromHTMLToContentBlocks-test.js
+++ b/src/model/encoding/__tests__/convertFromHTMLToContentBlocks-test.js
@@ -128,7 +128,9 @@ const testConvertingAdjacentHtmlElementsToContentBlocks = (
 const testConvertingHtmlElementsToContentBlocksAndRootContentBlockNodesMatch = (
   tag: string,
 ) => {
-  test(`must convert root ContentBlockNodes to matching ContentBlock nodes for <${tag} />`, () => {
+  test(`must convert root ContentBlockNodes to matching ContentBlock nodes for <${
+    tag
+  } />`, () => {
     expect(
       AreTreeBlockNodesEquivalent(`<${tag}>a</${tag}> `),
     ).toMatchSnapshot();
@@ -211,3 +213,47 @@ SUPPORTED_TAGS.forEach(tag =>
 SUPPORTED_TAGS.forEach(tag =>
   testConvertingHtmlElementsToContentBlocksAndRootContentBlockNodesMatch(tag),
 );
+
+test('Should not create empty container blocks around ul and their list items', () => {
+  const html_string = `
+    <ul>
+      <li>something</li>
+    </ul>
+  `;
+  assertConvertFromHTMLToContentBlocks(html_string, {
+    experimentalTreeDataSupport: false,
+  });
+});
+
+test('Should not create empty container blocks around ul and their list items when nesting enabled', () => {
+  const html_string = `
+    <ul>
+      <li>something</li>
+    </ul>
+  `;
+  assertConvertFromHTMLToContentBlocks(html_string, {
+    experimentalTreeDataSupport: true,
+  });
+});
+
+test('Should not create empty container blocks around ol and their list items', () => {
+  const html_string = `
+    <ol>
+      <li>something</li>
+    </ol>
+  `;
+  assertConvertFromHTMLToContentBlocks(html_string, {
+    experimentalTreeDataSupport: false,
+  });
+});
+
+test('Should not create empty container blocks around ol and their list items when nesting enabled', () => {
+  const html_string = `
+    <ol>
+      <li>something</li>
+    </ol>
+  `;
+  assertConvertFromHTMLToContentBlocks(html_string, {
+    experimentalTreeDataSupport: true,
+  });
+});

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -355,7 +355,18 @@ const genFragment = (
   // Base Case
   if (nodeName === '#text') {
     let text = node.textContent;
-    if (text.trim() === '' && inBlock !== 'pre') {
+    let nodeTextContent = text.trim();
+
+    // We should not create blocks for leading spaces that are
+    // existing around ol/ul and their children list items
+    if (lastList && nodeTextContent === '' && node.parentElement) {
+      const parentNodeName = node.parentElement.nodeName.toLowerCase();
+      if (parentNodeName === 'ol' || parentNodeName === 'ul') {
+        return {chunk: {...EMPTY_CHUNK}, entityMap};
+      }
+    }
+
+    if (nodeTextContent === '' && inBlock !== 'pre') {
       return {chunk: getWhitespaceChunk(inEntity), entityMap};
     }
     if (inBlock !== 'pre') {

--- a/src/model/paste/__tests__/__snapshots__/DraftPasteProcessor-test.js.snap
+++ b/src/model/paste/__tests__/__snapshots__/DraftPasteProcessor-test.js.snap
@@ -558,19 +558,6 @@ Array [
         "entity": null,
         "style": Array [],
       },
-    ],
-    "data": Object {},
-    "depth": 0,
-    "key": "key2",
-    "text": " ",
-    "type": "unstyled",
-  },
-  Object {
-    "characterList": Array [
-      Object {
-        "entity": null,
-        "style": Array [],
-      },
       Object {
         "entity": null,
         "style": Array [],
@@ -953,19 +940,6 @@ Array [
 
 exports[`must identify block styles 1`] = `
 Array [
-  Object {
-    "characterList": Array [
-      Object {
-        "entity": null,
-        "style": Array [],
-      },
-    ],
-    "data": Object {},
-    "depth": 0,
-    "key": "key4",
-    "text": " ",
-    "type": "unstyled",
-  },
   Object {
     "characterList": Array [
       Object {
@@ -1716,15 +1690,11 @@ Array [
         "entity": null,
         "style": Array [],
       },
-      Object {
-        "entity": null,
-        "style": Array [],
-      },
     ],
     "data": Object {},
     "depth": 0,
     "key": "key10",
-    "text": "what      ",
+    "text": "what     ",
     "type": "unstyled",
   },
   Object {
@@ -1838,15 +1808,11 @@ Array [
         "entity": null,
         "style": Array [],
       },
-      Object {
-        "entity": null,
-        "style": Array [],
-      },
     ],
     "data": Object {},
     "depth": 0,
     "key": "key2",
-    "text": "        what          ",
+    "text": "        what         ",
     "type": "unordered-list-item",
   },
   Object {


### PR DESCRIPTION
**Converting HTML that had ol/ul with spaces prior to first list item would create extra unstyled blocks**

Before if we tried to convert:

```html
<ul>
   <li>a</li>
</ul>
```

we would get 2 content blocks, with a unstyled one for the UL.

note that the same without leading spaces was converting fine:

```html
<ul><li>a</li></ul>
```

**Test Plan**

Added unit tests and updated old snapshots
