### PR TITLE
The textDecoration attribute can contain concurrently several values

### DIFF
--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -217,15 +217,12 @@ const processInlineTag = (
           style.remove('ITALIC');
         }
 
-        if (textDecoration === 'underline') {
-          style.add('UNDERLINE');
-        }
-        if (textDecoration === 'line-through') {
-          style.add('STRIKETHROUGH');
-        }
         if (textDecoration === 'none') {
           style.remove('UNDERLINE');
           style.remove('STRIKETHROUGH');
+        } else {
+          textDecoration.includes('underline') && style.add('UNDERLINE');
+          textDecoration.includes('line-through') && style.add('STRIKETHROUGH');
         }
       })
       .toOrderedSet();

--- a/src/model/encoding/convertFromHTMLToContentBlocks2.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks2.js
@@ -600,15 +600,12 @@ class ContentBlocksBuilder {
       this.removeStyle('ITALIC');
     }
 
-    if (textDecoration === 'underline') {
-      this.addStyle('UNDERLINE');
-    }
-    if (textDecoration === 'line-through') {
-      this.addStyle('STRIKETHROUGH');
-    }
     if (textDecoration === 'none') {
       this.removeStyle('UNDERLINE');
       this.removeStyle('STRIKETHROUGH');
+    } else {
+      textDecoration.includes('underline') && this.addStyle('UNDERLINE');
+      textDecoration.includes('line-through') && this.addStyle('STRIKETHROUGH');
     }
   }
 


### PR DESCRIPTION
If pasted text with underlining and strikethrough styles, these styles will be ignored. This pull request solves this problem.