### PR TITLE
updated hastext method to not account for zero space width chars

### DIFF
--- a/src/model/immutable/ContentState.js
+++ b/src/model/immutable/ContentState.js
@@ -127,7 +127,11 @@ class ContentState extends ContentStateRecord {
 
   hasText(): boolean {
     const blockMap = this.getBlockMap();
-    return blockMap.size > 1 || blockMap.first().getLength() > 0;
+    return (
+      blockMap.size > 1 ||
+      // make sure that there are no zero width space chars
+      escape(blockMap.first().getText()).replace(/%u200B/g, '').length > 0
+    );
   }
 
   createEntity(

--- a/src/model/immutable/__tests__/ContentState-test.js
+++ b/src/model/immutable/__tests__/ContentState-test.js
@@ -26,6 +26,7 @@ const MULTI_BLOCK = [
   {text: 'Four score', key: 'b'},
   {text: 'and seven', key: 'c'},
 ];
+const ZERO_WIDTH_CHAR_BLOCK = [{text: unescape('%u200B%u200B'), key: 'a'}];
 
 const SelectionState = require('SelectionState');
 
@@ -82,6 +83,12 @@ test('block fetching must retrieve or fail fetching block for key', () => {
   expect(block instanceof ContentBlock).toMatchSnapshot();
   expect(block.getText()).toMatchSnapshot();
   expect(state.getBlockForKey('x')).toMatchSnapshot();
+});
+
+test('must not include zero width chars for has text', () => {
+  expect(getSample(ZERO_WIDTH_CHAR_BLOCK).hasText()).toMatchSnapshot();
+  expect(getSample(SINGLE_BLOCK).hasText()).toMatchSnapshot();
+  expect(getSample(MULTI_BLOCK).hasText()).toMatchSnapshot();
 });
 
 test('must create entities instances', () => {

--- a/src/model/immutable/__tests__/__snapshots__/ContentState-test.js.snap
+++ b/src/model/immutable/__tests__/__snapshots__/ContentState-test.js.snap
@@ -40,6 +40,12 @@ Object {
 }
 `;
 
+exports[`must not include zero width chars for has text 1`] = `false`;
+
+exports[`must not include zero width chars for has text 2`] = `true`;
+
+exports[`must not include zero width chars for has text 3`] = `true`;
+
 exports[`must replace entities data 1`] = `
 Object {
   "newProp": "baz",


### PR DESCRIPTION
Summary: \u200B (zero space width chars) is put into the blockmap while inserting tokens. Therfore hastext returns true even when there is no text in the input. Updated hastext method to not account for zero space width chars.

Reviewed By: claudiopro

Differential Revision: D16868475

