### PR TITLE
Remove Node 6 from engines list in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "webpack-stream": "^4.0.0"
   },
   "devEngines": {
-    "node": "6.x || 8.x || 9.x",
+    "node": "8.x || 9.x",
     "npm": "2.x || 3.x || 5.x"
   },
   "jest": {


### PR DESCRIPTION
**Summary**

Fixes #1650. 

Travis is using Node 8 since 247a632ab6420e7809a8f7cf7dd2b31b495bb4c7, and Prettier is already configured in a way that's not Node-6 compatible:

https://github.com/facebook/draft-js/blob/a6317e60b06519d3c00a2c0621701f3da0837a88/prettier.config.js#L3

Node 8 is the LTS release line since late october 2017 so I think it's fair to remove support for Node 6.

NB: I see `devEngines` also states support for npm 2 and 3. Node 8 ships with npm 5 by default, so I imagine those 2 versions could be removed as well. Edit: Ah actually I see draft-js is at least partially using yarn since #1568 / #1570.

**Test plan**

No tests. This is only removing support, it doesn't affect supported versions.