### PR TITLE
Accept style prop to Editor

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -329,7 +329,7 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
       WebkitUserSelect: 'text',
       whiteSpace: 'pre-wrap',
       wordWrap: 'break-word',
-      ...style
+      ...style,
     };
 
     // The aria-expanded and aria-haspopup properties should only be rendered

--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -144,6 +144,7 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
     readOnly: false,
     spellCheck: false,
     stripPastedStyles: false,
+    style: {},
   };
 
   _blockSelectEvents: boolean;
@@ -294,6 +295,7 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
         editorState: this.props.editorState,
         textAlignment: this.props.textAlignment,
         accessibilityID: this._placeholderAccessibilityID,
+        style: this.props.style,
       };
 
       return <DraftEditorPlaceholder {...placeHolderProps} />;
@@ -310,7 +312,7 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
       customStyleMap,
       editorState,
       readOnly,
-      style = {},
+      style,
       textAlignment,
       textDirectionality,
     } = this.props;

--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -310,6 +310,7 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
       customStyleMap,
       editorState,
       readOnly,
+      style = {},
       textAlignment,
       textDirectionality,
     } = this.props;
@@ -328,6 +329,7 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
       WebkitUserSelect: 'text',
       whiteSpace: 'pre-wrap',
       wordWrap: 'break-word',
+      ...style
     };
 
     // The aria-expanded and aria-haspopup properties should only be rendered

--- a/src/component/base/DraftEditorPlaceholder.react.js
+++ b/src/component/base/DraftEditorPlaceholder.react.js
@@ -25,6 +25,7 @@ type Props = {
   editorState: EditorState,
   text: string,
   textAlignment: DraftTextAlignment,
+  style: Object,
 };
 
 /**
@@ -52,6 +53,7 @@ class DraftEditorPlaceholder extends React.Component<Props> {
 
     const contentStyle = {
       whiteSpace: 'pre-wrap',
+      ...this.props.style,
     };
 
     return (

--- a/src/component/base/DraftEditorProps.js
+++ b/src/component/base/DraftEditorProps.js
@@ -84,6 +84,9 @@ export type DraftEditorProps = {
   // that you set this to `true`.
   stripPastedStyles: boolean,
 
+  // inline styles to pass through to the content
+  style?: Object,
+
   tabIndex?: number,
 
   // exposed especially to help improve mobile web behaviors


### PR DESCRIPTION
**Summary**
This does the same thing as #139. Happy to pick up where it left off.

Here's my use case & why it's necessary:
- My editor is in a card component. The editor makes up the entire card.
- The card has a small padding between where the card starts and the text starts
- When the viewer clicks the card, _even on the padding_ the editor should gain focus

Without this PR, clicking on the padding will not focus the editor.

As a workaround, I have to:
- pass the editor reference to the parent card component, eg `editorRef`
- put a click listener on the card that calls `editorRef.focus()`
- style the card with `cursor: 'text'`

With this PR:

`<Editor style={{padding: 16}}/>`

***So much cleaner!***

Another use:
- `readOnly` is set and I want to set `userSelect: 'none'`. Currently, it's set to `text` to avoid the drag-n-drop bug, but none works, too.

**Test Plan**
I don't think one is needed, but I'm happy to write one if you want.
