### PR TITLE
Update documentation concerning immutable updates

### DIFF
--- a/docs/APIReference-ContentState.md
+++ b/docs/APIReference-ContentState.md
@@ -142,6 +142,13 @@ objects.
 
 > Use [Immutable Map API](http://facebook.github.io/immutable-js/docs/#/Map) to
 > set properties.
+> 
+> **Example**
+> ```
+> const editorState = EditorState.createEmpty();
+> const contentState = editorState.getCurrentContent();
+> const contentStateWithSelectionBefore = contentState.set('selectionBefore', SelectionState.createEmpty(contentState.getBlockForKey('1pu4d')));
+> ```
 
 <ul class="apiIndex">
   <li>

--- a/docs/APIReference-EditorState.md
+++ b/docs/APIReference-EditorState.md
@@ -118,7 +118,14 @@ The list below includes the most commonly used instance methods for `EditorState
 > Note
 >
 > Use the static `EditorState` methods to set properties, rather than using
-> the Immutable API directly.
+> the Immutable API directly. This means using `EditorState.set` to pass
+> new options to an EditorState instance.
+>
+> **Example**
+> ```
+> const editorState = EditorState.createEmpty();
+> const editorStateWithoutUndo = EditorState.set(editorState, {allowUndo: false});
+> ```
 
 <ul class="apiIndex">
   <li>

--- a/docs/APIReference-SelectionState.md
+++ b/docs/APIReference-SelectionState.md
@@ -141,6 +141,13 @@ _Start_ and _end_ values are derived.
 
 > Use [Immutable Map API](http://facebook.github.io/immutable-js/docs/#/Record/Record) to
 > set properties.
+> 
+> **Example**
+> ```
+> const selectionState = SelectionState.createEmpty();
+> const selectionStateWithNewFocusOffset = selection.set('focusOffset', 1);
+> ```
+
 
 <ul class="apiIndex">
   <li>


### PR DESCRIPTION
**Summary**
Adding some inline examples in the documentation around immutable updates for `EditorState`, `ContentState` and `SelectionState` based on the suggestions of #1445.

Let me know if there's more areas in the documentation that could use similar examples or if some editing needs to be done to what I've added.

**Test Plan**

N/A, but I did view in online markdown editor and it looks ok