### PR TITLE
Fixes incorrect docs, see #1497

### DIFF
--- a/docs/Advanced-Topics-Custom-Block-Render.md
+++ b/docs/Advanced-Topics-Custom-Block-Render.md
@@ -142,7 +142,7 @@ const blockRenderMap = Immutable.Map({
     // element is used during paste or html conversion to auto match your component;
     // it is also retained as part of this.props.children and not stripped out
     element: 'section',
-    wrapper: MyCustomBlock,
+    wrapper: <MyCustomBlock />,
   }
 });
 


### PR DESCRIPTION
**Summary**

Updates the docs to fix #1497. The current suggested method results in an `Element type is invalid:` error.

I can confirm that using the component itself rather than its name as a string works as expected.

Credit goes to @albertlockett