### PR TITLE
Support IE and Edge drag/drop text handling

### DIFF
--- a/src/component/handlers/drag/DraftEditorDragHandler.js
+++ b/src/component/handlers/drag/DraftEditorDragHandler.js
@@ -43,6 +43,14 @@ function getSelectionForEvent(
   } else if (event.rangeParent) {
     node = event.rangeParent;
     offset = event.rangeOffset;
+  } else if (window.getSelection) {
+    node = event.target;
+    var selection = window.getSelection();
+    var range = selection.getRangeAt ? selection.getRangeAt(0) : selection.createRange();
+
+    // If the range is collapsed, drag and drop occurred within the input.
+    // Otherwise it is from outside the input and we can't get where the user is positioned so copy to the end.
+    offset = range.collapsed ? selection.focusOffset : event.srcElement.innerText.length;
   } else {
     return null;
   }
@@ -122,6 +130,13 @@ var DraftEditorDragHandler = {
       insertTextAtSelection(editorState, dropSelection, data.getText()),
     );
   },
+
+  /**
+   * Handle on drag over event.
+   */
+  onDragOver: function onDragOver(editor: DraftEditor, e: Object): void {
+    e.preventDefault();
+  }
 };
 
 function moveText(


### PR DESCRIPTION
**Summary**

As described in #889 there are a couple of issues with handling drag+dropped text in IE and Edge.

1. Without a drag over handler the drop event is never given to the draft editor,
2. Even when a drop event is given to the draft editor, no content is added because there's no selection available from the event.

This pull request addresses both of these issues:
1. Add a drag over handler that prevents default so that we can receive the drop event,
2. Add an extra case that will infer the offset to copy to text to from the current window selection as follows:
    a. If we are dragging text within the editor then the selection will be correct and give us a valid offset,
    b. If we are dragging from outside the editor the selection won't exist so we are forced to place the text at the end of the editor content.

**Test Plan**

Case 1:
1. In Edge type some text content in the draft editor.
2. Select some of the text and drag it within the editor to a different offset

Expected:
The selected text is correctly moved to the new offset.

Case 2:
1. In Edge drag some text content from elsewhere on the page onto the draft editor

Expected:
Ideally it would place the text where the cursor in the editor is, however what you will see is that the text is always copied to the end of the editor content as there's no way to get the actual offset.
