### PR TITLE
Fix typo in editOnBeforeInput

### DIFF
--- a/src/component/handlers/edit/editOnBeforeInput.js
+++ b/src/component/handlers/edit/editOnBeforeInput.js
@@ -125,7 +125,7 @@ function editOnBeforeInput(
       .getPlainText()
       .slice(selectionStart, selectionEnd);
     if (chars === currentlySelectedChars) {
-      this.update(
+      editor.update(
         EditorState.forceSelection(
           editorState,
           selection.merge({


### PR DESCRIPTION
**what is the change?:**
We were calling `this.update` when there was no `update` method on
`this`. It should be `editor.update`.

This fix is not really complete in the first place, but I'll make any
follow-up changes in a new PR.

**why make this change?:**
This is causing an error to be thrown - see internal FB task t24443952

**test plan:**
I manually reproduce the bug before the fix -
![screen shot 2017-12-19 at 7 14 07 am](https://user-images.githubusercontent.com/1114467/34164097-8235b8b6-e48d-11e7-9dd6-3ef26d98b9f3.png)

and then was not able to reproduce with the same steps after the fix.

To reproduce -
- open the 'plaintext' example and type 'hello'
- select the 'o' with a forwards selection, left to right
- type 'o'. This was throwing, now it's not.