### PR TITLE
Pass correct click listener to editor wrapper

### DIFF
--- a/examples/draft-0-10-0/plaintext/plaintext.html
+++ b/examples/draft-0-10-0/plaintext/plaintext.html
@@ -47,7 +47,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         render() {
           return (
             <div style={styles.root}>
-              <div style={styles.editor} onClick={this.focus}>
+              <div style={styles.editor} onClick={this.domEditor.focus}>
                 <Editor
                   editorState={this.state.editorState}
                   onChange={this.onChange}


### PR DESCRIPTION
**Summary**

As I understand the `onClick` listener on the wrapper `div` element is suppose to replicate native `textarea/input` behavior. But the actual value of `onClick` property was `undefined` instead of a real method `domEditor`s method.

**Test Plan**

It's an example file, no test plan is required.
