### PR TITLE
Update babel-eslint to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "babel-core": "^6.8.0",
-    "babel-eslint": "^7.2.3",
+    "babel-eslint": "^10.0.1",
     "babel-preset-fbjs": "^2.1.0",
     "cross-env": "^5.1.3",
     "del": "^2.2.0",


### PR DESCRIPTION
**Summary**

When executing `npm run lint` I was getting the following error which was terminating ESLint before it completed:

```
Cannot read property 'type' of undefined
TypeError: Cannot read property 'type' of undefined
```
I updated `babel-eslint` from `7.2.3` to `10.0.1`, and when I executed `npm run lint` it ran without error.

It might be that my environment is different from other folks, and that's causing the issue. If that's the case I can work through it on my own and there's no need for this PR. I'll list my environment settings below just in case:

Node version: `v10.10.0`
NPM version: `6.4.1`

**Test Plan**

Execute `npm run lint` after upgrading to `10.0.1` and validated that it completed without throwing an error.
