### PR TITLE
Support npm version 6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   },
   "devEngines": {
     "node": "8.x || 9.x",
-    "npm": "2.x || 3.x || 5.x"
+    "npm": "2.x || 3.x || 5.x || 6.x"
   },
   "jest": {
     "automock": true,


### PR DESCRIPTION
**Summary**

Now nvm install 8 ends up installing npm 6.4.1 but our `package.json` doesn't support that npm version. This PR includes 6.x in the versions we support.

More context: https://github.com/facebook/draft-js/pull/1864#issuecomment-420574680

**Test Plan**

CI tests.
