### PR TITLE
Correct warning condition

### DIFF
--- a/src/component/handlers/edit/commands/moveSelectionBackward.js
+++ b/src/component/handlers/edit/commands/moveSelectionBackward.js
@@ -31,7 +31,7 @@ function moveSelectionBackward(
   const selection = editorState.getSelection();
   // Should eventually make this an invariant
   warning(
-    !selection.isCollapsed(),
+    selection.isCollapsed(),
     'moveSelectionBackward should only be called with a collapsed SelectionState',
   );
   const content = editorState.getCurrentContent();

--- a/src/component/handlers/edit/commands/moveSelectionForward.js
+++ b/src/component/handlers/edit/commands/moveSelectionForward.js
@@ -31,7 +31,7 @@ function moveSelectionForward(
   const selection = editorState.getSelection();
   // Should eventually make this an invariant
   warning(
-    !selection.isCollapsed(),
+    selection.isCollapsed(),
     'moveSelectionForward should only be called with a collapsed SelectionState',
   );
   const key = selection.getStartKey();


### PR DESCRIPTION
**Summary**

To my knowledge, ```warning``` works the way ```invariant``` does; it warns if the first argument is false not true.

Prior to this PR, ```moveSelectionBackward``` warns when the selection is collapsed when it should do the opposite. 
