### PR TITLE
Lock prettier version to 1.9.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-- 6
+- 8
 
 sudo: false
 

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.6",
     "jest": "^21.2.1",
-    "prettier": ">=1.7.4 <=1.8.2",
+    "prettier": "1.9.1",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-test-renderer": "^16.0.0",


### PR DESCRIPTION
www is now on 1.9.1. Since Draft syncs into and is beholden to the pre-commit hook, we should be using the same version.

Lint is clean, so looks like everything is in sync currently. Upgrading past 1.9.1 does cause a failure.