### PR TITLE
OnDrop don't insert if getText return null

### DIFF
--- a/src/component/handlers/drag/DraftEditorDragHandler.js
+++ b/src/component/handlers/drag/DraftEditorDragHandler.js
@@ -118,9 +118,12 @@ const DraftEditorDragHandler = {
     } else if (editor._internalDrag) {
       editor.update(moveText(editorState, dropSelection));
     } else {
-      editor.update(
-        insertTextAtSelection(editorState, dropSelection, data.getText()),
-      );
+      const droppedText = data.getText();
+      if (droppedText) {
+        editor.update(
+          insertTextAtSelection(editorState, dropSelection, droppedText),
+        );
+      }
     }
     endDrag(editor);
   },


### PR DESCRIPTION
Fix https://github.com/facebook/draft-js/issues/494
-

**Summary**

When drop a custom draggable object to DraftEditor, draft will try get text from object.

It can be fixed by stop insert if getText return null.

**Test Plan**

Drag and Drop behaviors difficult to write a test case.
