### PR TITLE
Move uglifyjs-webpack-plugin to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
   "dependencies": {
     "fbjs": "^0.8.15",
     "immutable": "~3.7.4",
-    "object-assign": "^4.1.0",
-    "uglifyjs-webpack-plugin": "^1.1.6"
+    "object-assign": "^4.1.0"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0-rc || ^16.0.0-rc || ^16.0.0",
@@ -81,6 +80,7 @@
     "run-sequence": "^1.1.2",
     "stats-webpack-plugin": "^0.6.2",
     "through2": "^2.0.1",
+    "uglifyjs-webpack-plugin": "^1.1.6",
     "vinyl-buffer": "^1.0.0",
     "webpack-stream": "^4.0.0"
   },


### PR DESCRIPTION
**Summary**

This dependency got introduced in a separate commit (f8ca29d1a7fa5a8bb89cb9be9a66d12732a0bfa7) from the others in #1644. I imagine this is a mistake since it only provides dev-time tooling.

**Test Plan**

For development, we can try a fresh install of the project:

1. `rm -rf node_modules`
2. `yarn install`. This runs `npm run build` via the `prepublish` script, so if it works it's good to go.

I don't think dependencies and devDependencies are processed any differently in a development environment, so not sure this check is even necessary.

For the published package:

1. `mkdir test`
2. `npm init -y`
3. `npm install git+https://github.com/thibaudcolas/draft-js.git#patch-2`
4. `npm ls --depth=1`

The `npm ls` result should be:

```
├─┬ draft-js@0.10.5 (git+https://github.com/thibaudcolas/draft-js.git#cb06920d0f3dea77692680dddba6ec475663c7b2)
│ ├── fbjs@0.8.16
│ ├── immutable@3.7.6
│ └── object-assign@4.1.1
├── UNMET PEER DEPENDENCY react@^0.14.0 || ^15.0.0-rc || ^16.0.0-rc || ^16.0.0
└── UNMET PEER DEPENDENCY react-dom@^0.14.0 || ^15.0.0-rc || ^16.0.0-rc || ^16.0.0
```

Note `uglifyjs-webpack-plugin` is absent, whereas it would have been there with `npm install git+https://github.com/thibaudcolas/draft-js.git#master`.