### PR TITLE
Exploration - Feature tree / Adding support for splitting transactions

### DIFF
--- a/src/model/transaction/__tests__/__snapshots__/splitBlockInContentState-test.js.snap
+++ b/src/model/transaction/__tests__/__snapshots__/splitBlockInContentState-test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`must split at the beginning of a block 1`] = `
-Object {
-  "a": Object {
+Array [
+  Object {
     "characterList": Array [],
     "data": Object {},
     "depth": 0,
@@ -10,138 +10,7 @@ Object {
     "text": "",
     "type": "unstyled",
   },
-  "b": Object {
-    "characterList": Array [
-      Object {
-        "entity": "1",
-        "style": Array [
-          "BOLD",
-        ],
-      },
-      Object {
-        "entity": "1",
-        "style": Array [
-          "BOLD",
-        ],
-      },
-      Object {
-        "entity": "1",
-        "style": Array [
-          "BOLD",
-        ],
-      },
-      Object {
-        "entity": "1",
-        "style": Array [
-          "BOLD",
-        ],
-      },
-      Object {
-        "entity": "1",
-        "style": Array [
-          "BOLD",
-        ],
-      },
-    ],
-    "data": Object {},
-    "depth": 0,
-    "key": "b",
-    "text": "Bravo",
-    "type": "unordered-list-item",
-  },
-  "c": Object {
-    "characterList": Array [
-      Object {
-        "entity": null,
-        "style": Array [],
-      },
-      Object {
-        "entity": null,
-        "style": Array [],
-      },
-      Object {
-        "entity": null,
-        "style": Array [],
-      },
-      Object {
-        "entity": null,
-        "style": Array [],
-      },
-    ],
-    "data": Object {},
-    "depth": 0,
-    "key": "c",
-    "text": "Test",
-    "type": "code-block",
-  },
-  "d": Object {
-    "characterList": Array [],
-    "data": Object {},
-    "depth": 0,
-    "key": "d",
-    "text": "",
-    "type": "code-block",
-  },
-  "e": Object {
-    "characterList": Array [],
-    "data": Object {},
-    "depth": 0,
-    "key": "e",
-    "text": "",
-    "type": "code-block",
-  },
-  "f": Object {
-    "characterList": Array [
-      Object {
-        "entity": null,
-        "style": Array [
-          "ITALIC",
-        ],
-      },
-      Object {
-        "entity": null,
-        "style": Array [
-          "ITALIC",
-        ],
-      },
-      Object {
-        "entity": null,
-        "style": Array [
-          "ITALIC",
-        ],
-      },
-      Object {
-        "entity": null,
-        "style": Array [
-          "ITALIC",
-        ],
-      },
-      Object {
-        "entity": null,
-        "style": Array [
-          "ITALIC",
-        ],
-      },
-      Object {
-        "entity": null,
-        "style": Array [
-          "ITALIC",
-        ],
-      },
-      Object {
-        "entity": null,
-        "style": Array [
-          "ITALIC",
-        ],
-      },
-    ],
-    "data": Object {},
-    "depth": 0,
-    "key": "f",
-    "text": "Charlie",
-    "type": "blockquote",
-  },
-  "key1": Object {
+  Object {
     "characterList": Array [
       Object {
         "entity": null,
@@ -170,12 +39,592 @@ Object {
     "text": "Alpha",
     "type": "unstyled",
   },
-}
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
+`;
+
+exports[`must split at the beginning of a nested ContentBlock 1`] = `
+Array [
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "A",
+    "nextSibling": "B",
+    "parent": null,
+    "prevSibling": null,
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [],
+    "children": Array [
+      "C",
+      "F",
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "B",
+    "nextSibling": "G",
+    "parent": null,
+    "prevSibling": "A",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [],
+    "children": Array [
+      "D",
+      "key7",
+      "E",
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "C",
+    "nextSibling": "F",
+    "parent": "B",
+    "prevSibling": null,
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "D",
+    "nextSibling": "key7",
+    "parent": "C",
+    "prevSibling": null,
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key7",
+    "nextSibling": "E",
+    "parent": "C",
+    "prevSibling": "D",
+    "text": "Delta",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "E",
+    "nextSibling": null,
+    "parent": "C",
+    "prevSibling": "key7",
+    "text": "Elephant",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "F",
+    "nextSibling": null,
+    "parent": "B",
+    "prevSibling": "C",
+    "text": "Fire",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "G",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": "B",
+    "text": "Gorila",
+    "type": "unstyled",
+  },
+]
+`;
+
+exports[`must split at the beginning of a root ContentBlock 1`] = `
+Array [
+  Object {
+    "characterList": Array [],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "A",
+    "nextSibling": "key6",
+    "parent": null,
+    "prevSibling": null,
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key6",
+    "nextSibling": "B",
+    "parent": null,
+    "prevSibling": "A",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [],
+    "children": Array [
+      "C",
+      "F",
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "B",
+    "nextSibling": "G",
+    "parent": null,
+    "prevSibling": "key6",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [],
+    "children": Array [
+      "D",
+      "E",
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "C",
+    "nextSibling": "F",
+    "parent": "B",
+    "prevSibling": null,
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "D",
+    "nextSibling": "E",
+    "parent": "C",
+    "prevSibling": null,
+    "text": "Delta",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "E",
+    "nextSibling": null,
+    "parent": "C",
+    "prevSibling": "D",
+    "text": "Elephant",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "F",
+    "nextSibling": null,
+    "parent": "B",
+    "prevSibling": "C",
+    "text": "Fire",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "G",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": "B",
+    "text": "Gorila",
+    "type": "unstyled",
+  },
+]
 `;
 
 exports[`must split at the end of a block 1`] = `
-Object {
-  "a": Object {
+Array [
+  Object {
     "characterList": Array [
       Object {
         "entity": null,
@@ -204,7 +653,15 @@ Object {
     "text": "Alpha",
     "type": "unstyled",
   },
-  "b": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key3",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
     "characterList": Array [
       Object {
         "entity": "1",
@@ -243,7 +700,7 @@ Object {
     "text": "Bravo",
     "type": "unordered-list-item",
   },
-  "c": Object {
+  Object {
     "characterList": Array [
       Object {
         "entity": null,
@@ -268,7 +725,7 @@ Object {
     "text": "Test",
     "type": "code-block",
   },
-  "d": Object {
+  Object {
     "characterList": Array [],
     "data": Object {},
     "depth": 0,
@@ -276,7 +733,7 @@ Object {
     "text": "",
     "type": "code-block",
   },
-  "e": Object {
+  Object {
     "characterList": Array [],
     "data": Object {},
     "depth": 0,
@@ -284,7 +741,7 @@ Object {
     "text": "",
     "type": "code-block",
   },
-  "f": Object {
+  Object {
     "characterList": Array [
       Object {
         "entity": null,
@@ -335,20 +792,461 @@ Object {
     "text": "Charlie",
     "type": "blockquote",
   },
-  "key3": Object {
-    "characterList": Array [],
+]
+`;
+
+exports[`must split at the end of a nested ContentBlock 1`] = `
+Array [
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
     "data": Object {},
     "depth": 0,
-    "key": "key3",
+    "key": "A",
+    "nextSibling": "B",
+    "parent": null,
+    "prevSibling": null,
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [],
+    "children": Array [
+      "C",
+      "F",
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "B",
+    "nextSibling": "G",
+    "parent": null,
+    "prevSibling": "A",
     "text": "",
     "type": "unstyled",
   },
-}
+  Object {
+    "characterList": Array [],
+    "children": Array [
+      "D",
+      "key11",
+      "E",
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "C",
+    "nextSibling": "F",
+    "parent": "B",
+    "prevSibling": null,
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "D",
+    "nextSibling": "key11",
+    "parent": "C",
+    "prevSibling": null,
+    "text": "Delta",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key11",
+    "nextSibling": "E",
+    "parent": "C",
+    "prevSibling": "D",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "E",
+    "nextSibling": null,
+    "parent": "C",
+    "prevSibling": "key11",
+    "text": "Elephant",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "F",
+    "nextSibling": null,
+    "parent": "B",
+    "prevSibling": "C",
+    "text": "Fire",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "G",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": "B",
+    "text": "Gorila",
+    "type": "unstyled",
+  },
+]
+`;
+
+exports[`must split at the end of a root ContentBlock 1`] = `
+Array [
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "A",
+    "nextSibling": "key10",
+    "parent": null,
+    "prevSibling": null,
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key10",
+    "nextSibling": "B",
+    "parent": null,
+    "prevSibling": "A",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [],
+    "children": Array [
+      "C",
+      "F",
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "B",
+    "nextSibling": "G",
+    "parent": null,
+    "prevSibling": "key10",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [],
+    "children": Array [
+      "D",
+      "E",
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "C",
+    "nextSibling": "F",
+    "parent": "B",
+    "prevSibling": null,
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "D",
+    "nextSibling": "E",
+    "parent": "C",
+    "prevSibling": null,
+    "text": "Delta",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "E",
+    "nextSibling": null,
+    "parent": "C",
+    "prevSibling": "D",
+    "text": "Elephant",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "F",
+    "nextSibling": null,
+    "parent": "B",
+    "prevSibling": "C",
+    "text": "Fire",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "G",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": "B",
+    "text": "Gorila",
+    "type": "unstyled",
+  },
+]
 `;
 
 exports[`must split within a block 1`] = `
-Object {
-  "a": Object {
+Array [
+  Object {
     "characterList": Array [
       Object {
         "entity": null,
@@ -369,7 +1267,24 @@ Object {
     "text": "Alp",
     "type": "unstyled",
   },
-  "b": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key2",
+    "text": "ha",
+    "type": "unstyled",
+  },
+  Object {
     "characterList": Array [
       Object {
         "entity": "1",
@@ -408,7 +1323,7 @@ Object {
     "text": "Bravo",
     "type": "unordered-list-item",
   },
-  "c": Object {
+  Object {
     "characterList": Array [
       Object {
         "entity": null,
@@ -433,7 +1348,7 @@ Object {
     "text": "Test",
     "type": "code-block",
   },
-  "d": Object {
+  Object {
     "characterList": Array [],
     "data": Object {},
     "depth": 0,
@@ -441,7 +1356,7 @@ Object {
     "text": "",
     "type": "code-block",
   },
-  "e": Object {
+  Object {
     "characterList": Array [],
     "data": Object {},
     "depth": 0,
@@ -449,7 +1364,7 @@ Object {
     "text": "",
     "type": "code-block",
   },
-  "f": Object {
+  Object {
     "characterList": Array [
       Object {
         "entity": null,
@@ -500,7 +1415,263 @@ Object {
     "text": "Charlie",
     "type": "blockquote",
   },
-  "key2": Object {
+]
+`;
+
+exports[`must split within a nested ContentBlock 1`] = `
+Array [
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "A",
+    "nextSibling": "B",
+    "parent": null,
+    "prevSibling": null,
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [],
+    "children": Array [
+      "C",
+      "F",
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "B",
+    "nextSibling": "G",
+    "parent": null,
+    "prevSibling": "A",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [],
+    "children": Array [
+      "D",
+      "E",
+      "key9",
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "C",
+    "nextSibling": "F",
+    "parent": "B",
+    "prevSibling": null,
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "D",
+    "nextSibling": "E",
+    "parent": "C",
+    "prevSibling": null,
+    "text": "Delta",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "E",
+    "nextSibling": "key9",
+    "parent": "C",
+    "prevSibling": "D",
+    "text": "Ele",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key9",
+    "nextSibling": null,
+    "parent": "C",
+    "prevSibling": "E",
+    "text": "phant",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "F",
+    "nextSibling": null,
+    "parent": "B",
+    "prevSibling": "C",
+    "text": "Fire",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "G",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": "B",
+    "text": "Gorila",
+    "type": "unstyled",
+  },
+]
+`;
+
+exports[`must split within a root ContentBlock 1`] = `
+Array [
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "A",
+    "nextSibling": "key8",
+    "parent": null,
+    "prevSibling": null,
+    "text": "Alp",
+    "type": "unstyled",
+  },
+  Object {
     "characterList": Array [
       Object {
         "entity": null,
@@ -511,11 +1682,189 @@ Object {
         "style": Array [],
       },
     ],
+    "children": Array [],
     "data": Object {},
     "depth": 0,
-    "key": "key2",
+    "key": "key8",
+    "nextSibling": "B",
+    "parent": null,
+    "prevSibling": "A",
     "text": "ha",
     "type": "unstyled",
   },
-}
+  Object {
+    "characterList": Array [],
+    "children": Array [
+      "C",
+      "F",
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "B",
+    "nextSibling": "G",
+    "parent": null,
+    "prevSibling": "key8",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [],
+    "children": Array [
+      "D",
+      "E",
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "C",
+    "nextSibling": "F",
+    "parent": "B",
+    "prevSibling": null,
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "D",
+    "nextSibling": "E",
+    "parent": "C",
+    "prevSibling": null,
+    "text": "Delta",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "E",
+    "nextSibling": null,
+    "parent": "C",
+    "prevSibling": "D",
+    "text": "Elephant",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "F",
+    "nextSibling": null,
+    "parent": "B",
+    "prevSibling": "C",
+    "text": "Fire",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "G",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": "B",
+    "text": "Gorila",
+    "type": "unstyled",
+  },
+]
 `;

--- a/src/model/transaction/__tests__/splitBlockInContentState-test.js
+++ b/src/model/transaction/__tests__/splitBlockInContentState-test.js
@@ -16,15 +16,71 @@ jest.disableAutomock();
 
 jest.mock('generateRandomKey');
 
+const BlockMapBuilder = require('BlockMapBuilder');
+const ContentBlockNode = require('ContentBlockNode');
+const Immutable = require('immutable');
+const SelectionState = require('SelectionState');
+
 const getSampleStateForTesting = require('getSampleStateForTesting');
 const splitBlockInContentState = require('splitBlockInContentState');
 
+const {List} = Immutable;
+
 const {contentState, selectionState} = getSampleStateForTesting();
 
-const assertSplitBlockInContentState = selection => {
+const contentBlockNodes = [
+  new ContentBlockNode({
+    key: 'A',
+    nextSibling: 'B',
+    text: 'Alpha',
+  }),
+  new ContentBlockNode({
+    key: 'B',
+    prevSibling: 'A',
+    nextSibling: 'G',
+    children: List(['C', 'F']),
+  }),
+  new ContentBlockNode({
+    parent: 'B',
+    key: 'C',
+    nextSibling: 'F',
+    children: List(['D', 'E']),
+  }),
+  new ContentBlockNode({
+    parent: 'C',
+    key: 'D',
+    nextSibling: 'E',
+    text: 'Delta',
+  }),
+  new ContentBlockNode({
+    parent: 'C',
+    key: 'E',
+    prevSibling: 'D',
+    text: 'Elephant',
+  }),
+  new ContentBlockNode({
+    parent: 'B',
+    key: 'F',
+    prevSibling: 'C',
+    text: 'Fire',
+  }),
+  new ContentBlockNode({
+    key: 'G',
+    prevSibling: 'B',
+    text: 'Gorila',
+  }),
+];
+const treeSelectionState = SelectionState.createEmpty('A');
+const treeContentState = contentState.set(
+  'blockMap',
+  BlockMapBuilder.createFromArray(contentBlockNodes),
+);
+
+const assertSplitBlockInContentState = (selection, content = contentState) => {
   expect(
-    splitBlockInContentState(contentState, selection)
+    splitBlockInContentState(content, selection)
       .getBlockMap()
+      .toIndexedSeq()
       .toJS(),
   ).toMatchSnapshot();
 };
@@ -66,5 +122,88 @@ test('must split at the end of a block', () => {
       anchorOffset: SPLIT_OFFSET,
       focusOffset: SPLIT_OFFSET,
     }),
+  );
+});
+
+test('must be restricted to collapsed selections for ContentBlocks', () => {
+  expect(() => {
+    const nonCollapsed = treeSelectionState.set('focusOffset', 1);
+    return splitBlockInContentState(treeContentState, nonCollapsed);
+  }).toThrow();
+
+  expect(() => {
+    return splitBlockInContentState(treeContentState, treeSelectionState);
+  }).not.toThrow();
+});
+
+test('must be restricted to ContentBlocks that do not have children', () => {
+  expect(() => {
+    const invalidSelection = treeSelectionState.merge({
+      anchorKey: 'B',
+      focusKey: 'B',
+    });
+    return splitBlockInContentState(treeContentState, invalidSelection);
+  }).toThrow();
+});
+
+test('must split at the beginning of a root ContentBlock', () => {
+  assertSplitBlockInContentState(treeSelectionState, treeContentState);
+});
+
+test('must split at the beginning of a nested ContentBlock', () => {
+  assertSplitBlockInContentState(
+    treeSelectionState.merge({
+      anchorKey: 'D',
+      focusKey: 'D',
+    }),
+    treeContentState,
+  );
+});
+
+test('must split within a root ContentBlock', () => {
+  const SPLIT_OFFSET = 3;
+  assertSplitBlockInContentState(
+    treeSelectionState.merge({
+      anchorOffset: SPLIT_OFFSET,
+      focusOffset: SPLIT_OFFSET,
+    }),
+    treeContentState,
+  );
+});
+
+test('must split within a nested ContentBlock', () => {
+  const SPLIT_OFFSET = 3;
+  assertSplitBlockInContentState(
+    treeSelectionState.merge({
+      anchorOffset: SPLIT_OFFSET,
+      focusOffset: SPLIT_OFFSET,
+      anchorKey: 'E',
+      focusKey: 'E',
+    }),
+    treeContentState,
+  );
+});
+
+test('must split at the end of a root ContentBlock', () => {
+  const SPLIT_OFFSET = contentBlockNodes[0].getLength();
+  assertSplitBlockInContentState(
+    treeSelectionState.merge({
+      anchorOffset: SPLIT_OFFSET,
+      focusOffset: SPLIT_OFFSET,
+    }),
+    treeContentState,
+  );
+});
+
+test('must split at the end of a nested ContentBlock', () => {
+  const SPLIT_OFFSET = contentBlockNodes[3].getLength();
+  assertSplitBlockInContentState(
+    treeSelectionState.merge({
+      anchorOffset: SPLIT_OFFSET,
+      focusOffset: SPLIT_OFFSET,
+      anchorKey: 'D',
+      focusKey: 'D',
+    }),
+    treeContentState,
   );
 });

--- a/src/model/transaction/splitBlockInContentState.js
+++ b/src/model/transaction/splitBlockInContentState.js
@@ -13,54 +13,124 @@
 
 'use strict';
 
+import type {BlockMap} from 'BlockMap';
 import type ContentState from 'ContentState';
 import type SelectionState from 'SelectionState';
 
-var Immutable = require('immutable');
+const ContentBlockNode = require('ContentBlockNode');
+const Immutable = require('immutable');
 
-var generateRandomKey = require('generateRandomKey');
-var invariant = require('invariant');
+const generateRandomKey = require('generateRandomKey');
+const invariant = require('invariant');
 
-const {Map} = Immutable;
+const {List, Map} = Immutable;
 
-function splitBlockInContentState(
+const transformBlock = (
+  key: ?string,
+  blockMap: BlockMap,
+  func: (block: ContentBlockNode) => void,
+): void => {
+  if (!key) {
+    return;
+  }
+
+  const block = blockMap.get(key);
+
+  if (!block) {
+    return;
+  }
+
+  blockMap.set(key, func(block));
+};
+
+const updateBlockMapLinks = (
+  blockMap: BlockMap,
+  originalBlock: ContentBlockNode,
+  belowBlock: ContentBlockNode,
+): BlockMap => {
+  return blockMap.withMutations(blocks => {
+    const originalBlockKey = originalBlock.getKey();
+    const belowBlockKey = belowBlock.getKey();
+
+    // update block parent
+    transformBlock(originalBlock.getParentKey(), blocks, block => {
+      const parentChildrenList = block.getChildKeys();
+      const insertionIndex = parentChildrenList.indexOf(originalBlockKey) + 1;
+      const newChildrenArray = parentChildrenList.toArray();
+
+      newChildrenArray.splice(insertionIndex, 0, belowBlockKey);
+
+      return block.merge({
+        children: List(newChildrenArray),
+      });
+    });
+
+    // update original next block
+    transformBlock(originalBlock.getNextSiblingKey(), blocks, block =>
+      block.merge({
+        prevSibling: belowBlockKey,
+      }),
+    );
+
+    // update original block
+    transformBlock(originalBlockKey, blocks, block =>
+      block.merge({
+        nextSibling: belowBlockKey,
+      }),
+    );
+
+    // update below block
+    transformBlock(belowBlockKey, blocks, block =>
+      block.merge({
+        prevSibling: originalBlockKey,
+      }),
+    );
+  });
+};
+
+const splitBlockInContentState = (
   contentState: ContentState,
   selectionState: SelectionState,
-): ContentState {
+): ContentState => {
   invariant(selectionState.isCollapsed(), 'Selection range must be collapsed.');
 
-  var key = selectionState.getAnchorKey();
-  var offset = selectionState.getAnchorOffset();
-  var blockMap = contentState.getBlockMap();
-  var blockToSplit = blockMap.get(key);
+  const key = selectionState.getAnchorKey();
+  const offset = selectionState.getAnchorOffset();
+  const blockMap = contentState.getBlockMap();
+  const blockToSplit = blockMap.get(key);
+  const text = blockToSplit.getText();
+  const chars = blockToSplit.getCharacterList();
+  const keyBelow = generateRandomKey();
+  const isExperimentalTreeBlock = blockToSplit instanceof ContentBlockNode;
 
-  var text = blockToSplit.getText();
-  var chars = blockToSplit.getCharacterList();
-
-  var blockAbove = blockToSplit.merge({
+  const blockAbove = blockToSplit.merge({
     text: text.slice(0, offset),
     characterList: chars.slice(0, offset),
   });
-
-  var keyBelow = generateRandomKey();
-  var blockBelow = blockAbove.merge({
+  const blockBelow = blockAbove.merge({
     key: keyBelow,
     text: text.slice(offset),
     characterList: chars.slice(offset),
     data: Map(),
   });
 
-  var blocksBefore = blockMap.toSeq().takeUntil(v => v === blockToSplit);
-  var blocksAfter = blockMap
+  const blocksBefore = blockMap.toSeq().takeUntil(v => v === blockToSplit);
+  const blocksAfter = blockMap
     .toSeq()
     .skipUntil(v => v === blockToSplit)
     .rest();
-  var newBlocks = blocksBefore
-    .concat(
-      [[blockAbove.getKey(), blockAbove], [blockBelow.getKey(), blockBelow]],
-      blocksAfter,
-    )
+  let newBlocks = blocksBefore
+    .concat([[key, blockAbove], [keyBelow, blockBelow]], blocksAfter)
     .toOrderedMap();
+
+  if (isExperimentalTreeBlock) {
+    invariant(
+      blockToSplit.getChildKeys().isEmpty(),
+      'ContentBlockNode must not have children',
+    );
+
+    newBlocks = updateBlockMapLinks(newBlocks, blockAbove, blockBelow);
+  }
 
   return contentState.merge({
     blockMap: newBlocks,
@@ -73,6 +143,6 @@ function splitBlockInContentState(
       isBackward: false,
     }),
   });
-}
+};
 
 module.exports = splitBlockInContentState;


### PR DESCRIPTION
### Context

This PR is part of a series of PR's that will be exploring **tree data block support** in Draft.


**Adding support for splitting transactions**

This PR adds support for tree block nodes splitting transactions

***

**Note:**
This is unstable and not part of the public API and should not be used by
production systems.
