### PR TITLE
fix copy/paste from MS Outlook etc. with required newlines

### DIFF
--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -354,6 +354,18 @@ const getListItemDepth = (node: HTMLElement, depth: number = 0): number => {
   return depth;
 };
 
+/**
+ * Soft trim any whitespace characters similar to string.trim() \s = [\r\n\t\f\v ],
+ * but excluding \r
+ * (fix copy/paste from MS Outlook etc. with required newlines)
+ * (bug: convertChunkToContentBlocks chunk.text.split('\r') is required \r to create newline ContentBlock)
+ * (MS Outlook newline: <p><span></span><span><o:p></o:p></span></p>)
+ * (getSoftNewlineChunk is waiting for <br /> but uses '\n')
+ */
+const softTrim = (text: string): string => {
+  return text.replace(/^[\n\t\f\v ]+|[\n\t\f\v ]+$/g, "");
+};
+
 const genFragment = (
   entityMap: EntityMap,
   node: Node,
@@ -380,7 +392,7 @@ const genFragment = (
   // Base Case
   if (nodeName === '#text') {
     let text = node.textContent;
-    const nodeTextContent = text.trim();
+    const nodeTextContent = softTrim(text);
 
     // We should not create blocks for leading spaces that are
     // existing around ol/ul and their children list items


### PR DESCRIPTION
- bug: convertChunkToContentBlocks chunk.text.split('\r') is required \r to create newline ContentBlock
- MS Outlook newline: <p><span></span><span><o:p></o:p></span></p>
(getSoftNewlineChunk is waiting for <br /> but uses '\n' and anyway is not used for this <p> case)

*Before* submitting a pull request, please make sure the following is done...

1. Fork the repo and create your branch from `master`.
2. If you've added code that should be tested, add tests!
3. If you've changed APIs, update the documentation.
4. Ensure that:
  * The test suite passes (`npm test`)
  * Your code lints (`npm run lint`) and passes Flow (`npm run flow`)
  * You have followed the [testing guidelines](https://github.com/facebook/draft-js/wiki/Testing-for-Pull-Requests)
5. If you haven't already, complete the [CLA](https://code.facebook.com/cla).

Please use the simple form below as a guideline for describing your pull request.

Thanks for contributing to Draft.js!

-

**Summary**

[...]

**Test Plan**

[...]
