### PR TITLE
Try clearing out node modules before running website

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ script:
     set -e
     ./node_modules/.bin/gulp
     cd website
+    rm -rf ./node_modules
     npm install
     ./setup.sh
     if [ "$TRAVIS_PULL_REQUEST" = false ] && [ "$TRAVIS_BRANCH" = master ]; then


### PR DESCRIPTION
**what is the change?:**
CI is failing with a segfault and it's not clear why - I can't repro
this locally.

When I tried the same steps locally that CI is doing, I did see an error
based on an incompatibility between jest versions. I couldn't find where
this was coming from, but when removing the 'node_modules' in both the
root directory and the website directory and then re-installing in both
places, the error no longer happened.

If this is related to the segfault, then it could be resolved by having
CI clear out the stale node_modules.

**why make this change?:**
To try and fix CI.

**test plan:**
push this to Github and let CI run

**issue:**
issue #1562
