### PR TITLE
Exploration - Feature tree / Adding support for text into tree nodes

### DIFF
--- a/src/model/paste/DraftPasteProcessor.js
+++ b/src/model/paste/DraftPasteProcessor.js
@@ -68,10 +68,15 @@ const DraftPasteProcessor = {
       if (experimentalTreeDataSupport && index !== 0) {
         const prevSiblingIndex = index - 1;
         // update previous block
-        const previousBlock = acc[prevSiblingIndex] = acc[prevSiblingIndex].merge({
+        const previousBlock = (acc[prevSiblingIndex] = acc[
+          prevSiblingIndex
+        ].merge({
           nextSibling: key,
-        });
-        blockNodeConfig.prevSibling = previousBlock.getKey();
+        }));
+        blockNodeConfig = {
+          ...blockNodeConfig,
+          prevSibling: previousBlock.getKey(),
+        };
       }
 
       acc.push(new ContentBlockRecord(blockNodeConfig));

--- a/src/model/paste/DraftPasteProcessor.js
+++ b/src/model/paste/DraftPasteProcessor.js
@@ -20,6 +20,8 @@ import type {EntityMap} from 'EntityMap';
 
 const CharacterMetadata = require('CharacterMetadata');
 const ContentBlock = require('ContentBlock');
+const ContentBlockNode = require('ContentBlockNode');
+const DraftFeatureFlags = require('DraftFeatureFlags');
 const Immutable = require('immutable');
 
 const convertFromHTMLtoContentBlocks = require('convertFromHTMLToContentBlocks');
@@ -28,6 +30,11 @@ const getSafeBodyFromHTML = require('getSafeBodyFromHTML');
 const sanitizeDraftText = require('sanitizeDraftText');
 
 const {List, Repeat} = Immutable;
+
+const experimentalTreeDataSupport = DraftFeatureFlags.draft_tree_data_support;
+const ContentBlockRecord = experimentalTreeDataSupport
+  ? ContentBlockNode
+  : ContentBlock;
 
 const DraftPasteProcessor = {
   processHTML(
@@ -46,15 +53,31 @@ const DraftPasteProcessor = {
     character: CharacterMetadata,
     type: DraftBlockType,
   ): Array<BlockNodeRecord> {
-    return textBlocks.map(textLine => {
+    return textBlocks.reduce((acc, textLine, index) => {
       textLine = sanitizeDraftText(textLine);
-      return new ContentBlock({
-        key: generateRandomKey(),
+      const key = generateRandomKey();
+
+      let blockNodeConfig = {
+        key,
         type,
         text: textLine,
         characterList: List(Repeat(character, textLine.length)),
-      });
-    });
+      };
+
+      // next block updates previous block
+      if (experimentalTreeDataSupport && index !== 0) {
+        const prevSiblingIndex = index - 1;
+        // update previous block
+        const previousBlock = acc[prevSiblingIndex] = acc[prevSiblingIndex].merge({
+          nextSibling: key,
+        });
+        blockNodeConfig.prevSibling = previousBlock.getKey();
+      }
+
+      acc.push(new ContentBlockRecord(blockNodeConfig));
+
+      return acc;
+    }, []);
   },
 };
 

--- a/src/model/paste/__tests__/DraftPasteProcessor-test.js
+++ b/src/model/paste/__tests__/DraftPasteProcessor-test.js
@@ -19,7 +19,9 @@ jest.mock('generateRandomKey');
 const DraftPasteProcessor = require('DraftPasteProcessor');
 const Immutable = require('immutable');
 
-const CUSTOM_BLOCK_MAP = Immutable.Map({
+const {OrderedSet, Map} = Immutable;
+
+const CUSTOM_BLOCK_MAP = Map({
   'header-one': {
     element: 'h1',
   },
@@ -49,16 +51,35 @@ const CUSTOM_BLOCK_MAP = Immutable.Map({
   },
 });
 
+const EMPTY_CHAR_METADATA = OrderedSet();
+
+const toggleExperimentalTreeDataSupport = enabled => {
+  jest.doMock('DraftFeatureFlags', () => {
+    return {
+      draft_tree_data_support: enabled,
+    };
+  });
+};
+
+const assertDraftPasteProcessorProcessText = (
+  textBlocks,
+  experimentalTreeDataSupport = false,
+) => {
+  toggleExperimentalTreeDataSupport(experimentalTreeDataSupport);
+  const contentBlocks = DraftPasteProcessor.processText(
+    textBlocks,
+    EMPTY_CHAR_METADATA,
+    'unstyled',
+  );
+  expect(contentBlocks.map(block => block.toJS())).toMatchSnapshot();
+};
+
 const assertDraftPasteProcessorProcessHTML = (
   html,
   blockMap = CUSTOM_BLOCK_MAP,
   experimentalTreeDataSupport = false,
 ) => {
-  jest.doMock('DraftFeatureFlags', () => {
-    return {
-      draft_tree_data_support: experimentalTreeDataSupport,
-    };
-  });
+  toggleExperimentalTreeDataSupport(experimentalTreeDataSupport);
   const {contentBlocks} = DraftPasteProcessor.processHTML(html, blockMap);
   expect(contentBlocks.map(block => block.toJS())).toMatchSnapshot();
 };
@@ -314,4 +335,12 @@ test('must create nested elements when experimentalTreeDataSupport is enabled', 
     CUSTOM_BLOCK_MAP,
     true,
   );
+});
+
+test('must create ContentBlocks when experimentalTreeDataSupport is disabled while processing text', () => {
+  assertDraftPasteProcessorProcessText(['Alpha', 'Beta', 'Charlie']);
+});
+
+test('must create ContentBlockNodes when experimentalTreeDataSupport is enabled while processing text', () => {
+  assertDraftPasteProcessorProcessText(['Alpha', 'Beta', 'Charlie'], true);
 });

--- a/src/model/paste/__tests__/__snapshots__/DraftPasteProcessor-test.js.snap
+++ b/src/model/paste/__tests__/__snapshots__/DraftPasteProcessor-test.js.snap
@@ -589,6 +589,114 @@ Array [
 ]
 `;
 
+exports[`must create ContentBlockNodes when experimentalTreeDataSupport is enabled while processing text 1`] = `
+Array [
+  Object {
+    "characterList": Array [
+      Array [],
+      Array [],
+      Array [],
+      Array [],
+      Array [],
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "nextSibling": "key1",
+    "parent": null,
+    "prevSibling": null,
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Array [],
+      Array [],
+      Array [],
+      Array [],
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key1",
+    "nextSibling": "key2",
+    "parent": null,
+    "prevSibling": "key0",
+    "text": "Beta",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Array [],
+      Array [],
+      Array [],
+      Array [],
+      Array [],
+      Array [],
+      Array [],
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key2",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": "key1",
+    "text": "Charlie",
+    "type": "unstyled",
+  },
+]
+`;
+
+exports[`must create ContentBlocks when experimentalTreeDataSupport is disabled while processing text 1`] = `
+Array [
+  Object {
+    "characterList": Array [
+      Array [],
+      Array [],
+      Array [],
+      Array [],
+      Array [],
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Array [],
+      Array [],
+      Array [],
+      Array [],
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key1",
+    "text": "Beta",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Array [],
+      Array [],
+      Array [],
+      Array [],
+      Array [],
+      Array [],
+      Array [],
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key2",
+    "text": "Charlie",
+    "type": "unstyled",
+  },
+]
+`;
+
 exports[`must create nested elements when experimentalTreeDataSupport is enabled 1`] = `
 Array [
   Object {


### PR DESCRIPTION
### Context

This PR is part of a series of PR's that will be exploring **tree data block support** in Draft.


**Adding support for text into tree nodes**

This PR adds support for converting pasted text into tree block nodes

***

**Note:**
This is unstable and not part of the public API and should not be used by
production systems.
