### PR TITLE
Fix collapsing of content blocks when pasting between different draft editor instances

### DIFF
--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -557,6 +557,12 @@ const genFragment = (
     child = sibling;
   }
 
+  const isTopLevelNode = node.parentNode.nodeName.toLowerCase() === 'body';
+  const isUnstyledNode = node.nodeName.toLowerCase() === 'div';
+  if (isTopLevelNode && isUnstyledNode && !chunk.blocks.length) {
+    newBlock = true;
+  }
+
   if (newBlock) {
     chunk = joinChunks(
       chunk,

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -557,7 +557,9 @@ const genFragment = (
     child = sibling;
   }
 
-  const isTopLevelNode = node.parentNode.nodeName.toLowerCase() === 'body';
+  // Make sure divs become blocks if they're at the top level and don't contain semantic markup
+  const isTopLevelNode =
+    node.parentNode && node.parentNode.nodeName.toLowerCase() === 'body';
   const isUnstyledNode = node.nodeName.toLowerCase() === 'div';
   if (isTopLevelNode && isUnstyledNode && !chunk.blocks.length) {
     newBlock = true;

--- a/src/model/paste/__tests__/DraftPasteProcessor-test.js
+++ b/src/model/paste/__tests__/DraftPasteProcessor-test.js
@@ -186,6 +186,20 @@ test('must NOT treat divs as Ps when we pave Ps', () => {
   `);
 });
 
+test('must treat DIVs as Ps when we have semantic markup NOT inside DIVs', () => {
+  assertDraftPasteProcessorProcessHTML(`
+    <div>p1</div>
+    <div>p2</div>
+    <h1>h1</h1>
+    <div>
+      <p>p3</p>
+      <p>p4</p>
+    </div>
+    <h2>h2</h2>
+    <div>p5</div>
+  `);
+});
+
 test('must replace br tags with soft newlines', () => {
   assertDraftPasteProcessorProcessHTML(`
     hi<br>hello

--- a/src/model/paste/__tests__/__snapshots__/DraftPasteProcessor-test.js.snap
+++ b/src/model/paste/__tests__/__snapshots__/DraftPasteProcessor-test.js.snap
@@ -2762,6 +2762,138 @@ Array [
 ]
 `;
 
+exports[`must treat DIVs as Ps when we have semantic markup NOT inside DIVs 1`] = `
+Array [
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key11",
+    "text": "p1",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "text": "p2",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key2",
+    "text": "h1",
+    "type": "header-one",
+  },
+  Object {
+    "characterList": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "key3",
+    "text": "",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key4",
+    "text": "p3",
+    "type": "paragraph",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key6",
+    "text": "p4",
+    "type": "paragraph",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key8",
+    "text": "h2",
+    "type": "header-two",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key9",
+    "text": "p5",
+    "type": "unstyled",
+  },
+]
+`;
+
 exports[`must treat divs as Ps when we do not have semantic markup 1`] = `
 Array [
   Object {


### PR DESCRIPTION
**Summary**

When pasting between draft-js editor instances (or when copying from a draft editor, refreshing the page, and pasting into the same editor), separate content blocks will collapse into one content block if our pasted HTML includes both div tags and other semantic tags at the root level. 

For example, the following markup:
```
<div>Rick</div>
<div>Morty</div>
<h1>Ricky & Morty</h1>
<div>Tiny Rick</div>
<div>Evil Morty</div>
```
![before](https://user-images.githubusercontent.com/1303285/38472258-fb0d494c-3baf-11e8-8e10-c2102f65266a.png)

when pasted into another editor instance will become:
```
<div>RickMorty</div>
<h1>Ricky & Morty</h1>
<div>Tiny RickEvil Morty</div>
```
![after](https://user-images.githubusercontent.com/1303285/38472273-1fe83c86-3bb0-11e8-9ec8-ec1b12566981.png)

This can also be reproduced if you copy the text in a draft editor, refresh the page (so we don't invoke the internal clipboard), and then paste it again into the same editor after refresh.

**Test Plan**
I've already added the appropriate tests in my commit.