### PR TITLE
Fix tree invariants test

### DIFF
--- a/src/component/utils/exploration/__tests__/DraftTreeInvariants-test.js
+++ b/src/component/utils/exploration/__tests__/DraftTreeInvariants-test.js
@@ -13,6 +13,8 @@
 
 'use strict';
 
+jest.disableAutomock();
+
 // missing parent -> child connection
 
 const ContentBlockNode = require('ContentBlockNode');


### PR DESCRIPTION
**Summary**

Disables auto-mocks on the tree data invariants test, thus fixing the Travis CI build.

**Test Plan**

```
npm test
```