### PR TITLE
Fix render crash of DraftEditorTextNode (BR -> text)

### DIFF
--- a/src/component/handlers/edit/editOnBeforeInput.js
+++ b/src/component/handlers/edit/editOnBeforeInput.js
@@ -185,6 +185,17 @@ function editOnBeforeInput(
         parentNode.firstChild.nodeType === Node.TEXT_NODE &&
         parentNode.firstChild.nodeValue.indexOf('\t') !== -1;
     }
+    // If selected block was empty, DraftEditorTextNode rendered it as <BR>.
+    // But now we typed some chars to it, so <BR> should be removed.
+    // We must let React render this properly.
+    if (
+      nativeSelection.anchorNode &&
+      nativeSelection.anchorNode.nodeName === 'SPAN' &&
+      nativeSelection.anchorNode.firstChild.nodeName == 'BR' &&
+      chars
+    ) {
+      mustPreventNative = true;
+    }
   }
   if (!mustPreventNative) {
     // Check the old and new "fingerprints" of the current block to determine


### PR DESCRIPTION
**Summary**
Fixes #1612
Native rendering must be prevented when <BR> should be replaced by <SPAN>.
By obvious reason. Otherwise React-rendering of DraftEditorTextNode will crash!

Tip: Also this bug can be prevented by using `const useNewlineChar = true` at DraftEditorTextNode (now it's true for IE only)

**Test Plan**
No unit tests. Just did manual ones.