### PR TITLE
Fix inline style

### DIFF
--- a/src/model/immutable/EditorState.js
+++ b/src/model/immutable/EditorState.js
@@ -505,7 +505,7 @@ function updateSelection(
   forceSelection: boolean,
 ): EditorState {
   // Only unset the nativelyRenderedContent and inlineStyleOverride if the
-  // position is different
+  // position is different, not on blur/focus.
   const editorSelection = editorState.getSelection();
   if (
     editorSelection.getAnchorKey() === selection.getAnchorKey() &&

--- a/src/model/immutable/EditorState.js
+++ b/src/model/immutable/EditorState.js
@@ -504,6 +504,21 @@ function updateSelection(
   selection: SelectionState,
   forceSelection: boolean,
 ): EditorState {
+  // Only unset the nativelyRenderedContent and inlineStyleOverride if the
+  // position is different
+  const editorSelection = editorState.getSelection();
+  if (
+    editorSelection.getAnchorKey() === selection.getAnchorKey() &&
+    editorSelection.getAnchorOffset() === selection.getAnchorOffset() &&
+    editorSelection.getFocusKey() === selection.getFocusKey() &&
+    editorSelection.getFocusOffset() === selection.getFocusOffset() &&
+    editorSelection.getIsBackward() === selection.getIsBackward()
+  ) {
+    return EditorState.set(editorState, {
+      selection,
+      forceSelection,
+    });
+  }
   return EditorState.set(editorState, {
     selection,
     forceSelection,

--- a/src/model/immutable/__tests__/EditorState-test.js
+++ b/src/model/immutable/__tests__/EditorState-test.js
@@ -181,6 +181,22 @@ test('does not discard style override when splitting block', () => {
   expect(editor.getCurrentInlineStyle().toJS()).toMatchSnapshot();
 });
 
+test('does not discard style override when gaining/losing focus', () => {
+  let editor = UNDECORATED_STATE;
+  editor = EditorState.moveFocusToEnd(editor);
+  editor = RichTextEditorUtil.toggleInlineStyle(editor, 'BOLD');
+  editor = EditorState.moveFocusToEnd(editor);
+  expect(editor.getCurrentInlineStyle().toJS()).toMatchSnapshot();
+});
+
+test('does discard style override when selection has changed', () => {
+  let editor = UNDECORATED_STATE;
+  editor = EditorState.acceptSelection(editor, collapsedSelection);
+  editor = RichTextEditorUtil.toggleInlineStyle(editor, 'BOLD');
+  editor = EditorState.acceptSelection(editor, rangedSelection);
+  expect(editor.getCurrentInlineStyle().toJS()).toMatchSnapshot();
+});
+
 test('uses right of the start for blocks with text', () => {
   assertGetCurrentInlineStyle(rangedSelection.set('focusKey', 'b'));
 });

--- a/src/model/immutable/__tests__/__snapshots__/EditorState-test.js.snap
+++ b/src/model/immutable/__tests__/__snapshots__/EditorState-test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`does discard style override when selection has changed 1`] = `Array []`;
+
 exports[`does not discard style override when adjusting depth 1`] = `
 Array [
   "BOLD",
@@ -8,6 +10,13 @@ Array [
 
 exports[`does not discard style override when changing block type 1`] = `
 Array [
+  "BOLD",
+]
+`;
+
+exports[`does not discard style override when gaining/losing focus 1`] = `
+Array [
+  "ITALIC",
   "BOLD",
 ]
 `;


### PR DESCRIPTION
*Before* submitting a pull request, please make sure the following is done...

1. Fork the repo and create your branch from `master`.
2. If you've added code that should be tested, add tests!
3. If you've changed APIs, update the documentation.
4. Ensure that:
  * The test suite passes (`npm test`)
  * Your code lints (`npm run lint`) and passes Flow (`npm run flow`)
  * You have followed the [testing guidelines](https://github.com/facebook/draft-js/wiki/Testing-for-Pull-Requests)
5. If you haven't already, complete the [CLA](https://code.facebook.com/cla).

Please use the simple form below as a guideline for describing your pull request.

Thanks for contributing to Draft.js!

-

**Summary**

This is a small addition to https://github.com/facebook/draft-js/pull/1176, adding tests and updating `var` to `const`.  The original PR is nearly 2 years old and my company desperately needs this change, however we'd prefer not to keep our own fork of Draft maintained forever. 


This addresses an issue in which `EditorState.updateSelection` discarded inlineStyleOverride on any update, including a change in `hasFocus`. This caused a bug in which you could not have a user input a hex color in one text field, and then type in that color in DraftJS. The change in focus would remove the previously set inlineStyleOverride. In some cases, developers could work around this by using `onMouseDown` rather than `onClick` to toggle styles, however this doesn't work with text inputs. 

Here is a JSFiddle showing the problem with a bold toggle: https://jsfiddle.net/mmissey/3mq62gu8/

**Test Plan**

A snapshot test has been added to ensure that inlineStyleOverrides are not discarded when only focus changes, and another test ensures that inlineStyleOverrides *are* discarded when the actual position of the selection has been changed.
