### PR TITLE
Add Node.js version 10 for CI 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 
 node_js:
 - 8
+- 10
 
 sudo: false
 

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "webpack-stream": "^4.0.0"
   },
   "devEngines": {
-    "node": "8.x || 9.x",
+    "node": "8.x || 9.x || 10.x",
     "npm": "2.x || 3.x || 5.x || 6.x"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,9 @@
     "vinyl-buffer": "^1.0.0",
     "webpack-stream": "^4.0.0"
   },
+  "resolutions": {
+    "gulp/**/natives": "1.1.3"
+  },
   "devEngines": {
     "node": "8.x || 9.x || 10.x",
     "npm": "2.x || 3.x || 5.x || 6.x"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4207,9 +4207,9 @@ nan@^2.3.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a"
 
-natives@^1.1.0:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.6.tgz#a603b4a498ab77173612b9ea1acdec4d980f00bb"
+natives@1.1.3, natives@^1.1.0:
+  version "1.1.3"
+  resolved "http://registry.npmjs.org/natives/-/natives-1.1.3.tgz#44a579be64507ea2d6ed1ca04a9415915cf75558"
 
 natural-compare@^1.4.0:
   version "1.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4208,8 +4208,8 @@ nan@^2.3.0:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a"
 
 natives@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.1.tgz#011acce1f7cbd87f7ba6b3093d6cd9392be1c574"
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.6.tgz#a603b4a498ab77173612b9ea1acdec4d980f00bb"
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
**Summary**

This PR adds nodejs version `10` for the Travis Ci build

Details: 
* https://github.com/nodejs/Release#end-of-life-releases
* https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#specifying-nodejs-versions

![image](https://user-images.githubusercontent.com/25740248/47252831-f1f67580-d485-11e8-8ae0-1525cfd154df.png)


**Test Plan**

Travis CI test