### PR TITLE
Fix React warnings

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -352,7 +352,6 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
       customStyleFn,
       editorKey: this._editorKey,
       editorState,
-      key: 'contents' + this.state.contentsKey,
       textDirectionality,
     };
 
@@ -420,7 +419,10 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
               all DraftEditorLeaf nodes so it's first in postorder traversal.
             */}
             <UpdateDraftEditorFlags editor={this} editorState={editorState} />
-            <DraftEditorContents {...editorContentsProps} />
+            <DraftEditorContents
+              {...editorContentsProps}
+              key={'contents' + this.state.contentsKey}
+            />
           </div>
         </div>
       </div>

--- a/src/component/contents/DraftEditorContents-core.react.js
+++ b/src/component/contents/DraftEditorContents-core.react.js
@@ -174,7 +174,6 @@ class DraftEditorContents extends React.Component<Props> {
         decorator,
         direction,
         forceSelection,
-        key,
         offsetKey,
         selection,
         tree: editorState.getBlockTree(key),
@@ -225,7 +224,7 @@ class DraftEditorContents extends React.Component<Props> {
       const child = React.createElement(
         Element,
         childProps,
-        <Component {...componentProps} />,
+        <Component {...componentProps} key={key} />,
       );
 
       processedBlocks.push({


### PR DESCRIPTION
**Summary**

Fix instances of the React warning:
```
React.jsx: Spreading a key to JSX is a deprecated pattern. ' +
        'Explicitly pass a key after spreading props in your JSX call. ' +
        'E.g. <ComponentName {...props} key={key} />'
```
originating from [React here](https://github.com/facebook/react/blob/18d2e0c03e4496a824fdb7f89ea2a3d60c30d49a/packages/react/src/ReactElementValidator.js#L366-L373)

This warning occurs when you spread a key with other props. There are probably more instances of this issue but these are the highest firing in our codebase.

**Test Plan**

`npm run lint && npm run test`