### PR TITLE
Remove unused var in BlockTree

### DIFF
--- a/src/model/immutable/BlockTree.js
+++ b/src/model/immutable/BlockTree.js
@@ -27,8 +27,6 @@ const {List, Repeat, Record} = Immutable;
 
 const returnTrue = emptyFunction.thatReturnsTrue;
 
-const FINGERPRINT_DELIMITER = '-';
-
 const defaultLeafRange: {
   start: ?number,
   end: ?number,


### PR DESCRIPTION
**Summary**

This variable is unused & caused a lint warning.

**Test Plan**
Old (with warning):
```
> npm run lint

> draft-js@0.10.5 lint /Users/niveditc/draft-js
> eslint .

/Users/niveditc/draft-js/src/model/immutable/BlockTree.js
  30:7  warning  'FINGERPRINT_DELIMITER' is assigned a value but never used. Allowed unused vars must match /^_/  no-unused-vars

✖ 1 problem (0 errors, 1 warning)
```

New:
```
> npm run lint

> draft-js@0.10.5 lint /Users/niveditc/draft-js
> eslint .
```