### PR TITLE
Feature - insert additional atomic block param for block data

### DIFF
--- a/src/model/modifier/AtomicBlockUtils.js
+++ b/src/model/modifier/AtomicBlockUtils.js
@@ -34,6 +34,7 @@ const AtomicBlockUtils = {
     editorState: EditorState,
     entityKey: string,
     character: string,
+    blockData?: Object
   ): EditorState {
     const contentState = editorState.getCurrentContent();
     const selectionState = editorState.getSelection();
@@ -62,6 +63,7 @@ const AtomicBlockUtils = {
         type: 'atomic',
         text: character,
         characterList: List(Repeat(charData, character.length)),
+        data: blockData
       }),
       new ContentBlock({
         key: generateRandomKey(),

--- a/src/model/modifier/__tests__/AtomicBlockUtils-test.js
+++ b/src/model/modifier/__tests__/AtomicBlockUtils-test.js
@@ -28,6 +28,7 @@ const {editorState, contentState, selectionState} = getSampleStateForTesting();
 const initialBlock = contentState.getBlockMap().first();
 const ENTITY_KEY = Entity.create('TOKEN', 'MUTABLE');
 const CHARACTER = ' ';
+const BLOCK_DATA = {};
 
 const assertAtomic = state => {
   expect(
@@ -47,8 +48,9 @@ const assertInsertAtomicBlock = (
   state = editorState,
   entity = ENTITY_KEY,
   character = CHARACTER,
+  blockData = BLOCK_DATA
 ) => {
-  const newState = insertAtomicBlock(state, entity, character);
+  const newState = insertAtomicBlock(state, entity, character, blockData);
   assertAtomic(newState);
   return newState;
 };


### PR DESCRIPTION
**Summary**
Added a param to `AtomicBlockUtils` - `insertAtomicBlock()`. When creating an Atomic block, there isn't an option to create with block data. This has been added as an optional param, which is then passed to the `new ContentBlock` within `fragmentArray`. 

**Test Plan**
`assertInsertAtomicBlock` has been updated to contain the blockData param, which for test purposes is an empty object.
