### PR TITLE
Match block and inline examples for consistency.

### DIFF
--- a/examples/draft-0-10-0/rich/rich.html
+++ b/examples/draft-0-10-0/rich/rich.html
@@ -217,10 +217,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       ];
 
       const InlineStyleControls = (props) => {
-        var currentStyle = props.editorState.getCurrentInlineStyle();
+        const currentStyle = props.editorState.getCurrentInlineStyle();
+        
         return (
           <div className="RichEditor-controls">
-            {INLINE_STYLES.map(type =>
+            {INLINE_STYLES.map((type) =>
               <StyleButton
                 key={type.label}
                 active={currentStyle.has(type.style)}


### PR DESCRIPTION
**Summary**

A simple update to keep the examples consistent. 
It could have gone either way, so I updated the second example to match the first.

**Test Plan**
N/A