### PR TITLE
Restores flow error suppression for fbjs@1.0.0

### DIFF
--- a/src/component/contents/DraftEditorContents-core.react.js
+++ b/src/component/contents/DraftEditorContents-core.react.js
@@ -197,6 +197,7 @@ class DraftEditorContents extends React.Component<Props> {
           lastWrapperTemplate !== wrapperTemplate ||
           currentDepth === null ||
           depth > currentDepth;
+        // $FlowExpectedError joinClasses args in fbjs@1.0.0 are incorrect
         className = joinClasses(
           className,
           getListItemClasses(blockType, depth, shouldResetCount, direction),


### PR DESCRIPTION
**Summary**

Restores a flow error suppression annotation removed with D14074027

**Test Plan**

`yarn run flow`
No errors