### PR TITLE
fix crash for non-text drops

### DIFF
--- a/src/component/handlers/drag/DraftEditorDragHandler.js
+++ b/src/component/handlers/drag/DraftEditorDragHandler.js
@@ -117,10 +117,12 @@ var DraftEditorDragHandler = {
       editor.update(moveText(editorState, dropSelection));
       return;
     }
-
-    editor.update(
-      insertTextAtSelection(editorState, dropSelection, data.getText()),
-    );
+    const text = data.getText();
+    if (text) { 
+      editor.update(
+        insertTextAtSelection(editorState, dropSelection, text),
+      );
+    }
   },
 };
 


### PR DESCRIPTION
**Summary**
My draft-js components are drag-n-drop enabled. sometimes, if i drag them by text, it triggers onDrop.
`data.getText()` returns null, but the handler don't care. It just keeps on goin.

Eventually, it hits an error:
```
Uncaught TypeError: Cannot read property 'length' of null
    at insertTextIntoContentState (insertTextIntoContentState.js:27)
    at Object.replaceText (DraftModifier.js:55)
    at Object.insertText (DraftModifier.js:60)
    at insertTextAtSelection (DraftEditorDragHandler.js:111)
```

This tells it to stop going when it knows the text isn't text. 