### PR TITLE
Workaround for BlockNode variance issue caused by flow transform (#1621)

### DIFF
--- a/src/model/immutable/BlockNode.js
+++ b/src/model/immutable/BlockNode.js
@@ -32,31 +32,31 @@ export type BlockNodeConfig = {
 // https://github.com/facebook/draft-js/issues/1492
 // prettier-ignore
 export interface BlockNode {
-  findEntityRanges(
+  +findEntityRanges: (
     filterFn: (value: CharacterMetadata) => boolean,
     callback: (start: number, end: number) => void,
-  ): void,
+  ) => void,
 
-  findStyleRanges(
+  +findStyleRanges: (
     filterFn: (value: CharacterMetadata) => boolean,
     callback: (start: number, end: number) => void,
-  ): void,
+  ) => void,
 
-  getCharacterList(): List<CharacterMetadata>,
+  +getCharacterList: () => List<CharacterMetadata>,
 
-  getData(): Map<any, any>,
+  +getData: () => Map<any, any>,
 
-  getDepth(): number,
+  +getDepth: () => number,
 
-  getEntityAt(offset: number): ?string,
+  +getEntityAt: (offset: number) => ?string,
 
-  getInlineStyleAt(offset: number): DraftInlineStyle,
+  +getInlineStyleAt: (offset: number) => DraftInlineStyle,
 
-  getKey(): BlockNodeKey,
+  +getKey: () => BlockNodeKey,
 
-  getLength(): number,
+  +getLength: () => number,
 
-  getText(): string,
+  +getText: () => string,
 
-  getType(): DraftBlockType,
+  +getType: () => DraftBlockType,
 }


### PR DESCRIPTION
**Summary**

This should fix #1621 (it does in our project).

This manually transforms the BlockNode interface to use properties like the build step will do, but it adds covariant property annotations to match the expectation that classes have read-only methods. A better solution would be to fix the transform itself to do the right thing with interface methods, but this should be equivalent and is easier (for me) to do.

**Test Plan**

Confirm that the output lib/BlockNode.js.flow includes the covariant property annotations (`+`) before each of the properties that were previously methods. The automated test infrastructure only runs over src so it's harder to verify in travis as-is.