### PR TITLE
fixed a bug related to draft losing its selection

### DIFF
--- a/src/component/selection/setDraftEditorSelection.js
+++ b/src/component/selection/setDraftEditorSelection.js
@@ -303,9 +303,14 @@ function addFocusToSelection(
     // Additionally, clone the selection range. IE11 throws an
     // InvalidStateError when attempting to access selection properties
     // after the range is detached.
-    var range = selection.getRangeAt(0);
-    range.setEnd(node, offset);
-    selection.addRange(range.cloneRange());
+    //
+    // Added rangeCount check
+    // https://stackoverflow.com/questions/22935320/uncaught-indexsizeerror-failed-to-execute-getrangeat-on-selection-0-is-not
+    if (selection.rangeCount > 0) {
+      var range = selection.getRangeAt(0);
+      range.setEnd(node, offset);
+      selection.addRange(range.cloneRange());
+    }
   }
 }
 


### PR DESCRIPTION
**Summary**

Sometimes rangeCount <= 0 and Draft tries to access an index that's out of range. See [stackoverflow](https://stackoverflow.com/questions/22935320/uncaught-indexsizeerror-failed-to-execute-getrangeat-on-selection-0-is-not) for a simplified example. Chrome throws the following exception:

    react-dom.development.js:10994 Uncaught DOMException: Failed to execute 'getRangeAt' on 'Selection': 0 is not a valid index.
        at addFocusToSelection (http://localhost:3002/vendor.bundle.js:47834:27)
        at setDraftEditorSelection (http://localhost:3002/vendor.bundle.js:47728:5)
        at DraftEditorLeaf._setSelection (http://localhost:3002/vendor.bundle.js:45761:5)
        at DraftEditorLeaf.componentDidUpdate (http://localhost:3002/vendor.bundle.js:45771:10)
        at commitLifeCycles (http://localhost:3002/vendor.bundle.js:34699:24)
        at commitAllLifeCycles (http://localhost:3002/vendor.bundle.js:35867:9)
        at HTMLUnknownElement.callCallback (http://localhost:3002/vendor.bundle.js:26463:14)
        at Object.invokeGuardedCallbackDev (http://localhost:3002/vendor.bundle.js:26502:16)
        at invokeGuardedCallback (http://localhost:3002/vendor.bundle.js:26359:27)
        at commitRoot (http://localhost:3002/vendor.bundle.js:35971:9)

&nbsp;

**Fix**

I added a rangeCount check.