### PR TITLE
Added information about nature of block keys

### DIFF
--- a/docs/APIReference-ContentBlock.md
+++ b/docs/APIReference-ContentBlock.md
@@ -161,7 +161,7 @@ supplied text.
 ```
 getKey(): string
 ```
-Returns the string key for this `ContentBlock`.
+Returns the string key for this `ContentBlock`. Block keys are alphanumeric string. It is recommended to use `generateRandomKey` to generate block keys.
 
 ### getType()
 


### PR DESCRIPTION
**Summary**

Added a note letting users know the block keys are strictly alphanumeric and using the `generateRandomKey` function to generate block keys is a good approach.

Any changes needed can be mentioned and will be implemented in a jiffy!

Issue in focus: #1843 