### PR TITLE
Update JSFiddle template to use latest versions of Draft & React + Hooks

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 **What is the current behavior?**
 
-**If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem. You can use this jsfiddle to get started: https://jsfiddle.net/stopachka/m6z0xn4r/.**
+**If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem. You can use this jsfiddle to get started: https://jsfiddle.net/dougmacknz/b5tukezn/.**
 
 **What is the expected behavior?**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Complete your CLA here: <https://code.facebook.com/cla>
 We use GitHub issues to track public bugs. Please ensure your description is
 clear and has sufficient instructions to be able to reproduce the issue.
 If possible please provide a minimal demo of the problem. You can use this
-jsfiddle to get started: https://jsfiddle.net/stopachka/m6z0xn4r/.
+jsfiddle to get started: https://jsfiddle.net/dougmacknz/b5tukezn/.
 
 Facebook has a [bounty program](https://www.facebook.com/whitehat/) for the safe
 disclosure of security bugs. In those cases, please go through the process


### PR DESCRIPTION
**Summary**

Closes https://github.com/facebook/draft-js/issues/1737. Updates the JSFiddle template for reporting issues to use the latest versions of Draft.js, React, ReactDOM, and changes the example to use Hooks. 

**Test Plan**

Head to https://jsfiddle.net/dougmacknz/b5tukezn/