### PR TITLE
Export RawDraftContentState publicly

### DIFF
--- a/src/Draft.js
+++ b/src/Draft.js
@@ -27,6 +27,7 @@ const DraftModifier = require('DraftModifier');
 const DraftEntityInstance = require('DraftEntityInstance');
 const EditorState = require('EditorState');
 const KeyBindingUtil = require('KeyBindingUtil');
+const RawDraftContentState = require('RawDraftContentState');
 const RichTextEditorUtil = require('RichTextEditorUtil');
 const SelectionState = require('SelectionState');
 
@@ -54,6 +55,7 @@ const DraftPublic = {
   CharacterMetadata,
   ContentBlock,
   ContentState,
+  RawDraftContentState,
   SelectionState,
 
   AtomicBlockUtils,


### PR DESCRIPTION
**Summary**

When I used v0.10.1 I was able to import `RawDraftContentState`. Since I upgraded to version 0.10.5 I can't.

Example of line that does not work anymore:

`import { RawDraftContentState } from 'draft-js';`