### PR TITLE
Close a race after handling before input

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -85,8 +85,9 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
   _editorKey: string;
   _placeholderAccessibilityID: string;
   _latestEditorState: EditorState;
+  _renderNativeContent: boolean;
+  _updatedNativeInsertionBlock: boolean;
   _latestCommittedEditorState: EditorState;
-  _pendingStateFromBeforeInput: void | EditorState;
 
   /**
    * Define proxies that can route events to the current handler.
@@ -461,7 +462,11 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
    * an `onChange` prop to receive state updates passed along from this
    * function.
    */
-  update = (editorState: EditorState): void => {
+  update = (
+    editorState: EditorState,
+    renderNativeContent: boolean = false,
+  ): void => {
+    this._renderNativeContent = renderNativeContent;
     this._latestEditorState = editorState;
     this.props.onChange(editorState);
   };

--- a/src/component/handlers/edit/editOnBeforeInput.js
+++ b/src/component/handlers/edit/editOnBeforeInput.js
@@ -26,6 +26,8 @@ const isEventHandled = require('isEventHandled');
 var isSelectionAtLeafStart = require('isSelectionAtLeafStart');
 var nullthrows = require('nullthrows');
 var setImmediate = require('setImmediate');
+var editOnInput = require('editOnInput');
+var editOnSelect = require('editOnSelect');
 
 // When nothing is focused, Firefox regards two characters, `'` and `/`, as
 // commands that should open and focus the "quickfind" search bar. This should
@@ -37,6 +39,7 @@ var setImmediate = require('setImmediate');
 var FF_QUICKFIND_CHAR = "'";
 var FF_QUICKFIND_LINK_CHAR = '/';
 var isFirefox = UserAgent.isBrowser('Firefox');
+var isIE = UserAgent.isBrowser('IE');
 
 function mustPreventDefaultForCharacter(character: string): boolean {
   return (
@@ -78,10 +81,10 @@ function editOnBeforeInput(
   editor: DraftEditor,
   e: SyntheticInputEvent<>,
 ): void {
-  if (editor._pendingStateFromBeforeInput !== undefined) {
-    editor.update(editor._pendingStateFromBeforeInput);
-    editor._pendingStateFromBeforeInput = undefined;
-  }
+  // React doesn't fire a selection event until mouseUp, so it's possible to
+  // click to change selection, hold the mouse down, and type a character
+  // without React registering it. Let's sync the selection manually now.
+  editOnSelect(editor);
 
   const editorState = editor._latestEditorState;
 
@@ -217,17 +220,38 @@ function editOnBeforeInput(
   newEditorState = EditorState.set(newEditorState, {
     nativelyRenderedContent: newEditorState.getCurrentContent(),
   });
-  // The native event is allowed to occur. To allow user onChange handlers to
-  // change the inserted text, we wait until the text is actually inserted
-  // before we actually update our state. That way when we rerender, the text
-  // we see in the DOM will already have been inserted properly.
-  editor._pendingStateFromBeforeInput = newEditorState;
-  setImmediate(() => {
-    if (editor._pendingStateFromBeforeInput !== undefined) {
-      editor.update(editor._pendingStateFromBeforeInput);
-      editor._pendingStateFromBeforeInput = undefined;
+
+  editor._updatedNativeInsertionBlock = editorState
+    .getCurrentContent()
+    .getBlockForKey(editorState.getSelection().getAnchorKey());
+
+  // Allow the native insertion to occur and update our internal state to match.
+  // If editor.update() does something like changing a typed 'x' to 'abc' in an
+  // onChange() handler, we don't want our editOnInput() logic to squash that
+  // change in favor of the typed 'x'. Set a flag to ignore the next
+  // editOnInput() event in favor of what's in our internal state.
+  editor.update(newEditorState, true);
+
+  var editorStateAfterUpdate = editor._latestEditorState;
+  var contentStateAfterUpdate = editorStateAfterUpdate.getCurrentContent();
+  var expectedContentStateAfterUpdate = editorStateAfterUpdate.getNativelyRenderedContent();
+
+  if (
+    expectedContentStateAfterUpdate &&
+    expectedContentStateAfterUpdate === contentStateAfterUpdate
+  ) {
+    if (isIE) {
+      setImmediate(() => {
+        editOnInput(editor);
+      });
     }
-  });
+  } else {
+    // Outside callers (via the editor.onChange prop) have changed the
+    // editorState. No longer allow native insertion.
+    e.preventDefault();
+    editor._updatedNativeInsertionBlock = null;
+    editor._renderNativeContent = false;
+  }
 }
 
 module.exports = editOnBeforeInput;

--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -19,12 +19,12 @@ const DraftFeatureFlags = require('DraftFeatureFlags');
 var DraftModifier = require('DraftModifier');
 var DraftOffsetKey = require('DraftOffsetKey');
 var EditorState = require('EditorState');
-var UserAgent = require('UserAgent');
+
+var editOnSelect = require('editOnSelect');
+var EditorBidiService = require('EditorBidiService');
 
 var findAncestorOffsetKey = require('findAncestorOffsetKey');
 var nullthrows = require('nullthrows');
-
-var isGecko = UserAgent.isEngine('Gecko');
 
 var DOUBLE_NEWLINE = '\n\n';
 
@@ -41,14 +41,49 @@ var DOUBLE_NEWLINE = '\n\n';
  * due to a spellcheck change, and we can incorporate it into our model.
  */
 function editOnInput(editor: DraftEditor): void {
-  if (editor._pendingStateFromBeforeInput !== undefined) {
-    editor.update(editor._pendingStateFromBeforeInput);
-    editor._pendingStateFromBeforeInput = undefined;
+  // We have already updated our internal state appropriately for this input
+  // event. See editOnBeforeInput() for more info
+  if (editor._updatedNativeInsertionBlock && !editor._renderNativeContent) {
+    editor._updatedNativeInsertionBlock = null;
+    return;
+  }
+
+  editOnSelect(editor);
+  var editorState = editor._latestEditorState;
+
+  if (editor._updatedNativeInsertionBlock) {
+    const oldBlock = editor._updatedNativeInsertionBlock;
+    if (editorState.getSelection().getFocusKey() !== oldBlock.getKey()) {
+      // The selection has changed between editOnBeforeInput and now, and our
+      // optimistically updated block is no longer valid.
+      // Replace it with the non-updated block and let the input fall through.
+      const currentContent = editorState.getCurrentContent();
+      const contentWithOldBlock = currentContent.merge({
+        blockMap: currentContent.getBlockMap().set(oldBlock.getKey(), oldBlock),
+        selectionBefore: currentContent.getSelectionBefore(),
+        selectionAfter: currentContent.getSelectionAfter(),
+      });
+
+      var directionMap = EditorBidiService.getDirectionMap(
+        contentWithOldBlock,
+        editorState.getDirectionMap(),
+      );
+
+      editor.update(
+        EditorState.set(editorState, {
+          currentContent: contentWithOldBlock,
+          directionMap,
+        }),
+      );
+
+      editorState = editor._latestEditorState;
+    }
+    editor._updatedNativeInsertionBlock = null;
   }
 
   var domSelection = global.getSelection();
 
-  var {anchorNode, isCollapsed} = domSelection;
+  var {anchorNode} = domSelection;
   const isNotTextNode = anchorNode.nodeType !== Node.TEXT_NODE;
   const isNotTextOrElementNode =
     anchorNode.nodeType !== Node.TEXT_NODE &&
@@ -87,7 +122,6 @@ function editOnInput(editor: DraftEditor): void {
   }
 
   var domText = anchorNode.textContent;
-  var editorState = editor._latestEditorState;
   var offsetKey = nullthrows(findAncestorOffsetKey(anchorNode));
   var {blockKey, decoratorKey, leafKey} = DraftOffsetKey.decode(offsetKey);
 
@@ -136,50 +170,21 @@ function editOnInput(editor: DraftEditor): void {
   // native browser undo.
   const changeType = preserveEntity ? 'spellcheck-change' : 'apply-entity';
 
+  // Replace the full text of the leaf and set the selection to the value
+  // calculated in editOnSelect() above, because replacing the leaf will move
+  // the selection to the end of the leaf rather than the end of the changed
+  // text.
   const newContent = DraftModifier.replaceText(
     content,
     targetRange,
     domText,
     block.getInlineStyleAt(start),
     preserveEntity ? block.getEntityAt(start) : null,
-  );
+  )
+    .set('selectionBefore', content.getSelectionBefore())
+    .set('selectionAfter', content.getSelectionAfter());
 
-  var anchorOffset, focusOffset, startOffset, endOffset;
-
-  if (isGecko) {
-    // Firefox selection does not change while the context menu is open, so
-    // we preserve the anchor and focus values of the DOM selection.
-    anchorOffset = domSelection.anchorOffset;
-    focusOffset = domSelection.focusOffset;
-    startOffset = start + Math.min(anchorOffset, focusOffset);
-    endOffset = startOffset + Math.abs(anchorOffset - focusOffset);
-    anchorOffset = startOffset;
-    focusOffset = endOffset;
-  } else {
-    // Browsers other than Firefox may adjust DOM selection while the context
-    // menu is open, and Safari autocorrect is prone to providing an inaccurate
-    // DOM selection. Don't trust it. Instead, use our existing SelectionState
-    // and adjust it based on the number of characters changed during the
-    // mutation.
-    var charDelta = domText.length - modelText.length;
-    startOffset = selection.getStartOffset();
-    endOffset = selection.getEndOffset();
-
-    anchorOffset = isCollapsed ? endOffset + charDelta : startOffset;
-    focusOffset = endOffset + charDelta;
-  }
-
-  // Segmented entities are completely or partially removed when their
-  // text content changes. For this case we do not want any text to be selected
-  // after the change, so we are not merging the selection.
-  var contentWithAdjustedDOMSelection = newContent.merge({
-    selectionBefore: content.getSelectionAfter(),
-    selectionAfter: selection.merge({anchorOffset, focusOffset}),
-  });
-
-  editor.update(
-    EditorState.push(editorState, contentWithAdjustedDOMSelection, changeType),
-  );
+  editor.update(EditorState.push(editorState, newContent, changeType));
 }
 
 module.exports = editOnInput;


### PR DESCRIPTION
**Summary**

The before input event is not a browser event, it is emulated by React. Draft uses this event in order to set up its expectation for the state of the document after the browser has had a chance to process user input and it relies on that expectation later when the input event comes in. Since before input is emulated this sets up a race condition in which the state of the DOM can change out from under Draft leading to a very broken experience.

This change closes this race condition by attempting to handle as much as possible during the before input event and by handling the case that the selection has changed between the time that the before input was handled and when the input event is handled.

This fixes #989

**Test Plan**

I've attempted to do some manual testing on this change. It has also been part of the textioHQ fork and running on our live site for almost a year.

Before:
![before](https://user-images.githubusercontent.com/6133448/34797179-71cbf52c-f60c-11e7-9f76-43fe90296bb5.gif)

After:
![after](https://user-images.githubusercontent.com/6133448/34797188-79c258c0-f60c-11e7-81d5-d11384388d1e.gif)
