### PR TITLE
Fix issue with jumping cursor in identical leafs

### DIFF
--- a/src/component/contents/DraftEditorLeaf.react.js
+++ b/src/component/contents/DraftEditorLeaf.react.js
@@ -115,10 +115,22 @@ class DraftEditorLeaf extends React.Component<Props> {
 
   shouldComponentUpdate(nextProps: Props): boolean {
     const leafNode = ReactDOM.findDOMNode(this.leaf);
+    const {selection} = nextProps;
+    let hasSelection = false;
+    // If selection state is within the current leaf
+    // force an update
+    if (selection && selection.getHasFocus()) {
+      const {block, start, text} = nextProps;
+      const blockKey = block.getKey();
+      const end = start + text.length;
+      hasSelection = selection.hasEdgeWithin(blockKey, start, end);
+    }
+
     invariant(leafNode, 'Missing leafNode');
     const shouldUpdate =
       leafNode.textContent !== nextProps.text ||
       nextProps.styleSet !== this.props.styleSet ||
+      hasSelection ||
       nextProps.forceSelection;
     return shouldUpdate;
   }


### PR DESCRIPTION
**Summary**

This fixes an issue with a jumping cursor. What is happening is the following: 

An entity is created call `@foo`. The entity has a key of `key-1-0`

By modifying some earlier content, an entity with the same key and content is created. It must be done in a way where when the entity creation is finished, the cursor is inside the word.

Because the key is the same for the new entity, the entity is not properly updated and does not pass the following condition in `shouldComponentUpdate`:

```javascript
leafNode.textContent !== nextProps.text ||
nextProps.styleSet !== this.props.styleSet ||
nextProps.forceSelection;
```

Because the component is not updated, `_setSelection` in `componentDidUpdate` is never called. 

This change ensures that if the selection is inside the leaf, the component will always update.

[Jumping Cursor](https://i.gyazo.com/6aefcea483208ba790089362b749a47c.gif)

**Test Plan**

Type some content and create an entity `@foo` at the end of the string. In the earlier part of the string, enter the same entity in a way where the cursor is in the middle of the word when finished. 

I believe that this should fix the issue reported in:
https://github.com/facebook/draft-js/issues/1338