### PR TITLE
Adding shims for jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,9 @@
     "roots": [
       "<rootDir>/src/"
     ],
+    "setupFiles": [
+      "<rootDir>/scripts/jest/shims.js"
+    ],
     "transform": {
       ".*": "<rootDir>/scripts/jest/preprocessor.js"
     },

--- a/scripts/jest/shims.js
+++ b/scripts/jest/shims.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @format
+ */
+
+// used for testing react fiber
+global.requestAnimationFrame = callback => global.setTimeout(callback, 0);


### PR DESCRIPTION
This PR is meant to address this warnings that we get when running jest

```
   console.error node_modules/fbjs/lib/warning.js:33
      Warning: React depends on requestAnimationFrame. Make sure that you load a polyfill in older browsers. http://fb.me/react-polyfills
```

Jest is including the polyfill as part of (21.3.0), so we should be able to clean this up later 