### PR TITLE
Editor API Ref: blockRendererMap to blockRenderMap

### DIFF
--- a/docs/APIReference-Editor.md
+++ b/docs/APIReference-Editor.md
@@ -73,9 +73,9 @@ Optionally set a function to define custom block rendering. See
 [Advanced Topics: Block Components](/docs/advanced-topics-block-components.html)
 for details on usage.
 
-#### blockRendererMap
+#### blockRenderMap
 ```
-blockRendererMap?: DraftBlockRenderMap
+blockRenderMap?: DraftBlockRenderMap
 ```
 Provide a map of block rendering configurations. Each block type maps to
 element tag and an optional react element wrapper. This configuration


### PR DESCRIPTION
**Summary**

https://draftjs.org/docs/api-reference-editor#blockrenderermap references a property called `blockRendererMap` instead of `blockRenderMap`.

For examples of usage of `blockRenderMap`, see:
https://draftjs.org/docs/advanced-topics-custom-block-render-map.html#configuring-block-render-map
and
https://github.com/facebook/draft-js/blob/master/src/component/base/DraftEditor.react.js#L308

**Test Plan**

Doc change only, not applicable.