### PR TITLE
Experiment - does updating Jest fix CI?

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.6",
-    "jest": "^21.2.1",
+    "jest": "^21.3.0-beta.13",
     "prettier": "^1.7.4",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",


### PR DESCRIPTION
**what is the change?:**
Bump the Jest version, undoing the revert commit landed in
https://github.com/facebook/draft-js/commit/e127090a2c23ea4de3e7396fa310a3ecc8c735ce

**why make this change?:**
CI is failing to do a segfault, and we have no strong theories yet about
why. The last commit to land before it started failing was the revert
commit, so let's see if that's what caused the failure.

**test plan:**
push this to Github and see if CI passes

tests are passing locally

**issue:**
#1562 
