### PR TITLE
Refactor buffer constructor

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -181,7 +181,7 @@ gulp.task('css', function() {
               }
             },
           );
-          file.contents = new Buffer(replaced);
+          file.contents = Buffer.from(replaced);
           callback(null, file);
         }),
       )


### PR DESCRIPTION
**Summary**

This PR replaces `new Buffer` with `Buffer.from` and removes its deprecation warning.

The behavior of new Buffer() is different depending on the type of the first argument, security and reliability issues can be inadvertently introduced into applications when argument validation or Buffer initialization is not performed.

To make the creation of Buffer instances more reliable and less error-prone, the various forms of the new Buffer() constructor have been deprecated and replaced by separate Buffer.from(), Buffer.alloc(), and Buffer.allocUnsafe() methods.

details: https://nodejs.org/api/buffer.html#buffer_buffer_from_buffer_alloc_and_buffer_allocunsafe
https://github.com/nodejs/Release#end-of-life-releases