### PR TITLE
Exploration - Feature tree / Adding support for container text nodes

### DIFF
--- a/src/model/encoding/__tests__/__snapshots__/convertFromHTMLToContentBlocks-test.js.snap
+++ b/src/model/encoding/__tests__/__snapshots__/convertFromHTMLToContentBlocks-test.js.snap
@@ -403,6 +403,205 @@ Array [
 ]
 `;
 
+exports[`converts text nodes to unstyled elements when leading nested blocks when experimentalTreeDataSupport is enabled 1`] = `
+Array [
+  Object {
+    "characterList": Array [],
+    "children": Array [
+      "key2",
+      "key1",
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": null,
+    "text": "",
+    "type": "blockquote",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key2",
+    "nextSibling": "key1",
+    "parent": "key0",
+    "prevSibling": null,
+    "text": "      Hello World!       ",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key1",
+    "nextSibling": null,
+    "parent": "key0",
+    "prevSibling": "key2",
+    "text": "lorem ipsum
+ ",
+    "type": "header-one",
+  },
+]
+`;
+
 exports[`does not convert deeply nested html blocks when experimentalTreeDataSupport is disabled 1`] = `false`;
 
 exports[`does not convert deeply nested html blocks when experimentalTreeDataSupport is disabled 2`] = `

--- a/src/model/encoding/__tests__/convertFromHTMLToContentBlocks-test.js
+++ b/src/model/encoding/__tests__/convertFromHTMLToContentBlocks-test.js
@@ -128,7 +128,9 @@ const testConvertingAdjacentHtmlElementsToContentBlocks = (
 const testConvertingHtmlElementsToContentBlocksAndRootContentBlockNodesMatch = (
   tag: string,
 ) => {
-  test(`must convert root ContentBlockNodes to matching ContentBlock nodes for <${tag} />`, () => {
+  test(`must convert root ContentBlockNodes to matching ContentBlock nodes for <${
+    tag
+  } />`, () => {
     expect(
       AreTreeBlockNodesEquivalent(`<${tag}>a</${tag}> `),
     ).toMatchSnapshot();
@@ -158,6 +160,19 @@ test('converts nested html blocks when experimentalTreeDataSupport is enabled', 
     <blockquote>
       <h1>Hello World!</h1>
       <p>lorem ipsum</p>
+    </blockquote>
+  `;
+
+  assertConvertFromHTMLToContentBlocks(html_string, {
+    experimentalTreeDataSupport: true,
+  });
+});
+
+test('converts text nodes to unstyled elements when leading nested blocks when experimentalTreeDataSupport is enabled', () => {
+  const html_string = `
+    <blockquote>
+      Hello World!
+      <h1>lorem ipsum</h1>
     </blockquote>
   `;
 

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -643,6 +643,42 @@ const convertChunkToContentBlocks = (chunk: Chunk): ?Array<BlockNodeRecord> => {
     const {depth, type, parent} = block;
 
     const key = block.key || generateRandomKey();
+    let parentTextNodeKey = null; // will be used to store container text nodes
+
+    // childrens add themselves to their parents since we are iterating in order
+    if (parent) {
+      const parentIndex = acc.cacheRef[parent];
+      let parentRecord = acc.contentBlocks[parentIndex];
+
+      // if parent has text we need to split it into a separate unstyled element
+      if (parentRecord.getChildKeys().isEmpty() && parentRecord.getText()) {
+        const parentCharacterList = parentRecord.getCharacterList();
+        const parentText = parentRecord.getText();
+        parentTextNodeKey = generateRandomKey();
+
+        const textNode = new ContentBlockNode({
+          key: parentTextNodeKey,
+          text: parentText,
+          characterList: parentCharacterList,
+          parent: parent,
+          nextSibling: key,
+        });
+
+        acc.contentBlocks.push(textNode);
+
+        parentRecord = parentRecord.withMutations(block => {
+          block
+            .set('characterList', List())
+            .set('text', '')
+            .set('children', parentRecord.children.push(textNode.getKey()));
+        });
+      }
+
+      acc.contentBlocks[parentIndex] = parentRecord.set(
+        'children',
+        parentRecord.children.push(key),
+      );
+    }
 
     const blockNode = new BlockNodeRecord({
       key,
@@ -652,24 +688,15 @@ const convertChunkToContentBlocks = (chunk: Chunk): ?Array<BlockNodeRecord> => {
       text: textBlock,
       characterList,
       prevSibling:
-        index === 0 || rawBlocks[index - 1].parent !== parent
+        parentTextNodeKey ||
+        (index === 0 || rawBlocks[index - 1].parent !== parent
           ? null
-          : rawBlocks[index - 1].key,
+          : rawBlocks[index - 1].key),
       nextSibling:
         index === rawBlocks.length - 1 || rawBlocks[index + 1].parent !== parent
           ? null
           : rawBlocks[index + 1].key,
     });
-
-    // childrens add themselves to their parents since we are iterating in order
-    if (parent) {
-      const parentIndex = acc.cacheRef[parent];
-      const parentRecord = acc.contentBlocks[parentIndex];
-      acc.contentBlocks[parentIndex] = parentRecord.set(
-        'children',
-        parentRecord.children.push(key),
-      );
-    }
 
     // insert node
     acc.contentBlocks.push(blockNode);


### PR DESCRIPTION
### Context

This PR is part of a series of PR's that will be exploring **tree data block support** in Draft.


**Adding support for container text nodes**

This PR will add support for handling container text nodes that precedes real block nodes.

example:

```html
<blockquote>
   some text
   <h1>header block</h1>
</blockquote>
```

***

**Note:**
This is unstable and not part of the public API and should not be used by
production systems.
