### PR TITLE
Fix typo

### DIFF
--- a/docs/Advanced-Topics-Custom-Block-Render.md
+++ b/docs/Advanced-Topics-Custom-Block-Render.md
@@ -38,7 +38,7 @@ Draft default block render map can be overwritten, by passing an
 [Immutable Map](http://facebook.github.io/immutable-js/docs/#/Map) to
 the editor blockRender props.
 
-*example of overwritting default block render map:*
+*example of overwriting default block render map:*
 
 ```js
 // The example below deliberately only allows

--- a/docs/Advanced-Topics-Issues-and-Pitfalls.md
+++ b/docs/Advanced-Topics-Issues-and-Pitfalls.md
@@ -83,7 +83,7 @@ many examples but you are free to use
 [babel-polyfill](https://babeljs.io/docs/usage/polyfill/) if that's more
 your scene.
 
-When using either polyfill/shim, you should include it as early as possibly in
+When using either polyfill/shim, you should include it as early as possible in
 your application's entrypoint (at the very minimum, before you import Draft).
 For instance, using
 [create-react-app](https://github.com/facebookincubator/create-react-app) and


### PR DESCRIPTION
**Summary**

This PR fixed the following typo:
* `overwritting` -> `overwriting`
* `as early as possibly` -> `as early as possible`