### PR TITLE
Pinning prettier to 1.9.1 and fixing travis segfault

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-- 6
+- 8
 
 sudo: false
 

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "webpack-stream": "^3.0.0"
   },
   "devEngines": {
-    "node": "6.x",
+    "node": "6.x || 8.x",
     "npm": "2.x || 3.x"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.6",
     "jest": "^21.2.1",
-    "prettier": "1.9.1",
+    "prettier": "1.9.2",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-test-renderer": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.6",
     "jest": "^21.2.1",
-    "prettier": ">=1.7.4 <=1.8.2",
+    "prettier": "1.9.1",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-test-renderer": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.6",
     "jest": "^21.2.1",
-    "prettier": "1.9.2",
+    "prettier": "1.9.1",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-test-renderer": "^16.0.0",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -3,5 +3,5 @@ module.exports = {
   trailingComma: 'all',
   bracketSpacing: false,
   jsxBracketSameLine: true,
-  parser: 'flow',
+  parser: 'babylon',
 };

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -3,5 +3,5 @@ module.exports = {
   trailingComma: 'all',
   bracketSpacing: false,
   jsxBracketSameLine: true,
-  parser: 'babylon',
+  parser: 'flow',
 };


### PR DESCRIPTION
Internally we are now using prettier 1.9.1.

This PR pins prettier to `1.9.1` and fixes the segfault builds that were caused by running travis on old node versions