### PR TITLE
Enabling a GK manager for the plaground

### DIFF
--- a/examples/draft-0-10-0/playground/src/GkManager.js
+++ b/examples/draft-0-10-0/playground/src/GkManager.js
@@ -1,0 +1,19 @@
+import querystring from 'querystring';
+
+const QUERY_STRINGS = querystring.parse(window.location.search.substring(1));
+
+// overwrite the feature flag stub object
+const GKManager = (window.__DRAFT_GKX = {});
+
+// enable or disable feature flags
+const flagControls = {
+  gk_disable: flags =>
+    flags.forEach(flag => (window.__DRAFT_GKX[flag] = false)),
+  gk_enable: flags => flags.forEach(flag => (window.__DRAFT_GKX[flag] = true)),
+};
+
+Object.keys(flagControls)
+  .filter(flag => QUERY_STRINGS[flag])
+  .forEach(flag => flagControls[flag](QUERY_STRINGS[flag].split(',')));
+
+export default GKManager;

--- a/examples/draft-0-10-0/playground/src/index.js
+++ b/examples/draft-0-10-0/playground/src/index.js
@@ -5,5 +5,7 @@ import './index.css';
 import App from './App';
 import registerServiceWorker from './registerServiceWorker';
 
+console.log("Applying feature flag overwrites: ", GkManager);
+
 ReactDOM.render(<App />, document.getElementById('root'));
 registerServiceWorker();

--- a/examples/draft-0-10-0/playground/src/index.js
+++ b/examples/draft-0-10-0/playground/src/index.js
@@ -1,3 +1,4 @@
+import GkManager from './GkManager';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';

--- a/src/stubs/gkx.js
+++ b/src/stubs/gkx.js
@@ -15,7 +15,7 @@
 
 module.exports = function(name: string) {
   if (typeof window !== 'undefined' && window.__DRAFT_GKX) {
-    return window.__DRAFT_GKX[name];
+    return !!window.__DRAFT_GKX[name];
   }
   return false;
 };


### PR DESCRIPTION
This enables on the playground for us to pass `gk_enable=foo,bar,foobar` or `gk_disable=foo,bar,foobar`, on the URI, 

Example: 

```
http://localhost:3000/?gk_enable=foo&gk_disable=bar,foobar
```

***

TLDR:

- Updating our Gkx stub to treat undefined gks on the stub object as falsy
- This will allow us to update GK flags while interacting with the playground.
