### PR TITLE
Exploration - Feature tree / Wiring up tree adapter on the raw

### DIFF
--- a/src/model/encoding/__tests__/__snapshots__/convertFromRawToDraftState-test.js.snap
+++ b/src/model/encoding/__tests__/__snapshots__/convertFromRawToDraftState-test.js.snap
@@ -278,6 +278,216 @@ Object {
 }
 `;
 
+exports[`must be able to convert content blocks that have list with depth from raw state to tree state when experimentalTreeDataSupport is enabled 1`] = `
+Object {
+  "A": Object {
+    "characterList": Array [],
+    "children": Array [
+      "B",
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "A",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": null,
+    "text": "",
+    "type": "ordered-list-item",
+  },
+  "B": Object {
+    "characterList": Array [],
+    "children": Array [
+      "C",
+    ],
+    "data": Object {},
+    "depth": 1,
+    "key": "B",
+    "nextSibling": null,
+    "parent": "A",
+    "prevSibling": null,
+    "text": "",
+    "type": "ordered-list-item",
+  },
+  "C": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 2,
+    "key": "C",
+    "nextSibling": null,
+    "parent": "B",
+    "prevSibling": null,
+    "text": "deeply nested list",
+    "type": "ordered-list-item",
+  },
+}
+`;
+
+exports[`must be able to convert from raw state to tree state when experimentalTreeDataSupport is enabled 1`] = `
+Object {
+  "A": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "A",
+    "nextSibling": "B",
+    "parent": null,
+    "prevSibling": null,
+    "text": "AAAA",
+    "type": "unstyled",
+  },
+  "B": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "B",
+    "nextSibling": "C",
+    "parent": null,
+    "prevSibling": "A",
+    "text": "BBBB",
+    "type": "unstyled",
+  },
+  "C": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "C",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": "B",
+    "text": "CCCC",
+    "type": "unstyled",
+  },
+}
+`;
+
 exports[`must be able to convert from styled blocks and entities mapped raw state 1`] = `
 Object {
   "a": Object {
@@ -398,6 +608,258 @@ Object {
     "key": "c",
     "text": "Charlie",
     "type": "blockquote",
+  },
+}
+`;
+
+exports[`must convert from raw tree draft to raw content state when experimentalTreeDataSupport is disabled 1`] = `
+Object {
+  "A": Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "A",
+    "text": "",
+    "type": "unstyled",
+  },
+  "B": Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "B",
+    "text": "",
+    "type": "unstyled",
+  },
+  "C": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "C",
+    "text": "left block",
+    "type": "unstyled",
+  },
+  "D": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "D",
+    "text": "right block",
+    "type": "unstyled",
+  },
+  "E": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "E",
+    "text": "This is a tree based document!",
+    "type": "header-one",
   },
 }
 `;

--- a/src/model/encoding/__tests__/convertFromHTMLToContentBlocks-test.js
+++ b/src/model/encoding/__tests__/convertFromHTMLToContentBlocks-test.js
@@ -128,7 +128,9 @@ const testConvertingAdjacentHtmlElementsToContentBlocks = (
 const testConvertingHtmlElementsToContentBlocksAndRootContentBlockNodesMatch = (
   tag: string,
 ) => {
-  test(`must convert root ContentBlockNodes to matching ContentBlock nodes for <${tag} />`, () => {
+  test(`must convert root ContentBlockNodes to matching ContentBlock nodes for <${
+    tag
+  } />`, () => {
     expect(
       AreTreeBlockNodesEquivalent(`<${tag}>a</${tag}> `),
     ).toMatchSnapshot();

--- a/src/model/encoding/__tests__/convertFromRawToDraftState-test.js
+++ b/src/model/encoding/__tests__/convertFromRawToDraftState-test.js
@@ -16,6 +16,14 @@ jest.disableAutomock();
 
 const convertFromRawToDraftState = require('convertFromRawToDraftState');
 
+const toggleExperimentalTreeDataSupport = enabled => {
+  jest.doMock('DraftFeatureFlags', () => {
+    return {
+      draft_tree_data_support: enabled,
+    };
+  });
+};
+
 const assertDraftState = rawState => {
   expect(
     convertFromRawToDraftState(rawState)
@@ -23,6 +31,10 @@ const assertDraftState = rawState => {
       .toJS(),
   ).toMatchSnapshot();
 };
+
+beforeEach(() => {
+  jest.resetModules();
+});
 
 test('must map falsey block types to default value of unstyled', () => {
   const rawState = {
@@ -102,7 +114,7 @@ test('must be able to convert from styled blocks and entities mapped raw state',
   assertDraftState(rawState);
 });
 
-test('convert from raw tree draft content state', () => {
+test('must convert from raw tree draft to raw content state when experimentalTreeDataSupport is disabled', () => {
   const rawState = {
     blocks: [
       {
@@ -124,6 +136,70 @@ test('convert from raw tree draft content state', () => {
             children: [],
           },
         ],
+      },
+    ],
+    entityMap: {},
+  };
+
+  assertDraftState(rawState);
+});
+
+test('convert from raw tree draft content state', () => {
+  toggleExperimentalTreeDataSupport(true);
+  const rawState = {
+    blocks: [
+      {
+        key: 'A',
+        text: '',
+        children: [
+          {
+            key: 'B',
+            text: '',
+            children: [
+              {key: 'C', text: 'left block', children: []},
+              {key: 'D', text: 'right block', children: []},
+            ],
+          },
+          {
+            key: 'E',
+            type: 'header-one',
+            text: 'This is a tree based document!',
+            children: [],
+          },
+        ],
+      },
+    ],
+    entityMap: {},
+  };
+
+  assertDraftState(rawState);
+});
+
+test('must be able to convert from raw state to tree state when experimentalTreeDataSupport is enabled', () => {
+  toggleExperimentalTreeDataSupport(true);
+  const rawState = {
+    blocks: [
+      {key: 'A', text: 'AAAA'},
+      {key: 'B', text: 'BBBB'},
+      {key: 'C', text: 'CCCC'},
+    ],
+    entityMap: {},
+  };
+
+  assertDraftState(rawState);
+});
+
+test('must be able to convert content blocks that have list with depth from raw state to tree state when experimentalTreeDataSupport is enabled', () => {
+  toggleExperimentalTreeDataSupport(true);
+  const rawState = {
+    blocks: [
+      {key: 'A', type: 'ordered-list-item', depth: 0, text: ''},
+      {key: 'B', type: 'ordered-list-item', depth: 1, text: ''},
+      {
+        key: 'C',
+        type: 'ordered-list-item',
+        depth: 2,
+        text: 'deeply nested list',
       },
     ],
     entityMap: {},


### PR DESCRIPTION

### Context

This PR is part of a series of PR's that will be exploring **tree data block support** in Draft.


**Wiring up tree adapter on the raw**

Making sure when the darkfeature flag is enabled/disabled we can handle both data formats to guarantee some degree of migration/backwards compatibility

***

**Note:**
This is unstable and not part of the public API and should not be used by
production systems.
