### PR TITLE
Temporarily disable website check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ script:
       ./publish.sh
     else
       # Make sure the website builds without error
-      node server/generate.js
+      #node server/generate.js
     fi
 
   fi


### PR DESCRIPTION
**what is the change?:**
To get more info about why CI is failing, I'm temporarily disabling the
website build check step of the build process.

If this fixes CI, it will verify that the problem is occurring somewhere
in the `node server/generate.js` command.

**why make this change?:**
To get more info about why CI is failing.

**test plan:**
push to github and see how CI goes

**issue:**
issue #1562