### PR TITLE
fix: prevent draft-js from splitting atomic block

### DIFF
--- a/src/model/transaction/__tests__/__snapshots__/splitBlockInContentState-test.js.snap
+++ b/src/model/transaction/__tests__/__snapshots__/splitBlockInContentState-test.js.snap
@@ -2164,3 +2164,25 @@ Array [
   },
 ]
 `;
+
+exports[`should not split atomic block 1`] = `
+Array [
+  Object {
+    "characterList": Array [
+      Object {
+        "entity": "1",
+        "style": Array [],
+      },
+    ],
+    "children": Array [],
+    "data": Object {},
+    "depth": 0,
+    "key": "A",
+    "nextSibling": null,
+    "parent": null,
+    "prevSibling": null,
+    "text": " ",
+    "type": "atomic",
+  },
+]
+`;

--- a/src/model/transaction/__tests__/splitBlockInContentState-test.js
+++ b/src/model/transaction/__tests__/splitBlockInContentState-test.js
@@ -18,6 +18,7 @@ jest.mock('generateRandomKey');
 const BlockMapBuilder = require('BlockMapBuilder');
 const ContentBlockNode = require('ContentBlockNode');
 const SelectionState = require('SelectionState');
+const CharacterMetadata = require('CharacterMetadata');
 
 const getSampleStateForTesting = require('getSampleStateForTesting');
 const Immutable = require('immutable');
@@ -222,5 +223,29 @@ test('must convert empty list item ContentBlock to unstyled rather than split', 
       focusKey: 'H',
     }),
     treeContentState,
+  );
+});
+
+test('should not split atomic block', () => {
+  const charData = CharacterMetadata.create({entity: '1'});
+  const contentStateWithAtomicBlock = contentState.set(
+    'blockMap',
+    BlockMapBuilder.createFromArray([
+      new ContentBlockNode({
+        key: 'A',
+        text: ' ',
+        type: 'atomic',
+        characterList: List([charData]),
+      }),
+    ]),
+  );
+  assertSplitBlockInContentState(
+    selectionState.merge({
+      anchorOffset: 0,
+      focusOffset: 0,
+      anchorKey: 'A',
+      focusKey: 'A',
+    }),
+    contentStateWithAtomicBlock,
   );
 });

--- a/src/model/transaction/splitBlockInContentState.js
+++ b/src/model/transaction/splitBlockInContentState.js
@@ -97,9 +97,13 @@ const splitBlockInContentState = (
   const blockMap = contentState.getBlockMap();
   const blockToSplit = blockMap.get(key);
   const text = blockToSplit.getText();
+  const blockType = blockToSplit.getType();
+
+  if (blockType === 'atomic') {
+    return contentState;
+  }
 
   if (!text) {
-    const blockType = blockToSplit.getType();
     if (
       blockType === 'unordered-list-item' ||
       blockType === 'ordered-list-item'


### PR DESCRIPTION
**Summary**

this is to fix issue #1353

The root cause of this issue is, when draft-js tries to split atomic block, it will create a new block with empty `characterList`. The following code will then throws error when receiving this atomic block, since `block.getEntityAt(0)` returns `null`:

```javascript
const entity = props.contentState.getEntity(
  props.block.getEntityAt(0)
);
```

Personally, I think atomic blocks are designed to be used as a single unit and thus cannot be splitted into parts.

**Test Plan**

You could test it using the media example in repo, using the reproduce steps provided in #1353.

Please notice that after step 4 mentioned in #1353, you could either insert a new image or simply press Enter to trigger the issue.