### PR TITLE
Update docs to ensure kebab menu shows subheads

### DIFF
--- a/docs/APIReference-CompositeDecorator.md
+++ b/docs/APIReference-CompositeDecorator.md
@@ -3,4 +3,6 @@ id: api-reference-composite-decorator
 title: CompositeDecorator
 ---
 
+## Advanced Topic Article
+
 See the [advanced topic article on Decorators](/docs/advanced-topics-decorators.html#compositedecorator).

--- a/docs/Advanced-Topics-Inline-Styles.md
+++ b/docs/Advanced-Topics-Inline-Styles.md
@@ -12,7 +12,7 @@ The [Rich Editor](http://github.com/facebook/draft-js/tree/master/examples/draft
 [Colorful Editor](http://github.com/facebook/draft-js/tree/master/examples/draft-0-10-0/color)
 examples demonstrate complex inline style behavior in action.
 
-### Model
+## Model
 
 Within the Draft model, inline styles are represented at the character level,
 using an immutable `OrderedSet` to define the list of styles to be applied to
@@ -38,7 +38,7 @@ In essence, our styles are:
 ]
 ```
 
-### Overlapping Styles
+## Overlapping Styles
 
 Now let's say that we wish to make the middle range of characters italic as well:
 "He_llo **wo**_**rld**". This operation can be performed via the
@@ -64,7 +64,7 @@ When determining how to render inline-styled text, Draft will identify
 contiguous ranges of identically styled characters and render those characters
 together in styled `span` nodes.
 
-### Mapping a style string to CSS
+## Mapping a style string to CSS
 
 By default, `Editor` provides support for a basic list of inline styles:
 `'BOLD'`, `'ITALIC'`, `'UNDERLINE'`, and `'CODE'`. These are mapped to simple CSS

--- a/docs/Advanced-Topics-Key-Bindings.md
+++ b/docs/Advanced-Topics-Key-Bindings.md
@@ -7,7 +7,7 @@ The `Editor` component offers flexibility to define custom key bindings
 for your editor, via the `keyBindingFn` prop. This allows you to match key
 commands to behaviors in your editor component.
 
-### Defaults
+## Defaults
 
 The default key binding function is `getDefaultKeyBinding`.
 
@@ -21,7 +21,7 @@ strings, which then correspond to behaviors within component handlers.
 For instance, `Ctrl+Z` (Win) and `Cmd+Z` (OSX) map to the `'undo'` command,
 which then routes our handler to perform an `EditorState.undo()`.
 
-### Customization
+## Customization
 
 You may provide your own key binding function to supply custom command strings.
 
@@ -33,7 +33,7 @@ prop function, which allows you to map that command string to your desired
 behavior. If `handleKeyCommand` returns `'handled'`, the command is considered
 handled. If it returns `'not-handled'`, the command will fall through.
 
-### Example
+## Example
 
 Let's say we have an editor that should have a "Save" mechanism to periodically
 write your contents to the server as a draft copy.

--- a/docs/Advanced-Topics-Nested-Lists.md
+++ b/docs/Advanced-Topics-Nested-Lists.md
@@ -7,6 +7,8 @@ The Draft framework provides support for nested lists, as demonstrated in the
 Facebook Notes editor. There, you can use `Tab` and `Shift+Tab` to add or remove
 depth to a list item.
 
+## Implementation
+
 The [`RichUtils`](/docs/api-reference-rich-utils.html) module provides a handy `onTab` method that manages this
 behavior, and should be sufficient for most nested list needs. You can use
 the `onTab` prop on your `Editor` to make use of this utility.

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -1,6 +1,7 @@
 ---
 id: getting-started
 title: Overview
+onPageNav: 'none'
 ---
 
 Draft.js is a framework for building rich text editors in React, powered by an immutable model and abstracting over cross-browser differences.
@@ -11,7 +12,7 @@ Draft.js was introduced at [React.js Conf](http://conf.reactjs.com/) in February
 
 <iframe width="650" height="365" src="https://www.youtube.com/embed/feUYwoLhE_4" frameborder="0" allowfullscreen></iframe>
 
-### Installation
+## Installation
 
 Draft.js is distributed via npm. It depends on React and React DOM which must also be installed.
 
@@ -31,7 +32,7 @@ yarn add draft-js react react-dom es6-shim
 
 Learn more about [using a shim with Draft](/docs/advanced-topics-issues-and-pitfalls.html#polyfills).
 
-### API Changes Notice
+## API Changes Notice
 
 Before getting started, please be aware that we recently changed the API of
 Entity storage in Draft. The latest version, `v0.10.0`, supports both the old
@@ -39,7 +40,7 @@ and new API.  Following that up will be `v0.11.0` which will remove the old API.
 If you are interested in helping out, or tracking the progress, please follow
 [issue 839](https://github.com/facebook/draft-js/issues/839).
 
-### Usage
+## Usage
 
 ```js
 import React from 'react';


### PR DESCRIPTION
**Summary**

Reference issue: #1873

The kebab menu for `docs` pages was empty on certain pages (it seems like a setting on the siteConfig.js that [controls whether this menu is shown or not](https://github.com/facebook/Docusaurus/blob/f2927a9fc458cc368ebae5474e55b755fe4120db/v1/lib/core/BlogPostLayout.js#L92). It doesn't seem like there's a way to override this on a per page basis with configuration). 

I modified the format of these pages to bring them more in line with similar `docs` pages. Also added headers to ensure all docs pages had a value in the kebab dropdown. Seemed easier than coding around it.

**Test Plan**

Verified the changes on `docs` pages locally
