### PR TITLE
Fix bad destructuring when content block key has a `-`

### DIFF
--- a/src/component/selection/DraftOffsetKey.js
+++ b/src/component/selection/DraftOffsetKey.js
@@ -25,7 +25,15 @@ const DraftOffsetKey = {
   },
 
   decode: function(offsetKey: string): DraftOffsetKeyPath {
-    const [blockKey, decoratorKey, leafKey] = offsetKey.split(KEY_DELIMITER);
+    const keyComponents = offsetKey.split(KEY_DELIMITER);
+    const blockKey = keyComponents
+      .slice(0, keyComponents.length - 2)
+      .join(KEY_DELIMITER);
+
+    const [decoratorKey, leafKey] = keyComponents.slice(
+      keyComponents.length - 2,
+    );
+
     return {
       blockKey,
       decoratorKey: parseInt(decoratorKey, 10),

--- a/src/component/selection/DraftOffsetKey.js
+++ b/src/component/selection/DraftOffsetKey.js
@@ -25,17 +25,14 @@ const DraftOffsetKey = {
   },
 
   decode: function(offsetKey: string): DraftOffsetKeyPath {
-    const keyComponents = offsetKey.split(KEY_DELIMITER);
-    const blockKey = keyComponents
-      .slice(0, keyComponents.length - 2)
-      .join(KEY_DELIMITER);
-
-    const [decoratorKey, leafKey] = keyComponents.slice(
-      keyComponents.length - 2,
-    );
+    // Extracts the last two parts of offsetKey and captures the rest in blockKeyParts
+    const [leafKey, decoratorKey, ...blockKeyParts] = offsetKey
+      .split(KEY_DELIMITER)
+      .reverse();
 
     return {
-      blockKey,
+      // Recomposes the parts of blockKey after reversing them
+      blockKey: blockKeyParts.reverse().join(KEY_DELIMITER),
       decoratorKey: parseInt(decoratorKey, 10),
       leafKey: parseInt(leafKey, 10),
     };

--- a/src/component/selection/__tests__/DraftOffsetKey-test.js
+++ b/src/component/selection/__tests__/DraftOffsetKey-test.js
@@ -6,6 +6,7 @@
  *
  * @emails oncall+draft_js
  * @format
+ * @flow strict-local
  */
 
 jest.disableAutomock();

--- a/src/component/selection/__tests__/DraftOffsetKey-test.js
+++ b/src/component/selection/__tests__/DraftOffsetKey-test.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+draft_js
+ * @format
+ */
+
+jest.disableAutomock();
+
+const DraftOffsetKey = require('DraftOffsetKey');
+
+test('decodes offset key with no delimeter', () => {
+  expect(DraftOffsetKey.decode('key-0-1')).toMatchSnapshot();
+});
+
+test('decodes offset key with delimiter in between', () => {
+  expect(DraftOffsetKey.decode('key-with-delimiter-0-1')).toMatchSnapshot();
+});
+
+test('decodes offset key with delimiter at the beginning', () => {
+  expect(DraftOffsetKey.decode('-key-0-1')).toMatchSnapshot();
+});
+
+test('decodes offset key with delimiter at the end', () => {
+  expect(DraftOffsetKey.decode('key--0-1')).toMatchSnapshot();
+});

--- a/src/component/selection/__tests__/DraftOffsetKey-test.js
+++ b/src/component/selection/__tests__/DraftOffsetKey-test.js
@@ -12,7 +12,7 @@ jest.disableAutomock();
 
 const DraftOffsetKey = require('DraftOffsetKey');
 
-test('decodes offset key with no delimeter', () => {
+test('decodes offset key with no delimiter', () => {
   expect(DraftOffsetKey.decode('key-0-1')).toMatchSnapshot();
 });
 

--- a/src/component/selection/__tests__/__snapshots__/DraftOffsetKey-test.js.snap
+++ b/src/component/selection/__tests__/__snapshots__/DraftOffsetKey-test.js.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`decodes offset key with delimiter at the beginning 1`] = `
+Object {
+  "blockKey": "-key",
+  "decoratorKey": 0,
+  "leafKey": 1,
+}
+`;
+
+exports[`decodes offset key with delimiter at the end 1`] = `
+Object {
+  "blockKey": "key-",
+  "decoratorKey": 0,
+  "leafKey": 1,
+}
+`;
+
+exports[`decodes offset key with delimiter in between 1`] = `
+Object {
+  "blockKey": "key-with-delimiter",
+  "decoratorKey": 0,
+  "leafKey": 1,
+}
+`;
+
+exports[`decodes offset key with no delimeter 1`] = `
+Object {
+  "blockKey": "key",
+  "decoratorKey": 0,
+  "leafKey": 1,
+}
+`;

--- a/src/component/selection/__tests__/__snapshots__/DraftOffsetKey-test.js.snap
+++ b/src/component/selection/__tests__/__snapshots__/DraftOffsetKey-test.js.snap
@@ -24,7 +24,7 @@ Object {
 }
 `;
 
-exports[`decodes offset key with no delimeter 1`] = `
+exports[`decodes offset key with no delimiter 1`] = `
 Object {
   "blockKey": "key",
   "decoratorKey": 0,


### PR DESCRIPTION
**Summary**

If a content block was created with a key that contains the `-`, it would fail to decode the `decoratorKey` and the `leafKey` because the current implementation relies on `-` to be a parsing delimiter. Here's an example:

```js
class SomeComponent extends React.Component {
  constructor(props) {
    super(props);

    const block = new ContentBlock({
      type: 'paragraph',
      text: 'some-text',
      key: 'some-key'
    });

    const contentState = ContentBlock.createFromBlockArray([block]);

    this.state = {editorState: EditorState.createWithContent(contentState)};

    this.onChange = editorState => this.setState({editorState});
  }

  render() {
    return (
      <Editor
        editorState={this.state.editorState}
        onChange={this.onChange}
      />
    );
  }
}
```

When you select anywhere on the editor, you'd get this error:

```
    TypeError: Cannot read property 'getIn' of undefined

      45 |   const focusBlockKey = focusPath.blockKey;
      46 |   const focusLeaf = editorState
    > 47 |     .getBlockTree(focusBlockKey)
         |                              ^
      48 |     .getIn([focusPath.decoratorKey, 'leaves', focusPath.leafKey]);
      49 |
      50 |   const anchorLeafStart: number = anchorLeaf.get('start');

      at getUpdatedSelectionState (src/component/selection/getUpdatedSelectionState.js:47:30)
      at getDraftEditorSelectionWithNodes (src/component/selection/getDraftEditorSelectionWithNodes.js:48:58)
      at getDraftEditorSelection (src/component/selection/getDraftEditorSelection.js:37:53)
      at assertGetDraftEditorSelection (src/component/selection/__tests__/getDraftEditorSelection-test.js:55:53)
      at Object.<anonymous> (src/component/selection/__tests__/getDraftEditorSelection-test.js:211:3)
```

**Test Plan**

Added a unit test for `DraftOffsetKey.js` to check for all delimiter cases.
