### PR TITLE
Restore DOM when selection length is greater than 1

### DIFF
--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -155,6 +155,8 @@ const DraftEditorCompositionHandler = {
       !composedChars ||
       isSelectionAtLeafStart(editorState) ||
       currentStyle.size > 0 ||
+      editorState.getSelection().getAnchorOffset() !==
+        editorState.getSelection().getFocusOffset() ||
       entityKey !== null;
 
     if (mustReset) {


### PR DESCRIPTION
**Summary**

This fixes issue listed in https://github.com/facebook/draft-js/issues/1301, but I believe it could fix #1320 as well. 

The editor state is not updated while an IME is composing text. In it's current state, the IME updates the DOM and then React tries to remove the nodes (entities, style ranges, etc) but the nodes are no longer there. 

If the selection contains an entity or style range, we need to restore the DOM so that React can properly remove the nodes. 

This change adds an extra condition to  the `mustRest` boolean where if the selection is not collapsed, then restore the editor before applying the updates below in lines 180-192.

I could see how one could get more sophisticated about this approach and examine the selection for an entity, style range or multiple blocks, however, I think this might add a lot of undo complexity. 

**Test Plan**

Make sure IME input works when selecting multiple ranges. Should work when selection contains multiple blocks, style ranges or entities. Should also work when the selection contains no entities, style ranges and just a single block.