### PR TITLE
Exports isSoftNewlineEvent as static method of KeyBindingUtil

### DIFF
--- a/src/component/utils/KeyBindingUtil.js
+++ b/src/component/utils/KeyBindingUtil.js
@@ -13,9 +13,9 @@
 
 const UserAgent = require('UserAgent');
 
-const isOSX = UserAgent.isPlatform('Mac OS X');
+const isSoftNewlineEvent = require('isSoftNewlineEvent');
 
-const isSoftNewlineEvent = require('./isSoftNewlineEvent');
+const isOSX = UserAgent.isPlatform('Mac OS X');
 
 const KeyBindingUtil = {
   /**

--- a/src/component/utils/KeyBindingUtil.js
+++ b/src/component/utils/KeyBindingUtil.js
@@ -15,6 +15,8 @@ const UserAgent = require('UserAgent');
 
 const isOSX = UserAgent.isPlatform('Mac OS X');
 
+const isSoftNewlineEvent = require('./isSoftNewlineEvent');
+
 const KeyBindingUtil = {
   /**
    * Check whether the ctrlKey modifier is *not* being used in conjunction with
@@ -38,6 +40,8 @@ const KeyBindingUtil = {
       ? !!e.metaKey && !e.altKey
       : KeyBindingUtil.isCtrlKeyCommand(e);
   },
+
+  isSoftNewlineEvent,
 };
 
 module.exports = KeyBindingUtil;


### PR DESCRIPTION
Exports isSoftNewlineEvent as static method of KeyBindingUtil, so it can be imported as 

```js
import { KeyBindingUtil } from 'draft-js';
// ...
KeyBindingUtil.isSoftNewlineEvent(...);
```

Fixes #2044 