### PR TITLE
Ensure selection collapses if user tries to replace with matching text

### DIFF
--- a/src/component/handlers/edit/__tests__/__snapshots__/editOnBeforeInput.test.js.snap
+++ b/src/component/handlers/edit/__tests__/__snapshots__/editOnBeforeInput.test.js.snap
@@ -76,74 +76,22 @@ Immutable.Record {
 
 exports[`editor selectionstate is updated if new text matches current selection 1`] = `
 Immutable.Record {
-  "entityMap": Object {
-    "__add": [Function],
-    "__create": [Function],
-    "__get": [Function],
-    "__getLastCreatedEntityKey": [Function],
-    "__mergeData": [Function],
-    "__replaceData": [Function],
-    "add": [Function],
-    "create": [Function],
-    "get": [Function],
-    "getLastCreatedEntityKey": [Function],
-    "mergeData": [Function],
-    "replaceData": [Function],
-  },
-  "blockMap": Immutable.OrderedMap {
-    "a": Immutable.Record {
-      "key": "a",
-      "type": "unstyled",
-      "text": "Arsenal",
-      "characterList": Immutable.List [
-        Immutable.Record {
-          "style": Immutable.OrderedSet [],
-          "entity": null,
-        },
-        Immutable.Record {
-          "style": Immutable.OrderedSet [],
-          "entity": null,
-        },
-        Immutable.Record {
-          "style": Immutable.OrderedSet [],
-          "entity": null,
-        },
-        Immutable.Record {
-          "style": Immutable.OrderedSet [],
-          "entity": null,
-        },
-        Immutable.Record {
-          "style": Immutable.OrderedSet [],
-          "entity": null,
-        },
-        Immutable.Record {
-          "style": Immutable.OrderedSet [],
-          "entity": null,
-        },
-        Immutable.Record {
-          "style": Immutable.OrderedSet [],
-          "entity": null,
-        },
-      ],
-      "depth": 0,
-      "data": Immutable.Map {},
-    },
-  },
-  "selectionBefore": Immutable.Record {
-    "anchorKey": "a",
-    "anchorOffset": 0,
-    "focusKey": "a",
-    "focusOffset": 0,
-    "isBackward": false,
-    "hasFocus": false,
-  },
-  "selectionAfter": Immutable.Record {
-    "anchorKey": "a",
-    "anchorOffset": 0,
-    "focusKey": "a",
-    "focusOffset": 0,
-    "isBackward": false,
-    "hasFocus": false,
-  },
+  "anchorKey": "a",
+  "anchorOffset": 1,
+  "focusKey": "a",
+  "focusOffset": 1,
+  "isBackward": false,
+  "hasFocus": true,
+}
+`;
+
+exports[`editor selectionstate is updated if new text matches current selection and user selected backwards 1`] = `
+Immutable.Record {
+  "anchorKey": "a",
+  "anchorOffset": 1,
+  "focusKey": "a",
+  "focusOffset": 1,
+  "isBackward": true,
+  "hasFocus": true,
 }
 `;

--- a/src/component/handlers/edit/__tests__/editOnBeforeInput.test.js
+++ b/src/component/handlers/edit/__tests__/editOnBeforeInput.test.js
@@ -29,11 +29,15 @@ const DEFAULT_SELECTION = {
   isBackward: false,
 };
 
-//const collapsedSelection = new SelectionState(DEFAULT_SELECTION);
-
 const rangedSelection = new SelectionState({
   ...DEFAULT_SELECTION,
   focusOffset: 1,
+});
+
+const rangedSelectionBackwards = new SelectionState({
+  ...DEFAULT_SELECTION,
+  anchorOffset: 1,
+  isBackward: true,
 });
 
 const getEditorState = () => {
@@ -125,5 +129,25 @@ test('editor selectionstate is updated if new text matches current selection', (
   expect(editor.update).toHaveBeenCalledTimes(1);
 
   const newEditorState = editor.update.mock.calls[0][0];
-  expect(newEditorState.getCurrentContent()).toMatchSnapshot();
+  expect(newEditorState.getSelection()).toMatchSnapshot();
+});
+
+test('editor selectionstate is updated if new text matches current selection and user selected backwards', () => {
+  const editorState = EditorState.acceptSelection(
+    getEditorState(),
+    rangedSelectionBackwards,
+  );
+
+  const editor = {
+    _latestEditorState: editorState,
+    props: {},
+    update: jest.fn(),
+  };
+
+  onBeforeInput(editor, getInputEvent('A'));
+
+  expect(editor.update).toHaveBeenCalledTimes(1);
+
+  const newEditorState = editor.update.mock.calls[0][0];
+  expect(newEditorState.getSelection()).toMatchSnapshot();
 });

--- a/src/component/handlers/edit/editOnBeforeInput.js
+++ b/src/component/handlers/edit/editOnBeforeInput.js
@@ -129,6 +129,7 @@ function editOnBeforeInput(
         EditorState.forceSelection(
           editorState,
           selection.merge({
+            anchorOffset: selectionEnd,
             focusOffset: selectionEnd,
           }),
         ),


### PR DESCRIPTION
**Summary**

This PR ensures that the selection is always collapsed for the cases where a user replaces the current selection with matching text.

I admittedly didn't really dig into the original issue when fixing the previous crash :)

**Test Plan**

Small repro:

1. Type in "abc"
1. Select "c" from right-to-left
1. Type "c"
1. Select "c" from left-to-right
1. Type "c"

Thanks to @JLarky for bringing this to my intention!