### PR TITLE
Fix copyright headers

### DIFF
--- a/examples/draft-0-10-0/playground/src/App.css
+++ b/examples/draft-0-10-0/playground/src/App.css
@@ -1,3 +1,7 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ */
+
 :root {
   --nav-main-height: 50px;
   --main-background: #f7f7f7;

--- a/examples/draft-0-10-0/playground/src/App.js
+++ b/examples/draft-0-10-0/playground/src/App.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2004-present Facebook. All Rights Reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * @flow
  * @format

--- a/examples/draft-0-10-0/playground/src/App.test.js
+++ b/examples/draft-0-10-0/playground/src/App.test.js
@@ -1,3 +1,7 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ */
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';

--- a/examples/draft-0-10-0/playground/src/DraftJsPlaygroundContainer.css
+++ b/examples/draft-0-10-0/playground/src/DraftJsPlaygroundContainer.css
@@ -1,7 +1,6 @@
 /**
- * Copyright 2004-present Facebook. All Rights Reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  */
-
 
 .DraftJsPlaygroundContainer-container {
   background: white;

--- a/examples/draft-0-10-0/playground/src/DraftJsPlaygroundContainer.react.js
+++ b/examples/draft-0-10-0/playground/src/DraftJsPlaygroundContainer.react.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2004-present Facebook. All Rights Reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * @flow
  * @format

--- a/examples/draft-0-10-0/playground/src/DraftJsRichEditorExample.css
+++ b/examples/draft-0-10-0/playground/src/DraftJsRichEditorExample.css
@@ -1,3 +1,7 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ */
+
 .DraftJsPlaygroundContainer-editor {
   padding: 0;
   background: #fff;

--- a/examples/draft-0-10-0/playground/src/DraftJsRichEditorExample.js
+++ b/examples/draft-0-10-0/playground/src/DraftJsRichEditorExample.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2004-present Facebook. All Rights Reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * @flow
  * @format

--- a/examples/draft-0-10-0/playground/src/GkManager.js
+++ b/examples/draft-0-10-0/playground/src/GkManager.js
@@ -1,3 +1,7 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ */
+
 import querystring from 'querystring';
 
 const QUERY_STRINGS = querystring.parse(window.location.search.substring(1));

--- a/examples/draft-0-10-0/playground/src/index.css
+++ b/examples/draft-0-10-0/playground/src/index.css
@@ -1,3 +1,7 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ */
+
 body {
   margin: 0;
   padding: 0;
@@ -9,4 +13,3 @@ body {
   height: 100vh;
   width: 100%;
 }
-

--- a/examples/draft-0-10-0/playground/src/index.js
+++ b/examples/draft-0-10-0/playground/src/index.js
@@ -1,3 +1,7 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ */
+
 import GkManager from './GkManager';
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/examples/draft-0-10-0/rich/RichEditor.css
+++ b/examples/draft-0-10-0/rich/RichEditor.css
@@ -1,3 +1,7 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ */
+
 .RichEditor-root {
   background: #fff;
   border: 1px solid #ddd;

--- a/examples/draft-0-10-0/tex/public/TeXEditor.css
+++ b/examples/draft-0-10-0/tex/public/TeXEditor.css
@@ -1,3 +1,7 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ */
+
 .TeXEditor-root {
   font-family: 'Century Schoolbook', serif;
   -webkit-font-smoothing: antialiased;

--- a/examples/draft-0-10-0/universal/client.js
+++ b/examples/draft-0-10-0/universal/client.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/examples/draft-0-10-0/universal/editor.js
+++ b/examples/draft-0-10-0/universal/editor.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/examples/draft-0-10-0/universal/index.js
+++ b/examples/draft-0-10-0/universal/index.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/examples/draft-0-9-1/universal/client.js
+++ b/examples/draft-0-9-1/universal/client.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/examples/draft-0-9-1/universal/editor.js
+++ b/examples/draft-0-9-1/universal/editor.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/examples/draft-0-9-1/universal/index.js
+++ b/examples/draft-0-9-1/universal/index.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/scripts/jest/hasteImpl.js
+++ b/scripts/jest/hasteImpl.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/scripts/jest/shims.js
+++ b/scripts/jest/shims.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/scripts/module-map.js
+++ b/scripts/module-map.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/Draft.js
+++ b/src/Draft.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/__mocks__/generateRandomKey.js
+++ b/src/__mocks__/generateRandomKey.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/base/DraftEditor.css
+++ b/src/component/base/DraftEditor.css
@@ -1,4 +1,6 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
  * @providesModule DraftEditor
  * @permanent
  */

--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/base/DraftEditorPlaceholder.css
+++ b/src/component/base/DraftEditorPlaceholder.css
@@ -1,4 +1,6 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
  * @providesModule DraftEditorPlaceholder
  * @permanent
  */

--- a/src/component/base/DraftEditorPlaceholder.react.js
+++ b/src/component/base/DraftEditorPlaceholder.react.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/base/DraftEditorProps.js
+++ b/src/component/base/DraftEditorProps.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/base/DraftScrollPosition.js
+++ b/src/component/base/DraftScrollPosition.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/base/DraftTextAlignment.js
+++ b/src/component/base/DraftTextAlignment.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/base/__tests__/DraftEditor.react-test.js
+++ b/src/component/base/__tests__/DraftEditor.react-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/contents/DraftEditorBlock.react.js
+++ b/src/component/contents/DraftEditorBlock.react.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/contents/DraftEditorContents-core.react.js
+++ b/src/component/contents/DraftEditorContents-core.react.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/contents/DraftEditorLeaf.react.js
+++ b/src/component/contents/DraftEditorLeaf.react.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/contents/DraftEditorTextNode.react.js
+++ b/src/component/contents/DraftEditorTextNode.react.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/contents/__tests__/DraftEditorBlock.react-test.js
+++ b/src/component/contents/__tests__/DraftEditorBlock.react-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/contents/__tests__/DraftEditorContents.react-test.js
+++ b/src/component/contents/__tests__/DraftEditorContents.react-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/contents/__tests__/DraftEditorTextNode-test.js
+++ b/src/component/contents/__tests__/DraftEditorTextNode-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/contents/exploration/DraftEditorBlockNode.react.js
+++ b/src/component/contents/exploration/DraftEditorBlockNode.react.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/contents/exploration/DraftEditorContentsExperimental.react.js
+++ b/src/component/contents/exploration/DraftEditorContentsExperimental.react.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/contents/exploration/DraftEditorDecoratedLeaves.react.js
+++ b/src/component/contents/exploration/DraftEditorDecoratedLeaves.react.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/contents/exploration/DraftEditorNode.react.js
+++ b/src/component/contents/exploration/DraftEditorNode.react.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/contents/exploration/__tests__/DraftEditorBlockNode.react-test.js
+++ b/src/component/contents/exploration/__tests__/DraftEditorBlockNode.react-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/contents/exploration/__tests__/DraftEditorContentsExperimental.react-test.js
+++ b/src/component/contents/exploration/__tests__/DraftEditorContentsExperimental.react-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/handlers/DraftEditorModes.js
+++ b/src/component/handlers/DraftEditorModes.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/handlers/drag/DraftEditorDragHandler.js
+++ b/src/component/handlers/drag/DraftEditorDragHandler.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/handlers/edit/DraftEditorEditHandler.js
+++ b/src/component/handlers/edit/DraftEditorEditHandler.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/handlers/edit/commands/SecondaryClipboard.js
+++ b/src/component/handlers/edit/commands/SecondaryClipboard.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/handlers/edit/commands/keyCommandBackspaceToStartOfLine.js
+++ b/src/component/handlers/edit/commands/keyCommandBackspaceToStartOfLine.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/handlers/edit/commands/keyCommandBackspaceWord.js
+++ b/src/component/handlers/edit/commands/keyCommandBackspaceWord.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/handlers/edit/commands/keyCommandDeleteWord.js
+++ b/src/component/handlers/edit/commands/keyCommandDeleteWord.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/handlers/edit/commands/keyCommandInsertNewline.js
+++ b/src/component/handlers/edit/commands/keyCommandInsertNewline.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/handlers/edit/commands/keyCommandMoveSelectionToEndOfBlock.js
+++ b/src/component/handlers/edit/commands/keyCommandMoveSelectionToEndOfBlock.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/handlers/edit/commands/keyCommandMoveSelectionToStartOfBlock.js
+++ b/src/component/handlers/edit/commands/keyCommandMoveSelectionToStartOfBlock.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/handlers/edit/commands/keyCommandPlainBackspace.js
+++ b/src/component/handlers/edit/commands/keyCommandPlainBackspace.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/handlers/edit/commands/keyCommandPlainDelete.js
+++ b/src/component/handlers/edit/commands/keyCommandPlainDelete.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/handlers/edit/commands/keyCommandTransposeCharacters.js
+++ b/src/component/handlers/edit/commands/keyCommandTransposeCharacters.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/handlers/edit/commands/keyCommandUndo.js
+++ b/src/component/handlers/edit/commands/keyCommandUndo.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/handlers/edit/commands/moveSelectionBackward.js
+++ b/src/component/handlers/edit/commands/moveSelectionBackward.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/handlers/edit/commands/moveSelectionForward.js
+++ b/src/component/handlers/edit/commands/moveSelectionForward.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/handlers/edit/commands/removeTextWithStrategy.js
+++ b/src/component/handlers/edit/commands/removeTextWithStrategy.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/handlers/edit/editOnBeforeInput.js
+++ b/src/component/handlers/edit/editOnBeforeInput.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/handlers/edit/editOnBlur.js
+++ b/src/component/handlers/edit/editOnBlur.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/handlers/edit/editOnCompositionStart.js
+++ b/src/component/handlers/edit/editOnCompositionStart.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/handlers/edit/editOnCopy.js
+++ b/src/component/handlers/edit/editOnCopy.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/handlers/edit/editOnCut.js
+++ b/src/component/handlers/edit/editOnCut.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/handlers/edit/editOnDragOver.js
+++ b/src/component/handlers/edit/editOnDragOver.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/handlers/edit/editOnDragStart.js
+++ b/src/component/handlers/edit/editOnDragStart.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/handlers/edit/editOnFocus.js
+++ b/src/component/handlers/edit/editOnFocus.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/handlers/edit/editOnKeyDown.js
+++ b/src/component/handlers/edit/editOnKeyDown.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/handlers/edit/editOnPaste.js
+++ b/src/component/handlers/edit/editOnPaste.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/handlers/edit/editOnSelect.js
+++ b/src/component/handlers/edit/editOnSelect.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/handlers/edit/getFragmentFromSelection.js
+++ b/src/component/handlers/edit/getFragmentFromSelection.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/selection/DOMDerivedSelection.js
+++ b/src/component/selection/DOMDerivedSelection.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/selection/DraftOffsetKey.js
+++ b/src/component/selection/DraftOffsetKey.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/selection/DraftOffsetKeyPath.js
+++ b/src/component/selection/DraftOffsetKeyPath.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/selection/expandRangeToStartOfLine.js
+++ b/src/component/selection/expandRangeToStartOfLine.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/selection/findAncestorOffsetKey.js
+++ b/src/component/selection/findAncestorOffsetKey.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/selection/getDraftEditorSelection.js
+++ b/src/component/selection/getDraftEditorSelection.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/selection/getDraftEditorSelectionWithNodes.js
+++ b/src/component/selection/getDraftEditorSelectionWithNodes.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/selection/getRangeBoundingClientRect.js
+++ b/src/component/selection/getRangeBoundingClientRect.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/selection/getRangeClientRects.js
+++ b/src/component/selection/getRangeClientRects.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/selection/getSampleSelectionMocksForTesting.js
+++ b/src/component/selection/getSampleSelectionMocksForTesting.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/selection/getSampleSelectionMocksForTestingNestedBlocks.js
+++ b/src/component/selection/getSampleSelectionMocksForTestingNestedBlocks.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/selection/getSelectionOffsetKeyForNode.js
+++ b/src/component/selection/getSelectionOffsetKeyForNode.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/selection/getUpdatedSelectionState.js
+++ b/src/component/selection/getUpdatedSelectionState.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/selection/getVisibleSelectionRect.js
+++ b/src/component/selection/getVisibleSelectionRect.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/selection/isSelectionAtLeafStart.js
+++ b/src/component/selection/isSelectionAtLeafStart.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/selection/setDraftEditorSelection.js
+++ b/src/component/selection/setDraftEditorSelection.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/utils/DraftStyleDefault.css
+++ b/src/component/utils/DraftStyleDefault.css
@@ -1,4 +1,6 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
  * @providesModule DraftStyleDefault
  * @permanent
  */

--- a/src/component/utils/KeyBindingUtil.js
+++ b/src/component/utils/KeyBindingUtil.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/utils/_DraftTestHelper.js
+++ b/src/component/utils/_DraftTestHelper.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/utils/exploration/DraftTreeAdapter.js
+++ b/src/component/utils/exploration/DraftTreeAdapter.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/utils/exploration/DraftTreeInvariants.js
+++ b/src/component/utils/exploration/DraftTreeInvariants.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/utils/exploration/__tests__/DraftTreeAdapter-test.js
+++ b/src/component/utils/exploration/__tests__/DraftTreeAdapter-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/utils/exploration/__tests__/DraftTreeInvariants-test.js
+++ b/src/component/utils/exploration/__tests__/DraftTreeInvariants-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/utils/getDefaultKeyBinding.js
+++ b/src/component/utils/getDefaultKeyBinding.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/utils/getTextContentFromFiles.js
+++ b/src/component/utils/getTextContentFromFiles.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/utils/isEventHandled.js
+++ b/src/component/utils/isEventHandled.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/utils/isSoftNewlineEvent.js
+++ b/src/component/utils/isSoftNewlineEvent.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/component/utils/splitTextIntoTextBlocks.js
+++ b/src/component/utils/splitTextIntoTextBlocks.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/constants/DraftBlockType.js
+++ b/src/model/constants/DraftBlockType.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/constants/DraftDragType.js
+++ b/src/model/constants/DraftDragType.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/constants/DraftEditorCommand.js
+++ b/src/model/constants/DraftEditorCommand.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/constants/DraftHandleValue.js
+++ b/src/model/constants/DraftHandleValue.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/constants/DraftInsertionType.js
+++ b/src/model/constants/DraftInsertionType.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/constants/DraftRemovalDirection.js
+++ b/src/model/constants/DraftRemovalDirection.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/decorators/CompositeDraftDecorator.js
+++ b/src/model/decorators/CompositeDraftDecorator.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/decorators/DraftDecorator.js
+++ b/src/model/decorators/DraftDecorator.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/decorators/DraftDecoratorType.js
+++ b/src/model/decorators/DraftDecoratorType.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/decorators/__tests__/CompositeDraftDecorator-test.js
+++ b/src/model/decorators/__tests__/CompositeDraftDecorator-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/encoding/DraftStringKey.js
+++ b/src/model/encoding/DraftStringKey.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/encoding/EntityRange.js
+++ b/src/model/encoding/EntityRange.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/encoding/InlineStyleRange.js
+++ b/src/model/encoding/InlineStyleRange.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/encoding/RawDraftContentBlock.js
+++ b/src/model/encoding/RawDraftContentBlock.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/encoding/RawDraftContentState.js
+++ b/src/model/encoding/RawDraftContentState.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/encoding/RawDraftEntity.js
+++ b/src/model/encoding/RawDraftEntity.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/encoding/__tests__/convertFromDraftStateToRaw-test.js
+++ b/src/model/encoding/__tests__/convertFromDraftStateToRaw-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/encoding/__tests__/convertFromHTMLToContentBlocks-test.js
+++ b/src/model/encoding/__tests__/convertFromHTMLToContentBlocks-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/encoding/__tests__/convertFromHTMLToContentBlocks2-test.js
+++ b/src/model/encoding/__tests__/convertFromHTMLToContentBlocks2-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/encoding/__tests__/convertFromRawToDraftState-test.js
+++ b/src/model/encoding/__tests__/convertFromRawToDraftState-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/encoding/__tests__/decodeEntityRanges-test.js
+++ b/src/model/encoding/__tests__/decodeEntityRanges-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/encoding/__tests__/decodeInlineStyleRanges-test.js
+++ b/src/model/encoding/__tests__/decodeInlineStyleRanges-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/encoding/__tests__/encodeEntityRanges-test.js
+++ b/src/model/encoding/__tests__/encodeEntityRanges-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/encoding/__tests__/encodeInlineStyleRanges-test.js
+++ b/src/model/encoding/__tests__/encodeInlineStyleRanges-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/encoding/__tests__/sanitizeDraftText-test.js
+++ b/src/model/encoding/__tests__/sanitizeDraftText-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/encoding/convertFromDraftStateToRaw.js
+++ b/src/model/encoding/convertFromDraftStateToRaw.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/encoding/convertFromHTMLToContentBlocks2.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks2.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/encoding/convertFromRawToDraftState.js
+++ b/src/model/encoding/convertFromRawToDraftState.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/encoding/createCharacterList.js
+++ b/src/model/encoding/createCharacterList.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/encoding/decodeEntityRanges.js
+++ b/src/model/encoding/decodeEntityRanges.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/encoding/decodeInlineStyleRanges.js
+++ b/src/model/encoding/decodeInlineStyleRanges.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/encoding/encodeEntityRanges.js
+++ b/src/model/encoding/encodeEntityRanges.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/encoding/encodeInlineStyleRanges.js
+++ b/src/model/encoding/encodeInlineStyleRanges.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/encoding/sanitizeDraftText.js
+++ b/src/model/encoding/sanitizeDraftText.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/entity/DraftEntity.js
+++ b/src/model/entity/DraftEntity.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/entity/DraftEntityInstance.js
+++ b/src/model/entity/DraftEntityInstance.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/entity/DraftEntityMutability.js
+++ b/src/model/entity/DraftEntityMutability.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/entity/DraftEntityType.js
+++ b/src/model/entity/DraftEntityType.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/entity/__mocks__/DraftEntity.js
+++ b/src/model/entity/__mocks__/DraftEntity.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/entity/__tests__/DraftEntity-test.js
+++ b/src/model/entity/__tests__/DraftEntity-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/entity/__tests__/getEntityKeyForSelection-test.js
+++ b/src/model/entity/__tests__/getEntityKeyForSelection-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/entity/getEntityKeyForSelection.js
+++ b/src/model/entity/getEntityKeyForSelection.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/entity/getTextAfterNearestEntity.js
+++ b/src/model/entity/getTextAfterNearestEntity.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/immutable/BlockMap.js
+++ b/src/model/immutable/BlockMap.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/immutable/BlockMapBuilder.js
+++ b/src/model/immutable/BlockMapBuilder.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/immutable/BlockNode.js
+++ b/src/model/immutable/BlockNode.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/immutable/BlockNodeRecord.js
+++ b/src/model/immutable/BlockNodeRecord.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/immutable/BlockTree.js
+++ b/src/model/immutable/BlockTree.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/immutable/CharacterMetadata.js
+++ b/src/model/immutable/CharacterMetadata.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/immutable/ContentBlock.js
+++ b/src/model/immutable/ContentBlock.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/immutable/ContentBlockNode.js
+++ b/src/model/immutable/ContentBlockNode.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/immutable/ContentState.js
+++ b/src/model/immutable/ContentState.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/immutable/DefaultDraftBlockRenderMap.js
+++ b/src/model/immutable/DefaultDraftBlockRenderMap.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/immutable/DefaultDraftInlineStyle.js
+++ b/src/model/immutable/DefaultDraftInlineStyle.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/immutable/DraftBlockRenderConfig.js
+++ b/src/model/immutable/DraftBlockRenderConfig.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/immutable/DraftBlockRenderMap.js
+++ b/src/model/immutable/DraftBlockRenderMap.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/immutable/DraftInlineStyle.js
+++ b/src/model/immutable/DraftInlineStyle.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/immutable/EditorBidiService.js
+++ b/src/model/immutable/EditorBidiService.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/immutable/EditorChangeType.js
+++ b/src/model/immutable/EditorChangeType.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/immutable/EditorState.js
+++ b/src/model/immutable/EditorState.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/immutable/EditorStateCreationConfig.js
+++ b/src/model/immutable/EditorStateCreationConfig.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/immutable/EntityMap.js
+++ b/src/model/immutable/EntityMap.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/immutable/SampleDraftInlineStyle.js
+++ b/src/model/immutable/SampleDraftInlineStyle.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/immutable/SelectionState.js
+++ b/src/model/immutable/SelectionState.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/immutable/__tests__/BlockTree-test.js
+++ b/src/model/immutable/__tests__/BlockTree-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/immutable/__tests__/CharacterMetadata-test.js
+++ b/src/model/immutable/__tests__/CharacterMetadata-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/immutable/__tests__/ContentBlock-test.js
+++ b/src/model/immutable/__tests__/ContentBlock-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/immutable/__tests__/ContentBlockNode-test.js
+++ b/src/model/immutable/__tests__/ContentBlockNode-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An addtestional grant

--- a/src/model/immutable/__tests__/ContentState-test.js
+++ b/src/model/immutable/__tests__/ContentState-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/immutable/__tests__/EditorBidiService-test.js
+++ b/src/model/immutable/__tests__/EditorBidiService-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/immutable/__tests__/EditorState-test.js
+++ b/src/model/immutable/__tests__/EditorState-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/immutable/__tests__/SelectionState-test.js
+++ b/src/model/immutable/__tests__/SelectionState-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/immutable/__tests__/findRangesImmutable-test.js
+++ b/src/model/immutable/__tests__/findRangesImmutable-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/immutable/findRangesImmutable.js
+++ b/src/model/immutable/findRangesImmutable.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/keys/generateRandomKey.js
+++ b/src/model/keys/generateRandomKey.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/modifier/AtomicBlockUtils.js
+++ b/src/model/modifier/AtomicBlockUtils.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/modifier/DraftEntitySegments.js
+++ b/src/model/modifier/DraftEntitySegments.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/modifier/DraftModifier.js
+++ b/src/model/modifier/DraftModifier.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/modifier/DraftRange.js
+++ b/src/model/modifier/DraftRange.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/modifier/DraftRemovableWord.js
+++ b/src/model/modifier/DraftRemovableWord.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/modifier/RichTextEditorUtil.js
+++ b/src/model/modifier/RichTextEditorUtil.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/modifier/RichTextUtils.js
+++ b/src/model/modifier/RichTextUtils.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/modifier/__tests__/AtomicBlockUtils-test.js
+++ b/src/model/modifier/__tests__/AtomicBlockUtils-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/modifier/__tests__/DraftRemovableWord-test.js
+++ b/src/model/modifier/__tests__/DraftRemovableWord-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/modifier/__tests__/RichTextEditorUtil-test.js
+++ b/src/model/modifier/__tests__/RichTextEditorUtil-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/modifier/exploration/DraftTreeOperations.js
+++ b/src/model/modifier/exploration/DraftTreeOperations.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/modifier/exploration/NestedRichTextEditorUtil.js
+++ b/src/model/modifier/exploration/NestedRichTextEditorUtil.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/modifier/exploration/__tests__/DraftTreeOperations-test.js
+++ b/src/model/modifier/exploration/__tests__/DraftTreeOperations-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/modifier/exploration/__tests__/NestedRichTextEditorUtil-test.js
+++ b/src/model/modifier/exploration/__tests__/NestedRichTextEditorUtil-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/modifier/getCharacterRemovalRange.js
+++ b/src/model/modifier/getCharacterRemovalRange.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/modifier/getRangesForDraftEntity.js
+++ b/src/model/modifier/getRangesForDraftEntity.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/paste/DraftPasteProcessor.js
+++ b/src/model/paste/DraftPasteProcessor.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/paste/__mocks__/getSafeBodyFromHTML.js
+++ b/src/model/paste/__mocks__/getSafeBodyFromHTML.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/paste/__tests__/DraftPasteProcessor-test.js
+++ b/src/model/paste/__tests__/DraftPasteProcessor-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/paste/getSafeBodyFromHTML.js
+++ b/src/model/paste/getSafeBodyFromHTML.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/ContentStateInlineStyle.js
+++ b/src/model/transaction/ContentStateInlineStyle.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/__tests__/ContentStateInlineStyle-test.js
+++ b/src/model/transaction/__tests__/ContentStateInlineStyle-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/__tests__/applyEntityToContentBlock-test.js
+++ b/src/model/transaction/__tests__/applyEntityToContentBlock-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/__tests__/applyEntityToContentState-test.js
+++ b/src/model/transaction/__tests__/applyEntityToContentState-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/__tests__/getContentStateFragment-test.js
+++ b/src/model/transaction/__tests__/getContentStateFragment-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/__tests__/insertFragmentIntoContentState-test.js
+++ b/src/model/transaction/__tests__/insertFragmentIntoContentState-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/__tests__/insertIntoList-test.js
+++ b/src/model/transaction/__tests__/insertIntoList-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/__tests__/insertTextIntoContentState-test.js
+++ b/src/model/transaction/__tests__/insertTextIntoContentState-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/__tests__/moveBlockInContentState-test.js
+++ b/src/model/transaction/__tests__/moveBlockInContentState-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/__tests__/randomizeBlockMapKeys-test.js
+++ b/src/model/transaction/__tests__/randomizeBlockMapKeys-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/__tests__/removeEntitiesAtEdges-test.js
+++ b/src/model/transaction/__tests__/removeEntitiesAtEdges-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/__tests__/removeRangeFromContentState-test.js
+++ b/src/model/transaction/__tests__/removeRangeFromContentState-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/__tests__/splitBlockInContentState-test.js
+++ b/src/model/transaction/__tests__/splitBlockInContentState-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/addEntityToContentState.js
+++ b/src/model/transaction/addEntityToContentState.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/addEntityToEntityMap.js
+++ b/src/model/transaction/addEntityToEntityMap.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/adjustBlockDepthForContentState.js
+++ b/src/model/transaction/adjustBlockDepthForContentState.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/applyEntityToContentBlock.js
+++ b/src/model/transaction/applyEntityToContentBlock.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/applyEntityToContentState.js
+++ b/src/model/transaction/applyEntityToContentState.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/createEntityInContentState.js
+++ b/src/model/transaction/createEntityInContentState.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/exploration/__tests__/getNextDelimiterBlockKey-test.js
+++ b/src/model/transaction/exploration/__tests__/getNextDelimiterBlockKey-test.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/exploration/getNextDelimiterBlockKey.js
+++ b/src/model/transaction/exploration/getNextDelimiterBlockKey.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/getContentStateFragment.js
+++ b/src/model/transaction/getContentStateFragment.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/getSampleStateForTesting.js
+++ b/src/model/transaction/getSampleStateForTesting.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/insertFragmentIntoContentState.js
+++ b/src/model/transaction/insertFragmentIntoContentState.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/insertIntoList.js
+++ b/src/model/transaction/insertIntoList.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/insertTextIntoContentState.js
+++ b/src/model/transaction/insertTextIntoContentState.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/modifyBlockForContentState.js
+++ b/src/model/transaction/modifyBlockForContentState.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/moveBlockInContentState.js
+++ b/src/model/transaction/moveBlockInContentState.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/randomizeBlockMapKeys.js
+++ b/src/model/transaction/randomizeBlockMapKeys.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/removeEntitiesAtEdges.js
+++ b/src/model/transaction/removeEntitiesAtEdges.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/removeRangeFromContentState.js
+++ b/src/model/transaction/removeRangeFromContentState.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/splitBlockInContentState.js
+++ b/src/model/transaction/splitBlockInContentState.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/model/transaction/updateEntityDataInContentState.js
+++ b/src/model/transaction/updateEntityDataInContentState.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/stubs/ComposedEntityMutability.js
+++ b/src/stubs/ComposedEntityMutability.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/stubs/ComposedEntityType.js
+++ b/src/stubs/ComposedEntityType.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/stubs/DraftEditorContents.react.js
+++ b/src/stubs/DraftEditorContents.react.js
@@ -1,6 +1,5 @@
 /**
- * Copyright 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/stubs/DraftEffects.js
+++ b/src/stubs/DraftEffects.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/stubs/DraftJsDebugLogging.js
+++ b/src/stubs/DraftJsDebugLogging.js
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/src/stubs/gkx.js
+++ b/src/stubs/gkx.js
@@ -1,6 +1,5 @@
 /**
- * Copyright 2013-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant


### PR DESCRIPTION
**Summary**
The open source checkup tool told us that we were missing copyright headers on some files. I also found out that the recommendation is now to remove the date from these headers, so updated existing files via codemod.

```
> codemod -m --extensions js -d src 'Copyright \(c\) 2013\-present, Facebook, Inc\.. \* All rights reserved\.' 'Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.'
```

**Test Plan**
None
