### PR TITLE
Re-enabling linting errors as part of the build

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,7 +16,7 @@ module.exports = {
     'prettier/standard',
   ],
   rules: {
-    'prettier/prettier': [1, 'fb'],
+    'prettier/prettier': ['error', 'fb'],
   },
   plugins: ['prettier'],
   overrides: [

--- a/src/model/transaction/__tests__/moveBlockInContentState-test.js
+++ b/src/model/transaction/__tests__/moveBlockInContentState-test.js
@@ -73,6 +73,15 @@ const contentBlockNodes = [
   }),
 ];
 
+// doing this filtering to make the snapshot more precise/concise in what we test
+const BLOCK_PROPS_BLACKLIST = [
+  'characterList',
+  'data',
+  'depth',
+  'text',
+  'type',
+];
+
 const assertMoveBlockInContentState = (
   blockToBeMovedKey,
   targetBlockKey,
@@ -96,18 +105,15 @@ const assertMoveBlockInContentState = (
       .getBlockMap()
       .toSetSeq()
       .toArray()
-      // doing this filtering to make the snapshot more precise/concise in what we test
-      .map(filter => {
-        const {
-          data,
-          characterList,
-          depth,
-          type,
-          text,
-          ...other
-        } = filter.toJS();
-        return other;
-      }),
+      .map(filter => filter.toJS())
+      .map(block =>
+        Object.keys(block)
+          .filter(prop => BLOCK_PROPS_BLACKLIST.indexOf(prop) === -1)
+          .reduce((acc, prop) => {
+            acc[prop] = block[prop];
+            return acc;
+          }, {}),
+      ),
   ).toMatchSnapshot();
 };
 


### PR DESCRIPTION
This PR makes linting part of the CI build once again. While we were out of sync with our internal Prettier version we had to downgrade linting as warnings, this brings prettier linting back to error.