### PR TITLE
Add description for customStyleFn to Advanced-Topics-Inline-Styles.md

### DIFF
--- a/docs/Advanced-Topics-Inline-Styles.md
+++ b/docs/Advanced-Topics-Inline-Styles.md
@@ -106,3 +106,30 @@ class MyEditor extends React.Component {
 
 When rendered, the `textDecoration: line-through` style will be applied to all
 character ranges with the `STRIKETHROUGH` style.
+
+## Adding custom styles
+
+You can add custom styles to the editor by using `customStyleFn` :
+
+```js
+import {Editor} from 'draft-js';
+
+const customStyle = {
+  fontSize: '18px',
+  color: 'cobalt'
+};
+
+class MyEditor extends React.Component {
+  // ...
+  render() {
+    return (
+      <Editor
+        customStyleFn={() => customStyle}
+        editorState={this.state.editorState}
+        ...
+      />
+    );
+  }
+}
+```
+


### PR DESCRIPTION
**Summary**

I've been searching for days to add custom styles to Draft editor. Luckily, I found that Draft.js has a `customStyleFn` prop which can lead to add custom styles! For now, [`api-reference-editor` doc](https://draftjs.org/docs/api-reference-editor.html#customstylefn) has a **short** description about `customStyleFn`, which says '... See [Advanced Topics: Inline Styles for details on usage](https://draftjs.org/docs/advanced-topics-inline-styles.html)', but there's no document describing `customStyleFn` on 'Advanced-Topics-Inline-Styles'.
So I add documentation to describe how to use `customStyleFn`.

**Test Plan**

It is a valid markdown document.
