### PR TITLE
Restrict 'prettier' version to unbreak CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.6",
     "jest": "^21.2.1",
-    "prettier": "^1.7.4",
+    "prettier": ">=1.7.4 <=1.8.2",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-test-renderer": "^16.0.0",


### PR DESCRIPTION
**what is the change?:**
We have verified that upgrading to Prettier v1.9.0 or v1.9.1 both cause
a Segmentation Fault when running `eslint`. This happens in CI, and I
was able to verify it locally.

**why make this change?:**
We want to use Prettier in CI and not get segmentation faults.

**test plan:**
Locally I did -
`rm -rf node_modules && yarn install && yarn lint` and got no segfault.
Pushing this to github and waiting for CI to pass will further verify.

**issue:**
fixes issue #1562