### PR TITLE
add path to include Draft.css

### DIFF
--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -73,4 +73,9 @@ Because Draft.js supports unicode, you must have the following meta tag in the `
 
 `Draft.css` should be included when rendering the editor. Learn more about [why](/docs/advanced-topics-issues-and-pitfalls.html#missing-draft-css).
 
+```js
+// It's located in node_modules/draft-js/dist/Draft.css.
+import 'draft-js/dist/Draft.css'; 
+```
+
 Next, let's go into the basics of the API and learn what else you can do with Draft.js.


### PR DESCRIPTION
**Summary**
The documentation mentions that `Draft.css` needs to be included but no mention on how to do it. 

This update gives a way and also gives the path of the CSS to if folks are using `webpack` they can include it either style code directly rather than JS.