### PR TITLE
Optionally preserve fragment type when inserting a single block

### DIFF
--- a/docs/APIReference-Modifier.md
+++ b/docs/APIReference-Modifier.md
@@ -137,6 +137,7 @@ replaceWithFragment(
   contentState: ContentState,
   targetRange: SelectionState,
   fragment: BlockMap
+  forceTypeOverride: ?boolean,
 ): ContentState
 ```
 A "fragment" is a section of a block map, effectively just an
@@ -144,6 +145,8 @@ A "fragment" is a section of a block map, effectively just an
 `ContentState` object.
 
 This method will replace the "target" range with the fragment.
+
+If the fragment to be inserted is a single block, by default it acquires the type of the target block. Passing `true` to `forceTypeOverride` will use the type of block to be inserted instead.
 
 Example: When pasting content, we convert the paste into a fragment to be inserted
 into the editor, then use this method to add it.

--- a/src/model/modifier/DraftModifier.js
+++ b/src/model/modifier/DraftModifier.js
@@ -120,6 +120,7 @@ var DraftModifier = {
     contentState: ContentState,
     targetRange: SelectionState,
     fragment: BlockMap,
+    forceTypeOverride: ?boolean,
   ): ContentState {
     var withoutEntities = removeEntitiesAtEdges(contentState, targetRange);
     var withoutText = removeRangeFromContentState(withoutEntities, targetRange);
@@ -128,6 +129,7 @@ var DraftModifier = {
       withoutText,
       withoutText.getSelectionAfter(),
       fragment,
+      forceTypeOverride,
     );
   },
 

--- a/src/model/transaction/__tests__/__snapshots__/insertFragmentIntoContentState-test.js.snap
+++ b/src/model/transaction/__tests__/__snapshots__/insertFragmentIntoContentState-test.js.snap
@@ -1395,3 +1395,353 @@ Array [
   },
 ]
 `;
+
+exports[`must insert with the fragment block type if passed forceTypeOverride 1`] = `
+Array [
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "a",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {
+      "a": 1,
+    },
+    "depth": 0,
+    "key": "b",
+    "text": "xxBravo",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
+`;
+
+exports[`must insert with the target block type by default 1`] = `
+Array [
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "a",
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+      Object {
+        "entity": "1",
+        "style": Array [
+          "BOLD",
+        ],
+      },
+    ],
+    "data": Object {
+      "a": 1,
+    },
+    "depth": 0,
+    "key": "b",
+    "text": "xxBravo",
+    "type": "unordered-list-item",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "c",
+    "text": "Test",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "d",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "e",
+    "text": "",
+    "type": "code-block",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+      Object {
+        "entity": null,
+        "style": Array [
+          "ITALIC",
+        ],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "f",
+    "text": "Charlie",
+    "type": "blockquote",
+  },
+]
+`;

--- a/src/model/transaction/__tests__/insertFragmentIntoContentState-test.js
+++ b/src/model/transaction/__tests__/insertFragmentIntoContentState-test.js
@@ -36,6 +36,7 @@ const DEFAULT_BLOCK_CONFIG = {
 };
 
 const initialBlock = contentState.getBlockMap().first();
+const secondBlock = contentState.getBlockForKey('b');
 
 const createFragment = (fragment = {}, experimentalTreeDataSupport = false) => {
   const ContentBlockNodeRecord = experimentalTreeDataSupport
@@ -62,9 +63,15 @@ const assertInsertFragmentIntoContentState = (
   fragment,
   selection = selectionState,
   content = contentState,
+  forceTypeOverride,
 ) => {
   expect(
-    insertFragmentIntoContentState(content, selection, fragment)
+    insertFragmentIntoContentState(
+      content,
+      selection,
+      fragment,
+      forceTypeOverride,
+    )
       .getBlockMap()
       .toIndexedSeq()
       .toJS(),
@@ -388,5 +395,29 @@ test('must throw an error when trying to apply ContentBlockNode fragments when s
     new Error(
       '`insertFragment` should not be called when a container node is selected.',
     ),
+  );
+});
+
+test('must insert with the target block type by default', () => {
+  assertInsertFragmentIntoContentState(
+    createFragment(),
+    selectionState.merge({
+      focusKey: secondBlock.getKey(),
+      anchorKey: secondBlock.getKey(),
+      isBackward: false,
+    }),
+  );
+});
+
+test('must insert with the fragment block type if passed forceTypeOverride', () => {
+  assertInsertFragmentIntoContentState(
+    createFragment(),
+    selectionState.merge({
+      focusKey: secondBlock.getKey(),
+      anchorKey: secondBlock.getKey(),
+      isBackward: false,
+    }),
+    undefined,
+    true,
   );
 });

--- a/src/model/transaction/insertFragmentIntoContentState.js
+++ b/src/model/transaction/insertFragmentIntoContentState.js
@@ -35,6 +35,7 @@ const updateExistingBlock = (
   fragmentBlock: BlockNodeRecord,
   targetKey: string,
   targetOffset: number,
+  forceTypeOverride: ?boolean,
 ): ContentState => {
   const targetBlock = blockMap.get(targetKey);
   const text = targetBlock.getText();
@@ -53,6 +54,7 @@ const updateExistingBlock = (
       targetOffset,
     ),
     data: fragmentBlock.getData(),
+    type: forceTypeOverride ? fragmentBlock.getType() : targetBlock.getType(),
   });
 
   return contentState.merge({
@@ -315,7 +317,7 @@ const insertFragmentIntoContentState = (
 
   // When we insert a fragment with a single block we simply update the target block
   // with the contents of the inserted fragment block
-  if (fragment.size === 1 && !forceTypeOverride) {
+  if (fragment.size === 1) {
     return updateExistingBlock(
       contentState,
       selectionState,
@@ -323,6 +325,7 @@ const insertFragmentIntoContentState = (
       fragment.first(),
       targetKey,
       targetOffset,
+      forceTypeOverride,
     );
   }
 

--- a/src/model/transaction/insertFragmentIntoContentState.js
+++ b/src/model/transaction/insertFragmentIntoContentState.js
@@ -292,6 +292,7 @@ const insertFragmentIntoContentState = (
   contentState: ContentState,
   selectionState: SelectionState,
   fragmentBlockMap: BlockMap,
+  forceTypeOverride: ?boolean,
 ): ContentState => {
   invariant(
     selectionState.isCollapsed(),
@@ -314,7 +315,7 @@ const insertFragmentIntoContentState = (
 
   // When we insert a fragment with a single block we simply update the target block
   // with the contents of the inserted fragment block
-  if (fragment.size === 1) {
+  if (fragment.size === 1 && !forceTypeOverride) {
     return updateExistingBlock(
       contentState,
       selectionState,


### PR DESCRIPTION
**Summary**

This resolves #1511. 

Although the current draft behavior of using the target block type when inserting a single block using `replaceWithFragment` is desirable in the majority of circumstances, this change would allow users to manually override that to use the type of the block being inserted.

For context, I have a custom block insertion util based on draft's `AtomicBlockUtils` (with variations to be able to insert multiple custom block types). The `AtomicBlockUtils` insertion function always includes an empty, unstyled divider block, and right now that's why my insertion function does as well.

However, this means that users wind up with a bunch of extra empty blocks getting inserted into their documents. This PR adds a flag, `forceTypeOverride`, to `replaceWithFragment` (similar to the `merge` flag in `updateEntityDataInContentState`) which indicates whether or not the block should override the type of the target block. Default behavior remains the same, so you would have to be really intentional about overriding the block type - but this adds the flexibility of inserting a single custom block without a divider block when needed.

**Test Plan**

Unit tests added for `insertFragmentIntoContentState` to test correct behavior of added `forceTypeOverride` parameter. Additionally, I manually tested behavior to confirm there was no bugginess, with particular focus on pasting into different block types.