### PR TITLE
Exploration - Feature tree / Adding support for removing tree nodes ranges from content state

### DIFF
--- a/src/model/transaction/__tests__/__snapshots__/removeRangeFromContentState-test.js.snap
+++ b/src/model/transaction/__tests__/__snapshots__/removeRangeFromContentState-test.js.snap
@@ -1,5 +1,394 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`must preserve B and C since E has not been removed 1`] = `
+Object {
+  "A": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "A",
+    "nextSibling": "B",
+    "parent": null,
+    "prevSibling": null,
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  "B": Object {
+    "characterList": Array [],
+    "children": Array [
+      "C",
+      "F",
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "B",
+    "nextSibling": "G",
+    "parent": null,
+    "prevSibling": "A",
+    "text": "",
+    "type": "unstyled",
+  },
+  "C": Object {
+    "characterList": Array [],
+    "children": Array [
+      "E",
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "C",
+    "nextSibling": "F",
+    "parent": "B",
+    "prevSibling": null,
+    "text": "",
+    "type": "unstyled",
+  },
+  "E": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "E",
+    "nextSibling": null,
+    "parent": "C",
+    "prevSibling": null,
+    "text": "Elephant",
+    "type": "unstyled",
+  },
+  "F": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "F",
+    "nextSibling": null,
+    "parent": "B",
+    "prevSibling": "C",
+    "text": "Fire",
+    "type": "unstyled",
+  },
+  "G": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "G",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": "B",
+    "text": "Gorila",
+    "type": "unstyled",
+  },
+}
+`;
+
+exports[`must remove B and all its children 1`] = `
+Object {
+  "A": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "A",
+    "nextSibling": "G",
+    "parent": null,
+    "prevSibling": null,
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  "G": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "G",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": "A",
+    "text": "Gorila",
+    "type": "unstyled",
+  },
+}
+`;
+
+exports[`must remove E and F entirely when selection is from end of D to end of F on nested blocks 1`] = `
+Object {
+  "A": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "A",
+    "nextSibling": "B",
+    "parent": null,
+    "prevSibling": null,
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  "B": Object {
+    "characterList": Array [],
+    "children": Array [
+      "C",
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "B",
+    "nextSibling": "G",
+    "parent": null,
+    "prevSibling": "A",
+    "text": "",
+    "type": "unstyled",
+  },
+  "C": Object {
+    "characterList": Array [],
+    "children": Array [
+      "D",
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "C",
+    "nextSibling": null,
+    "parent": "B",
+    "prevSibling": null,
+    "text": "",
+    "type": "unstyled",
+  },
+  "D": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "D",
+    "nextSibling": null,
+    "parent": "C",
+    "prevSibling": null,
+    "text": "Delta",
+    "type": "unstyled",
+  },
+  "G": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "G",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": "B",
+    "text": "Gorila",
+    "type": "unstyled",
+  },
+}
+`;
+
 exports[`must remove blocks entirely within the selection 1`] = `
 Object {
   "a": Object {
@@ -1735,6 +2124,124 @@ Object {
     "key": "f",
     "text": "Charlie",
     "type": "blockquote",
+  },
+}
+`;
+
+exports[`must retain B since F has not been removed 1`] = `
+Object {
+  "A": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "A",
+    "nextSibling": "B",
+    "parent": null,
+    "prevSibling": null,
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  "B": Object {
+    "characterList": Array [],
+    "children": Array [
+      "F",
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "B",
+    "nextSibling": "G",
+    "parent": null,
+    "prevSibling": "A",
+    "text": "",
+    "type": "unstyled",
+  },
+  "F": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "F",
+    "nextSibling": null,
+    "parent": "B",
+    "prevSibling": null,
+    "text": "Fire",
+    "type": "unstyled",
+  },
+  "G": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "G",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": "B",
+    "text": "Gorila",
+    "type": "unstyled",
   },
 }
 `;

--- a/src/model/transaction/__tests__/removeRangeFromContentState-test.js
+++ b/src/model/transaction/__tests__/removeRangeFromContentState-test.js
@@ -14,14 +14,71 @@
 
 jest.disableAutomock();
 
+const ContentBlockNode = require('ContentBlockNode');
+const BlockMapBuilder = require('BlockMapBuilder');
+const SelectionState = require('SelectionState');
 const getSampleStateForTesting = require('getSampleStateForTesting');
 const removeRangeFromContentState = require('removeRangeFromContentState');
+const Immutable = require('immutable');
+
+const {List} = Immutable;
 
 const {contentState, selectionState} = getSampleStateForTesting();
 
-const assertRemoveRangeFromContentState = selection => {
+const contentBlockNodes = [
+  new ContentBlockNode({
+    key: 'A',
+    nextSibling: 'B',
+    text: 'Alpha',
+  }),
+  new ContentBlockNode({
+    key: 'B',
+    prevSibling: 'A',
+    nextSibling: 'G',
+    children: List(['C', 'F']),
+  }),
+  new ContentBlockNode({
+    parent: 'B',
+    key: 'C',
+    nextSibling: 'F',
+    children: List(['D', 'E']),
+  }),
+  new ContentBlockNode({
+    parent: 'C',
+    key: 'D',
+    nextSibling: 'E',
+    text: 'Delta',
+  }),
+  new ContentBlockNode({
+    parent: 'C',
+    key: 'E',
+    prevSibling: 'D',
+    text: 'Elephant',
+  }),
+  new ContentBlockNode({
+    parent: 'B',
+    key: 'F',
+    prevSibling: 'C',
+    text: 'Fire',
+  }),
+  new ContentBlockNode({
+    key: 'G',
+    prevSibling: 'B',
+    text: 'Gorila',
+  }),
+];
+const treeSelectionState = SelectionState.createEmpty('A');
+const treeContentState = contentState.set(
+  'blockMap',
+  BlockMapBuilder.createFromArray(contentBlockNodes),
+);
+
+const assertRemoveRangeFromContentState = (
+  selection,
+  content = contentState,
+) => {
   expect(
-    removeRangeFromContentState(contentState, selection)
+    removeRangeFromContentState(content, selection)
       .getBlockMap()
       .toJS(),
   ).toMatchSnapshot();
@@ -153,5 +210,53 @@ test('must remove blocks entirely within the selection', () => {
       focusKey: 'c',
       focusOffset: 3,
     }),
+  );
+});
+
+test('must remove E and F entirely when selection is from end of D to end of F on nested blocks', () => {
+  assertRemoveRangeFromContentState(
+    treeSelectionState.merge({
+      anchorKey: 'D',
+      focusKey: 'F',
+      anchorOffset: contentBlockNodes[3].getLength(),
+      focusOffset: contentBlockNodes[5].getLength(),
+    }),
+    treeContentState,
+  );
+});
+
+test('must preserve B and C since E has not been removed', () => {
+  assertRemoveRangeFromContentState(
+    treeSelectionState.merge({
+      anchorKey: 'A',
+      focusKey: 'D',
+      anchorOffset: contentBlockNodes[0].getLength(),
+      focusOffset: contentBlockNodes[3].getLength(),
+    }),
+    treeContentState,
+  );
+});
+
+test('must remove B and all its children', () => {
+  assertRemoveRangeFromContentState(
+    treeSelectionState.merge({
+      anchorKey: 'A',
+      focusKey: 'F',
+      anchorOffset: contentBlockNodes[0].getLength(),
+      focusOffset: contentBlockNodes[5].getLength(),
+    }),
+    treeContentState,
+  );
+});
+
+test('must retain B since F has not been removed', () => {
+  assertRemoveRangeFromContentState(
+    treeSelectionState.merge({
+      anchorKey: 'A',
+      focusKey: 'E',
+      anchorOffset: contentBlockNodes[0].getLength(),
+      focusOffset: contentBlockNodes[4].getLength(),
+    }),
+    treeContentState,
   );
 });

--- a/src/model/transaction/exploration/__tests__/__snapshots__/getNextDelimiterBlockKey-test.js.snap
+++ b/src/model/transaction/exploration/__tests__/__snapshots__/getNextDelimiterBlockKey-test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`must find its next delimiter when block does not have siblings 1`] = `"D"`;
+
+exports[`must find its next sibling when has siblings 1`] = `"F"`;
+
+exports[`must return null when block is ContentBlock 1`] = `null`;
+
+exports[`must return null when block is the last block 1`] = `null`;
+
+exports[`must return null when only blocks after it are its own descendants 1`] = `null`;

--- a/src/model/transaction/exploration/__tests__/getNextDelimiterBlockKey-test.js
+++ b/src/model/transaction/exploration/__tests__/getNextDelimiterBlockKey-test.js
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+ui_infra
+ * @format
+ */
+
+'use strict';
+
+jest.disableAutomock();
+
+jest.mock('generateRandomKey');
+
+const ContentBlock = require('ContentBlock');
+const ContentBlockNode = require('ContentBlockNode');
+const ContentState = require('ContentState');
+const EditorState = require('EditorState');
+const Immutable = require('immutable');
+
+const getNextDelimiterBlockKey = require('getNextDelimiterBlockKey');
+
+const {List} = Immutable;
+
+const contentBlocks = [
+  new ContentBlock({
+    key: 'A',
+    text: 'Alpha',
+  }),
+  new ContentBlock({
+    key: 'B',
+    text: 'Beta',
+  }),
+  new ContentBlock({
+    key: 'C',
+    text: 'Charlie',
+  }),
+];
+
+const contentBlockNodes = [
+  new ContentBlockNode({
+    key: 'A',
+    text: 'Alpha',
+    nextSibling: 'B',
+  }),
+  new ContentBlockNode({
+    key: 'B',
+    text: '',
+    children: List(['C']),
+    nextSibling: 'D',
+    prevSibling: 'A',
+  }),
+  new ContentBlockNode({
+    key: 'C',
+    parent: 'B',
+    text: 'Charlie',
+  }),
+  new ContentBlockNode({
+    key: 'D',
+    text: '',
+    prevSibling: 'B',
+    children: List(['E', 'F']),
+  }),
+  new ContentBlockNode({
+    key: 'E',
+    parent: 'D',
+    nextSibling: 'F',
+    text: 'Elephant',
+  }),
+  new ContentBlockNode({
+    key: 'F',
+    parent: 'D',
+    prevSibling: 'E',
+    text: 'Fire',
+  }),
+];
+
+const assertGetNextDelimiterBlockKey = (
+  targetBlockKey,
+  blocksArray = contentBlockNodes,
+) => {
+  const editor = EditorState.createWithContent(
+    ContentState.createFromBlockArray(blocksArray),
+  );
+  const contentState = editor.getCurrentContent();
+  const targetBlock = contentState.getBlockForKey(targetBlockKey);
+
+  expect(
+    getNextDelimiterBlockKey(targetBlock, contentState.getBlockMap()),
+  ).toMatchSnapshot();
+};
+
+test('must return null when block is ContentBlock', () => {
+  assertGetNextDelimiterBlockKey('A', contentBlocks);
+});
+
+test('must return null when only blocks after it are its own descendants', () => {
+  assertGetNextDelimiterBlockKey('D');
+});
+
+test('must return null when block is the last block', () => {
+  assertGetNextDelimiterBlockKey('F');
+});
+
+test('must find its next sibling when has siblings', () => {
+  assertGetNextDelimiterBlockKey('E');
+});
+
+test('must find its next delimiter when block does not have siblings', () => {
+  assertGetNextDelimiterBlockKey('C');
+});

--- a/src/model/transaction/exploration/getNextDelimiterBlockKey.js
+++ b/src/model/transaction/exploration/getNextDelimiterBlockKey.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule getNextDelimiterBlockKey
+ * @format
+ * @flow
+ *
+ * This is unstable and not part of the public API and should not be used by
+ * production systems. This file may be update/removed without notice.
+ */
+
+import type {BlockMap} from 'BlockMap';
+import type {BlockNodeRecord} from 'BlockNodeRecord';
+
+const ContentBlockNode = require('ContentBlockNode');
+
+const getNextDelimiterBlockKey = (
+  block: BlockNodeRecord,
+  blockMap: BlockMap,
+): ?string => {
+  const isExperimentalTreeBlock = block instanceof ContentBlockNode;
+
+  if (!isExperimentalTreeBlock) {
+    return null;
+  }
+
+  const nextSiblingKey = block.getNextSiblingKey();
+
+  if (nextSiblingKey) {
+    return nextSiblingKey;
+  }
+
+  const parent = block.getParentKey();
+
+  if (!parent) {
+    return null;
+  }
+
+  let nextNonDescendantBlock = blockMap.get(parent);
+  while (
+    nextNonDescendantBlock &&
+    !nextNonDescendantBlock.getNextSiblingKey()
+  ) {
+    const parentKey = nextNonDescendantBlock.getParentKey();
+    nextNonDescendantBlock = parentKey ? blockMap.get(parentKey) : null;
+  }
+
+  if (!nextNonDescendantBlock) {
+    return null;
+  }
+
+  return nextNonDescendantBlock.getNextSiblingKey();
+};
+
+module.exports = getNextDelimiterBlockKey;

--- a/src/model/transaction/moveBlockInContentState.js
+++ b/src/model/transaction/moveBlockInContentState.js
@@ -21,42 +21,10 @@ import type {DraftInsertionType} from 'DraftInsertionType';
 const ContentBlockNode = require('ContentBlockNode');
 const Immutable = require('immutable');
 
+const getNextDelimiterBlockKey = require('getNextDelimiterBlockKey');
 const invariant = require('invariant');
 
 const {OrderedMap, List} = Immutable;
-
-const getNextDelimiterBlockKey = (
-  blockToBeMoved: BlockNodeRecord,
-  blockMap: BlockMap,
-): ?string => {
-  const nextSiblingKey = blockToBeMoved.getNextSiblingKey();
-
-  if (nextSiblingKey) {
-    return nextSiblingKey;
-  }
-
-  const parent = blockToBeMoved.getParentKey();
-
-  if (!parent) {
-    return null;
-  }
-
-  let nextNonDescendantBlock = blockMap.get(parent);
-  while (
-    nextNonDescendantBlock &&
-    (!nextNonDescendantBlock.getNextSiblingKey() ||
-      !nextNonDescendantBlock.getParentKey())
-  ) {
-    const parentKey = nextNonDescendantBlock.getParentKey();
-    nextNonDescendantBlock = parentKey ? blockMap.get(parentKey) : null;
-  }
-
-  if (!nextNonDescendantBlock) {
-    return null;
-  }
-
-  return nextNonDescendantBlock.getNextSiblingKey();
-};
 
 const updateBlockMapLinks = (
   blockMap: BlockMap,

--- a/src/model/transaction/removeRangeFromContentState.js
+++ b/src/model/transaction/removeRangeFromContentState.js
@@ -298,7 +298,7 @@ const removeRangeFromContentState = (
     .toSeq()
     .skipUntil((_, k) => k === startKey)
     .takeUntil((_, k) => k === endKey)
-    .filterNot((_, k) => parentAncestors.indexOf(k) !== -1)
+    .filter((_, k) => parentAncestors.indexOf(k) === -1)
     .concat(Map([[endKey, null]]))
     .map((_, k) => {
       return k === startKey ? modifiedStart : null;

--- a/src/model/transaction/removeRangeFromContentState.js
+++ b/src/model/transaction/removeRangeFromContentState.js
@@ -13,30 +13,266 @@
 
 'use strict';
 
+import type {BlockMap} from 'BlockMap';
 import type CharacterMetadata from 'CharacterMetadata';
 import type ContentState from 'ContentState';
 import type SelectionState from 'SelectionState';
-import type {List} from 'immutable';
 
-var Immutable = require('immutable');
+const ContentBlockNode = require('ContentBlockNode');
+const Immutable = require('immutable');
 
-function removeRangeFromContentState(
+const getNextDelimiterBlockKey = require('getNextDelimiterBlockKey');
+
+const {List, Map} = Immutable;
+
+const transformBlock = (
+  key: ?string,
+  blockMap: BlockMap,
+  func: (block: ContentBlockNode) => void,
+): void => {
+  if (!key) {
+    return;
+  }
+
+  const block = blockMap.get(key);
+
+  if (!block) {
+    return;
+  }
+
+  blockMap.set(key, func(block));
+};
+
+/**
+ * Ancestors needs to be preserved when there are non selected
+ * children to make sure we do not leave any orphans behind
+ */
+const getAncestorsKeys = (
+  blockKey: ?string,
+  blockMap: BlockMap,
+): Array<string> => {
+  const parents = [];
+
+  if (!blockKey) {
+    return parents;
+  }
+
+  let blockNode = blockMap.get(blockKey);
+  while (blockNode && blockNode.getParentKey()) {
+    const parentKey = blockNode.getParentKey();
+    parents.push(parentKey);
+    blockNode = blockMap.get(parentKey);
+  }
+
+  return parents;
+};
+
+/**
+ * Get all next delimiter keys until we hit a root delimiter and return
+ * an array of key references
+ */
+const getNextDelimitersBlockKeys = (
+  block: ContentBlockNode,
+  blockMap: BlockMap,
+): Array<string> => {
+  const nextDelimiters = [];
+
+  if (!block) {
+    return nextDelimiters;
+  }
+
+  let nextDelimiter = getNextDelimiterBlockKey(block, blockMap);
+  while (nextDelimiter && blockMap.get(nextDelimiter)) {
+    const block = blockMap.get(nextDelimiter);
+    nextDelimiters.push(nextDelimiter);
+
+    // we do not need to keep checking all root node siblings, just the first occurance
+    nextDelimiter = block.getParentKey()
+      ? getNextDelimiterBlockKey(block, blockMap)
+      : null;
+  }
+
+  return nextDelimiters;
+};
+
+const getNextValidSibling = (
+  block: ?ContentBlockNode,
+  blockMap: BlockMap,
+  originalBlockMap: BlockMap,
+): ?string => {
+  if (!block) {
+    return null;
+  }
+
+  // note that we need to make sure we refer to the original block since this
+  // function is called within a withMutations
+  let nextValidSiblingKey = originalBlockMap
+    .get(block.getKey())
+    .getNextSiblingKey();
+
+  while (nextValidSiblingKey && !blockMap.get(nextValidSiblingKey)) {
+    nextValidSiblingKey =
+      originalBlockMap.get(nextValidSiblingKey).getNextSiblingKey() || null;
+  }
+
+  return nextValidSiblingKey;
+};
+
+const getPrevValidSibling = (
+  block: ?ContentBlockNode,
+  blockMap: BlockMap,
+  originalBlockMap: BlockMap,
+): ?string => {
+  if (!block) {
+    return null;
+  }
+
+  // note that we need to make sure we refer to the original block since this
+  // function is called within a withMutations
+  let prevValidSiblingKey = originalBlockMap
+    .get(block.getKey())
+    .getPrevSiblingKey();
+
+  while (prevValidSiblingKey && !blockMap.get(prevValidSiblingKey)) {
+    prevValidSiblingKey =
+      originalBlockMap.get(prevValidSiblingKey).getPrevSiblingKey() || null;
+  }
+
+  return prevValidSiblingKey;
+};
+
+const updateBlockMapLinks = (
+  blockMap: BlockMap,
+  startBlock: ContentBlockNode,
+  endBlock: ContentBlockNode,
+  originalBlockMap: BlockMap,
+): BlockMap => {
+  return blockMap.withMutations(blocks => {
+    // update start block if its retained
+    transformBlock(startBlock.getKey(), blocks, block =>
+      block.merge({
+        nextSibling: getNextValidSibling(startBlock, blocks, originalBlockMap),
+        prevSibling: getPrevValidSibling(startBlock, blocks, originalBlockMap),
+      }),
+    );
+
+    // update endblock if its retained
+    transformBlock(endBlock.getKey(), blocks, block =>
+      block.merge({
+        nextSibling: getNextValidSibling(endBlock, blocks, originalBlockMap),
+        prevSibling: getPrevValidSibling(endBlock, blocks, originalBlockMap),
+      }),
+    );
+
+    // update start block parent ancestors
+    getAncestorsKeys(startBlock.getKey(), originalBlockMap).forEach(parentKey =>
+      transformBlock(parentKey, blocks, block =>
+        block.merge({
+          children: block.getChildKeys().filter(key => blocks.get(key)),
+          nextSibling: getNextValidSibling(block, blocks, originalBlockMap),
+          prevSibling: getPrevValidSibling(block, blocks, originalBlockMap),
+        }),
+      ),
+    );
+
+    // update start block next - can only happen if startBlock == endBlock
+    transformBlock(startBlock.getNextSiblingKey(), blocks, block =>
+      block.merge({
+        prevSibling: startBlock.getPrevSiblingKey(),
+      }),
+    );
+
+    // update start block prev
+    transformBlock(startBlock.getPrevSiblingKey(), blocks, block =>
+      block.merge({
+        nextSibling: getNextValidSibling(startBlock, blocks, originalBlockMap),
+      }),
+    );
+
+    // update end block next
+    transformBlock(endBlock.getNextSiblingKey(), blocks, block =>
+      block.merge({
+        prevSibling: getPrevValidSibling(endBlock, blocks, originalBlockMap),
+      }),
+    );
+
+    // update end block prev
+    transformBlock(endBlock.getPrevSiblingKey(), blocks, block =>
+      block.merge({
+        nextSibling: endBlock.getNextSiblingKey(),
+      }),
+    );
+
+    // update end block parent ancestors
+    getAncestorsKeys(endBlock.getKey(), originalBlockMap).forEach(parentKey => {
+      transformBlock(parentKey, blocks, block =>
+        block.merge({
+          children: block.getChildKeys().filter(key => blocks.get(key)),
+          nextSibling: getNextValidSibling(block, blocks, originalBlockMap),
+          prevSibling: getPrevValidSibling(block, blocks, originalBlockMap),
+        }),
+      );
+    });
+
+    // update next delimiters all the way to a root delimiter
+    getNextDelimitersBlockKeys(endBlock, originalBlockMap).forEach(
+      delimiterKey =>
+        transformBlock(delimiterKey, blocks, block =>
+          block.merge({
+            nextSibling: getNextValidSibling(block, blocks, originalBlockMap),
+            prevSibling: getPrevValidSibling(block, blocks, originalBlockMap),
+          }),
+        ),
+    );
+  });
+};
+
+const removeRangeFromContentState = (
   contentState: ContentState,
   selectionState: SelectionState,
-): ContentState {
+): ContentState => {
   if (selectionState.isCollapsed()) {
     return contentState;
   }
 
-  var blockMap = contentState.getBlockMap();
-  var startKey = selectionState.getStartKey();
-  var startOffset = selectionState.getStartOffset();
-  var endKey = selectionState.getEndKey();
-  var endOffset = selectionState.getEndOffset();
+  const blockMap = contentState.getBlockMap();
+  const startKey = selectionState.getStartKey();
+  const startOffset = selectionState.getStartOffset();
+  const endKey = selectionState.getEndKey();
+  const endOffset = selectionState.getEndOffset();
 
-  var startBlock = blockMap.get(startKey);
-  var endBlock = blockMap.get(endKey);
-  var characterList;
+  const startBlock = blockMap.get(startKey);
+  const endBlock = blockMap.get(endKey);
+
+  // we assume that ContentBlockNode and ContentBlocks are not mixed together
+  const isExperimentalTreeBlock = startBlock instanceof ContentBlockNode;
+
+  // used to retain blocks that should not be deleted to avoid orphan children
+  let parentAncestors = [];
+
+  if (isExperimentalTreeBlock) {
+    const endBlockchildrenKeys = endBlock.getChildKeys();
+    const endBlockAncestors = getAncestorsKeys(endKey, blockMap);
+
+    // endBlock has unselected sibblings so we can not remove its ancestors parents
+    if (endBlock.getNextSiblingKey()) {
+      parentAncestors = parentAncestors.concat(endBlockAncestors);
+    }
+
+    // endBlock has children so can not remove this block or any of its ancestors
+    if (!endBlockchildrenKeys.isEmpty()) {
+      parentAncestors = parentAncestors.concat(
+        endBlockAncestors.concat([endKey]),
+      );
+    }
+
+    // we need to retain all ancestors of the next delimiter block
+    parentAncestors = parentAncestors.concat(
+      getAncestorsKeys(getNextDelimiterBlockKey(endBlock, blockMap), blockMap),
+    );
+  }
+
+  let characterList;
 
   if (startBlock === endBlock) {
     characterList = removeFromList(
@@ -51,26 +287,36 @@ function removeRangeFromContentState(
       .concat(endBlock.getCharacterList().slice(endOffset));
   }
 
-  var modifiedStart = startBlock.merge({
+  const modifiedStart = startBlock.merge({
     text:
       startBlock.getText().slice(0, startOffset) +
       endBlock.getText().slice(endOffset),
     characterList,
   });
 
-  var newBlocks = blockMap
+  const newBlocks = blockMap
     .toSeq()
     .skipUntil((_, k) => k === startKey)
     .takeUntil((_, k) => k === endKey)
-    .concat(Immutable.Map([[endKey, null]]))
+    .filterNot((_, k) => parentAncestors.indexOf(k) !== -1)
+    .concat(Map([[endKey, null]]))
     .map((_, k) => {
       return k === startKey ? modifiedStart : null;
     });
 
-  blockMap = blockMap.merge(newBlocks).filter(block => !!block);
+  let updatedBlockMap = blockMap.merge(newBlocks).filter(block => !!block);
+
+  if (isExperimentalTreeBlock) {
+    updatedBlockMap = updateBlockMapLinks(
+      updatedBlockMap,
+      startBlock,
+      endBlock,
+      blockMap,
+    );
+  }
 
   return contentState.merge({
-    blockMap,
+    blockMap: updatedBlockMap,
     selectionBefore: selectionState,
     selectionAfter: selectionState.merge({
       anchorKey: startKey,
@@ -80,17 +326,17 @@ function removeRangeFromContentState(
       isBackward: false,
     }),
   });
-}
+};
 
 /**
  * Maintain persistence for target list when removing characters on the
  * head and tail of the character list.
  */
-function removeFromList(
+const removeFromList = (
   targetList: List<CharacterMetadata>,
   startOffset: number,
   endOffset: number,
-): List<CharacterMetadata> {
+): List<CharacterMetadata> => {
   if (startOffset === 0) {
     while (startOffset < endOffset) {
       targetList = targetList.shift();
@@ -102,11 +348,11 @@ function removeFromList(
       endOffset--;
     }
   } else {
-    var head = targetList.slice(0, startOffset);
-    var tail = targetList.slice(endOffset);
+    const head = targetList.slice(0, startOffset);
+    const tail = targetList.slice(endOffset);
     targetList = head.concat(tail).toList();
   }
   return targetList;
-}
+};
 
 module.exports = removeRangeFromContentState;


### PR DESCRIPTION

### Context

This PR is part of a series of PR's that will be exploring **tree data block support** in Draft.


**Adding support for removing content state**

This PR adds support for removing range transactions for ContentBlockNodes 

***

**Note:**
This is unstable and not part of the public API and should not be used by
production systems.
