### PR TITLE
Exploration - Feature tree / adding internal support for tree data structures

### DIFF
--- a/src/model/modifier/AtomicBlockUtils.js
+++ b/src/model/modifier/AtomicBlockUtils.js
@@ -19,6 +19,8 @@ import type {DraftInsertionType} from 'DraftInsertionType';
 const BlockMapBuilder = require('BlockMapBuilder');
 const CharacterMetadata = require('CharacterMetadata');
 const ContentBlock = require('ContentBlock');
+const ContentBlockNode = require('ContentBlockNode');
+const DraftFeatureFlags = require('DraftFeatureFlags');
 const DraftModifier = require('DraftModifier');
 const EditorState = require('EditorState');
 const Immutable = require('immutable');
@@ -26,6 +28,11 @@ const SelectionState = require('SelectionState');
 
 const generateRandomKey = require('generateRandomKey');
 const moveBlockInContentState = require('moveBlockInContentState');
+
+const experimentalTreeDataSupport = DraftFeatureFlags.draft_tree_data_support;
+const ContentBlockRecord = experimentalTreeDataSupport
+  ? ContentBlockNode
+  : ContentBlock;
 
 const {List, Repeat} = Immutable;
 
@@ -56,19 +63,32 @@ const AtomicBlockUtils = {
 
     const charData = CharacterMetadata.create({entity: entityKey});
 
+    let atomicBlockConfig = {
+      key: generateRandomKey(),
+      type: 'atomic',
+      text: character,
+      characterList: List(Repeat(charData, character.length)),
+    };
+
+    let atomicDividerBlockConfig = {
+      key: generateRandomKey(),
+      type: 'unstyled',
+    };
+
+    if (experimentalTreeDataSupport) {
+      atomicBlockConfig = {
+        ...atomicBlockConfig,
+        nextSibling: atomicDividerBlockConfig.key,
+      };
+      atomicDividerBlockConfig = {
+        ...atomicDividerBlockConfig,
+        prevSibling: atomicBlockConfig.key,
+      };
+    }
+
     const fragmentArray = [
-      new ContentBlock({
-        key: generateRandomKey(),
-        type: 'atomic',
-        text: character,
-        characterList: List(Repeat(charData, character.length)),
-      }),
-      new ContentBlock({
-        key: generateRandomKey(),
-        type: 'unstyled',
-        text: '',
-        characterList: List(),
-      }),
+      new ContentBlockRecord(atomicBlockConfig),
+      new ContentBlockRecord(atomicDividerBlockConfig),
     ];
 
     const fragment = BlockMapBuilder.createFromArray(fragmentArray);

--- a/src/model/modifier/__tests__/__snapshots__/AtomicBlockUtils-test.js.snap
+++ b/src/model/modifier/__tests__/__snapshots__/AtomicBlockUtils-test.js.snap
@@ -1,1306 +1,5573 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`must be able to insert atomic block when experimentalTreeDataSupport is enabled 1`] = `
+Array [
+  Object {
+    "characterList": Array [],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "A",
+    "nextSibling": "key0",
+    "parent": null,
+    "prevSibling": null,
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "2",
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "nextSibling": "key4",
+    "parent": null,
+    "prevSibling": "A",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": "key0",
+    "text": "first block",
+    "type": "unstyled",
+  },
+]
+`;
+
+exports[`must be able to move atomic block when experimentalTreeDataSupport is enabled 1`] = `
+Array [
+  Object {
+    "characterList": Array [],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "A",
+    "nextSibling": "key0",
+    "parent": null,
+    "prevSibling": null,
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "2",
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "nextSibling": "key4",
+    "parent": null,
+    "prevSibling": "A",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": "key0",
+    "text": "first block",
+    "type": "unstyled",
+  },
+]
+`;
+
+exports[`must be able to move atomic block when experimentalTreeDataSupport is enabled 2`] = `
+Array [
+  Object {
+    "characterList": Array [],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "A",
+    "nextSibling": "key4",
+    "parent": null,
+    "prevSibling": null,
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
+    "nextSibling": "key0",
+    "parent": null,
+    "prevSibling": "A",
+    "text": "first block",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "2",
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": "key4",
+    "text": " ",
+    "type": "atomic",
+  },
+]
+`;
+
 exports[`must insert atomic after a block with collapsed selection 1`] = `
-Object {
-  "a": Object {
+Array [
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "a",
     "text": "Alpha",
     "type": "unstyled",
   },
-  "b": Object {
-    "key": "b",
-    "text": "Bravo",
-    "type": "unordered-list-item",
-  },
-  "c": Object {
-    "key": "c",
-    "text": "Test",
-    "type": "code-block",
-  },
-  "d": Object {
-    "key": "d",
-    "text": "",
-    "type": "code-block",
-  },
-  "e": Object {
-    "key": "e",
-    "text": "",
-    "type": "code-block",
-  },
-  "f": Object {
-    "key": "f",
-    "text": "Charlie",
-    "type": "blockquote",
-  },
-  "key11": Object {
-    "key": "key11",
-    "text": "",
-    "type": "unstyled",
-  },
-  "key8": Object {
-    "key": "key8",
-    "text": " ",
-    "type": "atomic",
-  },
-}
-`;
-
-exports[`must insert atomic at end of block 1`] = `
-Object {
-  "a": Object {
-    "key": "a",
-    "text": "Alp",
-    "type": "unstyled",
-  },
-  "b": Object {
-    "key": "b",
-    "text": "Bravo",
-    "type": "unordered-list-item",
-  },
-  "c": Object {
-    "key": "c",
-    "text": "Test",
-    "type": "code-block",
-  },
-  "d": Object {
-    "key": "d",
-    "text": "",
-    "type": "code-block",
-  },
-  "e": Object {
-    "key": "e",
-    "text": "",
-    "type": "code-block",
-  },
-  "f": Object {
-    "key": "f",
-    "text": "Charlie",
-    "type": "blockquote",
-  },
-  "key45": Object {
-    "key": "key45",
-    "text": " ",
-    "type": "atomic",
-  },
-  "key48": Object {
-    "key": "key48",
-    "text": "",
-    "type": "unstyled",
-  },
-}
-`;
-
-exports[`must insert atomic at start of block 1`] = `
-Object {
-  "a": Object {
-    "key": "a",
-    "text": "",
-    "type": "unstyled",
-  },
-  "b": Object {
-    "key": "b",
-    "text": "Bravo",
-    "type": "unordered-list-item",
-  },
-  "c": Object {
-    "key": "c",
-    "text": "Test",
-    "type": "code-block",
-  },
-  "d": Object {
-    "key": "d",
-    "text": "",
-    "type": "code-block",
-  },
-  "e": Object {
-    "key": "e",
-    "text": "",
-    "type": "code-block",
-  },
-  "f": Object {
-    "key": "f",
-    "text": "Charlie",
-    "type": "blockquote",
-  },
-  "key37": Object {
-    "key": "key37",
-    "text": " ",
-    "type": "atomic",
-  },
-  "key40": Object {
-    "key": "key40",
-    "text": "pha",
-    "type": "unstyled",
-  },
-}
-`;
-
-exports[`must insert atomic at start of block with collapsed seletion 1`] = `
-Object {
-  "a": Object {
-    "key": "a",
-    "text": "",
-    "type": "unstyled",
-  },
-  "b": Object {
-    "key": "b",
-    "text": "Bravo",
-    "type": "unordered-list-item",
-  },
-  "c": Object {
-    "key": "c",
-    "text": "Test",
-    "type": "code-block",
-  },
-  "d": Object {
-    "key": "d",
-    "text": "",
-    "type": "code-block",
-  },
-  "e": Object {
-    "key": "e",
-    "text": "",
-    "type": "code-block",
-  },
-  "f": Object {
-    "key": "f",
-    "text": "Charlie",
-    "type": "blockquote",
-  },
-  "key0": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "2",
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "key0",
     "text": " ",
     "type": "atomic",
   },
-  "key3": Object {
-    "key": "key3",
-    "text": "Alpha",
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
+    "text": "",
     "type": "unstyled",
   },
-}
-`;
-
-exports[`must insert atomic for cross-block selection 1`] = `
-Object {
-  "a": Object {
-    "key": "a",
-    "text": "Al",
-    "type": "unstyled",
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
   },
-  "d": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "d",
     "text": "",
     "type": "code-block",
   },
-  "e": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "e",
     "text": "",
     "type": "code-block",
   },
-  "f": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "f",
     "text": "Charlie",
     "type": "blockquote",
   },
-  "key49": Object {
-    "key": "key49",
+]
+`;
+
+exports[`must insert atomic at end of block 1`] = `
+Array [
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "a",
+    "text": "Alp",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "2",
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
     "text": " ",
     "type": "atomic",
   },
-  "key52": Object {
-    "key": "key52",
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
+`;
+
+exports[`must insert atomic at start of block 1`] = `
+Array [
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "a",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "2",
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
+    "text": "pha",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
+`;
+
+exports[`must insert atomic at start of block with collapsed seletion 1`] = `
+Array [
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "a",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "2",
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
+`;
+
+exports[`must insert atomic for cross-block selection 1`] = `
+Array [
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "a",
+    "text": "Al",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "2",
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
     "text": "st",
     "type": "unstyled",
   },
-}
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
 `;
 
 exports[`must insert atomic within a block 1`] = `
-Object {
-  "a": Object {
+Array [
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "a",
     "text": "A",
     "type": "unstyled",
   },
-  "b": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "2",
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
+    "text": "pha",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "b",
     "text": "Bravo",
     "type": "unordered-list-item",
   },
-  "c": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "c",
     "text": "Test",
     "type": "code-block",
   },
-  "d": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "d",
     "text": "",
     "type": "code-block",
   },
-  "e": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "e",
     "text": "",
     "type": "code-block",
   },
-  "f": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "f",
     "text": "Charlie",
     "type": "blockquote",
   },
-  "key41": Object {
-    "key": "key41",
-    "text": " ",
-    "type": "atomic",
-  },
-  "key44": Object {
-    "key": "key44",
-    "text": "pha",
-    "type": "unstyled",
-  },
-}
+]
 `;
 
 exports[`must insert atomic within a block, via split with collapsed selection 1`] = `
-Object {
-  "a": Object {
+Array [
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "a",
     "text": "Al",
     "type": "unstyled",
   },
-  "b": Object {
-    "key": "b",
-    "text": "Bravo",
-    "type": "unordered-list-item",
-  },
-  "c": Object {
-    "key": "c",
-    "text": "Test",
-    "type": "code-block",
-  },
-  "d": Object {
-    "key": "d",
-    "text": "",
-    "type": "code-block",
-  },
-  "e": Object {
-    "key": "e",
-    "text": "",
-    "type": "code-block",
-  },
-  "f": Object {
-    "key": "f",
-    "text": "Charlie",
-    "type": "blockquote",
-  },
-  "key4": Object {
-    "key": "key4",
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "2",
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
     "text": " ",
     "type": "atomic",
   },
-  "key7": Object {
-    "key": "key7",
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
     "text": "pha",
     "type": "unstyled",
   },
-}
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
 `;
 
 exports[`must move atomic after block 1`] = `
-Object {
-  "a": Object {
+Array [
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "a",
     "text": "",
     "type": "unstyled",
   },
-  "b": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "2",
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "b",
     "text": "Bravo",
     "type": "unordered-list-item",
   },
-  "c": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "c",
     "text": "Test",
     "type": "code-block",
   },
-  "d": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "d",
     "text": "",
     "type": "code-block",
   },
-  "e": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "e",
     "text": "",
     "type": "code-block",
   },
-  "f": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "f",
     "text": "Charlie",
     "type": "blockquote",
   },
-  "key70": Object {
-    "key": "key70",
-    "text": " ",
-    "type": "atomic",
-  },
-  "key73": Object {
-    "key": "key73",
-    "text": "Alpha",
-    "type": "unstyled",
-  },
-}
+]
 `;
 
 exports[`must move atomic after block 2`] = `
-Object {
-  "a": Object {
+Array [
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "a",
     "text": "",
     "type": "unstyled",
   },
-  "b": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "b",
     "text": "Bravo",
     "type": "unordered-list-item",
   },
-  "c": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "c",
     "text": "Test",
     "type": "code-block",
   },
-  "d": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "d",
     "text": "",
     "type": "code-block",
   },
-  "e": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "e",
     "text": "",
     "type": "code-block",
   },
-  "f": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "f",
     "text": "Charlie",
     "type": "blockquote",
   },
-  "key70": Object {
-    "key": "key70",
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "2",
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
     "text": " ",
     "type": "atomic",
   },
-  "key73": Object {
-    "key": "key73",
-    "text": "Alpha",
-    "type": "unstyled",
-  },
-}
+]
 `;
 
 exports[`must move atomic after block with collapsed selection 1`] = `
-Object {
-  "a": Object {
+Array [
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "a",
     "text": "",
     "type": "unstyled",
   },
-  "b": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "2",
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "b",
     "text": "Bravo",
     "type": "unordered-list-item",
   },
-  "c": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "c",
     "text": "Test",
     "type": "code-block",
   },
-  "d": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "d",
     "text": "",
     "type": "code-block",
   },
-  "e": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "e",
     "text": "",
     "type": "code-block",
   },
-  "f": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "f",
     "text": "Charlie",
     "type": "blockquote",
   },
-  "key29": Object {
-    "key": "key29",
-    "text": " ",
-    "type": "atomic",
-  },
-  "key32": Object {
-    "key": "key32",
-    "text": "Alpha",
-    "type": "unstyled",
-  },
-}
+]
 `;
 
 exports[`must move atomic after block with collapsed selection 2`] = `
-Object {
-  "a": Object {
+Array [
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "a",
     "text": "",
     "type": "unstyled",
   },
-  "b": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "b",
     "text": "Bravo",
     "type": "unordered-list-item",
   },
-  "c": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "c",
     "text": "Test",
     "type": "code-block",
   },
-  "d": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "d",
     "text": "",
     "type": "code-block",
   },
-  "e": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "e",
     "text": "",
     "type": "code-block",
   },
-  "f": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "f",
     "text": "Charlie",
     "type": "blockquote",
   },
-  "key29": Object {
-    "key": "key29",
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "2",
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
     "text": " ",
     "type": "atomic",
   },
-  "key32": Object {
-    "key": "key32",
-    "text": "Alpha",
-    "type": "unstyled",
-  },
-}
+]
 `;
 
 exports[`must move atomic at end of block 1`] = `
-Object {
-  "a": Object {
+Array [
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "a",
     "text": "",
     "type": "unstyled",
   },
-  "b": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "2",
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "b",
     "text": "Bravo",
     "type": "unordered-list-item",
   },
-  "c": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "c",
     "text": "Test",
     "type": "code-block",
   },
-  "d": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "d",
     "text": "",
     "type": "code-block",
   },
-  "e": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "e",
     "text": "",
     "type": "code-block",
   },
-  "f": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "f",
     "text": "Charlie",
     "type": "blockquote",
   },
-  "key57": Object {
-    "key": "key57",
-    "text": " ",
-    "type": "atomic",
-  },
-  "key60": Object {
-    "key": "key60",
-    "text": "Alpha",
-    "type": "unstyled",
-  },
-}
+]
 `;
 
 exports[`must move atomic at end of block 2`] = `
-Object {
-  "a": Object {
+Array [
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "a",
     "text": "",
     "type": "unstyled",
   },
-  "b": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "b",
     "text": "Bravo",
     "type": "unordered-list-item",
   },
-  "c": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "c",
     "text": "Test",
     "type": "code-block",
   },
-  "d": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "d",
     "text": "",
     "type": "code-block",
   },
-  "e": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "e",
     "text": "",
     "type": "code-block",
   },
-  "f": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "f",
     "text": "Charl",
     "type": "blockquote",
   },
-  "key57": Object {
-    "key": "key57",
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "2",
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
     "text": " ",
     "type": "atomic",
   },
-  "key60": Object {
-    "key": "key60",
-    "text": "Alpha",
-    "type": "unstyled",
-  },
-}
+]
 `;
 
 exports[`must move atomic at end of block with collapsed selection 1`] = `
-Object {
-  "a": Object {
+Array [
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "a",
     "text": "",
     "type": "unstyled",
   },
-  "b": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "2",
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "b",
     "text": "Bravo",
     "type": "unordered-list-item",
   },
-  "c": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "c",
     "text": "Test",
     "type": "code-block",
   },
-  "d": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "d",
     "text": "",
     "type": "code-block",
   },
-  "e": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "e",
     "text": "",
     "type": "code-block",
   },
-  "f": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "f",
     "text": "Charlie",
     "type": "blockquote",
   },
-  "key16": Object {
-    "key": "key16",
-    "text": " ",
-    "type": "atomic",
-  },
-  "key19": Object {
-    "key": "key19",
-    "text": "Alpha",
-    "type": "unstyled",
-  },
-}
+]
 `;
 
 exports[`must move atomic at end of block with collapsed selection 2`] = `
-Object {
-  "a": Object {
+Array [
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "a",
     "text": "",
     "type": "unstyled",
   },
-  "b": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "b",
     "text": "Bravo",
     "type": "unordered-list-item",
   },
-  "c": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "c",
     "text": "Test",
     "type": "code-block",
   },
-  "d": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "d",
     "text": "",
     "type": "code-block",
   },
-  "e": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "e",
     "text": "",
     "type": "code-block",
   },
-  "f": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "f",
     "text": "Charlie",
     "type": "blockquote",
   },
-  "key16": Object {
-    "key": "key16",
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "2",
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
     "text": " ",
     "type": "atomic",
   },
-  "key19": Object {
-    "key": "key19",
-    "text": "Alpha",
-    "type": "unstyled",
-  },
-}
+]
 `;
 
 exports[`must move atomic at start of block 1`] = `
-Object {
-  "a": Object {
+Array [
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "a",
     "text": "",
     "type": "unstyled",
   },
-  "b": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "2",
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "b",
     "text": "Bravo",
     "type": "unordered-list-item",
   },
-  "c": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "c",
     "text": "Test",
     "type": "code-block",
   },
-  "d": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "d",
     "text": "",
     "type": "code-block",
   },
-  "e": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "e",
     "text": "",
     "type": "code-block",
   },
-  "f": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "f",
     "text": "Charlie",
     "type": "blockquote",
   },
-  "key53": Object {
-    "key": "key53",
-    "text": " ",
-    "type": "atomic",
-  },
-  "key56": Object {
-    "key": "key56",
-    "text": "Alpha",
-    "type": "unstyled",
-  },
-}
+]
 `;
 
 exports[`must move atomic at start of block 2`] = `
-Object {
-  "a": Object {
+Array [
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "a",
     "text": "",
     "type": "unstyled",
   },
-  "b": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "b",
     "text": "Bravo",
     "type": "unordered-list-item",
   },
-  "c": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "c",
     "text": "Test",
     "type": "code-block",
   },
-  "d": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "d",
     "text": "",
     "type": "code-block",
   },
-  "e": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "e",
     "text": "",
     "type": "code-block",
   },
-  "f": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "2",
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "f",
     "text": "arlie",
     "type": "blockquote",
   },
-  "key53": Object {
-    "key": "key53",
-    "text": " ",
-    "type": "atomic",
-  },
-  "key56": Object {
-    "key": "key56",
-    "text": "Alpha",
-    "type": "unstyled",
-  },
-}
+]
 `;
 
 exports[`must move atomic at start of block with collapsed selection 1`] = `
-Object {
-  "a": Object {
+Array [
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "a",
     "text": "",
     "type": "unstyled",
   },
-  "b": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "2",
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "b",
     "text": "Bravo",
     "type": "unordered-list-item",
   },
-  "c": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "c",
     "text": "Test",
     "type": "code-block",
   },
-  "d": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "d",
     "text": "",
     "type": "code-block",
   },
-  "e": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "e",
     "text": "",
     "type": "code-block",
   },
-  "f": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "f",
     "text": "Charlie",
     "type": "blockquote",
   },
-  "key12": Object {
-    "key": "key12",
-    "text": " ",
-    "type": "atomic",
-  },
-  "key15": Object {
-    "key": "key15",
-    "text": "Alpha",
-    "type": "unstyled",
-  },
-}
+]
 `;
 
 exports[`must move atomic at start of block with collapsed selection 2`] = `
-Object {
-  "a": Object {
+Array [
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "2",
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "a",
     "text": "",
     "type": "unstyled",
   },
-  "b": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "b",
     "text": "Bravo",
     "type": "unordered-list-item",
   },
-  "c": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "c",
     "text": "Test",
     "type": "code-block",
   },
-  "d": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "d",
     "text": "",
     "type": "code-block",
   },
-  "e": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "e",
     "text": "",
     "type": "code-block",
   },
-  "f": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "f",
     "text": "Charlie",
     "type": "blockquote",
   },
-  "key12": Object {
-    "key": "key12",
-    "text": " ",
-    "type": "atomic",
-  },
-  "key15": Object {
-    "key": "key15",
-    "text": "Alpha",
-    "type": "unstyled",
-  },
-}
+]
 `;
 
 exports[`must move atomic before block 1`] = `
-Object {
-  "a": Object {
+Array [
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "a",
     "text": "",
     "type": "unstyled",
   },
-  "b": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "2",
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "b",
     "text": "Bravo",
     "type": "unordered-list-item",
   },
-  "c": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "c",
     "text": "Test",
     "type": "code-block",
   },
-  "d": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "d",
     "text": "",
     "type": "code-block",
   },
-  "e": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "e",
     "text": "",
     "type": "code-block",
   },
-  "f": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "f",
     "text": "Charlie",
     "type": "blockquote",
   },
-  "key66": Object {
-    "key": "key66",
-    "text": " ",
-    "type": "atomic",
-  },
-  "key69": Object {
-    "key": "key69",
-    "text": "Alpha",
-    "type": "unstyled",
-  },
-}
+]
 `;
 
 exports[`must move atomic before block 2`] = `
-Object {
-  "a": Object {
+Array [
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "2",
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "a",
     "text": "",
     "type": "unstyled",
   },
-  "b": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "b",
     "text": "Bravo",
     "type": "unordered-list-item",
   },
-  "c": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "c",
     "text": "Test",
     "type": "code-block",
   },
-  "d": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "d",
     "text": "",
     "type": "code-block",
   },
-  "e": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "e",
     "text": "",
     "type": "code-block",
   },
-  "f": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "f",
     "text": "Charlie",
     "type": "blockquote",
   },
-  "key66": Object {
-    "key": "key66",
-    "text": " ",
-    "type": "atomic",
-  },
-  "key69": Object {
-    "key": "key69",
-    "text": "Alpha",
-    "type": "unstyled",
-  },
-}
+]
 `;
 
 exports[`must move atomic before block with collapsed selection 1`] = `
-Object {
-  "a": Object {
+Array [
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "a",
     "text": "",
     "type": "unstyled",
   },
-  "b": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "2",
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "b",
     "text": "Bravo",
     "type": "unordered-list-item",
   },
-  "c": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "c",
     "text": "Test",
     "type": "code-block",
   },
-  "d": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "d",
     "text": "",
     "type": "code-block",
   },
-  "e": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "e",
     "text": "",
     "type": "code-block",
   },
-  "f": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "f",
     "text": "Charlie",
     "type": "blockquote",
   },
-  "key25": Object {
-    "key": "key25",
-    "text": " ",
-    "type": "atomic",
-  },
-  "key28": Object {
-    "key": "key28",
-    "text": "Alpha",
-    "type": "unstyled",
-  },
-}
+]
 `;
 
 exports[`must move atomic before block with collapsed selection 2`] = `
-Object {
-  "a": Object {
+Array [
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "2",
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "a",
     "text": "",
     "type": "unstyled",
   },
-  "b": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "b",
     "text": "Bravo",
     "type": "unordered-list-item",
   },
-  "c": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "c",
     "text": "Test",
     "type": "code-block",
   },
-  "d": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "d",
     "text": "",
     "type": "code-block",
   },
-  "e": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "e",
     "text": "",
     "type": "code-block",
   },
-  "f": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "f",
     "text": "Charlie",
     "type": "blockquote",
   },
-  "key25": Object {
-    "key": "key25",
-    "text": " ",
-    "type": "atomic",
-  },
-  "key28": Object {
-    "key": "key28",
-    "text": "Alpha",
-    "type": "unstyled",
-  },
-}
+]
 `;
 
 exports[`must move atomic inbetween block 1`] = `
-Object {
-  "a": Object {
+Array [
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "a",
     "text": "",
     "type": "unstyled",
   },
-  "b": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "2",
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "b",
     "text": "Bravo",
     "type": "unordered-list-item",
   },
-  "c": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "c",
     "text": "Test",
     "type": "code-block",
   },
-  "d": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "d",
     "text": "",
     "type": "code-block",
   },
-  "e": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "e",
     "text": "",
     "type": "code-block",
   },
-  "f": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "f",
     "text": "Charlie",
     "type": "blockquote",
   },
-  "key61": Object {
-    "key": "key61",
-    "text": " ",
-    "type": "atomic",
-  },
-  "key64": Object {
-    "key": "key64",
-    "text": "Alpha",
-    "type": "unstyled",
-  },
-}
+]
 `;
 
 exports[`must move atomic inbetween block 2`] = `
-Object {
-  "a": Object {
+Array [
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "a",
     "text": "",
     "type": "unstyled",
   },
-  "b": Object {
-    "key": "b",
-    "text": "Bravo",
-    "type": "unordered-list-item",
-  },
-  "c": Object {
-    "key": "c",
-    "text": "Test",
-    "type": "code-block",
-  },
-  "d": Object {
-    "key": "d",
-    "text": "",
-    "type": "code-block",
-  },
-  "e": Object {
-    "key": "e",
-    "text": "",
-    "type": "code-block",
-  },
-  "f": Object {
-    "key": "f",
-    "text": "Charlie",
-    "type": "blockquote",
-  },
-  "key61": Object {
-    "key": "key61",
-    "text": " ",
-    "type": "atomic",
-  },
-  "key64": Object {
-    "key": "key64",
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
     "text": "A",
     "type": "unstyled",
   },
-  "key65": Object {
-    "key": "key65",
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "2",
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key5",
     "text": "pha",
     "type": "unstyled",
   },
-}
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
 `;
 
 exports[`must move atomic inbetween block with collapsed selection 1`] = `
-Object {
-  "a": Object {
+Array [
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "a",
     "text": "",
     "type": "unstyled",
   },
-  "b": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "2",
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "b",
     "text": "Bravo",
     "type": "unordered-list-item",
   },
-  "c": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "c",
     "text": "Test",
     "type": "code-block",
   },
-  "d": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "d",
     "text": "",
     "type": "code-block",
   },
-  "e": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "e",
     "text": "",
     "type": "code-block",
   },
-  "f": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "f",
     "text": "Charlie",
     "type": "blockquote",
   },
-  "key20": Object {
-    "key": "key20",
-    "text": " ",
-    "type": "atomic",
-  },
-  "key23": Object {
-    "key": "key23",
-    "text": "Alpha",
-    "type": "unstyled",
-  },
-}
+]
 `;
 
 exports[`must move atomic inbetween block with collapsed selection 2`] = `
-Object {
-  "a": Object {
+Array [
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "a",
     "text": "",
     "type": "unstyled",
   },
-  "b": Object {
-    "key": "b",
-    "text": "Bravo",
-    "type": "unordered-list-item",
-  },
-  "c": Object {
-    "key": "c",
-    "text": "Test",
-    "type": "code-block",
-  },
-  "d": Object {
-    "key": "d",
-    "text": "",
-    "type": "code-block",
-  },
-  "e": Object {
-    "key": "e",
-    "text": "",
-    "type": "code-block",
-  },
-  "f": Object {
-    "key": "f",
-    "text": "Charlie",
-    "type": "blockquote",
-  },
-  "key20": Object {
-    "key": "key20",
-    "text": " ",
-    "type": "atomic",
-  },
-  "key23": Object {
-    "key": "key23",
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
     "text": "Al",
     "type": "unstyled",
   },
-  "key24": Object {
-    "key": "key24",
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "2",
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key5",
     "text": "pha",
     "type": "unstyled",
   },
-}
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
 `;
 
 exports[`mustn't move atomic next to itself 1`] = `
-Object {
-  "a": Object {
+Array [
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "a",
     "text": "Alpha",
     "type": "unstyled",
   },
-  "b": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "2",
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "b",
     "text": "Bravo",
     "type": "unordered-list-item",
   },
-  "c": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "c",
     "text": "Test",
     "type": "code-block",
   },
-  "d": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "d",
     "text": "",
     "type": "code-block",
   },
-  "e": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "e",
     "text": "",
     "type": "code-block",
   },
-  "f": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "f",
     "text": "Charlie",
     "type": "blockquote",
   },
-  "key74": Object {
-    "key": "key74",
-    "text": " ",
-    "type": "atomic",
-  },
-  "key77": Object {
-    "key": "key77",
-    "text": "",
-    "type": "unstyled",
-  },
-}
+]
 `;
 
 exports[`mustn't move atomic next to itself with collapsed selection 1`] = `
-Object {
-  "a": Object {
+Array [
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "a",
     "text": "Alpha",
     "type": "unstyled",
   },
-  "b": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "2",
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "text": " ",
+    "type": "atomic",
+  },
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "b",
     "text": "Bravo",
     "type": "unordered-list-item",
   },
-  "c": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "c",
     "text": "Test",
     "type": "code-block",
   },
-  "d": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "d",
     "text": "",
     "type": "code-block",
   },
-  "e": Object {
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
     "key": "e",
     "text": "",
     "type": "code-block",
   },
-  "f": Object {
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
     "key": "f",
     "text": "Charlie",
     "type": "blockquote",
   },
-  "key33": Object {
-    "key": "key33",
-    "text": " ",
-    "type": "atomic",
-  },
-  "key36": Object {
-    "key": "key36",
-    "text": "",
-    "type": "unstyled",
-  },
-}
+]
 `;

--- a/src/model/transaction/__tests__/__snapshots__/getContentStateFragment-test.js.snap
+++ b/src/model/transaction/__tests__/__snapshots__/getContentStateFragment-test.js.snap
@@ -261,7 +261,7 @@ Object {
     "data": Object {},
     "depth": 0,
     "key": "key10",
-    "nextSibling": "D",
+    "nextSibling": null,
     "parent": null,
     "prevSibling": null,
     "text": "",

--- a/src/model/transaction/__tests__/__snapshots__/insertFragmentIntoContentState-test.js.snap
+++ b/src/model/transaction/__tests__/__snapshots__/insertFragmentIntoContentState-test.js.snap
@@ -1,796 +1,1361 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`must apply fragment at the end 1`] = `
-Object {
-  "blockMap": Object {
-    "a": Object {
-      "characterList": Array [
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-      ],
-      "data": Object {
-        "a": 1,
+Array [
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
       },
-      "depth": 0,
-      "key": "a",
-      "text": "Alphaxx",
-      "type": "unstyled",
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {
+      "a": 1,
     },
-    "b": Object {
-      "characterList": Array [
-        Object {
-          "entity": "1",
-          "style": Array [
-            "BOLD",
-          ],
-        },
-        Object {
-          "entity": "1",
-          "style": Array [
-            "BOLD",
-          ],
-        },
-        Object {
-          "entity": "1",
-          "style": Array [
-            "BOLD",
-          ],
-        },
-        Object {
-          "entity": "1",
-          "style": Array [
-            "BOLD",
-          ],
-        },
-        Object {
-          "entity": "1",
-          "style": Array [
-            "BOLD",
-          ],
-        },
-      ],
-      "data": Object {},
-      "depth": 0,
-      "key": "b",
-      "text": "Bravo",
-      "type": "unordered-list-item",
-    },
-    "c": Object {
-      "characterList": Array [
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-      ],
-      "data": Object {},
-      "depth": 0,
-      "key": "c",
-      "text": "Test",
-      "type": "code-block",
-    },
-    "d": Object {
-      "characterList": Array [],
-      "data": Object {},
-      "depth": 0,
-      "key": "d",
-      "text": "",
-      "type": "code-block",
-    },
-    "e": Object {
-      "characterList": Array [],
-      "data": Object {},
-      "depth": 0,
-      "key": "e",
-      "text": "",
-      "type": "code-block",
-    },
-    "f": Object {
-      "characterList": Array [
-        Object {
-          "entity": null,
-          "style": Array [
-            "ITALIC",
-          ],
-        },
-        Object {
-          "entity": null,
-          "style": Array [
-            "ITALIC",
-          ],
-        },
-        Object {
-          "entity": null,
-          "style": Array [
-            "ITALIC",
-          ],
-        },
-        Object {
-          "entity": null,
-          "style": Array [
-            "ITALIC",
-          ],
-        },
-        Object {
-          "entity": null,
-          "style": Array [
-            "ITALIC",
-          ],
-        },
-        Object {
-          "entity": null,
-          "style": Array [
-            "ITALIC",
-          ],
-        },
-        Object {
-          "entity": null,
-          "style": Array [
-            "ITALIC",
-          ],
-        },
-      ],
-      "data": Object {},
-      "depth": 0,
-      "key": "f",
-      "text": "Charlie",
-      "type": "blockquote",
-    },
+    "depth": 0,
+    "key": "a",
+    "text": "Alphaxx",
+    "type": "unstyled",
   },
-  "entityMap": Object {},
-  "selectionAfter": Object {
-    "anchorKey": "a",
-    "anchorOffset": 7,
-    "focusKey": "a",
-    "focusOffset": 7,
-    "hasFocus": true,
-    "isBackward": false,
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
   },
-  "selectionBefore": Object {
-    "anchorKey": "a",
-    "anchorOffset": 5,
-    "focusKey": "a",
-    "focusOffset": 5,
-    "hasFocus": true,
-    "isBackward": false,
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
   },
-}
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
 `;
 
 exports[`must apply fragment to the start 1`] = `
-Object {
-  "blockMap": Object {
-    "a": Object {
-      "characterList": Array [
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-      ],
-      "data": Object {
-        "a": 1,
+Array [
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
       },
-      "depth": 0,
-      "key": "a",
-      "text": "xxAlpha",
-      "type": "unstyled",
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {
+      "a": 1,
     },
-    "b": Object {
-      "characterList": Array [
-        Object {
-          "entity": "1",
-          "style": Array [
-            "BOLD",
-          ],
-        },
-        Object {
-          "entity": "1",
-          "style": Array [
-            "BOLD",
-          ],
-        },
-        Object {
-          "entity": "1",
-          "style": Array [
-            "BOLD",
-          ],
-        },
-        Object {
-          "entity": "1",
-          "style": Array [
-            "BOLD",
-          ],
-        },
-        Object {
-          "entity": "1",
-          "style": Array [
-            "BOLD",
-          ],
-        },
-      ],
-      "data": Object {},
-      "depth": 0,
-      "key": "b",
-      "text": "Bravo",
-      "type": "unordered-list-item",
-    },
-    "c": Object {
-      "characterList": Array [
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-      ],
-      "data": Object {},
-      "depth": 0,
-      "key": "c",
-      "text": "Test",
-      "type": "code-block",
-    },
-    "d": Object {
-      "characterList": Array [],
-      "data": Object {},
-      "depth": 0,
-      "key": "d",
-      "text": "",
-      "type": "code-block",
-    },
-    "e": Object {
-      "characterList": Array [],
-      "data": Object {},
-      "depth": 0,
-      "key": "e",
-      "text": "",
-      "type": "code-block",
-    },
-    "f": Object {
-      "characterList": Array [
-        Object {
-          "entity": null,
-          "style": Array [
-            "ITALIC",
-          ],
-        },
-        Object {
-          "entity": null,
-          "style": Array [
-            "ITALIC",
-          ],
-        },
-        Object {
-          "entity": null,
-          "style": Array [
-            "ITALIC",
-          ],
-        },
-        Object {
-          "entity": null,
-          "style": Array [
-            "ITALIC",
-          ],
-        },
-        Object {
-          "entity": null,
-          "style": Array [
-            "ITALIC",
-          ],
-        },
-        Object {
-          "entity": null,
-          "style": Array [
-            "ITALIC",
-          ],
-        },
-        Object {
-          "entity": null,
-          "style": Array [
-            "ITALIC",
-          ],
-        },
-      ],
-      "data": Object {},
-      "depth": 0,
-      "key": "f",
-      "text": "Charlie",
-      "type": "blockquote",
-    },
+    "depth": 0,
+    "key": "a",
+    "text": "xxAlpha",
+    "type": "unstyled",
   },
-  "entityMap": Object {},
-  "selectionAfter": Object {
-    "anchorKey": "a",
-    "anchorOffset": 2,
-    "focusKey": "a",
-    "focusOffset": 2,
-    "hasFocus": true,
-    "isBackward": false,
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
   },
-  "selectionBefore": Object {
-    "anchorKey": "a",
-    "anchorOffset": 0,
-    "focusKey": "a",
-    "focusOffset": 0,
-    "hasFocus": true,
-    "isBackward": false,
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
   },
-}
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
 `;
 
 exports[`must apply fragment to within block 1`] = `
-Object {
-  "blockMap": Object {
-    "a": Object {
-      "characterList": Array [
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-      ],
-      "data": Object {
-        "a": 1,
+Array [
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
       },
-      "depth": 0,
-      "key": "a",
-      "text": "Alxxpha",
-      "type": "unstyled",
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {
+      "a": 1,
     },
-    "b": Object {
-      "characterList": Array [
-        Object {
-          "entity": "1",
-          "style": Array [
-            "BOLD",
-          ],
-        },
-        Object {
-          "entity": "1",
-          "style": Array [
-            "BOLD",
-          ],
-        },
-        Object {
-          "entity": "1",
-          "style": Array [
-            "BOLD",
-          ],
-        },
-        Object {
-          "entity": "1",
-          "style": Array [
-            "BOLD",
-          ],
-        },
-        Object {
-          "entity": "1",
-          "style": Array [
-            "BOLD",
-          ],
-        },
-      ],
-      "data": Object {},
-      "depth": 0,
-      "key": "b",
-      "text": "Bravo",
-      "type": "unordered-list-item",
-    },
-    "c": Object {
-      "characterList": Array [
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-      ],
-      "data": Object {},
-      "depth": 0,
-      "key": "c",
-      "text": "Test",
-      "type": "code-block",
-    },
-    "d": Object {
-      "characterList": Array [],
-      "data": Object {},
-      "depth": 0,
-      "key": "d",
-      "text": "",
-      "type": "code-block",
-    },
-    "e": Object {
-      "characterList": Array [],
-      "data": Object {},
-      "depth": 0,
-      "key": "e",
-      "text": "",
-      "type": "code-block",
-    },
-    "f": Object {
-      "characterList": Array [
-        Object {
-          "entity": null,
-          "style": Array [
-            "ITALIC",
-          ],
-        },
-        Object {
-          "entity": null,
-          "style": Array [
-            "ITALIC",
-          ],
-        },
-        Object {
-          "entity": null,
-          "style": Array [
-            "ITALIC",
-          ],
-        },
-        Object {
-          "entity": null,
-          "style": Array [
-            "ITALIC",
-          ],
-        },
-        Object {
-          "entity": null,
-          "style": Array [
-            "ITALIC",
-          ],
-        },
-        Object {
-          "entity": null,
-          "style": Array [
-            "ITALIC",
-          ],
-        },
-        Object {
-          "entity": null,
-          "style": Array [
-            "ITALIC",
-          ],
-        },
-      ],
-      "data": Object {},
-      "depth": 0,
-      "key": "f",
-      "text": "Charlie",
-      "type": "blockquote",
-    },
+    "depth": 0,
+    "key": "a",
+    "text": "Alxxpha",
+    "type": "unstyled",
   },
-  "entityMap": Object {},
-  "selectionAfter": Object {
-    "anchorKey": "a",
-    "anchorOffset": 4,
-    "focusKey": "a",
-    "focusOffset": 4,
-    "hasFocus": true,
-    "isBackward": false,
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
   },
-  "selectionBefore": Object {
-    "anchorKey": "a",
-    "anchorOffset": 2,
-    "focusKey": "a",
-    "focusOffset": 2,
-    "hasFocus": true,
-    "isBackward": false,
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
   },
-}
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
 `;
 
 exports[`must apply multiblock fragments 1`] = `
-Object {
-  "blockMap": Object {
-    "a": Object {
-      "characterList": Array [
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-      ],
-      "data": Object {
-        "a": 1,
+Array [
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
       },
-      "depth": 0,
-      "key": "a",
-      "text": "xx",
-      "type": "unstyled",
-    },
-    "b": Object {
-      "characterList": Array [
-        Object {
-          "entity": "1",
-          "style": Array [
-            "BOLD",
-          ],
-        },
-        Object {
-          "entity": "1",
-          "style": Array [
-            "BOLD",
-          ],
-        },
-        Object {
-          "entity": "1",
-          "style": Array [
-            "BOLD",
-          ],
-        },
-        Object {
-          "entity": "1",
-          "style": Array [
-            "BOLD",
-          ],
-        },
-        Object {
-          "entity": "1",
-          "style": Array [
-            "BOLD",
-          ],
-        },
-      ],
-      "data": Object {},
-      "depth": 0,
-      "key": "b",
-      "text": "Bravo",
-      "type": "unordered-list-item",
-    },
-    "c": Object {
-      "characterList": Array [
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-      ],
-      "data": Object {},
-      "depth": 0,
-      "key": "c",
-      "text": "Test",
-      "type": "code-block",
-    },
-    "d": Object {
-      "characterList": Array [],
-      "data": Object {},
-      "depth": 0,
-      "key": "d",
-      "text": "",
-      "type": "code-block",
-    },
-    "e": Object {
-      "characterList": Array [],
-      "data": Object {},
-      "depth": 0,
-      "key": "e",
-      "text": "",
-      "type": "code-block",
-    },
-    "f": Object {
-      "characterList": Array [
-        Object {
-          "entity": null,
-          "style": Array [
-            "ITALIC",
-          ],
-        },
-        Object {
-          "entity": null,
-          "style": Array [
-            "ITALIC",
-          ],
-        },
-        Object {
-          "entity": null,
-          "style": Array [
-            "ITALIC",
-          ],
-        },
-        Object {
-          "entity": null,
-          "style": Array [
-            "ITALIC",
-          ],
-        },
-        Object {
-          "entity": null,
-          "style": Array [
-            "ITALIC",
-          ],
-        },
-        Object {
-          "entity": null,
-          "style": Array [
-            "ITALIC",
-          ],
-        },
-        Object {
-          "entity": null,
-          "style": Array [
-            "ITALIC",
-          ],
-        },
-      ],
-      "data": Object {},
-      "depth": 0,
-      "key": "f",
-      "text": "Charlie",
-      "type": "blockquote",
-    },
-    "key0": Object {
-      "characterList": Array [
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-        Object {
-          "entity": null,
-          "style": Array [],
-        },
-      ],
-      "data": Object {
-        "b": 2,
+      Object {
+        "entity": null,
+        "style": Array [],
       },
-      "depth": 0,
-      "key": "key0",
-      "text": "yyAlpha",
-      "type": "unstyled",
+    ],
+    "data": Object {
+      "a": 1,
     },
+    "depth": 0,
+    "key": "a",
+    "text": "xx",
+    "type": "unstyled",
   },
-  "entityMap": Object {},
-  "selectionAfter": Object {
-    "anchorKey": "key0",
-    "anchorOffset": 2,
-    "focusKey": "key0",
-    "focusOffset": 2,
-    "hasFocus": true,
-    "isBackward": false,
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {
+      "b": 2,
+    },
+    "depth": 0,
+    "key": "key4",
+    "text": "yyAlpha",
+    "type": "unstyled",
   },
-  "selectionBefore": Object {
-    "anchorKey": "a",
-    "anchorOffset": 0,
-    "focusKey": "a",
-    "focusOffset": 0,
-    "hasFocus": true,
-    "isBackward": false,
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "b",
+    "text": "Bravo",
+    "type": "unordered-list-item",
   },
-}
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
+`;
+
+exports[`must be able to insert a fragment of ContentBlockNodes while updating the target block with the first fragment block properties 1`] = `
+Array [
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {
+      "a": 1,
+    },
+    "depth": 0,
+    "key": "first",
+    "nextSibling": "key15",
+    "parent": null,
+    "prevSibling": null,
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [],
+    "children": Array [
+      "key16",
+    ],
+    "data": Object {
+      "a": 1,
+    },
+    "depth": 0,
+    "key": "key15",
+    "nextSibling": "second",
+    "parent": null,
+    "prevSibling": "first",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [],
+    "children": Array [
+      "key17",
+    ],
+    "data": Object {
+      "a": 1,
+    },
+    "depth": 0,
+    "key": "key16",
+    "nextSibling": null,
+    "parent": "key15",
+    "prevSibling": null,
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {
+      "a": 1,
+    },
+    "depth": 0,
+    "key": "key17",
+    "nextSibling": null,
+    "parent": "key16",
+    "prevSibling": null,
+    "text": "Delta",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [],
+    "children": Array [],
+    "data": Object {
+      "a": 1,
+    },
+    "depth": 0,
+    "key": "second",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": "key15",
+    "text": "",
+    "type": "unstyled",
+  },
+]
+`;
+
+exports[`must be able to insert a fragment of ContentBlockNodes while updating the target block with the first fragment block properties after nested block 1`] = `
+Array [
+  Object {
+    "characterList": Array [],
+    "children": Array [
+      "firstChild",
+      "key19",
+      "key22",
+      "lastChild",
+    ],
+    "data": Object {
+      "a": 1,
+    },
+    "depth": 0,
+    "key": "root",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": null,
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {
+      "a": 1,
+    },
+    "depth": 0,
+    "key": "firstChild",
+    "nextSibling": "key19",
+    "parent": "root",
+    "prevSibling": null,
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [],
+    "children": Array [
+      "key20",
+    ],
+    "data": Object {
+      "a": 1,
+    },
+    "depth": 0,
+    "key": "key19",
+    "nextSibling": "key22",
+    "parent": "root",
+    "prevSibling": "firstChild",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [],
+    "children": Array [
+      "key21",
+    ],
+    "data": Object {
+      "a": 1,
+    },
+    "depth": 0,
+    "key": "key20",
+    "nextSibling": null,
+    "parent": "key19",
+    "prevSibling": null,
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {
+      "a": 1,
+    },
+    "depth": 0,
+    "key": "key21",
+    "nextSibling": null,
+    "parent": "key20",
+    "prevSibling": null,
+    "text": "Delta",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {
+      "a": 1,
+    },
+    "depth": 0,
+    "key": "key22",
+    "nextSibling": "lastChild",
+    "parent": "root",
+    "prevSibling": "key19",
+    "text": "Delta",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [],
+    "children": Array [],
+    "data": Object {
+      "a": 1,
+    },
+    "depth": 0,
+    "key": "lastChild",
+    "nextSibling": null,
+    "parent": "root",
+    "prevSibling": "key22",
+    "text": "",
+    "type": "unstyled",
+  },
+]
+`;
+
+exports[`must be able to insert a fragment with a single ContentBlockNode 1`] = `
+Array [
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {
+      "a": 1,
+    },
+    "depth": 0,
+    "key": "A",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": null,
+    "text": "some text",
+    "type": "unstyled",
+  },
+]
+`;
+
+exports[`must be able to insert fragment of ContentBlockNodes 1`] = `
+Array [
+  Object {
+    "characterList": Array [],
+    "children": Array [],
+    "data": Object {
+      "a": 1,
+    },
+    "depth": 0,
+    "key": "first",
+    "nextSibling": "key6",
+    "parent": null,
+    "prevSibling": null,
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [],
+    "children": Array [
+      "key7",
+    ],
+    "data": Object {
+      "a": 1,
+    },
+    "depth": 0,
+    "key": "key6",
+    "nextSibling": "key9",
+    "parent": null,
+    "prevSibling": "first",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [],
+    "children": Array [
+      "key8",
+    ],
+    "data": Object {
+      "a": 1,
+    },
+    "depth": 0,
+    "key": "key7",
+    "nextSibling": null,
+    "parent": "key6",
+    "prevSibling": null,
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {
+      "a": 1,
+    },
+    "depth": 0,
+    "key": "key8",
+    "nextSibling": null,
+    "parent": "key7",
+    "prevSibling": null,
+    "text": "Delta",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {
+      "a": 1,
+    },
+    "depth": 0,
+    "key": "key9",
+    "nextSibling": "second",
+    "parent": null,
+    "prevSibling": "key6",
+    "text": "Delta",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [],
+    "children": Array [],
+    "data": Object {
+      "a": 1,
+    },
+    "depth": 0,
+    "key": "second",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": "key9",
+    "text": "",
+    "type": "unstyled",
+  },
+]
+`;
+
+exports[`must be able to insert fragment of ContentBlockNodes after nested block 1`] = `
+Array [
+  Object {
+    "characterList": Array [],
+    "children": Array [
+      "firstChild",
+      "key10",
+      "key13",
+      "lastChild",
+    ],
+    "data": Object {
+      "a": 1,
+    },
+    "depth": 0,
+    "key": "root",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": null,
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [],
+    "children": Array [],
+    "data": Object {
+      "a": 1,
+    },
+    "depth": 0,
+    "key": "firstChild",
+    "nextSibling": "key10",
+    "parent": "root",
+    "prevSibling": null,
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [],
+    "children": Array [
+      "key11",
+    ],
+    "data": Object {
+      "a": 1,
+    },
+    "depth": 0,
+    "key": "key10",
+    "nextSibling": "key13",
+    "parent": "root",
+    "prevSibling": "firstChild",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [],
+    "children": Array [
+      "key12",
+    ],
+    "data": Object {
+      "a": 1,
+    },
+    "depth": 0,
+    "key": "key11",
+    "nextSibling": null,
+    "parent": "key10",
+    "prevSibling": null,
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {
+      "a": 1,
+    },
+    "depth": 0,
+    "key": "key12",
+    "nextSibling": null,
+    "parent": "key11",
+    "prevSibling": null,
+    "text": "Delta",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {
+      "a": 1,
+    },
+    "depth": 0,
+    "key": "key13",
+    "nextSibling": "lastChild",
+    "parent": "root",
+    "prevSibling": "key10",
+    "text": "Delta",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [],
+    "children": Array [],
+    "data": Object {
+      "a": 1,
+    },
+    "depth": 0,
+    "key": "lastChild",
+    "nextSibling": null,
+    "parent": "root",
+    "prevSibling": "key13",
+    "text": "",
+    "type": "unstyled",
+  },
+]
 `;

--- a/src/model/transaction/__tests__/__snapshots__/insertFragmentIntoContentState-test.js.snap
+++ b/src/model/transaction/__tests__/__snapshots__/insertFragmentIntoContentState-test.js.snap
@@ -985,6 +985,18 @@ Array [
         "entity": null,
         "style": Array [],
       },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
     ],
     "children": Array [],
     "data": Object {
@@ -995,7 +1007,7 @@ Array [
     "nextSibling": "lastChild",
     "parent": "root",
     "prevSibling": "key19",
-    "text": "Delta",
+    "text": "Elephant",
     "type": "unstyled",
   },
   Object {
@@ -1176,6 +1188,18 @@ Array [
         "entity": null,
         "style": Array [],
       },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
     ],
     "children": Array [],
     "data": Object {
@@ -1186,7 +1210,7 @@ Array [
     "nextSibling": "second",
     "parent": null,
     "prevSibling": "key6",
-    "text": "Delta",
+    "text": "Elephant",
     "type": "unstyled",
   },
   Object {
@@ -1330,6 +1354,18 @@ Array [
         "entity": null,
         "style": Array [],
       },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
     ],
     "children": Array [],
     "data": Object {
@@ -1340,7 +1376,7 @@ Array [
     "nextSibling": "lastChild",
     "parent": "root",
     "prevSibling": "key10",
-    "text": "Delta",
+    "text": "Elephant",
     "type": "unstyled",
   },
   Object {

--- a/src/model/transaction/__tests__/__snapshots__/randomizeBlockMapKeys-test.js.snap
+++ b/src/model/transaction/__tests__/__snapshots__/randomizeBlockMapKeys-test.js.snap
@@ -1,8 +1,130 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`must be able to randomize keys for ContentBlockNodes BlockMap and make orphan blocks become root blocks 1`] = `
+Array [
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "nextSibling": "key1",
+    "parent": null,
+    "prevSibling": null,
+    "text": "Delta",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [],
+    "children": Array [
+      "key2",
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key1",
+    "nextSibling": "key3",
+    "parent": null,
+    "prevSibling": "key0",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key2",
+    "nextSibling": null,
+    "parent": "key1",
+    "prevSibling": null,
+    "text": "Fire",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key3",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": "key1",
+    "text": "Gorilla",
+    "type": "unstyled",
+  },
+]
+`;
+
 exports[`must be able to randomize keys for ContentBlockNodes BlockMap and update reference links to the new keys 1`] = `
-Object {
-  "key0": Object {
+Array [
+  Object {
     "characterList": Array [],
     "children": Array [
       "key1",
@@ -17,7 +139,7 @@ Object {
     "text": "",
     "type": "unstyled",
   },
-  "key1": Object {
+  Object {
     "characterList": Array [],
     "children": Array [
       "key2",
@@ -31,7 +153,7 @@ Object {
     "text": "",
     "type": "unstyled",
   },
-  "key2": Object {
+  Object {
     "characterList": Array [
       Object {
         "entity": null,
@@ -48,7 +170,7 @@ Object {
     "text": "X",
     "type": "unstyled",
   },
-  "key3": Object {
+  Object {
     "characterList": Array [
       Object {
         "entity": null,
@@ -65,12 +187,12 @@ Object {
     "text": "Y",
     "type": "unstyled",
   },
-}
+]
 `;
 
 exports[`must be able to randomize keys for ContentBlocks BlockMap 1`] = `
-Object {
-  "key0": Object {
+Array [
+  Object {
     "characterList": Array [
       Object {
         "entity": null,
@@ -99,7 +221,7 @@ Object {
     "text": "Alpha",
     "type": "unstyled",
   },
-  "key1": Object {
+  Object {
     "characterList": Array [
       Object {
         "entity": null,
@@ -124,7 +246,7 @@ Object {
     "text": "Beta",
     "type": "unstyled",
   },
-  "key2": Object {
+  Object {
     "characterList": Array [
       Object {
         "entity": null,
@@ -161,7 +283,7 @@ Object {
     "text": "Charlie",
     "type": "unstyled",
   },
-  "key3": Object {
+  Object {
     "characterList": Array [
       Object {
         "entity": null,
@@ -190,5 +312,5 @@ Object {
     "text": "Delta",
     "type": "unstyled",
   },
-}
+]
 `;

--- a/src/model/transaction/__tests__/insertFragmentIntoContentState-test.js
+++ b/src/model/transaction/__tests__/insertFragmentIntoContentState-test.js
@@ -17,39 +17,45 @@ jest.disableAutomock();
 jest.mock('generateRandomKey');
 
 const BlockMapBuilder = require('BlockMapBuilder');
-const CharacterMetadata = require('CharacterMetadata');
 const ContentBlock = require('ContentBlock');
+const ContentBlockNode = require('ContentBlockNode');
+const SelectionState = require('SelectionState');
 const Immutable = require('immutable');
 
 const getSampleStateForTesting = require('getSampleStateForTesting');
 const insertFragmentIntoContentState = require('insertFragmentIntoContentState');
 
 const {contentState, selectionState} = getSampleStateForTesting();
-const {EMPTY} = CharacterMetadata;
 const {List, Map} = Immutable;
 
 const DEFAULT_BLOCK_CONFIG = {
   key: 'j',
   type: 'unstyled',
   text: 'xx',
-  characterList: List.of(EMPTY, EMPTY),
   data: new Map({a: 1}),
 };
 
 const initialBlock = contentState.getBlockMap().first();
 
-const createFragment = (fragment = {}) => {
+const createFragment = (fragment = {}, experimentalTreeDataSupport = false) => {
+  const ContentBlockNodeRecord = experimentalTreeDataSupport
+    ? ContentBlockNode
+    : ContentBlock;
   fragment = Array.isArray(fragment) ? fragment : [fragment];
 
   return BlockMapBuilder.createFromArray(
     fragment.map(
       config =>
-        new ContentBlock({
+        new ContentBlockNodeRecord({
           ...DEFAULT_BLOCK_CONFIG,
           ...config,
         }),
     ),
   );
+};
+
+const createContentBlockNodeFragment = fragment => {
+  return createFragment(fragment, true);
 };
 
 const assertInsertFragmentIntoContentState = (
@@ -58,7 +64,10 @@ const assertInsertFragmentIntoContentState = (
   content = contentState,
 ) => {
   expect(
-    insertFragmentIntoContentState(content, selection, fragment).toJS(),
+    insertFragmentIntoContentState(content, selection, fragment)
+      .getBlockMap()
+      .toIndexedSeq()
+      .toJS(),
   ).toMatchSnapshot();
 };
 
@@ -105,5 +114,279 @@ test('must apply multiblock fragments', () => {
         data: new Map({b: 2}),
       },
     ]),
+  );
+});
+
+test('must be able to insert a fragment with a single ContentBlockNode', () => {
+  const initialSelection = SelectionState.createEmpty('A');
+  const initialContent = contentState.set(
+    'blockMap',
+    createContentBlockNodeFragment([
+      {
+        key: 'A',
+        text: '',
+        data: null,
+      },
+    ]),
+  );
+
+  assertInsertFragmentIntoContentState(
+    createContentBlockNodeFragment([
+      {
+        key: 'B',
+        text: 'some text',
+      },
+    ]),
+    initialSelection,
+    initialContent,
+  );
+});
+
+test('must be able to insert fragment of ContentBlockNodes', () => {
+  const initialSelection = SelectionState.createEmpty('first');
+  const initialContent = contentState.set(
+    'blockMap',
+    createContentBlockNodeFragment([
+      {
+        key: 'first',
+        text: '',
+        nextSibling: 'second',
+      },
+      {
+        key: 'second',
+        text: '',
+        prevSibling: 'first',
+      },
+    ]),
+  );
+
+  assertInsertFragmentIntoContentState(
+    createContentBlockNodeFragment([
+      {
+        key: 'B',
+        text: '',
+        children: List(['C']),
+        nextSibling: 'E',
+      },
+      {
+        key: 'C',
+        parent: 'B',
+        text: '',
+        children: List(['D']),
+      },
+      {
+        key: 'D',
+        parent: 'C',
+        text: 'Delta',
+      },
+      {
+        key: 'E',
+        text: 'Delta',
+        prevSibling: 'B',
+      },
+    ]),
+    initialSelection,
+    initialContent,
+  );
+});
+
+test('must be able to insert fragment of ContentBlockNodes after nested block', () => {
+  const initialSelection = SelectionState.createEmpty('firstChild');
+  const initialContent = contentState.set(
+    'blockMap',
+    createContentBlockNodeFragment([
+      {
+        key: 'root',
+        text: '',
+        children: List(['firstChild', 'lastChild']),
+      },
+      {
+        key: 'firstChild',
+        parent: 'root',
+        text: '',
+        nextSibling: 'lastChild',
+      },
+      {
+        key: 'lastChild',
+        parent: 'root',
+        text: '',
+        prevSibling: 'firstChild',
+      },
+    ]),
+  );
+
+  assertInsertFragmentIntoContentState(
+    createContentBlockNodeFragment([
+      {
+        key: 'B',
+        text: '',
+        children: List(['C']),
+        nextSibling: 'E',
+      },
+      {
+        key: 'C',
+        parent: 'B',
+        text: '',
+        children: List(['D']),
+      },
+      {
+        key: 'D',
+        parent: 'C',
+        text: 'Delta',
+      },
+      {
+        key: 'E',
+        text: 'Delta',
+        prevSibling: 'B',
+      },
+    ]),
+    initialSelection,
+    initialContent,
+  );
+});
+
+test('must be able to insert a fragment of ContentBlockNodes while updating the target block with the first fragment block properties', () => {
+  const initialSelection = SelectionState.createEmpty('first');
+  const initialContent = contentState.set(
+    'blockMap',
+    createContentBlockNodeFragment([
+      {
+        key: 'first',
+        text: '',
+        nextSibling: 'second',
+      },
+      {
+        key: 'second',
+        text: '',
+        prevSibling: 'first',
+      },
+    ]),
+  );
+
+  assertInsertFragmentIntoContentState(
+    createContentBlockNodeFragment([
+      {
+        key: 'A',
+        text: 'Alpha',
+        nextSibling: 'B',
+      },
+      {
+        key: 'B',
+        text: '',
+        children: List(['C']),
+        prevSibling: 'A',
+      },
+      {
+        key: 'C',
+        parent: 'B',
+        text: '',
+        children: List(['D']),
+      },
+      {
+        key: 'D',
+        parent: 'C',
+        text: 'Delta',
+      },
+    ]),
+    initialSelection,
+    initialContent,
+  );
+});
+
+test('must be able to insert a fragment of ContentBlockNodes while updating the target block with the first fragment block properties after nested block', () => {
+  const initialSelection = SelectionState.createEmpty('firstChild');
+  const initialContent = contentState.set(
+    'blockMap',
+    createContentBlockNodeFragment([
+      {
+        key: 'root',
+        text: '',
+        children: List(['firstChild', 'lastChild']),
+      },
+      {
+        key: 'firstChild',
+        parent: 'root',
+        text: '',
+        nextSibling: 'lastChild',
+      },
+      {
+        key: 'lastChild',
+        parent: 'root',
+        text: '',
+        prevSibling: 'firstChild',
+      },
+    ]),
+  );
+
+  assertInsertFragmentIntoContentState(
+    createContentBlockNodeFragment([
+      {
+        key: 'A',
+        text: 'Alpha',
+        nextSibling: 'B',
+      },
+      {
+        key: 'B',
+        text: '',
+        children: List(['C']),
+        prevSibling: 'A',
+        nextSibling: 'E',
+      },
+      {
+        key: 'C',
+        parent: 'B',
+        text: '',
+        children: List(['D']),
+      },
+      {
+        key: 'D',
+        parent: 'C',
+        text: 'Delta',
+      },
+      {
+        key: 'E',
+        text: 'Delta',
+        prevSibling: 'B',
+      },
+    ]),
+    initialSelection,
+    initialContent,
+  );
+});
+
+test('must throw an error when trying to apply ContentBlockNode fragments when selection is on a block that has children', () => {
+  const initialSelection = SelectionState.createEmpty('A');
+  const initialContent = contentState.set(
+    'blockMap',
+    createContentBlockNodeFragment([
+      {
+        key: 'A',
+        text: '',
+        data: null,
+        children: List(['B']),
+      },
+      {
+        key: 'B',
+        text: 'child',
+        parent: 'A',
+      },
+    ]),
+  );
+
+  expect(() =>
+    insertFragmentIntoContentState(
+      initialContent,
+      initialSelection,
+      createContentBlockNodeFragment([
+        {
+          key: 'C',
+          text: 'some text',
+        },
+      ]),
+    ),
+  ).toThrow(
+    new Error(
+      '`insertFragment` should not be called when a container node is selected.',
+    ),
   );
 });

--- a/src/model/transaction/__tests__/insertFragmentIntoContentState-test.js
+++ b/src/model/transaction/__tests__/insertFragmentIntoContentState-test.js
@@ -181,7 +181,7 @@ test('must be able to insert fragment of ContentBlockNodes', () => {
       },
       {
         key: 'E',
-        text: 'Delta',
+        text: 'Elephant',
         prevSibling: 'B',
       },
     ]),
@@ -236,7 +236,7 @@ test('must be able to insert fragment of ContentBlockNodes after nested block', 
       },
       {
         key: 'E',
-        text: 'Delta',
+        text: 'Elephant',
         prevSibling: 'B',
       },
     ]),
@@ -345,7 +345,7 @@ test('must be able to insert a fragment of ContentBlockNodes while updating the 
       },
       {
         key: 'E',
-        text: 'Delta',
+        text: 'Elephant',
         prevSibling: 'B',
       },
     ]),

--- a/src/model/transaction/__tests__/randomizeBlockMapKeys-test.js
+++ b/src/model/transaction/__tests__/randomizeBlockMapKeys-test.js
@@ -27,9 +27,9 @@ const {List} = Immutable;
 
 const assertRandomizeBlockMapKeys = blockMapArray => {
   expect(
-    randomizeBlockMapKeys(
-      BlockMapBuilder.createFromArray(blockMapArray),
-    ).toJS(),
+    randomizeBlockMapKeys(BlockMapBuilder.createFromArray(blockMapArray))
+      .toIndexedSeq()
+      .toJS(),
   ).toMatchSnapshot();
 };
 
@@ -82,6 +82,53 @@ test('must be able to randomize keys for ContentBlockNodes BlockMap and update r
       parent: 'A',
       prevSibling: 'B',
       text: 'Y',
+    }),
+  ]);
+});
+
+/**
+ * This could occur when extracting a fragment from a partial selection
+ * the bellow case could happen when selecting blocks D to G from blockMap like:
+ *
+ *
+ * A
+ *   B
+ *     C
+ *       D - Delta
+ *   E
+ *     F - Fire
+ *   g - gorilla
+ *
+ *
+ * Selected (D to G) - Expected outcome:
+ *
+ * => We should remove all parent links from the orphan blocks then they should be treated as root nodes
+ * making sure that next/pre links are amended accordingly
+ */
+test('must be able to randomize keys for ContentBlockNodes BlockMap and make orphan blocks become root blocks', () => {
+  assertRandomizeBlockMapKeys([
+    new ContentBlockNode({
+      key: 'D',
+      parent: 'C',
+      text: 'Delta',
+    }),
+    new ContentBlockNode({
+      key: 'E',
+      parent: 'A',
+      prevSibling: 'B',
+      nextSibling: 'G',
+      children: List(['F']),
+    }),
+    new ContentBlockNode({
+      key: 'F',
+      parent: 'E',
+      text: 'Fire',
+    }),
+    new ContentBlockNode({
+      key: 'G',
+      parent: 'A',
+      prevSibling: 'E',
+      text: 'Gorilla',
     }),
   ]);
 });

--- a/src/model/transaction/insertFragmentIntoContentState.js
+++ b/src/model/transaction/insertFragmentIntoContentState.js
@@ -13,121 +13,55 @@
 
 'use strict';
 
+// TODO
+// => once tests are passing refactor to make sure we pass the least amount of arguments
+// to each of the bellow functions transforms
+
 import type {BlockMap} from 'BlockMap';
 import type ContentState from 'ContentState';
 import type SelectionState from 'SelectionState';
+import type {BlockNodeRecord} from 'BlockNodeRecord';
 
-var BlockMapBuilder = require('BlockMapBuilder');
+const BlockMapBuilder = require('BlockMapBuilder');
+const ContentBlockNode = require('ContentBlockNode');
+const Immutable = require('immutable');
 
-var generateRandomKey = require('generateRandomKey');
-var insertIntoList = require('insertIntoList');
-var invariant = require('invariant');
+const insertIntoList = require('insertIntoList');
+const invariant = require('invariant');
+const randomizeBlockMapKeys = require('randomizeBlockMapKeys');
 
-function insertFragmentIntoContentState(
+const {List} = Immutable;
+
+const updateExistingBlock = (
   contentState: ContentState,
   selectionState: SelectionState,
+  blockMap: BlockMap,
   fragment: BlockMap,
-): ContentState {
-  invariant(
-    selectionState.isCollapsed(),
-    '`insertFragment` should only be called with a collapsed selection state.',
-  );
+  targetKey: string,
+  targetOffset: number,
+): ContentState => {
+  const targetBlock = blockMap.get(targetKey);
+  const pastedBlock = fragment.first();
+  const text = targetBlock.getText();
+  const chars = targetBlock.getCharacterList();
+  const finalKey = targetKey;
+  const finalOffset = targetOffset + pastedBlock.getText().length;
 
-  var targetKey = selectionState.getStartKey();
-  var targetOffset = selectionState.getStartOffset();
-
-  var blockMap = contentState.getBlockMap();
-
-  var fragmentSize = fragment.size;
-  var finalKey;
-  var finalOffset;
-
-  if (fragmentSize === 1) {
-    var targetBlock = blockMap.get(targetKey);
-    var pastedBlock = fragment.first();
-    var text = targetBlock.getText();
-    var chars = targetBlock.getCharacterList();
-
-    var newBlock = targetBlock.merge({
-      text:
-        text.slice(0, targetOffset) +
-        pastedBlock.getText() +
-        text.slice(targetOffset),
-      characterList: insertIntoList(
-        chars,
-        pastedBlock.getCharacterList(),
-        targetOffset,
-      ),
-      data: pastedBlock.getData(),
-    });
-
-    finalKey = targetKey;
-    finalOffset = targetOffset + pastedBlock.getText().length;
-
-    return contentState.merge({
-      blockMap: blockMap.set(targetKey, newBlock),
-      selectionBefore: selectionState,
-      selectionAfter: selectionState.merge({
-        anchorKey: finalKey,
-        anchorOffset: finalOffset,
-        focusKey: finalKey,
-        focusOffset: finalOffset,
-        isBackward: false,
-      }),
-    });
-  }
-
-  var newBlockArr = [];
-
-  contentState.getBlockMap().forEach((block, blockKey) => {
-    if (blockKey !== targetKey) {
-      newBlockArr.push(block);
-      return;
-    }
-
-    var text = block.getText();
-    var chars = block.getCharacterList();
-
-    // Modify head portion of block.
-    var blockSize = text.length;
-    var headText = text.slice(0, targetOffset);
-    var headCharacters = chars.slice(0, targetOffset);
-    var appendToHead = fragment.first();
-
-    var modifiedHead = block.merge({
-      text: headText + appendToHead.getText(),
-      characterList: headCharacters.concat(appendToHead.getCharacterList()),
-      type: headText ? block.getType() : appendToHead.getType(),
-      data: appendToHead.getData(),
-    });
-
-    newBlockArr.push(modifiedHead);
-
-    // Insert fragment blocks after the head and before the tail.
-    fragment.slice(1, fragmentSize - 1).forEach(fragmentBlock => {
-      newBlockArr.push(fragmentBlock.set('key', generateRandomKey()));
-    });
-
-    // Modify tail portion of block.
-    var tailText = text.slice(targetOffset, blockSize);
-    var tailCharacters = chars.slice(targetOffset, blockSize);
-    var prependToTail = fragment.last();
-    finalKey = generateRandomKey();
-
-    var modifiedTail = prependToTail.merge({
-      key: finalKey,
-      text: prependToTail.getText() + tailText,
-      characterList: prependToTail.getCharacterList().concat(tailCharacters),
-      data: prependToTail.getData(),
-    });
-
-    newBlockArr.push(modifiedTail);
+  const newBlock = targetBlock.merge({
+    text:
+      text.slice(0, targetOffset) +
+      pastedBlock.getText() +
+      text.slice(targetOffset),
+    characterList: insertIntoList(
+      chars,
+      pastedBlock.getCharacterList(),
+      targetOffset,
+    ),
+    data: pastedBlock.getData(),
   });
 
-  finalOffset = fragment.last().getLength();
-
   return contentState.merge({
-    blockMap: BlockMapBuilder.createFromArray(newBlockArr),
+    blockMap: blockMap.set(targetKey, newBlock),
     selectionBefore: selectionState,
     selectionAfter: selectionState.merge({
       anchorKey: finalKey,
@@ -137,6 +71,278 @@ function insertFragmentIntoContentState(
       isBackward: false,
     }),
   });
-}
+};
+
+/**
+ * Appends text/characterList from the fragment first block to
+ * target block.
+ */
+const updateHead = (
+  block: BlockNodeRecord,
+  targetOffset: number,
+  fragment: BlockMap,
+  shouldNotUpdateFromFragmentBlock: boolean,
+): BlockNodeRecord => {
+  if (shouldNotUpdateFromFragmentBlock) {
+    return block;
+  }
+
+  const text = block.getText();
+  const chars = block.getCharacterList();
+
+  // Modify head portion of block.
+  const headText = text.slice(0, targetOffset);
+  const headCharacters = chars.slice(0, targetOffset);
+  const appendToHead = fragment.first();
+
+  return block.merge({
+    text: headText + appendToHead.getText(),
+    characterList: headCharacters.concat(appendToHead.getCharacterList()),
+    type: headText ? block.getType() : appendToHead.getType(),
+    data: appendToHead.getData(),
+  });
+};
+
+/**
+ * Appends offset text/characterList from the target block to the last
+ * fragment block.
+ */
+const updateTail = (
+  block: BlockNodeRecord,
+  targetOffset: number,
+  fragment: BlockMap,
+): BlockNodeRecord => {
+  // Modify tail portion of block.
+  const text = block.getText();
+  const chars = block.getCharacterList();
+
+  // Modify head portion of block.
+  const blockSize = text.length;
+  const tailText = text.slice(targetOffset, blockSize);
+  const tailCharacters = chars.slice(targetOffset, blockSize);
+  const prependToTail = fragment.last();
+
+  return prependToTail.merge({
+    text: prependToTail.getText() + tailText,
+    characterList: prependToTail.getCharacterList().concat(tailCharacters),
+    data: prependToTail.getData(),
+  });
+};
+
+// TODO fix flow
+const getRootBlocks = (block: ContentBlockNode, blockMap: BlockMap): any => {
+  const headKey = block.getKey();
+  let rootBlock = block;
+  let rootBlocks = [];
+
+  // we need to account to when the head fragment block is merged with the target block
+  if (blockMap.get(headKey)) {
+    rootBlocks.push(headKey);
+  }
+
+  while (rootBlock && rootBlock.getNextSiblingKey()) {
+    const lastSiblingKey = rootBlock.getNextSiblingKey();
+    rootBlocks.push(lastSiblingKey);
+    rootBlock = blockMap.get(lastSiblingKey);
+  }
+
+  return rootBlocks;
+};
+
+const updateBlockMapLinks = (
+  blockMap: BlockMap,
+  originalBlockMap: BlockMap,
+  targetBlock: ContentBlockNode,
+  fragmentHeadBlock: ContentBlockNode,
+  didNotMergeFirstFragmentBlockWithTargetBlock: boolean,
+): BlockMap => {
+  return blockMap.withMutations(blockMapState => {
+    const targetKey = targetBlock.getKey();
+    const headKey = fragmentHeadBlock.getKey();
+    const targetNextKey = targetBlock.getNextSiblingKey();
+    const targetParentKey = targetBlock.getParentKey();
+    const fragmentRootBlocks = getRootBlocks(fragmentHeadBlock, blockMap);
+    const lastRootFragmentBlockKey =
+      fragmentRootBlocks[fragmentRootBlocks.length - 1];
+
+    if (didNotMergeFirstFragmentBlockWithTargetBlock) {
+      blockMapState.setIn([targetKey, 'nextSibling'], headKey);
+      blockMapState.setIn([headKey, 'prevSibling'], targetKey);
+    } else {
+      blockMapState.setIn(
+        [targetKey, 'nextSibling'],
+        fragmentHeadBlock.getNextSiblingKey(),
+      );
+      blockMapState.setIn(
+        [fragmentHeadBlock.getNextSiblingKey(), 'prevSibling'],
+        targetKey,
+      );
+    }
+
+    // update the last root block fragment
+    blockMapState.setIn(
+      [lastRootFragmentBlockKey, 'nextSibling'],
+      targetNextKey,
+    );
+
+    // update the original target next block
+    if (targetNextKey) {
+      blockMapState.setIn(
+        [targetNextKey, 'prevSibling'],
+        lastRootFragmentBlockKey,
+      );
+    }
+
+    // update fragment parent links
+    fragmentRootBlocks.forEach(blockKey =>
+      blockMapState.setIn([blockKey, 'parent'], targetParentKey),
+    );
+
+    // update targetBlock parent child links
+    if (targetParentKey) {
+      const targetParent = blockMap.get(targetParentKey);
+      const originalTargetParentChildKeys = targetParent.getChildKeys();
+
+      const targetBlockIndex = originalTargetParentChildKeys.indexOf(targetKey);
+      const insertionIndex = targetBlockIndex + 1;
+
+      const newChildrenArray = originalTargetParentChildKeys.toArray();
+
+      // insert fragment children
+      newChildrenArray.splice(insertionIndex, 0, ...fragmentRootBlocks);
+
+      blockMapState.setIn(
+        [targetParentKey, 'children'],
+        new List(newChildrenArray),
+      );
+    }
+  });
+};
+
+const insertFragment = (
+  contentState: ContentState,
+  selectionState: SelectionState,
+  blockMap: BlockMap,
+  fragment: BlockMap,
+  targetKey: string,
+  targetOffset: number,
+): ContentState => {
+  const isTreeBasedBlockMap = blockMap.first() instanceof ContentBlockNode;
+  const newBlockArr = [];
+  const fragmentSize = fragment.size;
+  const target = blockMap.get(targetKey);
+  const head = fragment.first();
+  const tail = fragment.last();
+  const finalOffset = tail.getLength();
+  const finalKey = tail.getKey();
+  const shouldNotUpdateFromFragmentBlock =
+    isTreeBasedBlockMap &&
+    (!target.getChildKeys().isEmpty() || !head.getChildKeys().isEmpty());
+
+  //
+  // TODO - improve the bellow comment
+  // the first fragment block's content is used to update the target block
+  // we should not skip the first fragment block since we cannot merge the
+  // target block with the first fragment block contents
+  const startFragmentOffset = shouldNotUpdateFromFragmentBlock ? 0 : 1;
+
+  // check here why the fragment block insertion seems messed up
+  // on the snapshots the 'root' block is not appearing correct order
+  blockMap.forEach((block, blockKey) => {
+    if (blockKey !== targetKey) {
+      newBlockArr.push(block);
+      return;
+    }
+
+    // update head
+    newBlockArr.push(
+      updateHead(
+        block,
+        targetOffset,
+        fragment,
+        shouldNotUpdateFromFragmentBlock,
+      ),
+    );
+
+    // Insert fragment blocks after the head and before the tail.
+    fragment
+      .slice(startFragmentOffset, fragmentSize - 1)
+      .forEach(fragmentBlock => newBlockArr.push(fragmentBlock));
+
+    // update tail
+    newBlockArr.push(updateTail(block, targetOffset, fragment));
+  });
+
+  let updatedBlockMap = BlockMapBuilder.createFromArray(newBlockArr);
+
+  if (isTreeBasedBlockMap) {
+    updatedBlockMap = updateBlockMapLinks(
+      updatedBlockMap,
+      blockMap,
+      target,
+      head,
+      shouldNotUpdateFromFragmentBlock,
+    );
+  }
+
+  return contentState.merge({
+    blockMap: updatedBlockMap,
+    selectionBefore: selectionState,
+    selectionAfter: selectionState.merge({
+      anchorKey: finalKey,
+      anchorOffset: finalOffset,
+      focusKey: finalKey,
+      focusOffset: finalOffset,
+      isBackward: false,
+    }),
+  });
+};
+
+const insertFragmentIntoContentState = (
+  contentState: ContentState,
+  selectionState: SelectionState,
+  fragmentBlockMap: BlockMap,
+): ContentState => {
+  invariant(
+    selectionState.isCollapsed(),
+    '`insertFragment` should only be called with a collapsed selection state.',
+  );
+
+  const blockMap = contentState.getBlockMap();
+  const fragment = randomizeBlockMapKeys(fragmentBlockMap);
+  const targetKey = selectionState.getStartKey();
+  const targetOffset = selectionState.getStartOffset();
+
+  const targetBlock = blockMap.get(targetKey);
+
+  if (targetBlock instanceof ContentBlockNode) {
+    invariant(
+      targetBlock.getChildKeys().isEmpty(),
+      '`insertFragment` should not be called when a container node is selected.',
+    );
+  }
+
+  // When we insert a fragment with a single block we simply update the target block
+  // with the contents of the inserted fragment block
+  if (fragment.size === 1) {
+    return updateExistingBlock(
+      contentState,
+      selectionState,
+      blockMap,
+      fragment,
+      targetKey,
+      targetOffset,
+    );
+  }
+
+  return insertFragment(
+    contentState,
+    selectionState,
+    blockMap,
+    fragment,
+    targetKey,
+    targetOffset,
+  );
+};
 
 module.exports = insertFragmentIntoContentState;

--- a/src/model/transaction/insertFragmentIntoContentState.js
+++ b/src/model/transaction/insertFragmentIntoContentState.js
@@ -37,7 +37,6 @@ const updateExistingBlock = (
   targetOffset: number,
 ): ContentState => {
   const targetBlock = blockMap.get(targetKey);
-  //const fragmentBlock = fragment.first();
   const text = targetBlock.getText();
   const chars = targetBlock.getCharacterList();
   const finalKey = targetKey;


### PR DESCRIPTION
### Context

This PR is part of a series of PR's that will be exploring **tree data block support** in Draft.

**Adding support for tree data structures**

This PR includes the missing parts for adding support for internal tree data structure by providing:
    
* last transaction insertFragmentIntoContentState.js
* last modifier AtomicBlockUtils
* fixing a bug on the randomizeBlockMapKeys to handle orphanated fragments

This is the last PR of the series to add support for internal tree data structures, from here we should then either update `RichTextEditorUtil` to have some `tree` awareness and having some controls for creating nesting content or create a new `NestedRichTextEditorUtil` that can be used for that. Ideally that work would also come with a `demo` example page

***

**Note:**
This is unstable and not part of the public API and should not be used by
production systems.
