### PR TITLE
Remove componentWillReceiveProps usages in examples

### DIFF
--- a/examples/draft-0-10-0/tex/js/components/TeXBlock.js
+++ b/examples/draft-0-10-0/tex/js/components/TeXBlock.js
@@ -30,7 +30,7 @@ class KatexOutput extends React.Component {
     this._update();
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps, prevState) {
     if (prevProps.content !== this.props.content) {
       this._update();
     }

--- a/examples/draft-0-10-0/tex/js/components/TeXBlock.js
+++ b/examples/draft-0-10-0/tex/js/components/TeXBlock.js
@@ -18,38 +18,22 @@ import katex from 'katex';
 import React from 'react';
 
 class KatexOutput extends React.Component {
-  constructor(props) {
-    super(props);
-    this._timer = null;
-  }
-
   _update() {
-    if (this._timer) {
-      clearTimeout(this._timer);
-    }
-
-    this._timer = setTimeout(() => {
-      katex.render(
-        this.props.content,
-        this.refs.container,
-        {displayMode: true},
-      );
-    }, 0);
+    katex.render(
+      this.props.content,
+      this.refs.container,
+      {displayMode: true},
+    );
   }
 
   componentDidMount() {
     this._update();
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.content !== this.props.content) {
+  componentDidUpdate(prevProps) {
+    if (prevProps.content !== this.props.content) {
       this._update();
     }
-  }
-
-  componentWillUnmount() {
-    clearTimeout(this._timer);
-    this._timer = null;
   }
 
   render() {

--- a/examples/draft-0-9-1/tex/js/components/TeXBlock.js
+++ b/examples/draft-0-9-1/tex/js/components/TeXBlock.js
@@ -35,7 +35,7 @@ class KatexOutput extends React.Component {
     this._update();
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps, prevState) {
     if (prevProps.content !== this.props.content) {
       this._update();
     }

--- a/examples/draft-0-9-1/tex/js/components/TeXBlock.js
+++ b/examples/draft-0-9-1/tex/js/components/TeXBlock.js
@@ -21,36 +21,24 @@ import {Entity} from 'draft-js';
 class KatexOutput extends React.Component {
   constructor(props) {
     super(props);
-    this._timer = null;
   }
 
   _update() {
-    if (this._timer) {
-      clearTimeout(this._timer);
-    }
-
-    this._timer = setTimeout(() => {
-      katex.render(
-        this.props.content,
-        this.container,
-        {displayMode: true},
-      );
-    }, 0);
+    katex.render(
+      this.props.content,
+      this.container,
+      {displayMode: true},
+    );
   }
 
   componentDidMount() {
     this._update();
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.content !== this.props.content) {
+  componentDidUpdate(prevProps) {
+    if (prevProps.content !== this.props.content) {
       this._update();
     }
-  }
-
-  componentWillUnmount() {
-    clearTimeout(this._timer);
-    this._timer = null;
   }
 
   render() {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "webpack-stream": "^4.0.0"
   },
   "resolutions": {
-    "gulp/**/natives": "1.1.6"
+    "gulp/**/natives": "1.1.3"
   },
   "devEngines": {
     "node": "8.x || 9.x || 10.x",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "webpack-stream": "^4.0.0"
   },
   "resolutions": {
-    "gulp/**/natives": "1.1.3"
+    "gulp/**/natives": "1.1.6"
   },
   "devEngines": {
     "node": "8.x || 9.x || 10.x",

--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -451,7 +451,6 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
 
   componentDidUpdate(): void {
     this._blockSelectEvents = false;
-    // moving this here, when it was previously set in componentWillUpdate
     this._latestEditorState = this.props.editorState;
     this._latestCommittedEditorState = this.props.editorState;
   }

--- a/website/static/lib/Draft.js
+++ b/website/static/lib/Draft.js
@@ -10084,7 +10084,6 @@ var DraftEditor = function (_React$Component2) {
 
   DraftEditor.prototype.componentDidUpdate = function componentDidUpdate() {
     this._blockSelectEvents = false;
-    // moving this here, when it was previously set in componentWillUpdate
     this._latestEditorState = this.props.editorState;
     this._latestCommittedEditorState = this.props.editorState;
   };


### PR DESCRIPTION
**Summary**
Resolves [1940](https://github.com/facebook/draft-js/issues/1940)
Change usage of `componentWillReceiveProps` in Tex examples to `componentDidUpdate`