### PR TITLE
Add meeting notes for 10/12

### DIFF
--- a/meta/meeting-notes/2018-10-12-meeting.md
+++ b/meta/meeting-notes/2018-10-12-meeting.md
@@ -1,0 +1,63 @@
+# Draft.js Meeting Notes - 10/12
+
+## Attendees
+Claudio Procida, Flarnie Marchan, Julian Krispel, Marco Botto, Nivedita Chopra, Philip Chmalts (Chegg), Sophie Alpert.
+
+## Updates
+
+**Tree Data (Nivedita)**
+
+* Currently being dogfooded internally.
+* Majority of the functionality is built, currently finding and fixing many small bugs.
+* Planning to write docs soon.
+* Phil's use case in Chegg is for nested entities, which nested blocks can help with.
+
+## Discussion
+
+**What are the blockers for cutting a new release?**
+
+* Bundle size has increased by 35% from 526.3 kb to 711.3 kb (more details below).
+* (not really a blocker) Tests are still insufficient and do not provide much coverage.
+
+**Bundle Size**
+
+* We currently have a script that generates bundle size stats. The idea is that this script can help (someone) look at each commit and each bundle and figure out where the most size was introduced.
+* It only runs on `yarn build` and so is included in some PRs and not others, causing some confusion amongst contributors. Flarnie has opened #1900 as follow-up for better documentation here.
+* Bundle size has increased by 200k. Top 3 causes of size increase from the previous release are:
+  * duplicate copy of the html converstion utility, we need to remove one.
+  * the tree-data migration in-progress
+  * the entity storage migration in-progress
+
+(thanks to Flarnie for pulling these stats and providing the historical context)
+
+**Will splitting `immutable` as a peer dependency help with bundle size?**
+
+* `npm` should automatically hoist dependencies so this shouldn't matter for size purposes.
+* Moving `immutable` to a peer dependency will add friction to using Draft.js out of the box, so it's a bad idea.
+
+**Guidelines for merging PRs**
+
+* Can we expose internal tests? No. There is also only one sanity check webdriver test & a few product tests that we have never seen fail.
+* For now, we're still prioritizing low-risk PRs for bugs, tests & docs.
+* Nivedita has been importing to Phabricator to run the internal test suite, doing a manual sanity check on FB composer & Intern Editor, and staggering each land by a few hours (during Menlo Park business hours only) to make it easier to bisect & revert in case of breakage.
+* If we publish a roadmap, it will help guide the community on which PRs are higher priority for us.
+
+## Roadmap - Initial Brainstorm
+* Publish a new release
+  * Not publishing `v0.11.0` yet ([which contains API-breaking changes](https://github.com/facebook/draft-js/issues/839)). 
+  * This will be `v0.10.6` since `v0.10.5` was published in January.
+  * Need to reduce bundle size (being led by Flarnie & Claudio, with community help).
+  * Will also need documentation updates & comms around the new release (Julian is leading this).
+  * (potential) Introduce semantic versioning for commits ([e.g. in React](https://reactjs.org/docs/how-to-contribute.html#semantic-versioning)) that will help with pulling release notes more easily (Marco may help with this).
+* Tree Data
+  * Goal is to cut a release (potentially `v0.10.7`) with stable Tree Data ready for opt-in use.
+  * Aim to have docs ready in the next two weeks (action item for Nivedita). This will give more context to potential dogfooders & contributors.
+  * Expose pending bugs, issues & release blockers on GitHub so the community can help with this (Julian & Flarnie are interested in this, as well as a couple of other folks at FB).
+  * Provide an example with tables implementation based on tree data (Nivedita will be building this initially for an internal use case & then exposing externally in Draft.js `examples` directory).
+* Community
+  * Guidelines for issue triage via tags (#1896).
+  * Guidelines for PRs to be merged (#1897).
+  * Publish roadmap for transparency (#1898).
+  * Continue to publish meeting notes.
+
+Next meeting in two weeks - we are now setting up a biweekly meeting series. The community can flag any issues that they would like to be addressed in our meetings by adding the `meeting agenda` tag.


### PR DESCRIPTION
**Summary**

Publishing meeting notes, fixes #1899 

**Test Plan**

Rendered in MacDown (
[2018-10-12-meeting.pdf](https://github.com/facebook/draft-js/files/2477047/2018-10-12-meeting.pdf))

