### PR TITLE
Fix error when anchorNode is missing in editOnInput

### DIFF
--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -49,6 +49,11 @@ function editOnInput(editor: DraftEditor): void {
   var domSelection = global.getSelection();
 
   var {anchorNode, isCollapsed} = domSelection;
+
+  if (!anchorNode) {
+    return;
+  }
+
   const isNotTextNode = anchorNode.nodeType !== Node.TEXT_NODE;
   const isNotTextOrElementNode =
     anchorNode.nodeType !== Node.TEXT_NODE &&


### PR DESCRIPTION
Fix for issue related to #1399. The fix is similar to #1407, in that it checks if `anchorNode` is falsy and if so bails. 