### PR TITLE
Exploration - Feature tree / Adding support for moving tree blocks

### DIFF
--- a/src/model/transaction/__tests__/__snapshots__/moveBlockInContentState-test.js.snap
+++ b/src/model/transaction/__tests__/__snapshots__/moveBlockInContentState-test.js.snap
@@ -1,0 +1,381 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must be able to move block after other block 1`] = `
+Array [
+  Object {
+    "key": "B",
+  },
+  Object {
+    "key": "C",
+  },
+  Object {
+    "key": "A",
+  },
+]
+`;
+
+exports[`must be able to move block after other nested block 1`] = `
+Array [
+  Object {
+    "children": Array [
+      "C",
+      "A",
+    ],
+    "key": "B",
+    "nextSibling": "D",
+    "parent": null,
+    "prevSibling": null,
+  },
+  Object {
+    "children": Array [],
+    "key": "C",
+    "nextSibling": "A",
+    "parent": "B",
+    "prevSibling": null,
+  },
+  Object {
+    "children": Array [],
+    "key": "A",
+    "nextSibling": null,
+    "parent": "B",
+    "prevSibling": "C",
+  },
+  Object {
+    "children": Array [
+      "E",
+    ],
+    "key": "D",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": "B",
+  },
+  Object {
+    "children": Array [],
+    "key": "E",
+    "nextSibling": null,
+    "parent": "D",
+    "prevSibling": null,
+  },
+]
+`;
+
+exports[`must be able to move block and its children after other block 1`] = `
+Array [
+  Object {
+    "children": Array [],
+    "key": "A",
+    "nextSibling": "D",
+    "parent": null,
+    "prevSibling": null,
+  },
+  Object {
+    "children": Array [
+      "E",
+    ],
+    "key": "D",
+    "nextSibling": "B",
+    "parent": null,
+    "prevSibling": "A",
+  },
+  Object {
+    "children": Array [],
+    "key": "E",
+    "nextSibling": null,
+    "parent": "D",
+    "prevSibling": null,
+  },
+  Object {
+    "children": Array [
+      "C",
+    ],
+    "key": "B",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": "D",
+  },
+  Object {
+    "children": Array [],
+    "key": "C",
+    "nextSibling": null,
+    "parent": "B",
+    "prevSibling": null,
+  },
+]
+`;
+
+exports[`must be able to move block and its children after other nested block 1`] = `
+Array [
+  Object {
+    "children": Array [],
+    "key": "A",
+    "nextSibling": "D",
+    "parent": null,
+    "prevSibling": null,
+  },
+  Object {
+    "children": Array [
+      "E",
+      "B",
+    ],
+    "key": "D",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": "A",
+  },
+  Object {
+    "children": Array [],
+    "key": "E",
+    "nextSibling": "B",
+    "parent": "D",
+    "prevSibling": null,
+  },
+  Object {
+    "children": Array [
+      "C",
+    ],
+    "key": "B",
+    "nextSibling": null,
+    "parent": "D",
+    "prevSibling": "E",
+  },
+  Object {
+    "children": Array [],
+    "key": "C",
+    "nextSibling": null,
+    "parent": "B",
+    "prevSibling": null,
+  },
+]
+`;
+
+exports[`must be able to move block and its children before other block 1`] = `
+Array [
+  Object {
+    "children": Array [
+      "C",
+    ],
+    "key": "B",
+    "nextSibling": "A",
+    "parent": null,
+    "prevSibling": null,
+  },
+  Object {
+    "children": Array [],
+    "key": "C",
+    "nextSibling": null,
+    "parent": "B",
+    "prevSibling": null,
+  },
+  Object {
+    "children": Array [],
+    "key": "A",
+    "nextSibling": "D",
+    "parent": null,
+    "prevSibling": "B",
+  },
+  Object {
+    "children": Array [
+      "E",
+    ],
+    "key": "D",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": "A",
+  },
+  Object {
+    "children": Array [],
+    "key": "E",
+    "nextSibling": null,
+    "parent": "D",
+    "prevSibling": null,
+  },
+]
+`;
+
+exports[`must be able to move block and its children before other nested block 1`] = `
+Array [
+  Object {
+    "children": Array [],
+    "key": "A",
+    "nextSibling": "B",
+    "parent": null,
+    "prevSibling": null,
+  },
+  Object {
+    "children": Array [
+      "D",
+      "C",
+    ],
+    "key": "B",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": "A",
+  },
+  Object {
+    "children": Array [
+      "E",
+    ],
+    "key": "D",
+    "nextSibling": "C",
+    "parent": "B",
+    "prevSibling": null,
+  },
+  Object {
+    "children": Array [],
+    "key": "E",
+    "nextSibling": null,
+    "parent": "D",
+    "prevSibling": null,
+  },
+  Object {
+    "children": Array [],
+    "key": "C",
+    "nextSibling": null,
+    "parent": "B",
+    "prevSibling": "D",
+  },
+]
+`;
+
+exports[`must be able to move block before other block 1`] = `
+Array [
+  Object {
+    "key": "C",
+  },
+  Object {
+    "key": "A",
+  },
+  Object {
+    "key": "B",
+  },
+]
+`;
+
+exports[`must be able to move block before other nested block 1`] = `
+Array [
+  Object {
+    "children": Array [
+      "A",
+      "C",
+    ],
+    "key": "B",
+    "nextSibling": "D",
+    "parent": null,
+    "prevSibling": null,
+  },
+  Object {
+    "children": Array [],
+    "key": "A",
+    "nextSibling": "C",
+    "parent": "B",
+    "prevSibling": null,
+  },
+  Object {
+    "children": Array [],
+    "key": "C",
+    "nextSibling": null,
+    "parent": "B",
+    "prevSibling": "A",
+  },
+  Object {
+    "children": Array [
+      "E",
+    ],
+    "key": "D",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": "B",
+  },
+  Object {
+    "children": Array [],
+    "key": "E",
+    "nextSibling": null,
+    "parent": "D",
+    "prevSibling": null,
+  },
+]
+`;
+
+exports[`must be able to move nested block after other block 1`] = `
+Array [
+  Object {
+    "children": Array [],
+    "key": "A",
+    "nextSibling": "C",
+    "parent": null,
+    "prevSibling": null,
+  },
+  Object {
+    "children": Array [],
+    "key": "C",
+    "nextSibling": "B",
+    "parent": null,
+    "prevSibling": "A",
+  },
+  Object {
+    "children": Array [
+      "E",
+    ],
+    "key": "D",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": "B",
+  },
+  Object {
+    "children": Array [],
+    "key": "E",
+    "nextSibling": null,
+    "parent": "D",
+    "prevSibling": null,
+  },
+  Object {
+    "children": Array [],
+    "key": "B",
+    "nextSibling": "D",
+    "parent": null,
+    "prevSibling": "C",
+  },
+]
+`;
+
+exports[`must be able to move nested block before other block 1`] = `
+Array [
+  Object {
+    "children": Array [],
+    "key": "C",
+    "nextSibling": "A",
+    "parent": null,
+    "prevSibling": null,
+  },
+  Object {
+    "children": Array [
+      "E",
+    ],
+    "key": "D",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": "B",
+  },
+  Object {
+    "children": Array [],
+    "key": "E",
+    "nextSibling": null,
+    "parent": "D",
+    "prevSibling": null,
+  },
+  Object {
+    "children": Array [],
+    "key": "A",
+    "nextSibling": "B",
+    "parent": null,
+    "prevSibling": "C",
+  },
+  Object {
+    "children": Array [],
+    "key": "B",
+    "nextSibling": "D",
+    "parent": null,
+    "prevSibling": "A",
+  },
+]
+`;

--- a/src/model/transaction/__tests__/__snapshots__/moveBlockInContentState-test.js.snap
+++ b/src/model/transaction/__tests__/__snapshots__/moveBlockInContentState-test.js.snap
@@ -313,6 +313,13 @@ Array [
     "prevSibling": "A",
   },
   Object {
+    "children": Array [],
+    "key": "B",
+    "nextSibling": "D",
+    "parent": null,
+    "prevSibling": "C",
+  },
+  Object {
     "children": Array [
       "E",
     ],
@@ -327,13 +334,6 @@ Array [
     "nextSibling": null,
     "parent": "D",
     "prevSibling": null,
-  },
-  Object {
-    "children": Array [],
-    "key": "B",
-    "nextSibling": "D",
-    "parent": null,
-    "prevSibling": "C",
   },
 ]
 `;
@@ -345,22 +345,6 @@ Array [
     "key": "C",
     "nextSibling": "A",
     "parent": null,
-    "prevSibling": null,
-  },
-  Object {
-    "children": Array [
-      "E",
-    ],
-    "key": "D",
-    "nextSibling": null,
-    "parent": null,
-    "prevSibling": "B",
-  },
-  Object {
-    "children": Array [],
-    "key": "E",
-    "nextSibling": null,
-    "parent": "D",
     "prevSibling": null,
   },
   Object {
@@ -376,6 +360,22 @@ Array [
     "nextSibling": "D",
     "parent": null,
     "prevSibling": "A",
+  },
+  Object {
+    "children": Array [
+      "E",
+    ],
+    "key": "D",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": "B",
+  },
+  Object {
+    "children": Array [],
+    "key": "E",
+    "nextSibling": null,
+    "parent": "D",
+    "prevSibling": null,
   },
 ]
 `;

--- a/src/model/transaction/__tests__/moveBlockInContentState-test.js
+++ b/src/model/transaction/__tests__/moveBlockInContentState-test.js
@@ -68,7 +68,7 @@ const contentBlockNodes = [
   new ContentBlockNode({
     key: 'E',
     parent: 'D',
-    text: 'Elefant',
+    text: 'Elephant',
   }),
 ];
 
@@ -95,15 +95,16 @@ const assertMoveBlockInContentState = (
       .getBlockMap()
       .toSetSeq()
       .toArray()
+      // doing this filtering to make the snapshot more precise/concise in what we test
       .map(filter => {
-          const {
-             data,
-             characterList,
-             depth,
-             type,
-             text,
-             ...other,
-          } = filter.toJS();
+        const {
+          data,
+          characterList,
+          depth,
+          type,
+          text,
+          ...other
+        } = filter.toJS();
         return other;
       }),
   ).toMatchSnapshot();

--- a/src/model/transaction/__tests__/moveBlockInContentState-test.js
+++ b/src/model/transaction/__tests__/moveBlockInContentState-test.js
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+ui_infra
+ * @format
+ */
+
+'use strict';
+
+jest.disableAutomock();
+
+jest.mock('generateRandomKey');
+
+const EditorState = require('EditorState');
+const ContentBlock = require('ContentBlock');
+const ContentBlockNode = require('ContentBlockNode');
+const ContentState = require('ContentState');
+const Immutable = require('immutable');
+
+const moveBlockInContentState = require('moveBlockInContentState');
+
+const {List} = Immutable;
+
+const contentBlocks = [
+  new ContentBlock({
+    key: 'A',
+    text: 'Alpha',
+  }),
+  new ContentBlock({
+    key: 'B',
+    text: 'Beta',
+  }),
+  new ContentBlock({
+    key: 'C',
+    text: 'Charlie',
+  }),
+];
+
+const contentBlockNodes = [
+  new ContentBlockNode({
+    key: 'A',
+    text: 'Alpha',
+    nextSibling: 'B',
+  }),
+  new ContentBlockNode({
+    key: 'B',
+    text: '',
+    children: List(['C']),
+    nextSibling: 'D',
+    prevSibling: 'A',
+  }),
+  new ContentBlockNode({
+    key: 'C',
+    parent: 'B',
+    text: 'Charlie',
+  }),
+  new ContentBlockNode({
+    key: 'D',
+    text: '',
+    prevSibling: 'B',
+    children: List(['E']),
+  }),
+  new ContentBlockNode({
+    key: 'E',
+    parent: 'D',
+    text: 'Elefant',
+  }),
+];
+
+const assertMoveBlockInContentState = (
+  blockToBeMovedKey,
+  targetBlockKey,
+  insertionMode,
+  blocksArray = contentBlocks,
+) => {
+  const editor = EditorState.createWithContent(
+    ContentState.createFromBlockArray(blocksArray),
+  );
+  const contentState = editor.getCurrentContent();
+  const blockToBeMoved = contentState.getBlockForKey(blockToBeMovedKey);
+  const targetBlock = contentState.getBlockForKey(targetBlockKey);
+
+  expect(
+    moveBlockInContentState(
+      contentState,
+      blockToBeMoved,
+      targetBlock,
+      insertionMode,
+    )
+      .getBlockMap()
+      .toSetSeq()
+      .toArray()
+      .map(filter => {
+          const {
+             data,
+             characterList,
+             depth,
+             type,
+             text,
+             ...other,
+          } = filter.toJS();
+        return other;
+      }),
+  ).toMatchSnapshot();
+};
+
+test('must be able to move block before other block', () => {
+  assertMoveBlockInContentState('C', 'A', 'before');
+});
+
+test('must be able to move block after other block', () => {
+  assertMoveBlockInContentState('A', 'C', 'after');
+});
+
+test('must be able to move nested block before other block', () => {
+  assertMoveBlockInContentState('C', 'A', 'before', contentBlockNodes);
+});
+
+test('must be able to move block before other nested block', () => {
+  assertMoveBlockInContentState('A', 'C', 'before', contentBlockNodes);
+});
+
+test('must be able to move nested block after other block', () => {
+  assertMoveBlockInContentState('C', 'A', 'after', contentBlockNodes);
+});
+
+test('must be able to move block after other nested block', () => {
+  assertMoveBlockInContentState('A', 'C', 'after', contentBlockNodes);
+});
+
+test('must be able to move block and its children before other block', () => {
+  assertMoveBlockInContentState('B', 'A', 'before', contentBlockNodes);
+});
+
+test('must be able to move block and its children after other block', () => {
+  assertMoveBlockInContentState('D', 'A', 'after', contentBlockNodes);
+});
+
+test('must be able to move block and its children before other nested block', () => {
+  assertMoveBlockInContentState('D', 'C', 'before', contentBlockNodes);
+});
+
+test('must be able to move block and its children after other nested block', () => {
+  assertMoveBlockInContentState('B', 'E', 'after', contentBlockNodes);
+});

--- a/src/model/transaction/moveBlockInContentState.js
+++ b/src/model/transaction/moveBlockInContentState.js
@@ -13,83 +13,272 @@
 
 'use strict';
 
+import type {BlockNodeConfig} from 'BlockNode';
 import type {BlockNodeRecord} from 'BlockNodeRecord';
 import type ContentState from 'ContentState';
 import type {DraftInsertionType} from 'DraftInsertionType';
+import type {BlockMap} from 'BlockMap';
 
+const ContentBlockNode = require('ContentBlockNode');
 const invariant = require('invariant');
 
-function moveBlockInContentState(
+const getNextDelimiterBlockKey = (
+  blockToBeMoved: BlockNodeRecord,
+  blockMap: BlockMap,
+): ?string => {
+  const nextSiblingKey = blockToBeMoved.getNextSiblingKey();
+
+  if (nextSiblingKey) {
+    return nextSiblingKey;
+  }
+
+  const parent = blockToBeMoved.getParentKey();
+
+  if (!parent) {
+    return null;
+  }
+
+  let nextNonDescendantBlock = blockMap.get(parent);
+  while (
+    nextNonDescendantBlock &&
+    (!nextNonDescendantBlock.getNextSiblingKey() ||
+      !nextNonDescendantBlock.getParentKey())
+  ) {
+    nextNonDescendantBlock = blockMap.get(
+      nextNonDescendantBlock.getParentKey(),
+    );
+  }
+
+  if (!nextNonDescendantBlock) {
+    return null;
+  }
+
+  return nextNonDescendantBlock.getNextSiblingKey();
+};
+
+const updateBlockMapLinks = (
+  blockMap: BlockMap,
+  originalBlockToBeMoved: BlockNodeRecord,
+  originalTargetBlock: BlockNodeRecord,
+  insertionMode: DraftInsertionType,
+  isExperimentalTreeBlock: boolean,
+): BlockMap => {
+  if (!isExperimentalTreeBlock) {
+    return blockMap;
+  }
+  // insertionMode can only either be after or before
+  const isInsertedAfterTarget = insertionMode === 'after';
+
+  const originalBlockKey = originalBlockToBeMoved.getKey();
+  const originalTargetKey = originalTargetBlock.getKey();
+  const originialParentKey = originalBlockToBeMoved.getParentKey();
+  const originalNextSiblingKey = originalBlockToBeMoved.getNextSiblingKey();
+  const originalPrevSiblingKey = originalBlockToBeMoved.getPrevSiblingKey();
+  const newParentKey = originalTargetBlock.getParentKey();
+  const newNextSiblingKey = isInsertedAfterTarget
+    ? originalTargetBlock.getNextSiblingKey()
+    : originalTargetKey;
+  const newPrevSiblingKey = isInsertedAfterTarget
+    ? originalTargetKey
+    : originalTargetBlock.getPrevSiblingKey();
+
+  return blockMap.withMutations(blocks => {
+    // update old parent
+    if (originialParentKey) {
+      const originialParentBlock = blocks.get(originialParentKey);
+      const parentChildrenList = originialParentBlock.getChildKeys();
+      blocks.mergeIn(
+        originialParentKey,
+        originialParentBlock.merge({
+          children: parentChildrenList.delete(
+            parentChildrenList.indexOf(originalBlockKey),
+          ),
+        }),
+      );
+    }
+
+    // update old prev
+    if (originalPrevSiblingKey) {
+      const originalPrevSiblingBlock = blocks.get(originalPrevSiblingKey);
+      blocks.mergeIn(
+        originalPrevSiblingKey,
+        originalPrevSiblingBlock.merge({
+          nextSibling: originalBlockToBeMoved.getNextSiblingKey(),
+        }),
+      );
+    }
+
+    // update old next
+    if (originalNextSiblingKey) {
+      const originalNextSiblingBlock = blocks.get(originalNextSiblingKey);
+      blocks.mergeIn(
+        originalNextSiblingKey,
+        originalNextSiblingBlock.merge({
+          prevSibling: originalBlockToBeMoved.getPrevSiblingKey(),
+        }),
+      );
+    }
+
+    // update new next
+    if (newNextSiblingKey) {
+      const newNextSiblingBlock = blocks.get(newNextSiblingKey);
+      blocks.mergeIn(
+        newNextSiblingKey,
+        newNextSiblingBlock.merge({
+          prevSibling: originalBlockKey,
+        }),
+      );
+    }
+
+    // update new prev
+    if (newPrevSiblingKey) {
+      const newPrevSiblingBlock = blocks.get(newPrevSiblingKey);
+      blocks.mergeIn(
+        newPrevSiblingKey,
+        newPrevSiblingBlock.merge({
+          nextSibling: originalBlockKey,
+        }),
+      );
+    }
+
+    // update new parent
+    if (newParentKey) {
+      const newParentBlock = blocks.get(newParentKey);
+      const newParentChildrenList = newParentBlock.getChildKeys();
+      const targetBlockIndex = newParentChildrenList.indexOf(originalTargetKey);
+
+      const insertionIndex = isInsertedAfterTarget
+        ? targetBlockIndex + 1
+        : targetBlockIndex !== 0 ? targetBlockIndex - 1 : 0;
+
+      blocks.mergeIn(
+        newParentKey,
+        newParentBlock.merge({
+          children: newParentChildrenList.insert(
+            insertionIndex,
+            originalBlockKey,
+          ),
+        }),
+      );
+    }
+
+    // update block
+    blocks.mergeIn(
+      originalBlockKey,
+      originalBlockToBeMoved.merge({
+        nextSibling: newNextSiblingKey,
+        prevSibling: newPrevSiblingKey,
+        parent: newParentKey,
+      }),
+    );
+  });
+};
+
+const moveBlockInContentState = (
   contentState: ContentState,
   blockToBeMoved: BlockNodeRecord,
   targetBlock: BlockNodeRecord,
   insertionMode: DraftInsertionType,
-): ContentState {
-  invariant(
-    blockToBeMoved.getKey() !== targetBlock.getKey(),
-    'Block cannot be moved next to itself.',
-  );
-
+): ContentState => {
   invariant(insertionMode !== 'replace', 'Replacing blocks is not supported.');
 
   const targetKey = targetBlock.getKey();
-  const blockBefore = contentState.getBlockBefore(targetKey);
-  const blockAfter = contentState.getBlockAfter(targetKey);
+  const blockKey = blockToBeMoved.getKey();
+
+  invariant(blockKey !== targetKey, 'Block cannot be moved next to itself.');
 
   const blockMap = contentState.getBlockMap();
-  const blockMapWithoutBlockToBeMoved = blockMap.delete(
-    blockToBeMoved.getKey(),
-  );
-  const blocksBefore = blockMapWithoutBlockToBeMoved
+  const isExperimentalTreeBlock = blockToBeMoved instanceof ContentBlockNode;
+
+  let blocksToBeMoved = [blockToBeMoved];
+  let blockMapWithoutBlocksToBeMoved = blockMap.delete(blockKey);
+
+  if (isExperimentalTreeBlock) {
+    blocksToBeMoved = [];
+    blockMapWithoutBlocksToBeMoved = blockMap.withMutations(blocks => {
+      const nextSiblingKey = blockToBeMoved.getNextSiblingKey();
+      const nextDelimiterBlockKey = getNextDelimiterBlockKey(
+        blockToBeMoved,
+        blocks,
+      );
+
+      blocks
+        .toSeq()
+        .skipUntil(block => block.getKey() === blockKey)
+        .takeWhile(block => {
+          const key = block.getKey();
+          const isBlockToBeMoved = key === blockKey;
+          const hasNextSiblingAndIsNotNextSibling =
+            nextSiblingKey && key !== nextSiblingKey;
+          const doesNotHaveNextSiblingAndIsNotDelimiter =
+            !nextSiblingKey &&
+            (!nextDelimiterBlockKey ||
+              block.getKey() !== nextDelimiterBlockKey);
+
+          return (
+            isBlockToBeMoved ||
+            hasNextSiblingAndIsNotNextSibling ||
+            doesNotHaveNextSiblingAndIsNotDelimiter
+          );
+        })
+        .forEach(block => {
+          blocksToBeMoved.push(block);
+          blocks.delete(block.getKey());
+        });
+    });
+  }
+
+  const blocksBefore = blockMapWithoutBlocksToBeMoved
     .toSeq()
     .takeUntil(v => v === targetBlock);
-  const blocksAfter = blockMapWithoutBlockToBeMoved
+
+  const blocksAfter = blockMapWithoutBlocksToBeMoved
     .toSeq()
     .skipUntil(v => v === targetBlock)
     .skip(1);
 
+  const slicedBlocks = blocksToBeMoved.map(block => [block.getKey(), block]);
+
   let newBlocks;
 
   if (insertionMode === 'before') {
+    const blockBefore = contentState.getBlockBefore(targetKey);
+
     invariant(
       !blockBefore || blockBefore.getKey() !== blockToBeMoved.getKey(),
       'Block cannot be moved next to itself.',
     );
 
     newBlocks = blocksBefore
-      .concat(
-        [
-          [blockToBeMoved.getKey(), blockToBeMoved],
-          [targetBlock.getKey(), targetBlock],
-        ],
-        blocksAfter,
-      )
+      .concat([...slicedBlocks, [targetKey, targetBlock]], blocksAfter)
       .toOrderedMap();
   } else if (insertionMode === 'after') {
+    const blockAfter = contentState.getBlockAfter(targetKey);
+
     invariant(
-      !blockAfter || blockAfter.getKey() !== blockToBeMoved.getKey(),
+      !blockAfter || blockAfter.getKey() !== blockKey,
       'Block cannot be moved next to itself.',
     );
 
     newBlocks = blocksBefore
-      .concat(
-        [
-          [targetBlock.getKey(), targetBlock],
-          [blockToBeMoved.getKey(), blockToBeMoved],
-        ],
-        blocksAfter,
-      )
+      .concat([[targetKey, targetBlock], ...slicedBlocks], blocksAfter)
       .toOrderedMap();
   }
 
   return contentState.merge({
-    blockMap: newBlocks,
+    blockMap: updateBlockMapLinks(
+      newBlocks,
+      blockToBeMoved,
+      targetBlock,
+      insertionMode,
+      isExperimentalTreeBlock,
+    ),
     selectionBefore: contentState.getSelectionAfter(),
     selectionAfter: contentState.getSelectionAfter().merge({
-      anchorKey: blockToBeMoved.getKey(),
-      focusKey: blockToBeMoved.getKey(),
+      anchorKey: blockKey,
+      focusKey: blockKey,
     }),
   });
-}
+};
 
 module.exports = moveBlockInContentState;

--- a/src/model/transaction/moveBlockInContentState.js
+++ b/src/model/transaction/moveBlockInContentState.js
@@ -13,7 +13,6 @@
 
 'use strict';
 
-import type {BlockNodeConfig} from 'BlockNode';
 import type {BlockNodeRecord} from 'BlockNodeRecord';
 import type ContentState from 'ContentState';
 import type {DraftInsertionType} from 'DraftInsertionType';
@@ -66,7 +65,7 @@ const updateBlockMapLinks = (
   if (!isExperimentalTreeBlock) {
     return blockMap;
   }
-  // insertionMode can only either be after or before
+  // possible values of 'insertionMode' are: 'after', 'before'
   const isInsertedAfterTarget = insertionMode === 'after';
 
   const originalBlockKey = originalBlockToBeMoved.getKey();
@@ -212,10 +211,10 @@ const moveBlockInContentState = (
             nextSiblingKey && key !== nextSiblingKey;
           const doesNotHaveNextSiblingAndIsNotDelimiter =
             !nextSiblingKey &&
-            (!nextDelimiterBlockKey ||
-              block.getKey() !== nextDelimiterBlockKey);
+            block.getParentKey() &&
+            (!nextDelimiterBlockKey || key !== nextDelimiterBlockKey);
 
-          return (
+          return !!(
             isBlockToBeMoved ||
             hasNextSiblingAndIsNotNextSibling ||
             doesNotHaveNextSiblingAndIsNotDelimiter


### PR DESCRIPTION
### Context

This PR is part of a series of PR's that will be exploring **tree data block support** in Draft.


**Adding support for moving tree blocks**

This PR adds support for moving tree blocks via the moveBlockInContentState transaction.

***

**Note:**
This is unstable and not part of the public API and should not be used by
production systems.
