### PR TITLE
Change immutable dependency to allow anything above 3.7.4 and below 4…

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "fbjs": "^0.8.15",
-    "immutable": "~3.7.4",
+    "immutable": "^3.7.4",
     "object-assign": "^4.1.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
This PR loosens the requirement for Immutable.js version to allow anything above (and including) 3.7.4 and below 4.0.0. In practice, at the moment this resolves to 3.8.2 if no other requirements are involved in dependency resolution.