### PR TITLE
Handling Enter and Backspace for empty list blocks closer to text processors behaviour

### DIFF
--- a/src/model/immutable/EditorChangeType.js
+++ b/src/model/immutable/EditorChangeType.js
@@ -30,5 +30,5 @@ export type EditorChangeType =
   | 'remove-range'
   | 'spellcheck-change'
   | 'split-block'
-  | 'replace-block-to-softline' 
+  | 'replace-block-to-softline'
   | 'undo';

--- a/src/model/immutable/EditorChangeType.js
+++ b/src/model/immutable/EditorChangeType.js
@@ -30,4 +30,5 @@ export type EditorChangeType =
   | 'remove-range'
   | 'spellcheck-change'
   | 'split-block'
+  | 'replace-block-to-softline' 
   | 'undo';

--- a/src/model/modifier/RichTextEditorUtil.js
+++ b/src/model/modifier/RichTextEditorUtil.js
@@ -114,25 +114,25 @@ const RichTextEditorUtil = {
       return null;
     }
 
-    // Try to use behaviour of text processors for backspace  
-    // on empty list item block - remove it and replace to soft newline 
-    // at preceding list item block. 
-    var replacedToSoftLine = RichTextEditorUtil.tryToReplaceBlockToSoftLine( 
-      editorState, 
-    ); 
-    if (replacedToSoftLine) { 
-      let newState = EditorState.push( 
-        editorState, 
-        replacedToSoftLine, 
-        'replace-block-to-softline', 
-      ); 
-      newState = EditorState.forceSelection( 
-        newState, 
-        replacedToSoftLine.getSelectionAfter(), 
-      ); 
-      return newState; 
-    } 
- 
+    // Try to use behaviour of text processors for backspace
+    // on empty list item block - remove it and replace to soft newline
+    // at preceding list item block.
+    var replacedToSoftLine = RichTextEditorUtil.tryToReplaceBlockToSoftLine(
+      editorState,
+    );
+    if (replacedToSoftLine) {
+      let newState = EditorState.push(
+        editorState,
+        replacedToSoftLine,
+        'replace-block-to-softline',
+      );
+      newState = EditorState.forceSelection(
+        newState,
+        replacedToSoftLine.getSelectionAfter(),
+      );
+      return newState;
+    }
+
     // Then, try to remove a preceding atomic block.
     var content = editorState.getCurrentContent();
     var startKey = selection.getStartKey();
@@ -385,51 +385,56 @@ const RichTextEditorUtil = {
     return EditorState.push(editorState, withoutLink, 'apply-entity');
   },
 
-  /** 
-   * When a collapsed cursor is at the start of non-first empty list  
-   * item then remove current block and insert soft newline at  
-   * preceding list item block. 
-   * Returns null if block or selection does not meet that criteria. 
-   */ 
-  tryToReplaceBlockToSoftLine: function(editorState: EditorState): ?ContentState { 
-    var selection = editorState.getSelection(); 
-    var offset = selection.getAnchorOffset(); 
-    if (selection.isCollapsed() && offset === 0) { 
-      var key = selection.getAnchorKey(); 
-      var content = editorState.getCurrentContent(); 
-      var block = content.getBlockForKey(key); 
-      var type = block.getType(); 
-      var depth = block.getDepth(); 
-      var blockBefore = content.getBlockBefore(key); 
- 
-      if ((type == 'ordered-list-item' || type == 'unordered-list-item')   
-        && blockBefore 
-        && blockBefore.getType() === type 
-      ) { 
-        const blockMap = content.getBlockMap().delete(block.getKey()); 
-        let selectionAtEndOfBlockBefore = SelectionState.createEmpty(blockBefore.getKey()).merge({ 
-          anchorKey: blockBefore.getKey(), 
-          anchorOffset: blockBefore.getLength(), 
-          focusKey: blockBefore.getKey(), 
-          focusOffset: blockBefore.getLength(), 
-        }); 
-        var withoutBlock = content.merge({ 
-          blockMap, 
-          selectionAfter: selectionAtEndOfBlockBefore, 
-        }); 
- 
-        var newContentState = DraftModifier.insertText( 
-          withoutBlock, 
-          selectionAtEndOfBlockBefore, 
-          '\n', 
-          editorState.getCurrentInlineStyle(), 
-          null, 
-        ); 
- 
-        return newContentState; 
-      } 
-    } 
-    return null; 
+  /**
+   * When a collapsed cursor is at the start of non-first empty list
+   * item then remove current block and insert soft newline at
+   * preceding list item block.
+   * Returns null if block or selection does not meet that criteria.
+   */
+
+  tryToReplaceBlockToSoftLine: function(
+    editorState: EditorState,
+  ): ?ContentState {
+    var selection = editorState.getSelection();
+    var offset = selection.getAnchorOffset();
+    if (selection.isCollapsed() && offset === 0) {
+      var key = selection.getAnchorKey();
+      var content = editorState.getCurrentContent();
+      var block = content.getBlockForKey(key);
+      var type = block.getType();
+      var blockBefore = content.getBlockBefore(key);
+
+      if (
+        (type == 'ordered-list-item' || type == 'unordered-list-item') &&
+        blockBefore &&
+        blockBefore.getType() === type
+      ) {
+        const blockMap = content.getBlockMap().delete(block.getKey());
+        let selectionAtEndOfBlockBefore = SelectionState.createEmpty(
+          blockBefore.getKey(),
+        ).merge({
+          anchorKey: blockBefore.getKey(),
+          anchorOffset: blockBefore.getLength(),
+          focusKey: blockBefore.getKey(),
+          focusOffset: blockBefore.getLength(),
+        });
+        var withoutBlock = content.merge({
+          blockMap,
+          selectionAfter: selectionAtEndOfBlockBefore,
+        });
+
+        var newContentState = DraftModifier.insertText(
+          withoutBlock,
+          selectionAtEndOfBlockBefore,
+          '\n',
+          editorState.getCurrentInlineStyle(),
+          null,
+        );
+
+        return newContentState;
+      }
+    }
+    return null;
   },
 
   /**

--- a/src/model/modifier/RichTextEditorUtil.js
+++ b/src/model/modifier/RichTextEditorUtil.js
@@ -249,8 +249,6 @@ const RichTextEditorUtil = {
       return editorState;
     }
 
-    maxDepth = Math.min(blockAbove.getDepth() + 1, maxDepth);
-
     var withAdjustment = adjustBlockDepthForContentState(
       content,
       selection,

--- a/src/model/modifier/RichTextEditorUtil.js
+++ b/src/model/modifier/RichTextEditorUtil.js
@@ -114,7 +114,26 @@ const RichTextEditorUtil = {
       return null;
     }
 
-    // First, try to remove a preceding atomic block.
+    // Try to use behaviour of text processors for backspace  
+    // on empty list item block - remove it and replace to soft newline 
+    // at preceding list item block. 
+    var replacedToSoftLine = RichTextEditorUtil.tryToReplaceBlockToSoftLine( 
+      editorState, 
+    ); 
+    if (replacedToSoftLine) { 
+      let newState = EditorState.push( 
+        editorState, 
+        replacedToSoftLine, 
+        'replace-block-to-softline', 
+      ); 
+      newState = EditorState.forceSelection( 
+        newState, 
+        replacedToSoftLine.getSelectionAfter(), 
+      ); 
+      return newState; 
+    } 
+ 
+    // Then, try to remove a preceding atomic block.
     var content = editorState.getCurrentContent();
     var startKey = selection.getStartKey();
     var blockBefore = content.getBlockBefore(startKey);
@@ -364,6 +383,53 @@ const RichTextEditorUtil = {
     );
 
     return EditorState.push(editorState, withoutLink, 'apply-entity');
+  },
+
+  /** 
+   * When a collapsed cursor is at the start of non-first empty list  
+   * item then remove current block and insert soft newline at  
+   * preceding list item block. 
+   * Returns null if block or selection does not meet that criteria. 
+   */ 
+  tryToReplaceBlockToSoftLine: function(editorState: EditorState): ?ContentState { 
+    var selection = editorState.getSelection(); 
+    var offset = selection.getAnchorOffset(); 
+    if (selection.isCollapsed() && offset === 0) { 
+      var key = selection.getAnchorKey(); 
+      var content = editorState.getCurrentContent(); 
+      var block = content.getBlockForKey(key); 
+      var type = block.getType(); 
+      var depth = block.getDepth(); 
+      var blockBefore = content.getBlockBefore(key); 
+ 
+      if ((type == 'ordered-list-item' || type == 'unordered-list-item')   
+        && blockBefore 
+        && blockBefore.getType() === type 
+      ) { 
+        const blockMap = content.getBlockMap().delete(block.getKey()); 
+        let selectionAtEndOfBlockBefore = SelectionState.createEmpty(blockBefore.getKey()).merge({ 
+          anchorKey: blockBefore.getKey(), 
+          anchorOffset: blockBefore.getLength(), 
+          focusKey: blockBefore.getKey(), 
+          focusOffset: blockBefore.getLength(), 
+        }); 
+        var withoutBlock = content.merge({ 
+          blockMap, 
+          selectionAfter: selectionAtEndOfBlockBefore, 
+        }); 
+ 
+        var newContentState = DraftModifier.insertText( 
+          withoutBlock, 
+          selectionAtEndOfBlockBefore, 
+          '\n', 
+          editorState.getCurrentInlineStyle(), 
+          null, 
+        ); 
+ 
+        return newContentState; 
+      } 
+    } 
+    return null; 
   },
 
   /**

--- a/src/model/transaction/splitBlockInContentState.js
+++ b/src/model/transaction/splitBlockInContentState.js
@@ -20,6 +20,7 @@ import type SelectionState from 'SelectionState';
 const ContentBlockNode = require('ContentBlockNode');
 const Immutable = require('immutable');
 
+const modifyBlockForContentState = require('modifyBlockForContentState');
 const generateRandomKey = require('generateRandomKey');
 const invariant = require('invariant');
 
@@ -102,6 +103,20 @@ const splitBlockInContentState = (
   const chars = blockToSplit.getCharacterList();
   const keyBelow = generateRandomKey();
   const isExperimentalTreeBlock = blockToSplit instanceof ContentBlockNode;
+  const blockAfter = contentState.getBlockAfter(key);
+  const isListItem = (blockToSplit.getType() === 'ordered-list-item' || blockToSplit.getType() === 'unordered-list-item');
+  const isNextListItem = blockAfter && (blockAfter.getType() === 'ordered-list-item' || blockAfter.getType() === 'unordered-list-item');
+
+  // If the block is a last list item without any text, unstyle the block (this will end list). 
+  if (text == "") { 
+    if (isListItem && (!blockAfter || blockAfter && !isNextListItem)) { 
+      return modifyBlockForContentState( 
+        contentState, 
+        selectionState, 
+        (block) => block.merge({type: 'unstyled', depth: 0}) 
+      ); 
+    } 
+  } 
 
   const blockAbove = blockToSplit.merge({
     text: text.slice(0, offset),

--- a/src/model/transaction/splitBlockInContentState.js
+++ b/src/model/transaction/splitBlockInContentState.js
@@ -104,19 +104,22 @@ const splitBlockInContentState = (
   const keyBelow = generateRandomKey();
   const isExperimentalTreeBlock = blockToSplit instanceof ContentBlockNode;
   const blockAfter = contentState.getBlockAfter(key);
-  const isListItem = (blockToSplit.getType() === 'ordered-list-item' || blockToSplit.getType() === 'unordered-list-item');
-  const isNextListItem = blockAfter && (blockAfter.getType() === 'ordered-list-item' || blockAfter.getType() === 'unordered-list-item');
+  const isListItem =
+    blockToSplit.getType() === 'ordered-list-item' ||
+    blockToSplit.getType() === 'unordered-list-item';
+  const isNextListItem =
+    blockAfter &&
+    (blockAfter.getType() === 'ordered-list-item' ||
+      blockAfter.getType() === 'unordered-list-item');
 
-  // If the block is a last list item without any text, unstyle the block (this will end list). 
-  if (text == "") { 
-    if (isListItem && (!blockAfter || blockAfter && !isNextListItem)) { 
-      return modifyBlockForContentState( 
-        contentState, 
-        selectionState, 
-        (block) => block.merge({type: 'unstyled', depth: 0}) 
-      ); 
-    } 
-  } 
+  // If the block is a last list item without any text, unstyle the block (this will end list).
+  if (text == '') {
+    if (isListItem && (!blockAfter || (blockAfter && !isNextListItem))) {
+      return modifyBlockForContentState(contentState, selectionState, block =>
+        block.merge({type: 'unstyled', depth: 0}),
+      );
+    }
+  }
 
   const blockAbove = blockToSplit.merge({
     text: text.slice(0, offset),


### PR DESCRIPTION
**Summary**
1. Handling Backspace when cursor is on empty non-first list item block. 
Current behaviour - unstyle current block, that will split a list of current list item is not last. 
Proposed behaviour - remove current block and replace it with soft newline at preceding list item block.
This behaviour is common to text processors. It will be possible to use multiline text at list item.

2. Handling Enter when cursor is on last empty list item.
Current behaviour - create new list item.
Proposed behaviour - unstyle the block, this will end a list.
If use this behaviour for every list item, not only last, this will split list. Which is not common for text processors. (Text processors can unstyle block and preserve it in list, but it's not possible in Draft.js for now)

3. Removed restriction on indenting beyond one level deeper than the block above (common behaviour of text processors).
Fixes issue #270.

**Test Plan**
No tests yet.
