### PR TITLE
Disable auto-mocking for tree data invariants test

### DIFF
--- a/src/component/utils/exploration/__tests__/DraftTreeInvariants-test.js
+++ b/src/component/utils/exploration/__tests__/DraftTreeInvariants-test.js
@@ -13,6 +13,8 @@
 
 'use strict';
 
+jest.disableAutomock()
+
 // missing parent -> child connection
 
 const ContentBlockNode = require('ContentBlockNode');


### PR DESCRIPTION
**Summary**
Travis build was failing because Jest was auto-mocking all modules.

**Test Plan**
```
yarn run test
```