### PR TITLE
fixed a typo in `docs/Overview.md`

### DIFF
--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -66,7 +66,7 @@ ReactDOM.render(
 );
 ```
 
-Since the release of React 16.8, use can use [Hooks](https://reactjs.org/docs/hooks-intro.html) as a way to work with `EditorState` without using a class.
+Since the release of React 16.8, we can use [Hooks](https://reactjs.org/docs/hooks-intro.html) as a way to work with `EditorState` without using a class.
 
 ```js
 import React from 'react';


### PR DESCRIPTION
**Summary**

This PR fixed a typo in file `docs/Overview.md`, where better options for word `use` in the changed place are  `we` and `users`, and `we` sounds better to me and thus the PR.

**Test Plan**

No test needed.
