### PR TITLE
Add blockKey, start, and end props to DecoratorComponent

### DIFF
--- a/src/component/contents/DraftEditorBlock.react.js
+++ b/src/component/contents/DraftEditorBlock.react.js
@@ -186,10 +186,9 @@ class DraftEditorBlock extends React.Component<Props> {
 
         const decoratorProps = decorator.getPropsForKey(decoratorKey);
         const decoratorOffsetKey = DraftOffsetKey.encode(blockKey, ii, 0);
-        const decoratedText = text.slice(
-          leavesForLeafSet.first().get('start'),
-          leavesForLeafSet.last().get('end'),
-        );
+        const start = leavesForLeafSet.first().get('start');
+        const end = leavesForLeafSet.last().get('end');
+        const decoratedText = text.slice(start, end);
 
         // Resetting dir to the same value on a child node makes Chrome/Firefox
         // confused on cursor movement. See http://jsfiddle.net/d157kLck/3/
@@ -205,8 +204,11 @@ class DraftEditorBlock extends React.Component<Props> {
             decoratedText={decoratedText}
             dir={dir}
             key={decoratorOffsetKey}
+            blockKey={blockKey}
             entityKey={block.getEntityAt(leafSet.get('start'))}
-            offsetKey={decoratorOffsetKey}>
+            offsetKey={decoratorOffsetKey}
+            start={start}
+            end={end}>
             {leaves}
           </DecoratorComponent>
         );

--- a/src/component/contents/exploration/DraftEditorDecoratedLeaves.react.js
+++ b/src/component/contents/exploration/DraftEditorDecoratedLeaves.react.js
@@ -61,10 +61,9 @@ class DraftEditorDecoratedLeaves extends React.Component<Props> {
       0,
     );
 
-    const decoratedText = text.slice(
-      leavesForLeafSet.first().get('start'),
-      leavesForLeafSet.last().get('end'),
-    );
+    const start = leavesForLeafSet.first().get('start');
+    const end = leavesForLeafSet.last().get('end');
+    const decoratedText = text.slice(start, end);
 
     // Resetting dir to the same value on a child node makes Chrome/Firefox
     // confused on cursor movement. See http://jsfiddle.net/d157kLck/3/
@@ -80,8 +79,11 @@ class DraftEditorDecoratedLeaves extends React.Component<Props> {
         decoratedText={decoratedText}
         dir={dir}
         key={decoratorOffsetKey}
+        blockKey={blockKey}
         entityKey={block.getEntityAt(leafSet.get('start'))}
-        offsetKey={decoratorOffsetKey}>
+        offsetKey={decoratorOffsetKey}
+        start={start}
+        end={end}>
         {children}
       </DecoratorComponent>
     );


### PR DESCRIPTION
**Summary**

Add `blockKey`, `start`, and `end` props to `DecoratorComponent` to allow for greater functionality in decorated components

Addresses https://github.com/facebook/draft-js/issues/1394
