### PR TITLE
fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ with [immutable-js](https://facebook.github.io/immutable-js/), offering
 an API with functional state updates and aggressively leveraging data persistence
 for scalable memory usage.
 
-[Learn how to use Draft.js in your own project.](http://draftjs.org/docs/overview.html)
+[Learn how to use Draft.js in your own project.](https://draftjs.org/docs/getting-started.html)
 
 ## API Notice
 


### PR DESCRIPTION
**Summary**

I fixed the broken link in the README. 

**Test Plan**

I tested the change by clicking on the link to make sure that it works now. 
