### PR TITLE
Add ClassNames support to the customStyleMap

### DIFF
--- a/examples/draft-0-10-0/color/ColorfulEditor.css
+++ b/examples/draft-0-10-0/color/ColorfulEditor.css
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+ *
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only. Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+.ColorfulEditor-orange {
+    color: rgba(255, 127, 0, 1.0);
+}
+
+.ColorfulEditor-yellow {
+    color: rgba(0, 180, 0, 1.0);
+}

--- a/examples/draft-0-10-0/color/color.html
+++ b/examples/draft-0-10-0/color/color.html
@@ -17,6 +17,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     <meta charset="utf-8" />
     <title>Draft • Color</title>
     <link rel="stylesheet" href="../../../dist/Draft.css" />
+    <link rel="stylesheet" href="ColorfulEditor.css" />
   </head>
   <body>
     <div style="font-family: Georgia, serif; font-size: 15px; padding: 20px; width: 600px; line-height: 24px;">
@@ -116,14 +117,21 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
         render() {
           let style;
+          let className;
           if (this.props.active) {
-            style = {...styles.styleButton, ...colorStyleMap[this.props.style]};
+            if (typeof colorStyleMap[this.props.style] === 'string') {
+              className = colorStyleMap[this.props.style];
+              const { color, ...rest } = styles.styleButton;
+              style = rest;
+            } else {
+              style = {...styles.styleButton, ...colorStyleMap[this.props.style]};
+            }
           } else {
             style = styles.styleButton;
           }
 
           return (
-            <span style={style} onMouseDown={this.onToggle}>
+            <span style={style} className={className} onMouseDown={this.onToggle}>
               {this.props.label}
             </span>
           );
@@ -163,12 +171,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         red: {
           color: 'rgba(255, 0, 0, 1.0)',
         },
-        orange: {
-          color: 'rgba(255, 127, 0, 1.0)',
-        },
-        yellow: {
-          color: 'rgba(180, 180, 0, 1.0)',
-        },
+        // pass classNames for these two colors
+        orange: 'ColorfulEditor-orange',
+        yellow: 'ColorfulEditor-yellow',
         green: {
           color: 'rgba(0, 180, 0, 1.0)',
         },

--- a/src/component/contents/DraftEditorLeaf.react.js
+++ b/src/component/contents/DraftEditorLeaf.react.js
@@ -142,9 +142,15 @@ class DraftEditorLeaf extends React.Component<Props> {
     }
 
     const {customStyleMap, customStyleFn, offsetKey, styleSet} = this.props;
+    const classNames = [];
     let styleObj = styleSet.reduce((map, styleName) => {
       const mergedStyles = {};
-      const style = customStyleMap[styleName];
+      let style;
+      if (typeof customStyleMap[styleName] === 'string') {
+        classNames.push(customStyleMap[styleName]);
+      } else {
+        style = customStyleMap[styleName];
+      }
 
       if (style !== undefined && map.textDecoration !== style.textDecoration) {
         // .trim() is necessary for IE9/10/11 and Edge
@@ -161,11 +167,20 @@ class DraftEditorLeaf extends React.Component<Props> {
       styleObj = Object.assign(styleObj, newStyles);
     }
 
+    // skip inserting an empty `class` property to the element
+    const classes = classNames.length
+      ? // we don't use `cx` here to allow users to take care their classNames
+        // minification by themselves. This is handy when used libraries like `jss`
+        // or similar
+        {className: classNames.join(' ').trim()}
+      : {};
+
     return (
       <span
         data-offset-key={offsetKey}
         ref={ref => (this.leaf = ref)}
-        style={styleObj}>
+        style={styleObj}
+        {...classes}>
         <DraftEditorTextNode>{text}</DraftEditorTextNode>
       </span>
     );


### PR DESCRIPTION
**Summary**

This PR makes it possible to pass classNames (strings) instead of styles (objects) to the `customStyleMap`

Related with #957, #1368, #1639
and partly related with #342, #521

If you will accept this PR, please, let me know which part of documentation should be updated and how

**Test Plan**

This changes can be tested via `Color` example which was slightly modified
