### PR TITLE
Adds email notifications for TravisCI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,4 +58,9 @@ script:
   fi
 
 notifications:
+  email:
+    recipients:
+      - claudio.procida@gmail.com
+    on_success: change # send a notification when the build status changes
+    on_failure: always # always send a notification
   webhooks: https://code.facebook.com/travis/webhook/

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,7 @@ notifications:
   email:
     recipients:
       - claudio.procida@gmail.com
+      - niveditc@gmail.com
     on_success: change # send a notification when the build status changes
     on_failure: always # always send a notification
   webhooks: https://code.facebook.com/travis/webhook/


### PR DESCRIPTION
**Summary**

Adds @claudiopro 's email for TravisCI build notifications. Feel free to do the same if you want to stay in the loop.

**Test Plan**

Wait for the next build to receive an email from TravisCI 🤦‍♂️ 
