### PR TITLE
Docs: add explicit deprecation notes to Entity methods

### DIFF
--- a/docs/APIReference-Entity.md
+++ b/docs/APIReference-Entity.md
@@ -53,7 +53,7 @@ be used only for retrieval.
 
 ## Methods
 
-### create
+### create _(Deprecated in favour of [contentState.createEntity](/docs/api-reference-content-state.html#createentity))_
 
 ```
 create(
@@ -70,7 +70,7 @@ are referenced by their string key in `ContentState`. The string value should
 be used within `CharacterMetadata` objects to track the entity for annotated
 characters.
 
-### add
+### add _(Deprecated in favour of [contentState.addEntity](/docs/api-reference-content-state.html#addentity))_
 
 ```
 add(instance: DraftEntityInstance): string
@@ -83,7 +83,7 @@ created, and now need to be added to the `Entity` store. This may occur in cases
 where a vanilla JavaScript representation of a `ContentState` is being revived
 for editing.
 
-### get
+### get _(Deprecated in favour of [contentState.getEntity](/docs/api-reference-content-state.html#getentity))_
 
 ```
 get(key: string): DraftEntityInstance
@@ -91,7 +91,7 @@ get(key: string): DraftEntityInstance
 Returns the `DraftEntityInstance` for the specified key. Throws if no instance
 exists for that key.
 
-### mergeData
+### mergeData _(Deprecated in favour of [contentState.mergeEntityData](/docs/api-reference-content-state.html#mergeentitydata))_
 
 ```
 mergeData(
@@ -104,7 +104,7 @@ metadata through typical mutative means.
 
 The `mergeData` method allows you to apply updates to the specified entity.
 
-### replaceData
+### replaceData _(Deprecated in favour of [contentState.replaceEntityData](/docs/api-reference-content-state.html#replaceentitydata))_
 
 ```
 replaceData(


### PR DESCRIPTION
**Summary**

The note in the docs `Please note that the API for entity storage and management has changed recently; for details on updating your application see our v0.10 API Migration Guide` doesn't give a quick clear idea of what I should use instead of the old methods (I need to go to that migration guide, but let's suppose I'm a new user and I don't have any code to migrate). The problem becomes obvious after getting warnings in the browser console.  So my suggestion is to place deprecation notice right in the name header. I believe this would save some time for those who open docs just to see the method signatures.

Now (https://draftjs.org/docs/api-reference-entity.html):
![image](https://user-images.githubusercontent.com/439939/41491613-39a1cfb2-710b-11e8-849b-4f8a13bf9088.png)


What I suggest:
![image](https://user-images.githubusercontent.com/439939/41491621-43f89af4-710b-11e8-8d71-2c3c20054e42.png)
