### PR TITLE
Fix drop issue

### DIFF
--- a/src/component/handlers/drag/DraftEditorDragHandler.js
+++ b/src/component/handlers/drag/DraftEditorDragHandler.js
@@ -84,6 +84,7 @@ var DraftEditorDragHandler = {
     );
 
     e.preventDefault();
+    editor._dragCount = 0;
     editor.exitCurrentMode();
 
     if (dropSelection == null) {


### PR DESCRIPTION
**Summary**

I have created a demo to illustrate this issue, feel free to look at [here](https://github.com/laysent/draft-js-drag-and-drop-issue)

If you look at `src/component/base/DraftEditor.react.js`, there is a problem with `_dragCount`:

When you drag a file into editor and drop it, `onDragEnter` will be triggered to increase `this._dragCount`. However, `onDragLeave` will not be triggered when dropping, thus `this._dragCount` will not be decreased back to 0.

Thus, after dragging and dropping, when user drags another file and NOT drop it, both `onDragEnter` and `onDragLeave` will be triggered. This time, `this._dragCount` will be increased then decreased. However, since it's initial value after dropping is not 0, it will not be decreased back to 0 after `dragLeave`, thus it will not trigger `this.exitCurrentMode()` in `onDragLeave`. Editor remains in "drag" mode.

To resolve this issue, simply set `_dragCount` back to 0 when dropping the file.

**Test Plan**

I don't think one is necessary for this issue. But would be happy to provide one if required.
