### PR TITLE
Upgrade Flow to 0.60.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eslint-plugin-react": "^7.3.0",
     "eslint-plugin-relay": "^0.0.8",
     "fbjs-scripts": "^0.8.0",
-    "flow-bin": "^0.59.0",
+    "flow-bin": "^0.60.1",
     "gulp": "^3.9.0",
     "gulp-babel": "^6.1.2",
     "gulp-browserify-thin": "^0.1.5",

--- a/src/.flowconfig
+++ b/src/.flowconfig
@@ -27,4 +27,4 @@ suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(2[0-8]\\|1[
 module.name_mapper='ReactDOM' -> 'react-dom'
 
 [version]
-^0.59.0
+^0.60.1


### PR DESCRIPTION
**Summary**

The latest version of Flow doesn't generate any additional Flow errors, so this appears to just require updating the version numbers in `package.json` and `.flowconfig`.

**Test Plan**
  - `npm run flow`
  - Ensure that Flow doesn't output any errors