### PR TITLE
Remove flow typing for DraftEntity mock

### DIFF
--- a/src/model/entity/__mocks__/DraftEntity.js
+++ b/src/model/entity/__mocks__/DraftEntity.js
@@ -7,7 +7,6 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @format
- * @flow strict-local
  * @emails oncall+draft_js
  */
 


### PR DESCRIPTION
**Summary**

Flow typing this file breaks Travis CI. See also discussion in #1890 

**Test Plan**
`yarn run flow`
