### PR TITLE
Fix SelectionState’s `hasEdgeWithin`

### DIFF
--- a/src/model/immutable/SelectionState.js
+++ b/src/model/immutable/SelectionState.js
@@ -91,7 +91,10 @@ class SelectionState extends SelectionStateRecord {
     if (anchorKey === focusKey && anchorKey === blockKey) {
       const selectionStart = this.getStartOffset();
       const selectionEnd = this.getEndOffset();
-      return start <= selectionEnd && selectionStart <= end;
+      return (
+        (start <= selectionStart && selectionStart <= end) || // selectionStart is between start and end, or
+        (start <= selectionEnd && selectionEnd <= end) // selectionEnd is between start and end
+      );
     }
 
     if (blockKey !== anchorKey && blockKey !== focusKey) {

--- a/src/model/immutable/__tests__/SelectionState-test.js
+++ b/src/model/immutable/__tests__/SelectionState-test.js
@@ -134,6 +134,11 @@ describe('hasEdgeWithin', () => {
     expect(MULTI_BLOCK.hasEdgeWithin('b', 5, 20)).toBe(true);
     expect(MULTI_BLOCK.hasEdgeWithin('c', 5, 20)).toBe(true);
   });
+
+  test('is false if test range is entirely within selection range', () => {
+    expect(WITHIN_BLOCK.hasEdgeWithin('a', 12, 15)).toBe(false);
+    expect(MULTI_BLOCK.hasEdgeWithin('b', 12, 15)).toBe(false);
+  });
 });
 
 test('detects collapsed selection properly', () => {

--- a/src/model/immutable/__tests__/SelectionState-test.js
+++ b/src/model/immutable/__tests__/SelectionState-test.js
@@ -76,7 +76,7 @@ const WITHIN_BLOCK = getSample('WITHIN_BLOCK');
 
 test('must create a new instance', () => {
   const state = COLLAPSED;
-  expect(state instanceof SelectionState).toMatchSnapshot();
+  expect(state instanceof SelectionState).toBe(true);
 });
 
 test('must retrieve properties correctly', () => {
@@ -98,23 +98,23 @@ test('must serialize properties correctly', () => {
 });
 
 test('is false for non-edge block keys', () => {
-  expect(COLLAPSED.hasEdgeWithin('b', 0, 0)).toMatchSnapshot();
-  expect(WITHIN_BLOCK.hasEdgeWithin('b', 0, 0)).toMatchSnapshot();
-  expect(MULTI_BLOCK.hasEdgeWithin('d', 0, 0)).toMatchSnapshot();
+  expect(COLLAPSED.hasEdgeWithin('b', 0, 0)).toBe(false);
+  expect(WITHIN_BLOCK.hasEdgeWithin('b', 0, 0)).toBe(false);
+  expect(MULTI_BLOCK.hasEdgeWithin('d', 0, 0)).toBe(false);
 });
 
 test('is false if offset is outside the selection range', () => {
-  expect(COLLAPSED.hasEdgeWithin('a', 1, 1)).toMatchSnapshot();
-  expect(WITHIN_BLOCK.hasEdgeWithin('a', 1, 1)).toMatchSnapshot();
-  expect(MULTI_BLOCK.hasEdgeWithin('b', 1, 1)).toMatchSnapshot();
+  expect(COLLAPSED.hasEdgeWithin('a', 1, 1)).toBe(false);
+  expect(WITHIN_BLOCK.hasEdgeWithin('a', 1, 1)).toBe(false);
+  expect(MULTI_BLOCK.hasEdgeWithin('b', 1, 1)).toBe(false);
 });
 
 test('is true if key match and offset equals selection edge', () => {
-  expect(COLLAPSED.hasEdgeWithin('a', 0, 1)).toMatchSnapshot();
-  expect(WITHIN_BLOCK.hasEdgeWithin('a', 10, 15)).toMatchSnapshot();
-  expect(WITHIN_BLOCK.hasEdgeWithin('a', 15, 20)).toMatchSnapshot();
-  expect(MULTI_BLOCK.hasEdgeWithin('b', 10, 20)).toMatchSnapshot();
-  expect(MULTI_BLOCK.hasEdgeWithin('c', 15, 20)).toMatchSnapshot();
+  expect(COLLAPSED.hasEdgeWithin('a', 0, 1)).toBe(true);
+  expect(WITHIN_BLOCK.hasEdgeWithin('a', 10, 15)).toBe(true);
+  expect(WITHIN_BLOCK.hasEdgeWithin('a', 15, 20)).toBe(true);
+  expect(MULTI_BLOCK.hasEdgeWithin('b', 10, 20)).toBe(true);
+  expect(MULTI_BLOCK.hasEdgeWithin('c', 15, 20)).toBe(true);
 });
 
 test('is true if selection range is entirely within test range', () => {
@@ -123,21 +123,21 @@ test('is true if selection range is entirely within test range', () => {
       anchorOffset: 5,
       focusOffset: 5,
     }).hasEdgeWithin('a', 0, 10),
-  ).toMatchSnapshot();
-  expect(WITHIN_BLOCK.hasEdgeWithin('a', 0, 40)).toMatchSnapshot();
+  ).toBe(true);
+  expect(WITHIN_BLOCK.hasEdgeWithin('a', 0, 40)).toBe(true);
 });
 
 test('is true if selection range edge overlaps test range', () => {
-  expect(WITHIN_BLOCK.hasEdgeWithin('a', 5, 15)).toMatchSnapshot();
-  expect(WITHIN_BLOCK.hasEdgeWithin('a', 15, 25)).toMatchSnapshot();
-  expect(MULTI_BLOCK.hasEdgeWithin('b', 5, 20)).toMatchSnapshot();
-  expect(MULTI_BLOCK.hasEdgeWithin('c', 5, 20)).toMatchSnapshot();
+  expect(WITHIN_BLOCK.hasEdgeWithin('a', 5, 15)).toBe(true);
+  expect(WITHIN_BLOCK.hasEdgeWithin('a', 15, 25)).toBe(true);
+  expect(MULTI_BLOCK.hasEdgeWithin('b', 5, 20)).toBe(true);
+  expect(MULTI_BLOCK.hasEdgeWithin('c', 5, 20)).toBe(true);
 });
 
 test('detects collapsed selection properly', () => {
-  expect(COLLAPSED.isCollapsed()).toMatchSnapshot();
-  expect(WITHIN_BLOCK.isCollapsed()).toMatchSnapshot();
-  expect(MULTI_BLOCK.isCollapsed()).toMatchSnapshot();
+  expect(COLLAPSED.isCollapsed()).toBe(true);
+  expect(WITHIN_BLOCK.isCollapsed()).toBe(false);
+  expect(MULTI_BLOCK.isCollapsed()).toBe(false);
 });
 
 test('properly identifies start and end keys', () => {

--- a/src/model/immutable/__tests__/SelectionState-test.js
+++ b/src/model/immutable/__tests__/SelectionState-test.js
@@ -97,41 +97,43 @@ test('must serialize properties correctly', () => {
   expect(MULTI_BLOCK.serialize()).toMatchSnapshot();
 });
 
-test('is false for non-edge block keys', () => {
-  expect(COLLAPSED.hasEdgeWithin('b', 0, 0)).toBe(false);
-  expect(WITHIN_BLOCK.hasEdgeWithin('b', 0, 0)).toBe(false);
-  expect(MULTI_BLOCK.hasEdgeWithin('d', 0, 0)).toBe(false);
-});
+describe('hasEdgeWithin', () => {
+  test('is false for non-edge block keys', () => {
+    expect(COLLAPSED.hasEdgeWithin('b', 0, 0)).toBe(false);
+    expect(WITHIN_BLOCK.hasEdgeWithin('b', 0, 0)).toBe(false);
+    expect(MULTI_BLOCK.hasEdgeWithin('d', 0, 0)).toBe(false);
+  });
 
-test('is false if offset is outside the selection range', () => {
-  expect(COLLAPSED.hasEdgeWithin('a', 1, 1)).toBe(false);
-  expect(WITHIN_BLOCK.hasEdgeWithin('a', 1, 1)).toBe(false);
-  expect(MULTI_BLOCK.hasEdgeWithin('b', 1, 1)).toBe(false);
-});
+  test('is false if offset is outside the selection range', () => {
+    expect(COLLAPSED.hasEdgeWithin('a', 1, 1)).toBe(false);
+    expect(WITHIN_BLOCK.hasEdgeWithin('a', 1, 1)).toBe(false);
+    expect(MULTI_BLOCK.hasEdgeWithin('b', 1, 1)).toBe(false);
+  });
 
-test('is true if key match and offset equals selection edge', () => {
-  expect(COLLAPSED.hasEdgeWithin('a', 0, 1)).toBe(true);
-  expect(WITHIN_BLOCK.hasEdgeWithin('a', 10, 15)).toBe(true);
-  expect(WITHIN_BLOCK.hasEdgeWithin('a', 15, 20)).toBe(true);
-  expect(MULTI_BLOCK.hasEdgeWithin('b', 10, 20)).toBe(true);
-  expect(MULTI_BLOCK.hasEdgeWithin('c', 15, 20)).toBe(true);
-});
+  test('is true if key match and offset equals selection edge', () => {
+    expect(COLLAPSED.hasEdgeWithin('a', 0, 1)).toBe(true);
+    expect(WITHIN_BLOCK.hasEdgeWithin('a', 10, 15)).toBe(true);
+    expect(WITHIN_BLOCK.hasEdgeWithin('a', 15, 20)).toBe(true);
+    expect(MULTI_BLOCK.hasEdgeWithin('b', 10, 20)).toBe(true);
+    expect(MULTI_BLOCK.hasEdgeWithin('c', 15, 20)).toBe(true);
+  });
 
-test('is true if selection range is entirely within test range', () => {
-  expect(
-    getSample('COLLAPSED', {
-      anchorOffset: 5,
-      focusOffset: 5,
-    }).hasEdgeWithin('a', 0, 10),
-  ).toBe(true);
-  expect(WITHIN_BLOCK.hasEdgeWithin('a', 0, 40)).toBe(true);
-});
+  test('is true if selection range is entirely within test range', () => {
+    expect(
+      getSample('COLLAPSED', {
+        anchorOffset: 5,
+        focusOffset: 5,
+      }).hasEdgeWithin('a', 0, 10),
+    ).toBe(true);
+    expect(WITHIN_BLOCK.hasEdgeWithin('a', 0, 40)).toBe(true);
+  });
 
-test('is true if selection range edge overlaps test range', () => {
-  expect(WITHIN_BLOCK.hasEdgeWithin('a', 5, 15)).toBe(true);
-  expect(WITHIN_BLOCK.hasEdgeWithin('a', 15, 25)).toBe(true);
-  expect(MULTI_BLOCK.hasEdgeWithin('b', 5, 20)).toBe(true);
-  expect(MULTI_BLOCK.hasEdgeWithin('c', 5, 20)).toBe(true);
+  test('is true if selection range edge overlaps test range', () => {
+    expect(WITHIN_BLOCK.hasEdgeWithin('a', 5, 15)).toBe(true);
+    expect(WITHIN_BLOCK.hasEdgeWithin('a', 15, 25)).toBe(true);
+    expect(MULTI_BLOCK.hasEdgeWithin('b', 5, 20)).toBe(true);
+    expect(MULTI_BLOCK.hasEdgeWithin('c', 5, 20)).toBe(true);
+  });
 });
 
 test('detects collapsed selection properly', () => {

--- a/src/model/immutable/__tests__/__snapshots__/SelectionState-test.js.snap
+++ b/src/model/immutable/__tests__/__snapshots__/SelectionState-test.js.snap
@@ -33,7 +33,7 @@ Object {
 }
 `;
 
-exports[`is true if selection range is entirely within test range 1`] = `
+exports[`hasEdgeWithin is true if selection range is entirely within test range 1`] = `
 Object {
   "anchorKey": "a",
   "anchorOffset": 5,

--- a/src/model/immutable/__tests__/__snapshots__/SelectionState-test.js.snap
+++ b/src/model/immutable/__tests__/__snapshots__/SelectionState-test.js.snap
@@ -33,42 +33,6 @@ Object {
 }
 `;
 
-exports[`detects collapsed selection properly 1`] = `true`;
-
-exports[`detects collapsed selection properly 2`] = `false`;
-
-exports[`detects collapsed selection properly 3`] = `false`;
-
-exports[`is false for non-edge block keys 1`] = `false`;
-
-exports[`is false for non-edge block keys 2`] = `false`;
-
-exports[`is false for non-edge block keys 3`] = `false`;
-
-exports[`is false if offset is outside the selection range 1`] = `false`;
-
-exports[`is false if offset is outside the selection range 2`] = `false`;
-
-exports[`is false if offset is outside the selection range 3`] = `false`;
-
-exports[`is true if key match and offset equals selection edge 1`] = `true`;
-
-exports[`is true if key match and offset equals selection edge 2`] = `true`;
-
-exports[`is true if key match and offset equals selection edge 3`] = `true`;
-
-exports[`is true if key match and offset equals selection edge 4`] = `true`;
-
-exports[`is true if key match and offset equals selection edge 5`] = `true`;
-
-exports[`is true if selection range edge overlaps test range 1`] = `true`;
-
-exports[`is true if selection range edge overlaps test range 2`] = `true`;
-
-exports[`is true if selection range edge overlaps test range 3`] = `true`;
-
-exports[`is true if selection range edge overlaps test range 4`] = `true`;
-
 exports[`is true if selection range is entirely within test range 1`] = `
 Object {
   "anchorKey": "a",
@@ -79,12 +43,6 @@ Object {
   "isBackward": false,
 }
 `;
-
-exports[`is true if selection range is entirely within test range 2`] = `true`;
-
-exports[`is true if selection range is entirely within test range 3`] = `true`;
-
-exports[`must create a new instance 1`] = `true`;
 
 exports[`must retrieve properties correctly 1`] = `
 Array [


### PR DESCRIPTION
Fixes #1700, which includes a detailed description and reproduction of the issue.

Hopefully it's ok that I refactored the true/false assertions not to use snapshots; I found them confusing and tedious and figured it was probably just an artifact of migrating to Jest a long time ago.