### PR TITLE
Added details in docs for how to import `Draft.css` in overview page.

### DIFF
--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -74,4 +74,8 @@ Because Draft.js supports unicode, you must have the following meta tag in the `
 
 `Draft.css` should be included when rendering the editor. Learn more about [why](/docs/advanced-topics-issues-and-pitfalls.html#missing-draft-css).
 
+```
+import 'draft-js/dist/Draft.css';
+```
+
 Next, let's go into the basics of the API and learn what else you can do with Draft.js.

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -74,7 +74,7 @@ Because Draft.js supports unicode, you must have the following meta tag in the `
 
 `Draft.css` should be included when rendering the editor. Learn more about [why](/docs/advanced-topics-issues-and-pitfalls.html#missing-draft-css).
 
-```
+```js
 import 'draft-js/dist/Draft.css';
 ```
 


### PR DESCRIPTION

**Summary**

added details in docs for how to import `Draft.css` in overview page.