### PR TITLE
Exploration - Feature tree / Fixing range removal for adjcent retained

### DIFF
--- a/src/model/transaction/__tests__/__snapshots__/removeRangeFromContentState-test.js.snap
+++ b/src/model/transaction/__tests__/__snapshots__/removeRangeFromContentState-test.js.snap
@@ -1,5 +1,82 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`must not remove links of retained parents 1`] = `
+Object {
+  "A": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "A",
+    "nextSibling": "B",
+    "parent": null,
+    "prevSibling": null,
+    "text": "Alpha",
+    "type": "unstyled",
+  },
+  "B": Object {
+    "characterList": Array [],
+    "children": Array [
+      "D",
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "B",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": "A",
+    "text": "",
+    "type": "blockquote",
+  },
+  "D": Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "D",
+    "nextSibling": null,
+    "parent": "B",
+    "prevSibling": null,
+    "text": "Foo",
+    "type": "unordered-list-item",
+  },
+}
+`;
+
 exports[`must preserve B and C since E has not been removed 1`] = `
 Object {
   "A": Object {

--- a/src/model/transaction/__tests__/removeRangeFromContentState-test.js
+++ b/src/model/transaction/__tests__/removeRangeFromContentState-test.js
@@ -261,3 +261,56 @@ test('must retain B since F has not been removed', () => {
     treeContentState,
   );
 });
+
+/**
+ * Simulate a BACKSPACE action on <__CURSOR__>
+ *
+ * <h1>Alpha</h1>
+ * <blockquote>
+ *   <ul>
+ *     <li><__CURSOR__>Foo</li>
+ *     <li>Bar</li>
+ *   </ul>
+ * </blockquote>
+ */
+test('must not remove links of retained parents', () => {
+  assertRemoveRangeFromContentState(
+    treeSelectionState.merge({
+      anchorKey: 'B',
+      focusKey: 'C',
+      anchorOffset: 0,
+      focusOffset: contentBlockNodes[2].getLength(),
+    }),
+    treeContentState.set(
+      'blockMap',
+      BlockMapBuilder.createFromArray([
+        new ContentBlockNode({
+          key: 'A',
+          nextSibling: 'B',
+          text: 'Alpha',
+        }),
+        new ContentBlockNode({
+          key: 'B',
+          prevSibling: 'A',
+          text: '',
+          type: 'blockquote',
+          children: List(['C', 'D']),
+        }),
+        new ContentBlockNode({
+          key: 'C',
+          parent: 'B',
+          nextSibling: 'D',
+          text: 'Foo',
+          type: 'unordered-list-item',
+        }),
+        new ContentBlockNode({
+          key: 'D',
+          parent: 'B',
+          prevSibling: 'C',
+          text: 'Foo',
+          type: 'unordered-list-item',
+        }),
+      ]),
+    ),
+  );
+});

--- a/src/model/transaction/removeRangeFromContentState.js
+++ b/src/model/transaction/removeRangeFromContentState.js
@@ -153,16 +153,16 @@ const updateBlockMapLinks = (
     // update start block if its retained
     transformBlock(startBlock.getKey(), blocks, block =>
       block.merge({
-        nextSibling: getNextValidSibling(startBlock, blocks, originalBlockMap),
-        prevSibling: getPrevValidSibling(startBlock, blocks, originalBlockMap),
+        nextSibling: getNextValidSibling(block, blocks, originalBlockMap),
+        prevSibling: getPrevValidSibling(block, blocks, originalBlockMap),
       }),
     );
 
     // update endblock if its retained
     transformBlock(endBlock.getKey(), blocks, block =>
       block.merge({
-        nextSibling: getNextValidSibling(endBlock, blocks, originalBlockMap),
-        prevSibling: getPrevValidSibling(endBlock, blocks, originalBlockMap),
+        nextSibling: getNextValidSibling(block, blocks, originalBlockMap),
+        prevSibling: getPrevValidSibling(block, blocks, originalBlockMap),
       }),
     );
 
@@ -187,14 +187,14 @@ const updateBlockMapLinks = (
     // update start block prev
     transformBlock(startBlock.getPrevSiblingKey(), blocks, block =>
       block.merge({
-        nextSibling: getNextValidSibling(startBlock, blocks, originalBlockMap),
+        nextSibling: getNextValidSibling(block, blocks, originalBlockMap),
       }),
     );
 
     // update end block next
     transformBlock(endBlock.getNextSiblingKey(), blocks, block =>
       block.merge({
-        prevSibling: getPrevValidSibling(endBlock, blocks, originalBlockMap),
+        prevSibling: getPrevValidSibling(block, blocks, originalBlockMap),
       }),
     );
 


### PR DESCRIPTION
### Context

This PR is part of a series of PR's that will be exploring **tree data block support** in Draft.

**Fixing case where immediate parent is selected as anchor node and is retained**

 Fixing case where imediate parent is selected as anchor node. Due to how
  we do moveSelectionForward and moveSelectionBackward we highjack the
    natural selection and get in cases where the parent has the anchor or
    focus where it does not have text.
    
    This PR ensures that when the parent is selected and retained that its
    previous block does not lose its links


***

**Note:**
This is unstable and not part of the public API and should not be used by
production systems.
