### PR TITLE
Styling Controls in UI Readme

### DIFF
--- a/docs/QuickStart-Rich-Styling.md
+++ b/docs/QuickStart-Rich-Styling.md
@@ -110,3 +110,29 @@ class MyEditor extends React.Component {
   }
 }
 ```
+
+You might run into issues where your editor loses focus and is therefore unable to modify styles within the editor. In such cases, you can try using the onMouseDown event as follows.
+
+```js
+class MyEditor extends React.Component {
+  // …
+
+  _onBoldClick(e) {
+    e.preventDefault();
+    this.onChange(RichUtils.toggleInlineStyle(this.state.editorState, 'BOLD'));
+  }
+
+  render() {
+    return (
+      <div>
+        <button onMouseDown={this._onBoldClick.bind(this)}>Bold</button>
+        <Editor
+          editorState={this.state.editorState}
+          handleKeyCommand={this.handleKeyCommand}
+          onChange={this.onChange}
+        />
+      </div>
+    );
+  }
+}
+```


### PR DESCRIPTION
*Before* submitting a pull request, please make sure the following is done...

1. Fork the repo and create your branch from `master`.
2. If you've added code that should be tested, add tests!
3. If you've changed APIs, update the documentation.
4. Ensure that:
  * The test suite passes (`npm test`)
  * Your code lints (`npm run lint`) and passes Flow (`npm run flow`)
  * You have followed the [testing guidelines](https://github.com/facebook/draft-js/wiki/Testing-for-Pull-Requests)
5. If you haven't already, complete the [CLA](https://code.facebook.com/cla).

Please use the simple form below as a guideline for describing your pull request.

Thanks for contributing to Draft.js!

-

**Summary**

The current example for styling controls (applying bold, italics etc.) using UI causes the editor to lose focus. This can be resolved by using the onMouseDown event to toggleInlineStyle. This event does not cause the editor to lose focus. Any character typed after that is "boldened" which is what we want.

**Test Plan**

[...]
