### PR TITLE
Transfer selected content via HTML clipboard on copy-paste between editors

### DIFF
--- a/src/component/handlers/edit/editOnCopy.js
+++ b/src/component/handlers/edit/editOnCopy.js
@@ -14,6 +14,8 @@
 
 import type DraftEditor from 'DraftEditor.react';
 
+const ContentState = require('ContentState');
+const convertFromDraftStateToRaw = require('convertFromDraftStateToRaw');
 const getFragmentFromSelection = require('getFragmentFromSelection');
 
 /**
@@ -31,7 +33,31 @@ function editOnCopy(editor: DraftEditor, e: SyntheticClipboardEvent<>): void {
     return;
   }
 
-  editor.setClipboard(getFragmentFromSelection(editor._latestEditorState));
+  const fragment = getFragmentFromSelection(editor._latestEditorState);
+
+  editor.setClipboard(fragment);
+
+  // IE11 does not support ClipboardEvent.clipboardData.
+  if (e.clipboardData && fragment) {
+    const content = ContentState.createFromBlockArray(fragment.toArray());
+    const serialisedContent = JSON.stringify(
+      convertFromDraftStateToRaw(content),
+    );
+
+    const fragmentElt = document.createElement('div');
+    const domSelection = window.getSelection();
+    fragmentElt.appendChild(domSelection.getRangeAt(0).cloneContents());
+    fragmentElt.setAttribute('data-editor-content', serialisedContent);
+    // We set the style property to replicate the browser's behavior of inline
+    // styles in rich text copy-paste. This is important for line breaks to be
+    // interpreted correctly when pasted into another word processor.
+    fragmentElt.setAttribute('style', 'white-space: pre-wrap;');
+
+    e.clipboardData.setData('text/plain', domSelection.toString());
+    e.clipboardData.setData('text/html', fragmentElt.outerHTML);
+
+    e.preventDefault();
+  }
 }
 
 module.exports = editOnCopy;

--- a/src/model/paste/DraftPasteProcessor.js
+++ b/src/model/paste/DraftPasteProcessor.js
@@ -24,6 +24,7 @@ const Immutable = require('immutable');
 
 const convertFromHTMLtoContentBlocksClassic = require('convertFromHTMLToContentBlocks');
 const convertFromHTMLtoContentBlocksNew = require('convertFromHTMLToContentBlocks2');
+const convertFromRawToDraftState = require('convertFromRawToDraftState');
 const generateRandomKey = require('generateRandomKey');
 const getSafeBodyFromHTML = require('getSafeBodyFromHTML');
 const gkx = require('gkx');
@@ -46,6 +47,29 @@ const DraftPasteProcessor = {
     html: string,
     blockRenderMap?: DraftBlockRenderMap,
   ): ?{contentBlocks: ?Array<BlockNodeRecord>, entityMap: EntityMap} {
+    const body = getSafeBodyFromHTML(html);
+    const fragmentElt = body && body.querySelector('[data-editor-content]');
+    const fragmentAttr =
+      (fragmentElt && fragmentElt.getAttribute('data-editor-content')) || null;
+
+    // Handle the paste without converting the HTML if it comes from another Draft.js editor.
+    if (fragmentAttr) {
+      let rawContent;
+
+      try {
+        // If JSON parsing fails, handle the paste as normal HTML.
+        rawContent = JSON.parse(fragmentAttr);
+      } catch (error) {}
+
+      if (rawContent) {
+        const content = convertFromRawToDraftState(rawContent);
+        return {
+          contentBlocks: content.getBlocksAsArray(),
+          entityMap: content.getEntityMap(),
+        };
+      }
+    }
+
     return convertFromHTMLtoContentBlocks(
       html,
       getSafeBodyFromHTML,

--- a/src/model/paste/__tests__/DraftPasteProcessor-test.js
+++ b/src/model/paste/__tests__/DraftPasteProcessor-test.js
@@ -342,3 +342,37 @@ test('must create ContentBlocks when experimentalTreeDataSupport is disabled whi
 test('must create ContentBlockNodes when experimentalTreeDataSupport is enabled while processing text', () => {
   assertDraftPasteProcessorProcessText(['Alpha', 'Beta', 'Charlie'], true);
 });
+
+test('must use serialised Draft.js fragment when available', () => {
+  assertDraftPasteProcessorProcessHTML(`
+    <div data-editor-content='${JSON.stringify({
+      entityMap: {},
+      blocks: [
+        {
+          key: 'a',
+          text: 'line\nbreak',
+          type: 'unstyled',
+        },
+      ],
+    })}'>
+        <p>line\nbreak</p>
+    </div>
+  `);
+});
+
+test('must fallback to HTML if serialised Draft.js fragment is invalid JSON', () => {
+  assertDraftPasteProcessorProcessHTML(`
+      <div data-editor-content='${JSON.stringify({
+        entityMap: {},
+        blocks: [
+          {
+            key: 'a',
+            text: 'line\nbreak',
+            type: 'unstyled',
+          },
+        ],
+      }).substring(0, 20)}'>
+      <p>line\nbreak</p>
+      </div>
+    `);
+});

--- a/src/model/paste/__tests__/__snapshots__/DraftPasteProcessor-test.js.snap
+++ b/src/model/paste/__tests__/__snapshots__/DraftPasteProcessor-test.js.snap
@@ -1046,6 +1046,73 @@ Array [
 ]
 `;
 
+exports[`must fallback to HTML if serialised Draft.js fragment is invalid JSON 1`] = `
+Array [
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key2",
+    "text": " ",
+    "type": "unstyled",
+  },
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "key0",
+    "text": "line break",
+    "type": "paragraph",
+  },
+]
+`;
+
 exports[`must identify block styles 1`] = `
 Array [
   Object {
@@ -2808,6 +2875,61 @@ Array [
     "depth": 0,
     "key": "key2",
     "text": "hello",
+    "type": "unstyled",
+  },
+]
+`;
+
+exports[`must use serialised Draft.js fragment when available 1`] = `
+Array [
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+      Object {
+        "entity": null,
+        "style": Array [],
+      },
+    ],
+    "data": Object {},
+    "depth": 0,
+    "key": "a",
+    "text": "line
+break",
     "type": "unstyled",
   },
 ]


### PR DESCRIPTION
**Summary**

This PR changes how Draft.js handles copy-cut-paste between editors so all content is kept as-is.  I’ve been working on this as an external package at https://github.com/thibaudcolas/draftjs-conductor, but there is no reason for this not to just be fixed in Draft.js directly.

On copy, we store the selected content within the clipboard’s HTML, overriding the browser’s default copy/cut handling, so that the Draft.js paste processor can then retrieve content from the serialised "Raw" content instead of relying on HTML parsing.

This fixes the following issues: #380, #787, #1389, #1163, #1154, https://github.com/facebook/draft-js/pull/1605#pullrequestreview-87340460, and #523 but only for the copy-paste case, https://github.com/facebook/draft-js/issues/523#issuecomment-371098488. Here's what it looks like in practice, copy-pasting between two tabs in the media example:

![draftjs-copy-paste-787](https://user-images.githubusercontent.com/877585/41206783-81474e5c-6d12-11e8-9441-412558fdca9b.gif)

As-is, the new copy/cut behavior and HTML clipboard generation doesn't replicate browsers’ behavior of inlining styles into the clipboard content (e.g. if you copy content in a particular font into Google Docs, browsers will try to preserve that). This seems like an advantage to me, but might be worth assessing further. For example, it means that copy-pasting nested lists into Google Docs will no longer add extra indentation to the (otherwise not nested anymore) list items there.

Edit: one last thing – I put the serialised content inside `text/html` instead of using a separate mime type for two reasons. First one is that without this PR, Draft.js only offered access to HTML via  `handlePastedText` for me to hook into. Second reason is that I've heard some browsers didn't support custom mime types. Fixing this issue in Draft.js itself, we could revisit this.

**Test Plan**

- [ ] Add unit tests for `editOnCopy` – I don't think I've seen any yet, would welcome some direction on how to test this.
- [x] Add unit tests for `DraftPasteProcessor`
- [ ] Run the manual [copy-paste test plan](https://github.com/facebook/draft-js/wiki/Manual-Testing#cutcopypaste) in browsers supported by Draft.js (particularly IE11)
- [ ] Go through copy-pasting into multiple word processors, with the following [support matrix](https://github.com/thibaudcolas/draftjs-filters#word-processor-support).

---

Before making this PR, I first fixed this issue for my own editor. If you want to learn more, have a look at https://github.com/wagtail/wagtail/pull/4582.

If you want to use this in your own editor without waiting for the PR to be merged, I made my fix available as a separate package: https://github.com/thibaudcolas/draftjs-conductor#idempotent-copy-paste-between-draftjs-editors. Here's what it looks like to use it:

<details>

```
npm install --save draftjs-conductor
```

Then:

```js
import {
  registerCopySource,
  handleDraftEditorPastedText,
} from "draftjs-conductor";

class MyEditor extends Component {
  constructor(props: Props) {
    super(props);

    this.state = {
      editorState: EditorState.createEmpty(),
    };

    this.onChange = this.onChange.bind(this);
    this.handlePastedText = this.handlePastedText.bind(this);
  }

  componentDidMount() {
    this.copySource = registerCopySource(this.editorRef);
  }

  onChange(nextState: EditorState) {
    this.setState({ editorState: nextState });
  }

  handlePastedText(text: string, html: ?string, editorState: EditorState) {
    let newState = handleDraftEditorPastedText(html, editorState);

    if (newState) {
      this.onChange(newState);
      return true;
    }

    return false;
  }

  componentWillUnmount() {
    if (this.copySource) {
      this.copySource.unregister();
    }
  }

  render() {
    const { editorState } = this.state;

    return (
      <Editor
        ref={(ref) => {
          this.editorRef = ref;
        }}
        editorState={editorState}
        onChange={this.onChange}
        handlePastedText={this.handlePastedText}
      />
    );
  }
}
```

</details>