### PR TITLE
Exploration - Feature tree / Adding support for getting transaction fragments

### DIFF
--- a/src/model/transaction/__tests__/__snapshots__/getContentStateFragment-test.js.snap
+++ b/src/model/transaction/__tests__/__snapshots__/getContentStateFragment-test.js.snap
@@ -1,0 +1,523 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must be able to return all selected contentBlockNodes 1`] = `
+Object {
+  "key4": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
+    "nextSibling": "key5",
+    "parent": null,
+    "prevSibling": null,
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  "key5": Object {
+    "characterList": Array [],
+    "children": Array [
+      "key6",
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key5",
+    "nextSibling": "key7",
+    "parent": null,
+    "prevSibling": "key4",
+    "text": "",
+    "type": "unstyled",
+  },
+  "key6": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key6",
+    "nextSibling": null,
+    "parent": "key5",
+    "prevSibling": null,
+    "text": "Charlie",
+    "type": "unstyled",
+  },
+  "key7": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key7",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": "key5",
+    "text": "Delta",
+    "type": "unstyled",
+  },
+}
+`;
+
+exports[`must be able to return all selected contentBlocks 1`] = `
+Object {
+  "key0": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  "key1": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key1",
+    "text": "Beta",
+    "type": "unstyled",
+  },
+  "key2": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key2",
+    "text": "Charlie",
+    "type": "unstyled",
+  },
+  "key3": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key3",
+    "text": "Delta",
+    "type": "unstyled",
+  },
+}
+`;
+
+exports[`must be able to return contentBlockNodes selected within 1`] = `
+Object {
+  "key10": Object {
+    "characterList": Array [],
+    "children": Array [
+      "key11",
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key10",
+    "nextSibling": "D",
+    "parent": null,
+    "prevSibling": null,
+    "text": "",
+    "type": "unstyled",
+  },
+  "key11": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key11",
+    "nextSibling": null,
+    "parent": "key10",
+    "prevSibling": null,
+    "text": "Charlie",
+    "type": "unstyled",
+  },
+}
+`;
+
+exports[`must be able to return contentBlocks selected within 1`] = `
+Object {
+  "key8": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key8",
+    "text": "Beta",
+    "type": "unstyled",
+  },
+  "key9": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key9",
+    "text": "Charlie",
+    "type": "unstyled",
+  },
+}
+`;
+
+exports[`must be able to return first ContentBlock selected 1`] = `
+Object {
+  "key12": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key12",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+}
+`;
+
+exports[`must be able to return first ContentBlockNode selected 1`] = `
+Object {
+  "key13": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key13",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": null,
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+}
+`;
+
+exports[`must be able to return last ContentBlock selected 1`] = `
+Object {
+  "key14": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key14",
+    "text": "Delta",
+    "type": "unstyled",
+  },
+}
+`;
+
+exports[`must be able to return last ContentBlockNode selected 1`] = `
+Object {
+  "key15": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key15",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": null,
+    "text": "Delta",
+    "type": "unstyled",
+  },
+}
+`;

--- a/src/model/transaction/__tests__/__snapshots__/randomizeBlockMapKeys-test.js.snap
+++ b/src/model/transaction/__tests__/__snapshots__/randomizeBlockMapKeys-test.js.snap
@@ -1,0 +1,194 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must be able to randomize keys for ContentBlockNodes BlockMap and update reference links to the new keys 1`] = `
+Object {
+  "key0": Object {
+    "characterList": Array [],
+    "children": Array [
+      "key1",
+      "key3",
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": null,
+    "text": "",
+    "type": "unstyled",
+  },
+  "key1": Object {
+    "characterList": Array [],
+    "children": Array [
+      "key2",
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key1",
+    "nextSibling": "key3",
+    "parent": "key0",
+    "prevSibling": null,
+    "text": "",
+    "type": "unstyled",
+  },
+  "key2": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key2",
+    "nextSibling": null,
+    "parent": "key1",
+    "prevSibling": null,
+    "text": "X",
+    "type": "unstyled",
+  },
+  "key3": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key3",
+    "nextSibling": null,
+    "parent": "key0",
+    "prevSibling": "key1",
+    "text": "Y",
+    "type": "unstyled",
+  },
+}
+`;
+
+exports[`must be able to randomize keys for ContentBlocks BlockMap 1`] = `
+Object {
+  "key0": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  "key1": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key1",
+    "text": "Beta",
+    "type": "unstyled",
+  },
+  "key2": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key2",
+    "text": "Charlie",
+    "type": "unstyled",
+  },
+  "key3": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key3",
+    "text": "Delta",
+    "type": "unstyled",
+  },
+}
+`;

--- a/src/model/transaction/__tests__/getContentStateFragment-test.js
+++ b/src/model/transaction/__tests__/getContentStateFragment-test.js
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+ui_infra
+ * @format
+ */
+
+'use strict';
+
+jest.disableAutomock();
+
+jest.mock('generateRandomKey');
+
+const EditorState = require('EditorState');
+const ContentBlock = require('ContentBlock');
+const ContentBlockNode = require('ContentBlockNode');
+const ContentState = require('ContentState');
+const Immutable = require('immutable');
+const SelectionState = require('SelectionState');
+
+const getContentStateFragment = require('getContentStateFragment');
+
+const {List} = Immutable;
+
+const contentBlocks = [
+  new ContentBlock({
+    key: 'A',
+    text: 'Alpha',
+  }),
+  new ContentBlock({
+    key: 'B',
+    text: 'Beta',
+  }),
+  new ContentBlock({
+    key: 'C',
+    text: 'Charlie',
+  }),
+  new ContentBlock({
+    key: 'D',
+    text: 'Delta',
+  }),
+];
+
+const contentBlockNodes = [
+  new ContentBlockNode({
+    key: 'A',
+    text: 'Alpha',
+    nextSibling: 'B',
+  }),
+  new ContentBlockNode({
+    key: 'B',
+    text: '',
+    children: List(['C']),
+    nextSibling: 'D',
+    prevSibling: 'A',
+  }),
+  new ContentBlockNode({
+    key: 'C',
+    parent: 'B',
+    text: 'Charlie',
+  }),
+  new ContentBlockNode({
+    key: 'D',
+    text: 'Delta',
+    prevSibling: 'B',
+  }),
+];
+
+const DEFAULT_SELECTION = {
+  anchorKey: 'A',
+  anchorOffset: 0,
+  focusKey: 'D',
+  focusOffset: 0,
+  isBackward: false,
+};
+
+const assertGetContentStateFragment = (blocksArray, selection = {}) => {
+  const editor = EditorState.acceptSelection(
+    EditorState.createWithContent(
+      ContentState.createFromBlockArray([...blocksArray]),
+    ),
+    new SelectionState({
+      ...DEFAULT_SELECTION,
+      ...selection,
+    }),
+  );
+
+  expect(
+    getContentStateFragment(
+      editor.getCurrentContent(),
+      editor.getSelection(),
+    ).toJS(),
+  ).toMatchSnapshot();
+};
+
+test('must be able to return all selected contentBlocks', () => {
+  assertGetContentStateFragment(contentBlocks, {
+    focusOffset: contentBlocks[3].getLength(),
+  });
+});
+
+test('must be able to return all selected contentBlockNodes', () => {
+  assertGetContentStateFragment(contentBlockNodes, {
+    focusOffset: contentBlockNodes[3].getLength(),
+  });
+});
+
+test('must be able to return contentBlocks selected within', () => {
+  assertGetContentStateFragment(contentBlocks, {
+    anchorKey: 'B',
+    focusKey: 'C',
+    focusOffset: contentBlockNodes[2].getLength(),
+  });
+});
+
+test('must be able to return contentBlockNodes selected within', () => {
+  assertGetContentStateFragment(contentBlockNodes, {
+    anchorKey: 'B',
+    focusKey: 'C',
+    focusOffset: contentBlockNodes[2].getLength(),
+  });
+});
+
+test('must be able to return first ContentBlock selected', () => {
+  assertGetContentStateFragment(contentBlocks, {
+    anchorKey: 'A',
+    focusKey: 'A',
+    focusOffset: contentBlocks[0].getLength(),
+  });
+});
+
+test('must be able to return first ContentBlockNode selected', () => {
+  assertGetContentStateFragment(contentBlockNodes, {
+    anchorKey: 'A',
+    focusKey: 'A',
+    focusOffset: contentBlockNodes[0].getLength(),
+  });
+});
+
+test('must be able to return last ContentBlock selected', () => {
+  assertGetContentStateFragment(contentBlocks, {
+    anchorKey: 'D',
+    focusKey: 'D',
+    focusOffset: contentBlocks[3].getLength(),
+  });
+});
+
+test('must be able to return last ContentBlockNode selected', () => {
+  assertGetContentStateFragment(contentBlockNodes, {
+    anchorKey: 'D',
+    focusKey: 'D',
+    focusOffset: contentBlockNodes[3].getLength(),
+  });
+});

--- a/src/model/transaction/__tests__/randomizeBlockMapKeys-test.js
+++ b/src/model/transaction/__tests__/randomizeBlockMapKeys-test.js
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+ui_infra
+ * @format
+ */
+
+'use strict';
+
+jest.disableAutomock();
+
+jest.mock('generateRandomKey');
+
+const randomizeBlockMapKeys = require('randomizeBlockMapKeys');
+const BlockMapBuilder = require('BlockMapBuilder');
+const ContentBlock = require('ContentBlock');
+const ContentBlockNode = require('ContentBlockNode');
+const Immutable = require('immutable');
+
+const {List} = Immutable;
+
+const assertRandomizeBlockMapKeys = blockMapArray => {
+  expect(
+    randomizeBlockMapKeys(
+      BlockMapBuilder.createFromArray(blockMapArray),
+    ).toJS(),
+  ).toMatchSnapshot();
+};
+
+beforeEach(() => {
+  jest.resetModules();
+});
+
+test('must be able to randomize keys for ContentBlocks BlockMap', () => {
+  assertRandomizeBlockMapKeys([
+    new ContentBlock({
+      key: 'A',
+      text: 'Alpha',
+    }),
+    new ContentBlock({
+      key: 'B',
+      text: 'Beta',
+    }),
+    new ContentBlock({
+      key: 'C',
+      text: 'Charlie',
+    }),
+    new ContentBlock({
+      key: 'D',
+      text: 'Delta',
+    }),
+  ]);
+});
+
+test('must be able to randomize keys for ContentBlockNodes BlockMap and update reference links to the new keys', () => {
+  assertRandomizeBlockMapKeys([
+    new ContentBlockNode({
+      key: 'A',
+      text: '',
+      children: List(['B', 'D']),
+    }),
+    new ContentBlockNode({
+      key: 'B',
+      parent: 'A',
+      children: List(['C']),
+      nextSibling: 'D',
+      text: '',
+    }),
+    new ContentBlockNode({
+      key: 'C',
+      parent: 'B',
+      text: 'X',
+    }),
+    new ContentBlockNode({
+      key: 'D',
+      parent: 'A',
+      prevSibling: 'B',
+      text: 'Y',
+    }),
+  ]);
+});

--- a/src/model/transaction/getContentStateFragment.js
+++ b/src/model/transaction/getContentStateFragment.js
@@ -17,65 +17,60 @@ import type {BlockMap} from 'BlockMap';
 import type ContentState from 'ContentState';
 import type SelectionState from 'SelectionState';
 
-var generateRandomKey = require('generateRandomKey');
-var removeEntitiesAtEdges = require('removeEntitiesAtEdges');
+const removeEntitiesAtEdges = require('removeEntitiesAtEdges');
+const randomizeBlockMapKeys = require('randomizeBlockMapKeys');
 
-function getContentStateFragment(
+const getContentStateFragment = (
   contentState: ContentState,
   selectionState: SelectionState,
-): BlockMap {
-  var startKey = selectionState.getStartKey();
-  var startOffset = selectionState.getStartOffset();
-  var endKey = selectionState.getEndKey();
-  var endOffset = selectionState.getEndOffset();
+): BlockMap => {
+  const startKey = selectionState.getStartKey();
+  const startOffset = selectionState.getStartOffset();
+  const endKey = selectionState.getEndKey();
+  const endOffset = selectionState.getEndOffset();
 
   // Edge entities should be stripped to ensure that we don't preserve
   // invalid partial entities when the fragment is reused. We do, however,
   // preserve entities that are entirely within the selection range.
-  var contentWithoutEdgeEntities = removeEntitiesAtEdges(
+  const contentWithoutEdgeEntities = removeEntitiesAtEdges(
     contentState,
     selectionState,
   );
 
-  var blockMap = contentWithoutEdgeEntities.getBlockMap();
-  var blockKeys = blockMap.keySeq();
-  var startIndex = blockKeys.indexOf(startKey);
-  var endIndex = blockKeys.indexOf(endKey) + 1;
+  const blockMap = contentWithoutEdgeEntities.getBlockMap();
+  const blockKeys = blockMap.keySeq();
+  const startIndex = blockKeys.indexOf(startKey);
+  const endIndex = blockKeys.indexOf(endKey) + 1;
 
-  var slice = blockMap.slice(startIndex, endIndex).map((block, blockKey) => {
-    var newKey = generateRandomKey();
+  return randomizeBlockMapKeys(
+    blockMap.slice(startIndex, endIndex).map((block, blockKey) => {
+      const text = block.getText();
+      const chars = block.getCharacterList();
 
-    var text = block.getText();
-    var chars = block.getCharacterList();
+      if (startKey === endKey) {
+        return block.merge({
+          text: text.slice(startOffset, endOffset),
+          characterList: chars.slice(startOffset, endOffset),
+        });
+      }
 
-    if (startKey === endKey) {
-      return block.merge({
-        key: newKey,
-        text: text.slice(startOffset, endOffset),
-        characterList: chars.slice(startOffset, endOffset),
-      });
-    }
+      if (blockKey === startKey) {
+        return block.merge({
+          text: text.slice(startOffset),
+          characterList: chars.slice(startOffset),
+        });
+      }
 
-    if (blockKey === startKey) {
-      return block.merge({
-        key: newKey,
-        text: text.slice(startOffset),
-        characterList: chars.slice(startOffset),
-      });
-    }
+      if (blockKey === endKey) {
+        return block.merge({
+          text: text.slice(0, endOffset),
+          characterList: chars.slice(0, endOffset),
+        });
+      }
 
-    if (blockKey === endKey) {
-      return block.merge({
-        key: newKey,
-        text: text.slice(0, endOffset),
-        characterList: chars.slice(0, endOffset),
-      });
-    }
-
-    return block.set('key', newKey);
-  });
-
-  return slice.toOrderedMap();
-}
+      return block;
+    }),
+  );
+};
 
 module.exports = getContentStateFragment;

--- a/src/model/transaction/randomizeBlockMapKeys.js
+++ b/src/model/transaction/randomizeBlockMapKeys.js
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule randomizeBlockMapKeys
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+import type {BlockMap} from 'BlockMap';
+
+const ContentBlockNode = require('ContentBlockNode');
+const generateRandomKey = require('generateRandomKey');
+const Immutable = require('immutable');
+
+const {OrderedMap} = Immutable;
+
+const randomizeContentBlockNodeKeys = (blockMap: BlockMap): BlockMap => {
+  const newKeys = [];
+  return OrderedMap(
+    blockMap
+      .withMutations(blockMapState => {
+        blockMapState.forEach((block, index) => {
+          const oldKey = block.getKey();
+          const nextKey = block.getNextSiblingKey();
+          const prevKey = block.getPrevSiblingKey();
+          const childrenKeys = block.getChildKeys();
+          const parentKey = block.getParentKey();
+
+          // new key that we will use to build linking
+          const key = generateRandomKey();
+
+          // we will add it here to re-use it later
+          newKeys.push(key);
+
+          if (nextKey) {
+            const nextBlock = blockMapState.get(nextKey);
+            if (nextBlock) {
+              blockMapState.mergeIn(
+                nextKey,
+                nextBlock.merge({
+                  prevSibling: key,
+                }),
+              );
+            } else {
+              // this can happen when generating random keys for fragments
+              blockMapState.mergeIn(
+                oldKey,
+                block.merge({
+                  nextSibling: null,
+                }),
+              );
+            }
+          }
+
+          if (prevKey) {
+            const prevBlock = blockMapState.get(prevKey);
+            if (prevBlock) {
+              blockMapState.mergeIn(
+                prevKey,
+                prevBlock.merge({
+                  nextSibling: key,
+                }),
+              );
+            } else {
+              // this can happen when generating random keys for fragments
+              blockMapState.mergeIn(
+                oldKey,
+                block.merge({
+                  prevSibling: null,
+                }),
+              );
+            }
+          }
+
+          if (parentKey) {
+            const parentBlock = blockMapState.get(parentKey);
+            if (parentBlock) {
+              const parentChildrenList = parentBlock.getChildKeys();
+              blockMapState.setIn(
+                parentKey,
+                parentBlock.merge({
+                  children: parentChildrenList.set(
+                    parentChildrenList.indexOf(block.getKey()),
+                    key,
+                  ),
+                }),
+              );
+            } else {
+              blockMapState.mergeIn(
+                oldKey,
+                block.merge({
+                  parent: null,
+                }),
+              );
+            }
+          }
+
+          childrenKeys.forEach(childKey => {
+            const childBlock = blockMapState.get(childKey);
+            if (childBlock) {
+              blockMapState.mergeIn(
+                childKey,
+                childBlock.merge({
+                  parent: key,
+                }),
+              );
+            } else {
+              blockMapState.mergeIn(
+                oldKey,
+                block.merge({
+                  children: block
+                    .getChildKeys()
+                    .filter(child => child !== childKey),
+                }),
+              );
+            }
+          });
+        });
+      })
+      .toArray()
+      .map((block, index) => [
+        newKeys[index],
+        block.set('key', newKeys[index]),
+      ]),
+  );
+};
+
+const randomizeContentBlockKeys = (blockMap: BlockMap): BlockMap => {
+  return OrderedMap(
+    blockMap.toArray().map(block => {
+      const key = generateRandomKey();
+      return [key, block.set('key', key)];
+    }),
+  );
+};
+
+const randomizeBlockMapKeys = (blockMap: BlockMap): BlockMap => {
+  const isTreeBasedBlockMap = blockMap.first() instanceof ContentBlockNode;
+
+  if (!isTreeBasedBlockMap) {
+    return randomizeContentBlockKeys(blockMap);
+  }
+
+  return randomizeContentBlockNodeKeys(blockMap);
+};
+
+module.exports = randomizeBlockMapKeys;


### PR DESCRIPTION
### Context

This PR is part of a series of PR's that will be exploring **tree data block support** in Draft.


**Adding support for getting transaction fragments**

This PR adds support for getting tree based fragments from the content state transaction


***

**Note:**
This is unstable and not part of the public API and should not be used by
production systems.
