### PR TITLE
[WIP] adding method to EditorState.js to make it easier to select all editor contents 

### DIFF
--- a/src/model/immutable/EditorState.js
+++ b/src/model/immutable/EditorState.js
@@ -41,6 +41,7 @@ type EditorStateRecordType = {
   selection: ?SelectionState,
   treeMap: ?OrderedMap<string, List<any>>,
   undoStack: Stack<ContentState>,
+  selectAllContents: ?SelectionState,
 };
 
 const defaultRecord: EditorStateRecordType = {
@@ -174,6 +175,23 @@ class EditorState {
 
   getSelection(): SelectionState {
     return this.getImmutable().get('selection');
+  }
+
+  selectAllContents(): SelectionState {
+
+    const content = this.getImmutable().get('currentContent');
+    let selection = this.getImmutable().get('selection');
+
+    // create a selection from beginning of first block,
+    // to end of last block
+    selection = selection.merge({
+      anchorKey: content.getFirstBlock().getKey(),
+      anchorOffset: 0,
+      focusOffset: content.getLastBlock().getText().length,
+      focusKey: content.getLastBlock().getKey(),
+    })
+
+    return selection;
   }
 
   getDecorator(): ?DraftDecoratorType {
@@ -662,3 +680,4 @@ function lookUpwardForInlineStyle(
 }
 
 module.exports = EditorState;
+


### PR DESCRIPTION
This is a WIP but I'd love some feedback if anyone is able to let me know whether it's worth investing the time to make this feature PR. 

If I get the green light i'll go ahead and learn how to add tests and documentation for this feature. 

Thanks! 


=====================================================================

*Before* submitting a pull request, please make sure the following is done...

1. Fork the repo and create your branch from `master`.
2. If you've added code that should be tested, add tests! 
3. If you've changed APIs, update the documentation.
4. Ensure that:
  * The test suite passes (`npm test`)
  * Your code lints (`npm run lint`) and passes Flow (`npm run flow`)
  * You have followed the [testing guidelines](https://github.com/facebook/draft-js/wiki/Testing-for-Pull-Requests)
5. If you haven't already, complete the [CLA](https://code.facebook.com/cla).

Please use the simple form below as a guideline for describing your pull request.

Thanks for contributing to Draft.js!

-

**Summary**

This small patch lets someone get a SelectionState containing the entire contents of the EditorState. It seemed silly for someone to learn the semantics of the Selection Abstraction in order to apply styles to the entire window. 

**Test Plan**
TODO 
