### PR TITLE
Changes reference to BSD license to MIT

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,4 +73,4 @@ Our philosophy regarding API changes is as follows:
 
 ## License
 By contributing to Draft.js, you agree that your contributions will be licensed
-under its BSD license.
+under its MIT license.


### PR DESCRIPTION
**Summary**
Changes reference to the BSD license to MIT in the contributing guidelines. Fixes #2129 

**Test Plan**
Proofreading
