### PR TITLE
Improve docs syntax and formatting

### DIFF
--- a/docs/APIReference-APIMigration.md
+++ b/docs/APIReference-APIMigration.md
@@ -23,7 +23,7 @@ Here is a quick list of what has been changed and how to update your application
 
 **Old Syntax**
 
-```
+```js
 const entityKey = Entity.create(
   urlType,
   'IMMUTABLE',
@@ -33,7 +33,7 @@ const entityKey = Entity.create(
 
 **New Syntax**
 
-```
+```js
 const contentStateWithEntity = contentState.createEntity(
   urlType,
   'IMMUTABLE',
@@ -46,14 +46,14 @@ const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
 
 **Old Syntax**
 
-```
+```js
 const entityInstance = Entity.get(entityKey);
 // entityKey is a string key associated with that entity when it was created
 ```
 
 **New Syntax**
 
-```
+```js
 const entityInstance = contentState.getEntity(entityKey);
 // entityKey is a string key associated with that entity when it was created
 ```
@@ -62,7 +62,7 @@ const entityInstance = contentState.getEntity(entityKey);
 
 **Old Syntax**
 
-```
+```js
 const compositeDecorator = new CompositeDecorator([
   {
     strategy: (contentBlock, callback) => exampleFindTextRange(contentBlock, callback),
@@ -73,7 +73,7 @@ const compositeDecorator = new CompositeDecorator([
 
 **New Syntax**
 
-```
+```js
 const compositeDecorator = new CompositeDecorator([
   {
     strategy: (
@@ -90,7 +90,7 @@ Note that ExampleTokenComponent will receive contentState as a prop.
 
 Why does the 'contentState' get passed into the decorator strategy now? Because we may need it if our strategy is to  find certain entities in the contentBlock:
 
-```
+```js
 const mutableEntityStrategy = function(contentBlock, callback, contentState) {
   contentBlock.findEntityRanges(
     (character) => {
@@ -113,7 +113,7 @@ const mutableEntityStrategy = function(contentBlock, callback, contentState) {
 
 **Old Syntax**
 
-```
+```js
 function findLinkEntities(contentBlock, callback) {
   contentBlock.findEntityRanges(
     (character) => {
@@ -130,7 +130,7 @@ function findLinkEntities(contentBlock, callback) {
 
 **New Syntax**
 
-```
+```js
 function findLinkEntities(contentBlock, callback, contentState) {
   contentBlock.findEntityRanges(
     (character) => {

--- a/docs/APIReference-AtomicBlockUtils.md
+++ b/docs/APIReference-AtomicBlockUtils.md
@@ -11,7 +11,7 @@ parameters and return `EditorState` objects.
 
 ## Static Methods
 
-### insertAtomicBlock
+### `insertAtomicBlock()`
 
 ```js
 insertAtomicBlock: function(
@@ -21,7 +21,7 @@ insertAtomicBlock: function(
 ): EditorState
 ```
 
-### moveAtomicBlock
+### `moveAtomicBlock()`
 
 ```js
 moveAtomicBlock: function(

--- a/docs/APIReference-AtomicBlockUtils.md
+++ b/docs/APIReference-AtomicBlockUtils.md
@@ -13,7 +13,7 @@ parameters and return `EditorState` objects.
 
 ### insertAtomicBlock
 
-```
+```js
 insertAtomicBlock: function(
   editorState: EditorState,
   entityKey: string,
@@ -23,7 +23,7 @@ insertAtomicBlock: function(
 
 ### moveAtomicBlock
 
-```
+```js
 moveAtomicBlock: function(
   editorState: EditorState,
   atomicBlock: ContentBlock,

--- a/docs/APIReference-CharacterMetadata.md
+++ b/docs/APIReference-CharacterMetadata.md
@@ -21,7 +21,7 @@ operations are already implemented and available via utility modules. The getter
 methods, however, may come in handy at render time.
 
 See the API reference on
-[ContentBlock](/docs/api-reference-content-block.html#representing-styles-and-entities)
+[ContentBlock](/docs/api-reference-content-block#representing-styles-and-entities)
 for information on how `CharacterMetadata` is used within `ContentBlock`.
 
 ## Overview
@@ -78,9 +78,10 @@ or return a new object if none exists.
 
 ### create
 
-```
+```js
 static create(config?: CharacterMetadataConfig): CharacterMetadata
 ```
+
 Generates a `CharacterMetadata` object from the provided configuration. This
 function should be used in lieu of a constructor.
 
@@ -91,27 +92,29 @@ and returned.
 
 ### applyStyle
 
-```
+```js
 static applyStyle(
   record: CharacterMetadata,
   style: string
 ): CharacterMetadata
 ```
+
 Apply an inline style to this `CharacterMetadata`.
 
 ### removeStyle
 
-```
+```js
 static removeStyle(
   record: CharacterMetadata,
   style: string
 ): CharacterMetadata
 ```
+
 Remove an inline style from this `CharacterMetadata`.
 
 ### applyEntity
 
-```
+```js
 static applyEntity(
   record: CharacterMetadata,
   entityKey: ?string
@@ -125,24 +128,27 @@ Apply an entity key -- or provide `null` to remove an entity key -- on this
 
 ### getStyle
 
-```
+```js
 getStyle(): DraftInlineStyle
 ```
+
 Returns the `DraftInlineStyle` for this character, an `OrderedSet` of strings
 that represents the inline style to apply for the character at render time.
 
 ### hasStyle
 
-```
+```js
 hasStyle(style: string): boolean
 ```
+
 Returns whether this character has the specified style.
 
 ### getEntity
 
-```
+```js
 getEntity(): ?string
 ```
+
 Returns the entity key (if any) for this character, as mapped to the global set of
 entities tracked by the [`Entity`](https://github.com/facebook/draft-js/blob/master/src/model/entity/DraftEntity.js)
 module.

--- a/docs/APIReference-CharacterMetadata.md
+++ b/docs/APIReference-CharacterMetadata.md
@@ -76,7 +76,7 @@ for information on how `CharacterMetadata` is used within `ContentBlock`.
 Under the hood, these methods will utilize pooling to return a matching object,
 or return a new object if none exists.
 
-### create
+### `create()`
 
 ```js
 static create(config?: CharacterMetadataConfig): CharacterMetadata
@@ -90,7 +90,7 @@ configuration already exists. If so, the pooled object will be returned.
 Otherwise, a new `CharacterMetadata` will be pooled for this configuration,
 and returned.
 
-### applyStyle
+### `applyStyle()`
 
 ```js
 static applyStyle(
@@ -101,7 +101,7 @@ static applyStyle(
 
 Apply an inline style to this `CharacterMetadata`.
 
-### removeStyle
+### `removeStyle()`
 
 ```js
 static removeStyle(
@@ -112,7 +112,7 @@ static removeStyle(
 
 Remove an inline style from this `CharacterMetadata`.
 
-### applyEntity
+### `applyEntity()`
 
 ```js
 static applyEntity(
@@ -126,7 +126,7 @@ Apply an entity key -- or provide `null` to remove an entity key -- on this
 
 ## Methods
 
-### getStyle
+### `getStyle()`
 
 ```js
 getStyle(): DraftInlineStyle
@@ -135,7 +135,7 @@ getStyle(): DraftInlineStyle
 Returns the `DraftInlineStyle` for this character, an `OrderedSet` of strings
 that represents the inline style to apply for the character at render time.
 
-### hasStyle
+### `hasStyle()`
 
 ```js
 hasStyle(style: string): boolean
@@ -143,7 +143,7 @@ hasStyle(style: string): boolean
 
 Returns whether this character has the specified style.
 
-### getEntity
+### `getEntity()`
 
 ```js
 getEntity(): ?string

--- a/docs/APIReference-CompositeDecorator.md
+++ b/docs/APIReference-CompositeDecorator.md
@@ -5,4 +5,4 @@ title: CompositeDecorator
 
 ## Advanced Topic Article
 
-See the [advanced topic article on Decorators](/docs/advanced-topics-decorators.html#compositedecorator).
+See the [advanced topic article on Decorators](/docs/advanced-topics-decorators#compositedecorator).

--- a/docs/APIReference-ContentBlock.md
+++ b/docs/APIReference-ContentBlock.md
@@ -156,103 +156,101 @@ supplied text.
 
 ## Methods
 
-### getKey()
+### `getKey()`
 
 ```
 getKey(): string
 ```
 Returns the string key for this `ContentBlock`. Block keys are alphanumeric string. It is recommended to use `generateRandomKey` to generate block keys.
 
-### getType()
+### `getType()`
 
-```
+```js
 getType(): DraftBlockType
 ```
 Returns the type for this `ContentBlock`. Type values are largely analogous to
 block-level HTML elements.
 
-### getText()
+### `getText()`
 
-```
+```js
 getText(): string
 ```
 Returns the full plaintext for this `ContentBlock`. This value does not contain
 any styling, decoration, or HTML information.
 
-### getCharacterList()
+### `getCharacterList()`
 
-```
+```js
 getCharacterList(): List<CharacterMetadata>
 ```
-Returns an immutable `List` of `CharacterMetadata` objects, one for each
-character in the `ContentBlock`. (See [CharacterMetadata](/docs/api-reference-character-metadata.html)
-for details.)
+
+Returns an immutable `List` of `CharacterMetadata` objects, one for each character in the `ContentBlock`. (See [CharacterMetadata](/docs/api-reference-character-metadata) for details.)
 
 This `List` contains all styling and entity information for the block.
 
-### getLength()
+### `getLength()`
 
-```
+```js
 getLength(): number
 ```
+
 Returns the length of the plaintext for the `ContentBlock`.
 
-This value uses the standard JavaScript `length` property for the string, and
-is therefore not Unicode-aware -- surrogate pairs will be counted as two
-characters.
+This value uses the standard JavaScript `length` property for the string, and is therefore not Unicode-aware -- surrogate pairs will be counted as two characters.
 
-### getDepth()
+### `getDepth()`
 
-```
+```js
 getDepth(): number
 ```
-Returns the depth value for this block, if any. This is currently used only
-for list items.
+Returns the depth value for this block, if any. This is currently used only for list items.
 
-### getInlineStyleAt()
+### `getInlineStyleAt()`
 
-```
+```js
 getInlineStyleAt(offset: number): DraftInlineStyle
 ```
-Returns the `DraftInlineStyle` value (an `OrderedSet<string>`) at a given offset
-within this `ContentBlock`.
 
-### getEntityAt()
+Returns the `DraftInlineStyle` value (an `OrderedSet<string>`) at a given offset within this `ContentBlock`.
 
-```
+### `getEntityAt()`
+
+```js
 getEntityAt(offset: number): ?string
 ```
-Returns the entity key value (or `null` if none) at a given offset within this
-`ContentBlock`.
 
-### getData()
+Returns the entity key value (or `null` if none) at a given offset within this `ContentBlock`.
 
-```
+### `getData()`
+
+```js
 getData(): Map<any, any>
 ```
+
 Returns block-level metadata.
 
-### findStyleRanges()
+### `findStyleRanges()`
 
-```
+```js
 findStyleRanges(
   filterFn: (value: CharacterMetadata) => boolean,
   callback: (start: number, end: number) => void
 ): void
 ```
-Executes a callback for each contiguous range of styles within this
-`ContentBlock`.
 
-### findEntityRanges()
+Executes a callback for each contiguous range of styles within this `ContentBlock`.
 
-```
+### `findEntityRanges()`
+
+```js
 findEntityRanges(
   filterFn: (value: CharacterMetadata) => boolean,
   callback: (start: number, end: number) => void
 ): void
 ```
-Executes a callback for each contiguous range of entities within this
-`ContentBlock`.
+
+Executes a callback for each contiguous range of entities within this `ContentBlock`.
 
 ## Properties
 
@@ -262,19 +260,25 @@ Executes a callback for each contiguous range of entities within this
 > for the `ContentBlock` constructor or to set properties.
 
 ### key
+
 See `getKey()`.
 
 ### text
+
 See `getText()`.
 
 ### type
+
 See `getType()`.
 
 ### characterList
+
 See `getCharacterList()`.
 
 ### depth
+
 See `getDepth()`.
 
 ### data
+
 See `getData()`.

--- a/docs/APIReference-ContentBlock.md
+++ b/docs/APIReference-ContentBlock.md
@@ -158,7 +158,7 @@ supplied text.
 
 ### `getKey()`
 
-```
+```js
 getKey(): string
 ```
 Returns the string key for this `ContentBlock`. Block keys are alphanumeric string. It is recommended to use `generateRandomKey` to generate block keys.
@@ -259,26 +259,26 @@ Executes a callback for each contiguous range of entities within this `ContentBl
 > Use [Immutable Map API](http://facebook.github.io/immutable-js/docs/#/Map)
 > for the `ContentBlock` constructor or to set properties.
 
-### key
+### `key`
 
 See `getKey()`.
 
-### text
+### `text`
 
 See `getText()`.
 
-### type
+### `type`
 
 See `getType()`.
 
-### characterList
+### `characterList`
 
 See `getCharacterList()`.
 
-### depth
+### `depth`
 
 See `getDepth()`.
 
-### data
+### `data`
 
 See `getData()`.

--- a/docs/APIReference-ContentState.md
+++ b/docs/APIReference-ContentState.md
@@ -142,7 +142,7 @@ objects.
 
 > Use [Immutable Map API](http://facebook.github.io/immutable-js/docs/#/Map) to
 > set properties.
-> 
+>
 > **Example**
 > ```
 > const editorState = EditorState.createEmpty();
@@ -170,36 +170,39 @@ objects.
 
 ## Static Methods
 
-### createFromText
+### `createFromText`
 
-```
+```js
 static createFromText(
   text: string,
   delimiter?: string
 ): ContentState
 ```
+
 Generates a `ContentState` from a string, with a delimiter to split the string
 into `ContentBlock` objects. If no delimiter is provided, '`\n`' is used.
 
-### createFromBlockArray
+### `createFromBlockArray`
 
-```
+```js
 static createFromBlockArray(
   blocks: Array<ContentBlock>,
   entityMap: ?OrderedMap
 ): ContentState
 ```
+
 Generates a `ContentState` from an array of `ContentBlock` objects. The default
 `selectionBefore` and `selectionAfter` states have the cursor at the start of
 the content.
 
 ## Methods
 
-### getEntityMap
+### `getEntityMap`
 
-```
+```js
 getEntityMap(): EntityMap
 ```
+
 Returns an object store containing all `DraftEntity` records that have been
 created.  In upcoming v0.11.0 the map returned will be an Immutable ordered map
 of `DraftEntity` records.
@@ -208,47 +211,51 @@ In most cases, you should be able to use the convenience methods below to target
 specific `DraftEntity` records or obtain information about the state of the
 content.
 
-### getBlockMap
+### `getBlockMap`
 
-```
+```js
 getBlockMap(): BlockMap
 ```
+
 Returns the full ordered map of `ContentBlock` objects representing the state
 of an entire document.
 
 In most cases, you should be able to use the convenience methods below to target
 specific `ContentBlock` objects or obtain information about the state of the content.
 
-### getSelectionBefore
+### `getSelectionBefore`
 
-```
+```js
 getSelectionBefore(): SelectionState
 ```
+
 Returns the `SelectionState` displayed in the editor before rendering `blockMap`.
 
 When performing an `undo` action in the editor, the `selectionBefore` of the current
 `ContentState` is used to place the selection range in the appropriate position.
 
-### getSelectionAfter
+### `getSelectionAfter`
 
-```
+```js
 getSelectionAfter(): SelectionState
 ```
+
 Returns the `SelectionState` displayed in the editor after rendering `blockMap`.
 
 When performing any action in the editor that leads to this `blockMap` being rendered,
 the selection range will be placed in the `selectionAfter` position.
 
-### getBlockForKey
+### `getBlockForKey`
 
-```
+```js
 getBlockForKey(key: string): ContentBlock
 ```
+
 Returns the `ContentBlock` corresponding to the given block key.
 
 #### Example
 
-```
+```js
 var {editorState} = this.state;
 var startKey = editorState.getSelection().getStartKey();
 var selectedBlockType = editorState
@@ -257,131 +264,144 @@ var selectedBlockType = editorState
   .getType();
 ```
 
-### getKeyBefore
+### `getKeyBefore`
 
-```
+```js
 getKeyBefore(key: string): ?string
 ```
+
 Returns the key before the specified key in `blockMap`, or null if this is the first key.
 
-### getKeyAfter
+### `getKeyAfter`
 
-```
+```js
 getKeyAfter(key: string): ?string
 ```
+
 Returns the key after the specified key in `blockMap`, or null if this is the last key.
 
-### getBlockBefore
+### `getBlockBefore`
 
-```
+```js
 getBlockBefore(key: string): ?ContentBlock
 ```
+
 Returns the `ContentBlock` before the specified key in `blockMap`, or null if this is
 the first key.
 
-### getBlockAfter
+### `getBlockAfter`
 
-```
+```js
 getBlockAfter(key: string): ?ContentBlock
 ```
+
 Returns the `ContentBlock` after the specified key in `blockMap`, or null if this is the last key.
 
-### getBlocksAsArray
+### `getBlocksAsArray`
 
-```
+```js
 getBlocksAsArray(): Array<ContentBlock>
 ```
+
 Returns the values of `blockMap` as an array.
 
 You generally won't need to use this method, since `getBlockMap` provides an `OrderedMap` that you should use for iteration.
 
-### getFirstBlock
+### `getFirstBlock`
 
-```
+```js
 getFirstBlock(): ContentBlock
 ```
+
 Returns the first `ContentBlock`.
 
-### getLastBlock
+### `getLastBlock`
 
-```
+```js
 getLastBlock(): ContentBlock
 ```
+
 Returns the last `ContentBlock`.
 
-### getPlainText
+### `getPlainText`
 
-```
+```js
 getPlainText(delimiter?: string): string
 ```
+
 Returns the full plaintext value of the contents, joined with a delimiter. If no
 delimiter is specified, the line feed character (`\u000A`) is used.
 
-### getLastCreatedEntityKey
+### `getLastCreatedEntityKey`
 
-```
+```js
 getLastCreatedEntityKey(): string
 ```
+
 Returns the string key that can be used to reference the most recently created
 `DraftEntity` record. This is because entities are referenced by their string
 key in ContentState. The string value should be used within CharacterMetadata
 objects to track the entity for annotated characters.
 
-### hasText
+### `hasText`
 
-```
+```js
 hasText(): boolean
 ```
+
 Returns whether the contents contain any text at all.
 
-### createEntity
+### `createEntity`
 
-```
+```js
 createEntity(
   type: DraftEntityType,
   mutability: DraftEntityMutability,
   data?: Object
 ): ContentState
 ```
-Returns `ContentState` record updated to include the newly created
-DraftEntity record in it's `EntityMap`. Call `getLastCreatedEntityKey` to get
-the key of the newly created `DraftEntity` record.
 
-### getEntity
+Returns `ContentState` record updated to include the newly created `DraftEntity` record in it's `EntityMap`. Call `getLastCreatedEntityKey` to get the key of the newly created `DraftEntity` record.
 
-```
+### `getEntity`
+
+```js
 getEntity(key: string): DraftEntityInstance
 ```
+
 Returns the DraftEntityInstance for the specified key. Throws if no instance exists for that key.
 
-### mergeEntityData
+### `mergeEntityData`
 
-```
+```js
 mergeEntityData(
   key: string,
   toMerge: {[key: string]: any}
 ): ContentState
 ```
+
 Since DraftEntityInstance objects are immutable, you cannot update an entity's
 metadata through typical mutative means.
 
 The mergeData method allows you to apply updates to the specified entity.
 
-### replaceEntityData
+### `replaceEntityData`
 
-```
+```js
 replaceEntityData(
   key: string,
   newData: {[key: string]: any}
 ): ContentState
 ```
+
 The replaceData method is similar to the mergeData method, except it will totally discard the existing data value for the instance and replace it with the specified newData.
 
-### addEntity
+### `addEntity`
 
-```
+```js
 addEntity(instance: DraftEntityInstance): ContentState
 ```
+
 In most cases, you will use contentState.createEntity(). This is a convenience
 method that you probably will not need in typical Draft usage.
 
@@ -396,10 +416,13 @@ editing.
 > set properties.
 
 ### blockMap
+
 See `getBlockMap()`.
 
 ### selectionBefore
+
 See `getSelectionBefore()`.
 
 ### selectionAfter
+
 See `getSelectionAfter()`.

--- a/docs/APIReference-ContentState.md
+++ b/docs/APIReference-ContentState.md
@@ -144,7 +144,8 @@ objects.
 > set properties.
 >
 > **Example**
-> ```
+>
+> ```js
 > const editorState = EditorState.createEmpty();
 > const contentState = editorState.getCurrentContent();
 > const contentStateWithSelectionBefore = contentState.set('selectionBefore', SelectionState.createEmpty(contentState.getBlockForKey('1pu4d')));
@@ -170,7 +171,7 @@ objects.
 
 ## Static Methods
 
-### `createFromText`
+### `createFromText()`
 
 ```js
 static createFromText(
@@ -182,7 +183,7 @@ static createFromText(
 Generates a `ContentState` from a string, with a delimiter to split the string
 into `ContentBlock` objects. If no delimiter is provided, '`\n`' is used.
 
-### `createFromBlockArray`
+### `createFromBlockArray()`
 
 ```js
 static createFromBlockArray(
@@ -197,7 +198,7 @@ the content.
 
 ## Methods
 
-### `getEntityMap`
+### `getEntityMap()`
 
 ```js
 getEntityMap(): EntityMap
@@ -211,7 +212,7 @@ In most cases, you should be able to use the convenience methods below to target
 specific `DraftEntity` records or obtain information about the state of the
 content.
 
-### `getBlockMap`
+### `getBlockMap()`
 
 ```js
 getBlockMap(): BlockMap
@@ -223,7 +224,7 @@ of an entire document.
 In most cases, you should be able to use the convenience methods below to target
 specific `ContentBlock` objects or obtain information about the state of the content.
 
-### `getSelectionBefore`
+### `getSelectionBefore()`
 
 ```js
 getSelectionBefore(): SelectionState
@@ -234,7 +235,7 @@ Returns the `SelectionState` displayed in the editor before rendering `blockMap`
 When performing an `undo` action in the editor, the `selectionBefore` of the current
 `ContentState` is used to place the selection range in the appropriate position.
 
-### `getSelectionAfter`
+### `getSelectionAfter()`
 
 ```js
 getSelectionAfter(): SelectionState
@@ -245,7 +246,7 @@ Returns the `SelectionState` displayed in the editor after rendering `blockMap`.
 When performing any action in the editor that leads to this `blockMap` being rendered,
 the selection range will be placed in the `selectionAfter` position.
 
-### `getBlockForKey`
+### `getBlockForKey()`
 
 ```js
 getBlockForKey(key: string): ContentBlock
@@ -264,7 +265,7 @@ var selectedBlockType = editorState
   .getType();
 ```
 
-### `getKeyBefore`
+### `getKeyBefore()`
 
 ```js
 getKeyBefore(key: string): ?string
@@ -272,7 +273,7 @@ getKeyBefore(key: string): ?string
 
 Returns the key before the specified key in `blockMap`, or null if this is the first key.
 
-### `getKeyAfter`
+### `getKeyAfter()`
 
 ```js
 getKeyAfter(key: string): ?string
@@ -280,7 +281,7 @@ getKeyAfter(key: string): ?string
 
 Returns the key after the specified key in `blockMap`, or null if this is the last key.
 
-### `getBlockBefore`
+### `getBlockBefore()`
 
 ```js
 getBlockBefore(key: string): ?ContentBlock
@@ -289,7 +290,7 @@ getBlockBefore(key: string): ?ContentBlock
 Returns the `ContentBlock` before the specified key in `blockMap`, or null if this is
 the first key.
 
-### `getBlockAfter`
+### `getBlockAfter()`
 
 ```js
 getBlockAfter(key: string): ?ContentBlock
@@ -297,7 +298,7 @@ getBlockAfter(key: string): ?ContentBlock
 
 Returns the `ContentBlock` after the specified key in `blockMap`, or null if this is the last key.
 
-### `getBlocksAsArray`
+### `getBlocksAsArray()`
 
 ```js
 getBlocksAsArray(): Array<ContentBlock>
@@ -307,7 +308,7 @@ Returns the values of `blockMap` as an array.
 
 You generally won't need to use this method, since `getBlockMap` provides an `OrderedMap` that you should use for iteration.
 
-### `getFirstBlock`
+### `getFirstBlock()`
 
 ```js
 getFirstBlock(): ContentBlock
@@ -315,7 +316,7 @@ getFirstBlock(): ContentBlock
 
 Returns the first `ContentBlock`.
 
-### `getLastBlock`
+### `getLastBlock()`
 
 ```js
 getLastBlock(): ContentBlock
@@ -323,7 +324,7 @@ getLastBlock(): ContentBlock
 
 Returns the last `ContentBlock`.
 
-### `getPlainText`
+### `getPlainText()`
 
 ```js
 getPlainText(delimiter?: string): string
@@ -332,7 +333,7 @@ getPlainText(delimiter?: string): string
 Returns the full plaintext value of the contents, joined with a delimiter. If no
 delimiter is specified, the line feed character (`\u000A`) is used.
 
-### `getLastCreatedEntityKey`
+### `getLastCreatedEntityKey()`
 
 ```js
 getLastCreatedEntityKey(): string
@@ -343,7 +344,7 @@ Returns the string key that can be used to reference the most recently created
 key in ContentState. The string value should be used within CharacterMetadata
 objects to track the entity for annotated characters.
 
-### `hasText`
+### `hasText()`
 
 ```js
 hasText(): boolean
@@ -351,7 +352,7 @@ hasText(): boolean
 
 Returns whether the contents contain any text at all.
 
-### `createEntity`
+### `createEntity()`
 
 ```js
 createEntity(
@@ -363,7 +364,7 @@ createEntity(
 
 Returns `ContentState` record updated to include the newly created `DraftEntity` record in it's `EntityMap`. Call `getLastCreatedEntityKey` to get the key of the newly created `DraftEntity` record.
 
-### `getEntity`
+### `getEntity()`
 
 ```js
 getEntity(key: string): DraftEntityInstance
@@ -371,7 +372,7 @@ getEntity(key: string): DraftEntityInstance
 
 Returns the DraftEntityInstance for the specified key. Throws if no instance exists for that key.
 
-### `mergeEntityData`
+### `mergeEntityData()`
 
 ```js
 mergeEntityData(
@@ -385,7 +386,7 @@ metadata through typical mutative means.
 
 The mergeData method allows you to apply updates to the specified entity.
 
-### `replaceEntityData`
+### `replaceEntityData()`
 
 ```js
 replaceEntityData(
@@ -396,7 +397,7 @@ replaceEntityData(
 
 The replaceData method is similar to the mergeData method, except it will totally discard the existing data value for the instance and replace it with the specified newData.
 
-### `addEntity`
+### `addEntity()`
 
 ```js
 addEntity(instance: DraftEntityInstance): ContentState
@@ -415,14 +416,14 @@ editing.
 > Use [Immutable Map API](http://facebook.github.io/immutable-js/docs/#/Map) to
 > set properties.
 
-### blockMap
+### `blockMap`
 
 See `getBlockMap()`.
 
-### selectionBefore
+### `selectionBefore`
 
 See `getSelectionBefore()`.
 
-### selectionAfter
+### `selectionAfter`
 
 See `getSelectionAfter()`.

--- a/docs/APIReference-Data-Conversion.md
+++ b/docs/APIReference-Data-Conversion.md
@@ -22,18 +22,18 @@ objects.
 
 ## Functions
 
-### convertFromRaw
+### `convertFromRaw()`
 
-```
+```js
 convertFromRaw(rawState: RawDraftContentState): ContentState
 ```
 
 Given a raw state, convert it to a `ContentState`. This is useful when
 restoring contents to use within a Draft editor.
 
-### convertToRaw
+### `convertToRaw()`
 
-```
+```js
 convertToRaw(contentState: ContentState): RawDraftContentState
 ```
 
@@ -42,9 +42,9 @@ when saving an editor state for storage, conversion to other formats, or
 other usage within an application.
 
 
-### convertFromHTML
+### `convertFromHTML()`
 
-```
+```js
 const sampleMarkup =
   '<b>Bold text</b>, <i>Italic text</i><br/ ><br />' +
   '<a href="http://www.facebook.com">Example link</a>';

--- a/docs/APIReference-Editor.md
+++ b/docs/APIReference-Editor.md
@@ -9,41 +9,48 @@ component itself, `Editor`. Props are defined within
 
 ## Props
 
-### Basics
+## Basics
 
-See [API Basics](/docs/quickstart-api-basics.html) for an introduction.
+See [API Basics](/docs/quickstart-api-basics) for an introduction.
 
-#### editorState
-```
+### `editorState`
+
+```js
 editorState: EditorState
 ```
+
 The `EditorState` object to be rendered by the `Editor`.
 
-#### onChange
-```
+### `onChange`
+
+```js
 onChange: (editorState: EditorState) => void
 ```
+
 The `onChange` function to be executed by the `Editor` when edits and selection
 changes occur.
 
-### Presentation (Optional)
+## Presentation (Optional)
 
-#### placeholder
-```
+### `placeholder`
+
+```js
 placeholder?: string
 ```
+
 Optional placeholder string to display when the editor is empty.
 
 Note: You can use CSS to style or hide your placeholder as needed. For instance,
-in the [rich editor example](https://github.com/facebook/draft-js/tree/master/examples/draft-0-10-0/rich),
-the placeholder is hidden when the user changes block styling in an empty editor.
+in the [rich editor example](https://github.com/facebook/draft-js/tree/master/examples/draft-0-10-0/rich), the placeholder is hidden when the user changes block styling in an empty editor.
 This is because the placeholder may not line up with the cursor when the style
 is changed.
 
-#### textAlignment
-```
+### `textAlignment`
+
+```js
 textAlignment?: DraftTextAlignment
 ```
+
 Optionally set the overriding text alignment for this editor. This alignment value will
 apply to the entire contents, regardless of default text direction for input text.
 
@@ -53,107 +60,101 @@ to fit it within your UI design.
 If this value is not set, text alignment will be based on the characters within
 the editor, on a per-block basis.
 
-#### textDirectionality
-```
+### `textDirectionality`
+
+```js
 textDirectionality?: DraftTextDirectionality
 ```
-Optionally set the overriding text directionality for this editor. The values
-include 'RTL' for right-to-left text, like Hebrew or Arabic, and 'LTR' for
-left-to-right text, like English or Spanish. This directionality will apply to
-the entire contents, regardless of default text direction for input text.
+
+Optionally set the overriding text directionality for this editor. The values include 'RTL' for right-to-left text, like Hebrew or Arabic, and 'LTR' for left-to-right text, like English or Spanish. This directionality will apply to the entire contents, regardless of default text direction for input text.
 
 If this value is not set, text directionality will be based on the characters
 within the editor, on a per-block basis.
 
-#### blockRendererFn
-```
+### `blockRendererFn`
+
+```js
 blockRendererFn?: (block: ContentBlock) => ?Object
 ```
-Optionally set a function to define custom block rendering. See
-[Advanced Topics: Block Components](/docs/advanced-topics-block-components.html)
-for details on usage.
 
-#### blockRendererMap
-```
+Optionally set a function to define custom block rendering. See [Advanced Topics: Block Components](/docs/advanced-topics-block-components) for details on usage.
+
+### `blockRendererMap`
+
+```js
 blockRendererMap?: DraftBlockRenderMap
 ```
-Provide a map of block rendering configurations. Each block type maps to
-element tag and an optional react element wrapper. This configuration
-is used for both rendering and paste processing. See
-[Advanced Topics: Custom Block Rendering](https://draftjs.org/docs/advanced-topics-custom-block-render-map.html)
-for details on usage.
+Provide a map of block rendering configurations. Each block type maps to element tag and an optional react element wrapper. This configuration is used for both rendering and paste processing. See
+[Advanced Topics: Custom Block Rendering](/docs/advanced-topics-custom-block-render-map) for details on usage.
 
-#### blockStyleFn
-```
+### `blockStyleFn`
+
+```js
 blockStyleFn?: (block: ContentBlock) => string
 ```
-Optionally set a function to define class names to apply to the given block
-when it is rendered. See
-[Advanced Topics: Block Styling](/docs/advanced-topics-block-styling.html)
-for details on usage.
 
-#### customStyleMap
-```
+Optionally set a function to define class names to apply to the given block when it is rendered. See [Advanced Topics: Block Styling](/docs/advanced-topics-block-styling) for details on usage.
+
+### customStyleMap
+
+```js
 customStyleMap?: Object
 ```
-Optionally define a map of inline styles to apply to spans of text with the specified
-style. See
-[Advanced Topics: Inline Styles](/docs/advanced-topics-inline-styles.html)
-for details on usage.
 
-#### customStyleFn
-```
+Optionally define a map of inline styles to apply to spans of text with the specified style. See [Advanced Topics: Inline Styles](/docs/advanced-topics-inline-styles) for details on usage.
+
+### `customStyleFn`
+
+```js
 customStyleFn?: (style: DraftInlineStyle, block: ContentBlock) => ?Object
 ```
-Optionally define a function to transform inline styles to CSS objects that are applied
-to spans of text. See
-[Advanced Topics: Inline Styles](/docs/advanced-topics-inline-styles.html)
-for details on usage.
 
-### Behavior (Optional)
+Optionally define a function to transform inline styles to CSS objects that are applied to spans of text. See [Advanced Topics: Inline Styles](/docs/advanced-topics-inline-styles) for details on usage.
 
-### autoCapitalize?: string
+## Behavior (Optional)
 
-```
+### `autoCapitalize`
+
+```js
 autoCapitalize?: string
 ```
 
 Set if auto capitalization is turned on and how it behaves. More about platform availability and usage can [be found on mdn](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input#attr-autocapitalize).
 
-### autoComplete?: string
+### `autoComplete`
 
-```
+```js
 autoComplete?: string
 ```
 
 Set if auto complete is turned on and how it behaves. More about platform availability and usage can [be found on mdn](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input#attr-autocomplete).
 
-### autoCorrect?: string
+### `autoCorrect`
 
-```
+```js
 autoCorrect?: string
 ```
 
-Set if auto correct is turned on and how it behaves. More about platform availability and usage can [be found on mdn](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input#attr-autocorrect).
+Set if auto correct is turned on and how it behaves. More about platform availability and usage can [be found on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input#attr-autocorrect).
 
+### `readOnly`
 
-#### readOnly
-```
+```js
 readOnly?: boolean
 ```
-Set whether the editor should be rendered as static DOM, with all editability
-disabled.
 
-This is useful when supporting interaction within
-[custom block components](/docs/advanced-topics-block-components.html)
-or if you only want to display content for a static use case.
+Set whether the editor should be rendered as static DOM, with all editability disabled.
+
+This is useful when supporting interaction within [custom block components](/docs/advanced-topics-block-components) or if you only want to display content for a static use case.
 
 Default is `false`.
 
-#### spellCheck
-```
+### `spellCheck`
+
+```js
 spellCheck?: boolean
 ```
+
 Set whether spellcheck is turned on for your editor.
 
 Note that in OSX Safari, enabling spellcheck also enables autocorrect, if the user
@@ -162,26 +163,30 @@ needed to observe spellcheck events are not fired in IE.
 
 Default is `false`.
 
-#### stripPastedStyles
-```
+### `stripPastedStyles`
+
+```js
 stripPastedStyles?: boolean
 ```
+
 Set whether to remove all information except plaintext from pasted content.
 
 This should be used if your editor does not support rich styles.
 
 Default is `false`.
 
-### DOM and Accessibility (Optional)
+## DOM and Accessibility (Optional)
 
-#### tabIndex
-#### ARIA props
+### `tabIndex`
+
+### ARIA props
 
 These props allow you to set accessibility properties on your editor. See
 [DraftEditorProps](https://github.com/facebook/draft-js/blob/master/src/component/base/DraftEditorProps.js) for the exhaustive list of supported attributes.
 
-#### editorKey
-```
+### `editorKey`
+
+```js
 editorKey?: string
 ```
 
@@ -197,32 +202,49 @@ If you _do_ set this prop, the key should be unique _per-editor_, as it is
 used to determine if styles should be preserved when pasting text within an
 editor.
 
-### Cancelable Handlers (Optional)
+## Cancelable Handlers (Optional)
 
 These prop functions are provided to allow custom event handling for a small
 set of useful events. By returning `'handled'` from your handler, you indicate that
 the event is handled and the Draft core should do nothing more with it. By returning
 `'not-handled'`, you defer to Draft to handle the event.
 
-#### handleReturn
+### `handleReturn`
+
+```js
+handleReturn?: (
+  e: SyntheticKeyboardEvent,
+  editorState: EditorState,
+) => DraftHandleValue
 ```
-handleReturn?: (e: SyntheticKeyboardEvent, editorState: EditorState) => DraftHandleValue
-```
+
 Handle a `RETURN` keydown event. Example usage: Choosing a mention tag from a
 rendered list of results to trigger applying the mention entity to your content.
 
-#### handleKeyCommand
+### `handleKeyCommand`
+
+```js
+handleKeyCommand?: (
+  command: string,
+  editorState: EditorState,
+  eventTimeStamp: number,
+) => DraftHandleValue
 ```
-handleKeyCommand?: (command: string, editorState: EditorState, eventTimeStamp: number) => DraftHandleValue
-```
+
 Handle the named editor command. See
-[Advanced Topics: Key Bindings](/docs/advanced-topics-key-bindings.html)
+[Advanced Topics: Key Bindings](/docs/advanced-topics-key-bindings)
 for details on usage.
 
-#### handleBeforeInput
+### `handleBeforeInput`
+
+```js
+handleBeforeInput?: (
+  chars: string,
+  editorState: EditorState,
+  eventTimeStamp: number,
+) => DraftHandleValue
 ```
-handleBeforeInput?: (chars: string, editorState: EditorState, eventTimeStamp: number) => DraftHandleValue
-```
+
 Handle the characters to be inserted from a `beforeInput` event. Returning `'handled'`
 causes the default behavior of the `beforeInput` event to be prevented (i.e. it is
 the same as calling the `preventDefault` method on the event).
@@ -232,38 +254,57 @@ convert that `ContentBlock` into an `unordered-list-item`.
 At Facebook, we also use this to convert typed ASCII quotes into "smart" quotes,
 and to convert typed emoticons into images.
 
-#### handlePastedText
+### `handlePastedText`
+
+```js
+handlePastedText?: (
+  text: string,
+  html?: string,
+  editorState: EditorState,
+) => DraftHandleValue
 ```
-handlePastedText?: (text: string, html?: string, editorState: EditorState) => DraftHandleValue
-```
+
 Handle text and html(for rich text) that has been pasted directly into the editor. Returning true will prevent the default paste behavior.
 
-#### handlePastedFiles
-```
+### `handlePastedFiles`
+
+```js
 handlePastedFiles?: (files: Array<Blob>) => DraftHandleValue
 ```
+
 Handle files that have been pasted directly into the editor.
 
-#### handleDroppedFiles
+### `handleDroppedFiles`
+
+```js
+handleDroppedFiles?: (
+  selection: SelectionState,
+  files: Array<Blob>,
+) => DraftHandleValue
 ```
-handleDroppedFiles?: (selection: SelectionState, files: Array<Blob>) => DraftHandleValue
-```
+
 Handle files that have been dropped into the editor.
 
-#### handleDrop
+### `handleDrop`
+
+```js
+handleDrop?: (
+  selection: SelectionState,
+  dataTransfer: Object,
+  isInternal: DraftDragType,
+) => DraftHandleValue
 ```
-handleDrop?: (selection: SelectionState, dataTransfer: Object, isInternal: DraftDragType) => DraftHandleValue
-```
+
 Handle other drop operations.
 
-### Key Handlers (Optional)
+## Key Handlers (Optional)
 
 Draft lets you supply a custom `keyDown` handler that wraps or overrides its
 default one.
 
-#### keyBindingFn
+### `keyBindingFn`
 
-```
+```js
 keyBindingFn?: (e: SyntheticKeyboardEvent) => ?string
 ```
 
@@ -273,33 +314,35 @@ corresponding to a `DraftEditorCommand` or a custom editor command of your
 own creation. Example: At Facebook, this is used to provide keyboard interaction
 for the mentions autocomplete menu that appears when typing a friend's name.
 You can find a more detailed explanation of this
-[here](/docs/advanced-topics-key-bindings.html).
+[here](/docs/advanced-topics-key-bindings).
 
-### Mouse events
+## Mouse events
 
-### onFocus
-```
+### `onFocus`
+
+```js
 onFocus?: (e: SyntheticFocusEvent) => void
 ```
 
-### onBlur
-```
+### `onBlur`
+
+```js
 onBlur?: (e: SyntheticFocusEvent) => void
 ```
 
 ## Methods
 
-#### focus
+### `focus`
 
-```
+```js
 focus(): void
 ```
 
 Force focus back onto the editor node.
 
-#### blur
+### `blur`
 
-```
+```js
 blur(): void
 ```
 

--- a/docs/APIReference-EditorChangeType.md
+++ b/docs/APIReference-EditorChangeType.md
@@ -22,68 +22,68 @@ static typechecking on your project. Flow will enforce the use of an appropriate
 
 ## Values
 
-#### `adjust-depth`
+### `adjust-depth`
 
 The `depth` value of one or more `ContentBlock` objects is being changed.
 
-#### `apply-entity`
+### `apply-entity`
 
 An entity is being applied (or removed via `null`) to one or more characters.
 
-#### `backspace-character`
+### `backspace-character`
 
 A single character is being backward-removed.
 
-#### `change-block-data`
+### `change-block-data`
 
 The `data` value of one or more `ContentBlock` objects is being changed.
 
-#### `change-block-type`
+### `change-block-type`
 
 The `type` value of one or more `ContentBlock` objects is being changed.
 
-#### `change-inline-style`
+### `change-inline-style`
 
 An inline style is being applied or removed for one or more characters.
 
-#### `move-block`
+### `move-block`
 
 A block is being moved within the [BlockMap](https://github.com/facebook/draft-js/blob/master/src/model/immutable/BlockMap.js).
 
-#### `delete-character`
+### `delete-character`
 
 A single character is being forward-removed.
 
-#### `insert-characters`
+### `insert-characters`
 
 One or more characters is being inserted at a selection state.
 
-#### `insert-fragment`
+### `insert-fragment`
 
 A "fragment" of content (i.e. a
 [BlockMap](https://github.com/facebook/draft-js/blob/master/src/model/immutable/BlockMap.js))
 is being inserted at a selection state.
 
-#### `redo`
+### `redo`
 
 A redo operation is being performed. Since redo behavior is handled by the
 Draft core, it is unlikely that you will need to use this explicitly.
 
-#### `remove-range`
+### `remove-range`
 
 Multiple characters or blocks are being removed.
 
-#### `spellcheck-change`
+### `spellcheck-change`
 
 A spellcheck or autocorrect change is being performed. This is used to inform
 the core editor whether to try to allow native undo behavior.
 
-#### `split-block`
+### `split-block`
 
 A single `ContentBlock` is being split into two, for instance when the user
 presses return.
 
-#### `undo`
+### `undo`
 
 An undo operation is being performed. Since undo behavior is handled by the
 Draft core, it is unlikely that you will need to use this explicitly.

--- a/docs/APIReference-EditorState.md
+++ b/docs/APIReference-EditorState.md
@@ -197,25 +197,28 @@ The list below includes the most commonly used instance methods for `EditorState
 
 ## Common Instance Methods
 
-### getCurrentContent
+### `getCurrentContent`
 
-```
+```js
 getCurrentContent(): ContentState
 ```
+
 Returns the current contents of the editor.
 
-### getSelection
+### `getSelection`
 
-```
+```js
 getSelection(): SelectionState
 ```
+
 Returns the current cursor/selection state of the editor.
 
-### getCurrentInlineStyle
+### `getCurrentInlineStyle`
 
-```
+```js
 getCurrentInlineStyle(): DraftInlineStyle
 ```
+
 Returns an `OrderedSet<string>` that represents the "current" inline style
 for the editor.
 
@@ -223,11 +226,12 @@ This is the inline style value that would be used if a character were inserted
 for the current `ContentState` and `SelectionState`, and takes into account
 any inline style overrides that should be applied.
 
-### getBlockTree
+### `getBlockTree`
 
-```
+```js
 getBlockTree(blockKey: string): List;
 ```
+
 Returns an Immutable `List` of decorated and styled ranges. This is used for
 rendering purposes, and is generated based on the `currentContent` and
 `decorator`.
@@ -237,42 +241,45 @@ block, decorator, and styled range components.
 
 ## Static Methods
 
-### createEmpty
+### `createEmpty`
 
-```
+```js
 static createEmpty(decorator?: DraftDecoratorType): EditorState
 ```
+
 Returns a new `EditorState` object with an empty `ContentState` and default
 configuration.
 
-### createWithContent
+### `createWithContent`
 
-```
+```js
 static createWithContent(
   contentState: ContentState,
   decorator?: DraftDecoratorType
 ): EditorState
 ```
+
 Returns a new `EditorState` object based on the `ContentState` and decorator
 provided.
 
-### create
+### `create`
 
-```
+```js
 static create(config: EditorStateCreationConfig): EditorState
 ```
 Returns a new `EditorState` object based on a configuration object. Use this
 if you need custom configuration not available via the methods above.
 
-### push
+### `push`
 
-```
+```js
 static push(
   editorState: EditorState,
   contentState: ContentState,
   changeType: EditorChangeType
 ): EditorState
 ```
+
 Returns a new `EditorState` object with the specified `ContentState` applied
 as the new `currentContent`. Based on the `changeType`, this `ContentState`
 may be regarded as a boundary state for undo/redo behavior.
@@ -281,86 +288,93 @@ All content changes must be applied to the EditorState with this method.
 
 _To be renamed._
 
-### undo
+### `undo`
 
-```
+```js
 static undo(editorState: EditorState): EditorState
 ```
+
 Returns a new `EditorState` object with the top of the undo stack applied
 as the new `currentContent`.
 
 The existing `currentContent` is pushed onto the `redo` stack.
 
-### redo
+### `redo`
 
-```
+```js
 static redo(editorState: EditorState): EditorState
 ```
-Returns a new `EditorState` object with the top of the redo stack applied
-as the new `currentContent`.
+
+Returns a new `EditorState` object with the top of the redo stack applied as the new `currentContent`.
 
 The existing `currentContent` is pushed onto the `undo` stack.
 
-### acceptSelection
+### `acceptSelection`
 
-```
+```js
 static acceptSelection(
   editorState: EditorState,
   selectionState: SelectionState
 ): EditorState
 ```
+
 Returns a new `EditorState` object with the specified `SelectionState` applied,
 but without requiring the selection to be rendered.
 
 For example, this is useful when the DOM selection has changed outside of our
 control, and no re-renders are necessary.
 
-### forceSelection
+### `forceSelection`
 
-```
+```js
 static forceSelection(
   editorState: EditorState,
   selectionState: SelectionState
 ): EditorState
 ```
+
 Returns a new `EditorState` object with the specified `SelectionState` applied,
 forcing the selection to be rendered.
 
 This is useful when the selection should be manually rendered in the correct
 location to maintain control of the rendered output.
 
-### moveSelectionToEnd
+### `moveSelectionToEnd`
 
-```
+```js
 static moveSelectionToEnd(editorState: EditorState): EditorState
 ```
+
 Returns a new `EditorState` object with the selection at the end.
 
 Moves selection to the end of the editor without forcing focus.
 
-### moveFocusToEnd
+### `moveFocusToEnd`
 
-```
+```js
 static moveFocusToEnd(editorState: EditorState): EditorState
 ```
+
 Returns a new `EditorState` object with selection at the end and forces focus.
 
 This is useful in scenarios where we want to programmatically focus the input
 and it makes sense to allow the user to continue working seamlessly.
 
-### setInlineStyleOverride
+### `setInlineStyleOverride`
 
-```
+```js
 static setInlineStyleOverride(editorState: EditorState, inlineStyleOverride: DraftInlineStyle): EditorState
 ```
+
 Returns a new `EditorState` object with the specified `DraftInlineStyle` applied
 as the set of inline styles to be applied to the next inserted characters.
 
-### set
+### `set`
 
-```
+```js
 static set(editorState: EditorState, options: EditorStateRecordType): EditorState
 ```
+
 Returns a new `EditorState` object with new options passed in. The method is
 inherited from the Immutable `record` API.
 
@@ -378,74 +392,81 @@ state tracked in this object.
 > You should not use the Immutable API when using EditorState objects.
 > Instead, use the instance getters and static methods above.
 
-### allowUndo
+### `allowUndo`
 
-```
+```js
 allowUndo: boolean;
 getAllowUndo()
 ```
+
 Whether to allow undo/redo behavior in this editor. Default is `true`.
 
 Since the undo/redo stack is the major source of memory retention, if you have
 an editor UI that does not require undo/redo behavior, you might consider
 setting this to `false`.
 
-### currentContent
+### `currentContent`
 
-```
+```js
 currentContent: ContentState;
 getCurrentContent()
 ```
+
 The currently rendered `ContentState`. See [getCurrentContent()](#getcurrentcontent).
 
-### decorator
+### `decorator`
 
-```
+```js
 decorator: ?DraftDecoratorType;
 getDecorator()
 ```
+
 The current decorator object, if any.
 
 Note that the `ContentState` is independent of your decorator. If a decorator
 is provided, it will be used to decorate ranges of text for rendering.
 
-### directionMap
+### `directionMap`
 
-```
+```js
 directionMap: BlockMap;
 getDirectionMap()
 ```
+
 A map of each block and its text direction, as determined by UnicodeBidiService.
 
 You should not manage this manually.
 
-### forceSelection
+### `forceSelection`
 
-```
+```js
 forceSelection: boolean;
 mustForceSelection()
 ```
+
 Whether to force the current `SelectionState` to be rendered.
 
 You should not set this property manually -- see
-[forceSelection()](#forceselection).
+[`forceSelection()`](#forceselection).
 
-### inCompositionMode
+### `inCompositionMode`
 
-```
+```js
 inCompositionMode: boolean;
 isInCompositionMode()
 ```
+
 Whether the user is in IME composition mode. This is useful for rendering the
 appropriate UI for IME users, even when no content changes have been committed
 to the editor. You should not set this property manually.
 
-### inlineStyleOverride
+### `inlineStyleOverride`
 
-```
+```js
 inlineStyleOverride: DraftInlineStyle;
 getInlineStyleOverride()
 ```
+
 An inline style value to be applied to the next inserted characters. This is
 used when keyboard commands or style buttons are used to apply an inline style
 for a collapsed selection range.
@@ -453,21 +474,23 @@ for a collapsed selection range.
 `DraftInlineStyle` is a type alias for an immutable `OrderedSet` of strings,
 each of which corresponds to an inline style.
 
-### lastChangeType
+### `lastChangeType`
 
-```
+```js
 lastChangeType: EditorChangeType;
 getLastChangeType()
 ```
+
 The type of content change that took place in order to bring us to our current
 `ContentState`. This is used when determining boundary states for undo/redo.
 
-### nativelyRenderedContent
+### `nativelyRenderedContent`
 
-```
+```js
 nativelyRenderedContent: ?ContentState;
 getNativelyRenderedContent()
 ```
+
 During edit behavior, the editor may allow certain actions to render natively.
 For instance, during normal typing behavior in the contentEditable-based component,
 we can typically allow key events to fall through to print characters in the DOM.
@@ -477,12 +500,13 @@ When allowing native rendering behavior, it is appropriate to use the
 `nativelyRenderedContent` property to indicate that no re-render is necessary
 for this `EditorState`.
 
-### redoStack
+### `redoStack`
 
-```
+```js
 redoStack: Stack<ContentState>;
 getRedoStack()
 ```
+
 An immutable stack of `ContentState` objects that can be resurrected for redo
 operations. When performing an undo operation, the current `ContentState` is
 pushed onto the `redoStack`.
@@ -492,22 +516,24 @@ undo/redo behavior, use the `allowUndo` property.
 
 See also [undoStack](#undostack).
 
-### selection
+### `selection`
 
-```
+```js
 selection: SelectionState;
 getSelection()
 ```
+
 The currently rendered `SelectionState`. See [acceptSelection()](#acceptselection)
 and [forceSelection()](#forceselection).
 
 You should not manage this property manually.
 
-### treeMap
+### `treeMap`
 
-```
+```js
 treeMap: OrderedMap<string, List>;
 ```
+
 The fully decorated and styled tree of ranges to be rendered in the editor
 component. The `treeMap` object is generated based on a `ContentState` and an
 optional decorator (`DraftDecoratorType`).
@@ -518,12 +544,13 @@ method.
 
 You should not manage this property manually.
 
-### undoStack
+### `undoStack`
 
-```
+```js
 undoStack: Stack<ContentState>;
 getUndoStack()
 ```
+
 An immutable stack of `ContentState` objects that can be restored for undo
 operations.
 
@@ -535,4 +562,4 @@ onto the `undoStack`. If not, the outgoing `ContentState` is discarded.
 You should not manage this property manually. If you would like to disable
 undo/redo behavior, use the `allowUndo` property.
 
-See also [redoStack](#redostack).
+See also [`redoStack`](#redostack).

--- a/docs/APIReference-EditorState.md
+++ b/docs/APIReference-EditorState.md
@@ -122,7 +122,8 @@ The list below includes the most commonly used instance methods for `EditorState
 > new options to an EditorState instance.
 >
 > **Example**
-> ```
+>
+> ```js
 > const editorState = EditorState.createEmpty();
 > const editorStateWithoutUndo = EditorState.set(editorState, {allowUndo: false});
 > ```

--- a/docs/APIReference-Entity.md
+++ b/docs/APIReference-Entity.md
@@ -8,12 +8,12 @@ updating entity objects, which are used for annotating text ranges with metadata
 This module also houses the single store used to maintain entity data.
 
 This article is dedicated to covering the details of the API. See the
-[advanced topics article on entities](/docs/advanced-topics-entities.html)
+[advanced topics article on entities](/docs/advanced-topics-entities)
 for more detail on how entities may be used.
 
 Please note that the API for entity storage and management has changed recently;
 for details on updating your application
-[see our v0.10 API Migration Guide](/docs/v0-10-api-migration.html#content).
+[see our v0.10 API Migration Guide](/docs/v0-10-api-migration#content).
 
 Entity objects returned by `Entity` methods are represented as
 [DraftEntityInstance](https://github.com/facebook/draft-js/blob/master/src/model/entity/DraftEntityInstance.js) immutable records. These have a small set of getter functions and should
@@ -53,15 +53,16 @@ be used only for retrieval.
 
 ## Methods
 
-### create _(Deprecated in favour of [contentState.createEntity](/docs/api-reference-content-state.html#createentity))_
+### `create` _(Deprecated in favour of [`contentState.createEntity`](/docs/api-reference-content-state#createentity))_
 
-```
+```js
 create(
   type: DraftEntityType,
   mutability: DraftEntityMutability,
   data?: Object
 ): string
 ```
+
 The `create` method should be used to generate a new entity object with the
 supplied properties.
 
@@ -70,11 +71,12 @@ are referenced by their string key in `ContentState`. The string value should
 be used within `CharacterMetadata` objects to track the entity for annotated
 characters.
 
-### add _(Deprecated in favour of [contentState.addEntity](/docs/api-reference-content-state.html#addentity))_
+### `add` _(Deprecated in favour of [`contentState.addEntity`](/docs/api-reference-content-state#addentity))_
 
-```
+```js
 add(instance: DraftEntityInstance): string
 ```
+
 In most cases, you will use `Entity.create()`. This is a convenience method
 that you probably will not need in typical Draft usage.
 
@@ -83,35 +85,38 @@ created, and now need to be added to the `Entity` store. This may occur in cases
 where a vanilla JavaScript representation of a `ContentState` is being revived
 for editing.
 
-### get _(Deprecated in favour of [contentState.getEntity](/docs/api-reference-content-state.html#getentity))_
+### `get` _(Deprecated in favour of [`contentState.getEntity`](/docs/api-reference-content-state#getentity))_
 
-```
+```js
 get(key: string): DraftEntityInstance
 ```
+
 Returns the `DraftEntityInstance` for the specified key. Throws if no instance
 exists for that key.
 
-### mergeData _(Deprecated in favour of [contentState.mergeEntityData](/docs/api-reference-content-state.html#mergeentitydata))_
+### `mergeData` _(Deprecated in favour of [`contentState.mergeEntityData`](/docs/api-reference-content-state#mergeentitydata))_
 
-```
+```js
 mergeData(
   key: string,
   toMerge: {[key: string]: any}
 ): DraftEntityInstance
 ```
+
 Since `DraftEntityInstance` objects are immutable, you cannot update an entity's
 metadata through typical mutative means.
 
 The `mergeData` method allows you to apply updates to the specified entity.
 
-### replaceData _(Deprecated in favour of [contentState.replaceEntityData](/docs/api-reference-content-state.html#replaceentitydata))_
+### `replaceData` _(Deprecated in favour of [`contentState.replaceEntityData`](/docs/api-reference-content-state#replaceentitydata))_
 
-```
+```js
 replaceData(
   key: string,
   newData: {[key: string]: any}
 ): DraftEntityInstance
 ```
+
 The `replaceData` method is similar to the `mergeData` method, except it will
 totally discard the existing `data` value for the instance and replace it with
 the specified `newData`.

--- a/docs/APIReference-KeyBindingUtil.md
+++ b/docs/APIReference-KeyBindingUtil.md
@@ -8,9 +8,9 @@ defining key bindings.
 
 ## Static Methods
 
-### isCtrlKeyCommand
+### `isCtrlKeyCommand`
 
-```
+```js
 isCtrlKeyCommand: function(
   e: SyntheticKeyboardEvent
 ): boolean
@@ -20,26 +20,26 @@ Check whether the `ctrlKey` modifier is *not* being used in conjunction with
 the `altKey` modifier. If they are combined, the result is an `altGraph`
 key modifier, which is not handled by this set of key bindings.
 
-### isOptionKeyCommand
+### `isOptionKeyCommand`
 
-```
+```js
 isOptionKeyCommand: function(
   e: SyntheticKeyboardEvent
 ): boolean
 ```
 
-### usesMacOSHeuristics
+### `usesMacOSHeuristics`
 
-```
+```js
 usesMacOSHeuristics: function(): boolean
 ```
 
 Check whether heuristics that only apply to macOS are used internally, for
 example when determining the key combination used as command modifier.
 
-### hasCommandModifier
+### `hasCommandModifier`
 
-```
+```js
 hasCommandModifier: function(
   e: SyntheticKeyboardEvent
 ): boolean

--- a/docs/APIReference-KeyBindingUtil.md
+++ b/docs/APIReference-KeyBindingUtil.md
@@ -8,7 +8,7 @@ defining key bindings.
 
 ## Static Methods
 
-### `isCtrlKeyCommand`
+### `isCtrlKeyCommand()`
 
 ```js
 isCtrlKeyCommand: function(
@@ -20,7 +20,7 @@ Check whether the `ctrlKey` modifier is *not* being used in conjunction with
 the `altKey` modifier. If they are combined, the result is an `altGraph`
 key modifier, which is not handled by this set of key bindings.
 
-### `isOptionKeyCommand`
+### `isOptionKeyCommand()`
 
 ```js
 isOptionKeyCommand: function(
@@ -28,7 +28,7 @@ isOptionKeyCommand: function(
 ): boolean
 ```
 
-### `usesMacOSHeuristics`
+### `usesMacOSHeuristics()`
 
 ```js
 usesMacOSHeuristics: function(): boolean
@@ -37,7 +37,7 @@ usesMacOSHeuristics: function(): boolean
 Check whether heuristics that only apply to macOS are used internally, for
 example when determining the key combination used as command modifier.
 
-### `hasCommandModifier`
+### `hasCommandModifier()`
 
 ```js
 hasCommandModifier: function(

--- a/docs/APIReference-Modifier.md
+++ b/docs/APIReference-Modifier.md
@@ -83,9 +83,9 @@ will be the same as the input object if no edit was actually performed.
 
 ## Static Methods
 
-### replaceText
+### `replaceText`
 
-```
+```js
 replaceText(
   contentState: ContentState,
   rangeToReplace: SelectionState,
@@ -94,6 +94,7 @@ replaceText(
   entityKey?: ?string
 ): ContentState
 ```
+
 Replaces the specified range of this `ContentState` with the supplied string,
 with the inline style and entity key applied to the entire inserted string.
 
@@ -101,9 +102,9 @@ Example: On Facebook, when replacing `@abraham lincoln` with a mention of
 Abraham Lincoln, the entire old range is the target to replace and the mention
 entity should be applied to the inserted string.
 
-### insertText
+### `insertText`
 
-```
+```js
 insertText(
   contentState: ContentState,
   targetRange: SelectionState,
@@ -112,11 +113,12 @@ insertText(
   entityKey?: ?string
 ): ContentState
 ```
+
 Identical to `replaceText`, but enforces that the target range is collapsed
 so that no characters are replaced. This is only for convenience, since text
 edits are so often insertions rather than replacements.
 
-### moveText
+### `moveText`
 
 ```
 moveText(
@@ -125,17 +127,19 @@ moveText(
   targetRange: SelectionState
 ): ContentState
 ```
+
 Moves the "removal" range to the "target" range, replacing the target text.
 
-### replaceWithFragment
+### `replaceWithFragment`
 
-```
+```js
 replaceWithFragment(
   contentState: ContentState,
   targetRange: SelectionState,
   fragment: BlockMap
 ): ContentState
 ```
+
 A "fragment" is a section of a block map, effectively only an
 `OrderedMap<string, ContentBlock>` much the same as the full block map of a
 `ContentState` object.
@@ -145,92 +149,99 @@ This method will replace the "target" range with the fragment.
 Example: When pasting content, we convert the paste into a fragment to be inserted
 into the editor, then use this method to add it.
 
-### removeRange
+### `removeRange`
 
-```
+```js
 removeRange(
   contentState: ContentState,
   rangeToRemove: SelectionState,
   removalDirection: DraftRemovalDirection
 ): ContentState
 ```
+
 Remove an entire range of text from the editor. The removal direction is important
 for proper entity deletion behavior.
 
-### splitBlock
+### `splitBlock`
 
-```
+```js
 splitBlock(
   contentState: ContentState,
   selectionState: SelectionState
 ): ContentState
 ```
+
 Split the selected block into two blocks. This should only be used if the
 selection is collapsed.
 
-### applyInlineStyle
+### `applyInlineStyle`
 
-```
+```js
 applyInlineStyle(
   contentState: ContentState,
   selectionState: SelectionState,
   inlineStyle: string
 ): ContentState
 ```
+
 Apply the specified inline style to the entire selected range.
 
-### removeInlineStyle
+### `removeInlineStyle`
 
-```
+```js
 removeInlineStyle(
   contentState: ContentState,
   selectionState: SelectionState,
   inlineStyle: string
 ): ContentState
 ```
+
 Remove the specified inline style from the entire selected range.
 
-### setBlockType
+### `setBlockType`
 
-```
+```js
 setBlockType(
   contentState: ContentState,
   selectionState: SelectionState,
   blockType: DraftBlockType
 ): ContentState
 ```
+
 Set the block type for all selected blocks.
 
-### setBlockData
+### `setBlockData`
 
-```
+```js
 setBlockData(
   contentState: ContentState,
   selectionState: SelectionState,
   blockData: Map<any, any>
 ): ContentState
 ```
+
 Set the block data for all selected blocks.
 
-### mergeBlockData
+### `mergeBlockData`
 
-```
+```js
 mergeBlockData(
   contentState: ContentState,
   selectionState: SelectionState,
   blockData: Map<any, any>
 ): ContentState
 ```
+
 Update block data for all selected blocks.
 
-### applyEntity
+### `applyEntity`
 
-```
+```js
 applyEntity(
   contentState: ContentState,
   selectionState: SelectionState,
   entityKey: ?string
 ): ContentState
 ```
-Apply an entity to the entire selected range, or remove all entities from the
-range if `entityKey` is `null`.
+
+Apply an entity to the entire selected range, or remove all entities from the range if `entityKey` is `null`.

--- a/docs/APIReference-Modifier.md
+++ b/docs/APIReference-Modifier.md
@@ -83,7 +83,7 @@ will be the same as the input object if no edit was actually performed.
 
 ## Static Methods
 
-### `replaceText`
+### `replaceText()`
 
 ```js
 replaceText(
@@ -102,7 +102,7 @@ Example: On Facebook, when replacing `@abraham lincoln` with a mention of
 Abraham Lincoln, the entire old range is the target to replace and the mention
 entity should be applied to the inserted string.
 
-### `insertText`
+### `insertText()`
 
 ```js
 insertText(
@@ -118,9 +118,9 @@ Identical to `replaceText`, but enforces that the target range is collapsed
 so that no characters are replaced. This is only for convenience, since text
 edits are so often insertions rather than replacements.
 
-### `moveText`
+### `moveText()`
 
-```
+```js
 moveText(
   contentState: ContentState,
   removalRange: SelectionState,
@@ -130,7 +130,7 @@ moveText(
 
 Moves the "removal" range to the "target" range, replacing the target text.
 
-### `replaceWithFragment`
+### `replaceWithFragment()`
 
 ```js
 replaceWithFragment(
@@ -149,7 +149,7 @@ This method will replace the "target" range with the fragment.
 Example: When pasting content, we convert the paste into a fragment to be inserted
 into the editor, then use this method to add it.
 
-### `removeRange`
+### `removeRange()`
 
 ```js
 removeRange(
@@ -162,7 +162,7 @@ removeRange(
 Remove an entire range of text from the editor. The removal direction is important
 for proper entity deletion behavior.
 
-### `splitBlock`
+### `splitBlock()`
 
 ```js
 splitBlock(
@@ -174,7 +174,7 @@ splitBlock(
 Split the selected block into two blocks. This should only be used if the
 selection is collapsed.
 
-### `applyInlineStyle`
+### `applyInlineStyle()`
 
 ```js
 applyInlineStyle(
@@ -186,7 +186,7 @@ applyInlineStyle(
 
 Apply the specified inline style to the entire selected range.
 
-### `removeInlineStyle`
+### `removeInlineStyle()`
 
 ```js
 removeInlineStyle(
@@ -198,7 +198,7 @@ removeInlineStyle(
 
 Remove the specified inline style from the entire selected range.
 
-### `setBlockType`
+### `setBlockType()`
 
 ```js
 setBlockType(
@@ -210,7 +210,7 @@ setBlockType(
 
 Set the block type for all selected blocks.
 
-### `setBlockData`
+### `setBlockData()`
 
 ```js
 setBlockData(
@@ -222,7 +222,7 @@ setBlockData(
 
 Set the block data for all selected blocks.
 
-### `mergeBlockData`
+### `mergeBlockData()`
 
 ```js
 mergeBlockData(
@@ -234,7 +234,7 @@ mergeBlockData(
 
 Update block data for all selected blocks.
 
-### `applyEntity`
+### `applyEntity()`
 
 ```js
 applyEntity(

--- a/docs/APIReference-RichUtils.md
+++ b/docs/APIReference-RichUtils.md
@@ -11,58 +11,58 @@ parameters and return `EditorState` objects.
 
 ## Static Methods
 
-### currentBlockContainsLink
+### `currentBlockContainsLink`
 
-```
+```js
 currentBlockContainsLink(
   editorState: EditorState
 ): boolean
 ```
 
-### getCurrentBlockType
+### `getCurrentBlockType`
 
-```
+```js
 getCurrentBlockType(
   editorState: EditorState
 ): string
 ```
 
-### handleKeyCommand
+### `handleKeyCommand`
 
-```
+```js
 handleKeyCommand(
   editorState: EditorState,
   command: string
 ): ?EditorState
 ```
 
-### insertSoftNewline
+### `insertSoftNewline`
 
-```
+```js
 insertSoftNewline(
   editorState: EditorState
 ): EditorState
 ```
 
-### onBackspace
+### `onBackspace`
 
-```
+```js
 onBackspace(
   editorState: EditorState
 ): EditorState?
 ```
 
-### onDelete
+### `onDelete`
 
-```
+```js
 onDelete(
   editorState: EditorState
 ): EditorState?
 ```
 
-### onTab
+### `onTab`
 
-```
+```js
 onTab(
   event: SyntheticEvent,
   editorState: EditorState,
@@ -70,26 +70,26 @@ onTab(
 ): EditorState
 ```
 
-### toggleBlockType
+### `toggleBlockType`
 
-```
+```js
 toggleBlockType(
   editorState: EditorState,
   blockType: string
 ): EditorState
 ```
 
-### toggleCode
+### `toggleCode`
 
-```
+```js
 toggleCode(
   editorState: EditorState
 ): EditorState
 ```
 
-### toggleInlineStyle
+### `toggleInlineStyle`
 
-```
+```js
 toggleInlineStyle(
   editorState: EditorState,
   inlineStyle: string
@@ -101,9 +101,9 @@ user's selection is collapsed, apply or remove the style for the
 internal state. If it is not collapsed, apply the change directly
 to the document state.
 
-### toggleLink
+### `toggleLink`
 
-```
+```js
 toggleLink(
   editorState: EditorState,
   targetSelection: SelectionState,
@@ -111,9 +111,9 @@ toggleLink(
 ): EditorState
 ```
 
-### tryToRemoveBlockStyle
+### `tryToRemoveBlockStyle`
 
-```
+```js
 tryToRemoveBlockStyle(
   editorState: EditorState
 ): ContentState?

--- a/docs/APIReference-RichUtils.md
+++ b/docs/APIReference-RichUtils.md
@@ -11,7 +11,7 @@ parameters and return `EditorState` objects.
 
 ## Static Methods
 
-### `currentBlockContainsLink`
+### `currentBlockContainsLink()`
 
 ```js
 currentBlockContainsLink(
@@ -19,7 +19,7 @@ currentBlockContainsLink(
 ): boolean
 ```
 
-### `getCurrentBlockType`
+### `getCurrentBlockType()`
 
 ```js
 getCurrentBlockType(
@@ -27,7 +27,7 @@ getCurrentBlockType(
 ): string
 ```
 
-### `handleKeyCommand`
+### `handleKeyCommand()`
 
 ```js
 handleKeyCommand(
@@ -36,7 +36,7 @@ handleKeyCommand(
 ): ?EditorState
 ```
 
-### `insertSoftNewline`
+### `insertSoftNewline()`
 
 ```js
 insertSoftNewline(
@@ -44,7 +44,7 @@ insertSoftNewline(
 ): EditorState
 ```
 
-### `onBackspace`
+### `onBackspace()`
 
 ```js
 onBackspace(
@@ -52,7 +52,7 @@ onBackspace(
 ): EditorState?
 ```
 
-### `onDelete`
+### `onDelete()`
 
 ```js
 onDelete(
@@ -60,7 +60,7 @@ onDelete(
 ): EditorState?
 ```
 
-### `onTab`
+### `onTab()`
 
 ```js
 onTab(
@@ -70,7 +70,7 @@ onTab(
 ): EditorState
 ```
 
-### `toggleBlockType`
+### `toggleBlockType()`
 
 ```js
 toggleBlockType(
@@ -79,7 +79,7 @@ toggleBlockType(
 ): EditorState
 ```
 
-### `toggleCode`
+### `toggleCode()`
 
 ```js
 toggleCode(
@@ -87,7 +87,7 @@ toggleCode(
 ): EditorState
 ```
 
-### `toggleInlineStyle`
+### `toggleInlineStyle()`
 
 ```js
 toggleInlineStyle(
@@ -101,7 +101,7 @@ user's selection is collapsed, apply or remove the style for the
 internal state. If it is not collapsed, apply the change directly
 to the document state.
 
-### `toggleLink`
+### `toggleLink()`
 
 ```js
 toggleLink(
@@ -111,7 +111,7 @@ toggleLink(
 ): EditorState
 ```
 
-### `tryToRemoveBlockStyle`
+### `tryToRemoveBlockStyle()`
 
 ```js
 tryToRemoveBlockStyle(

--- a/docs/APIReference-SelectionState.md
+++ b/docs/APIReference-SelectionState.md
@@ -3,9 +3,7 @@ id: api-reference-selection-state
 title: SelectionState
 ---
 
-`SelectionState` is an Immutable
-[Record](http://facebook.github.io/immutable-js/docs/#/Record/Record) that
-represents a selection range in the editor.
+`SelectionState` is an Immutable [Record](http://facebook.github.io/immutable-js/docs/#/Record/Record) that represents a selection range in the editor.
 
 The most common use for the `SelectionState` object is via `EditorState.getSelection()`,
 which provides the `SelectionState` currently being rendered in the editor.
@@ -141,13 +139,12 @@ _Start_ and _end_ values are derived.
 
 > Use [Immutable Map API](http://facebook.github.io/immutable-js/docs/#/Record/Record) to
 > set properties.
-> 
+>
 > **Example**
 > ```
 > const selectionState = SelectionState.createEmpty();
 > const selectionStateWithNewFocusOffset = selection.set('focusOffset', 1);
 > ```
-
 
 <ul class="apiIndex">
   <li>
@@ -184,103 +181,116 @@ _Start_ and _end_ values are derived.
 
 ## Static Methods
 
-### createEmpty()
+### `createEmpty()`
 
-```
+```js
 createEmpty(blockKey: string): SelectionState
 ```
+
 Create a `SelectionState` object at the zero offset of the provided block key
 and `hasFocus` set to false.
 
 ## Methods
 
-### getStartKey()
+### `getStartKey()`
 
-```
+```js
 getStartKey(): string
 ```
+
 Returns the key of the block containing the start position of the selection range.
 
-### getStartOffset()
+### `getStartOffset()`
 
-```
+```js
 getStartOffset(): number
 ```
+
 Returns the block-level character offset of the start position of the selection range.
 
-### getEndKey()
+### `getEndKey()`
 
-```
+```js
 getEndKey(): string
 ```
+
 Returns the key of the block containing the end position of the selection range.
 
-### getEndOffset()
+### `getEndOffset()`
 
-```
+```js
 getEndOffset(): number
 ```
+
 Returns the block-level character offset of the end position of the selection range.
 
-### getAnchorKey()
+### `getAnchorKey()`
 
-```
+```js
 getAnchorKey(): string
 ```
+
 Returns the key of the block containing the anchor position of the selection range.
 
-### getAnchorOffset()
+### `getAnchorOffset()`
 
-```
+```js
 getAnchorOffset(): number
 ```
+
 Returns the block-level character offset of the anchor position of the selection range.
 
-### getFocusKey()
+### `getFocusKey()`
 
-```
+```js
 getFocusKey(): string
 ```
+
 Returns the key of the block containing the focus position of the selection range.
 
-### getFocusOffset()
+### `getFocusOffset()`
 
-```
+```js
 getFocusOffset(): number
 ```
+
 Returns the block-level character offset of the focus position of the selection range.
 
-### getIsBackward()
+### `getIsBackward()`
 
-```
+```js
 getIsBackward(): boolean
 ```
+
 Returns whether the focus position is before the anchor position in the document.
 
 This must be derived from the key order of the active `ContentState`, or if the selection
 range is entirely within one block, a comparison of the anchor and focus offset values.
 
-### getHasFocus()
+### `getHasFocus()`
 
-```
+```js
 getHasFocus(): boolean
 ```
+
 Returns whether the editor has focus.
 
-### isCollapsed()
+### `isCollapsed()`
 
-```
+```js
 isCollapsed(): boolean
 ```
+
 Returns whether the selection range is collapsed, i.e. a caret. This is true
 when the anchor and focus keys are the same /and/ the anchor and focus offsets
 are the same.
 
-### hasEdgeWithin()
+### `hasEdgeWithin()`
 
-```
+```js
 hasEdgeWithin(blockKey: string, start: number, end: number): boolean
 ```
+
 Returns whether the selection range has an edge that overlaps with the specified
 start/end range within a given block.
 
@@ -289,9 +299,10 @@ rendered.
 
 ### serialize()
 
-```
+```js
 serialize(): string
 ```
+
 Returns a serialized version of the `SelectionState`. Useful for debugging.
 
 ## Properties
@@ -299,7 +310,7 @@ Returns a serialized version of the `SelectionState`. Useful for debugging.
 > Use [Immutable Map API](http://facebook.github.io/immutable-js/docs/#/Record/Record) to
 > set properties.
 
-```
+```js
 var selectionState = SelectionState.createEmpty('foo');
 var updatedSelection = selectionState.merge({
   focusKey: 'bar',
@@ -309,23 +320,26 @@ var anchorKey = updatedSelection.getAnchorKey(); // 'foo'
 var focusKey = updatedSelection.getFocusKey(); // 'bar'
 ```
 
-### anchorKey
+### `anchorKey`
+
 The block containing the anchor end of the selection range.
 
-### anchorOffset
+### `anchorOffset`
+
 The offset position of the anchor end of the selection range.
 
-### focusKey
+### `focusKey`
+
 The block containing the focus end of the selection range.
 
-### focusOffset
+### `focusOffset`
+
 The offset position of the focus end of the selection range.
 
-### isBackward
-If the anchor position is lower in the document than the focus position, the
-selection is backward. Note: The `SelectionState` is an object with
-no knowledge of the `ContentState` structure. Therefore, when updating
-`SelectionState` values, you are responsible for updating `isBackward` as well.
+### `isBackward`
 
-### hasFocus
+If the anchor position is lower in the document than the focus position, the selection is backward. Note: The `SelectionState` is an object with no knowledge of the `ContentState` structure. Therefore, when updating `SelectionState` values, you are responsible for updating `isBackward` as well.
+
+### `hasFocus`
+
 Whether the editor currently has focus.

--- a/docs/APIReference-SelectionState.md
+++ b/docs/APIReference-SelectionState.md
@@ -40,7 +40,7 @@ and _end_ values.
 For instance, when extracting a slice of text from a block based on a
 `SelectionState`, it is irrelevant whether the selection is backward:
 
-```
+```js
 var selectionState = editorState.getSelection();
 var anchorKey = selectionState.getAnchorKey();
 var currentContent = editorState.getCurrentContent();
@@ -141,7 +141,8 @@ _Start_ and _end_ values are derived.
 > set properties.
 >
 > **Example**
-> ```
+>
+> ```js
 > const selectionState = SelectionState.createEmpty();
 > const selectionStateWithNewFocusOffset = selection.set('focusOffset', 1);
 > ```
@@ -297,7 +298,7 @@ start/end range within a given block.
 This is useful when setting DOM selection within a block after contents are
 rendered.
 
-### serialize()
+### `serialize()`
 
 ```js
 serialize(): string

--- a/docs/Advanced-Topics-Custom-Block-Render.md
+++ b/docs/Advanced-Topics-Custom-Block-Render.md
@@ -8,7 +8,7 @@ The block rendering is used to define supported block types and their respective
 renderers, as well as converting pasted content to known Draft block types.
 
 When pasting content, or when calling
-[convertFromHTML](/docs/api-reference-data-conversion.html#convertfromhtml),
+[convertFromHTML](/docs/api-reference-data-conversion#convertfromhtml),
 Draft will convert pasted content to the respective block rendering type
 by matching the Draft block render map with the matched tag.
 
@@ -99,7 +99,7 @@ particular block type, you can add the array `aliasedElements` to the block conf
 
 *example of unstyled block type alias usage:*
 
-```
+```js
 'unstyled': {
   element: 'div',
   aliasedElements: ['p'],
@@ -111,8 +111,8 @@ particular block type, you can add the array `aliasedElements` to the block conf
 By default, the html element is used to wrap block types. However, a react component
 can also be provided to the _blockRenderMap_ to wrap the EditorBlock.
 
-During pasting, or when calling 
-[convertFromHTML](/docs/api-reference-data-conversion.html#convertfromhtml),
+During pasting, or when calling
+[convertFromHTML](/docs/api-reference-data-conversion#convertfromhtml),
 the html will be scanned for matching tag elements. A wrapper will be used when there is a definition for
 it on the _blockRenderMap_ to wrap that particular block type. For example:
 

--- a/docs/Advanced-Topics-Decorators.md
+++ b/docs/Advanced-Topics-Decorators.md
@@ -14,7 +14,7 @@ offers a live example of decorators in action.
 ## CompositeDecorator
 
 The decorator concept is based on scanning the contents of a given
-[ContentBlock](/docs/api-reference-content-block.html)
+[ContentBlock](/docs/api-reference-content-block)
 for ranges of text that match a defined strategy, then rendering them
 with a specified React component.
 

--- a/docs/Advanced-Topics-EditorState-Race-Conditions.md
+++ b/docs/Advanced-Topics-EditorState-Race-Conditions.md
@@ -3,10 +3,11 @@ id: advanced-topics-editorstate-race-conditions
 title: EditorState Race Conditions
 ---
 
-Draft `Editor` is a *controlled input* component (you can read about this in detail in the [API Basics](/docs/quickstart-api-basics.html) section), meaning that changes made to the `Editor` state are propagated upwards through `onChange` and it's up to the app to feed it back to the `Editor` component.
+Draft `Editor` is a *controlled input* component (you can read about this in detail in the [API Basics](/docs/quickstart-api-basics) section), meaning that changes made to the `Editor` state are propagated upwards through `onChange` and it's up to the app to feed it back to the `Editor` component.
 
 This cycle usually looks like:
-```
+
+```js
 ...
 this.onChange = function(editorState) {
   this.setState({editorState: editorState});
@@ -18,21 +19,28 @@ this.onChange = function(editorState) {
   placeholder="Enter some text..."
 />
 ```
+
 Different browser events can trigger the `Editor` to create a new state and call `onChange`. For instance, when the user pastes text into it, Draft parses the new content and creates the necessary data structure to represent it.
 
 This cycle works great, however, it is an asynchronous operation because of the `setState` call. This introduces a delay between setting the state and rendering the `Editor` with the new state. During this time period other JS code can be executed.
-![](/img/editorstate-race-condition-1-handler.png)
+
+![Race condition diagram 1](/img/editorstate-race-condition-1-handler.png)
+
 Non-atomic operations like this can potentially introduce race conditions.
 Here's an example: Suppose you want to remove all the text styles that come from the paste. This can be implemented by listening to the onPaste event and removing all styles from the `EditorState`:
-```
+
+```js
 this.onPaste = function() {
   this.setState({
     editorState: removeEditorStyles(this.state.editorState)
   });
 }
 ```
+
 However, this won't work as expected. You now have two event handlers that set a new `EditorState` in the exact same browser event. Since the event handlers will run one after the other only the last `setState` will prevail. Here's how it looks like in the JS timeline:
-![](/img/editorstate-race-condition-2-handlers.png)
+
+![Race condition diagram 2](/img/editorstate-race-condition-2-handlers.png)
+
 As you can see, since `setState` is an asynchronous operation, the second `setState` will override whatever it was set on the first one making the `Editor` lose all the contents from the pasted text.
 
 You can observe and explore the race condition in [this running example](https://jsfiddle.net/qecccw3r/). The example also has logging to highlight the JS timeline so make sure to open the developer tools.
@@ -52,7 +60,8 @@ Here's a list of supported callbacks on the `Editor`:
 * `handlePastedText(text, html, editorState)`
 
 The paste example can then be re-written in a race condition free way by using these methods:
-```
+
+```js
 this.handlePastedText = (text, styles, editorState) => {
   this.setState({
     editorState: removeEditorStyles(text, editorState)
@@ -66,6 +75,7 @@ this.handlePastedText = (text, styles, editorState) => {
   placeholder="Enter some text..."
 />
 ```
+
 With `handlePastedText` you can implement the paste behavior by yourself.
 
 NOTE: If you need to have this behavior in your Editor, you can achieve it by setting the `Editor`'s `stripPastedStyles` property to `true`.

--- a/docs/Advanced-Topics-Entities.md
+++ b/docs/Advanced-Topics-Entities.md
@@ -15,13 +15,13 @@ and
 provide live code examples to help clarify how entities can be used, as well
 as their built-in behavior.
 
-The [Entity API Reference](/docs/api-reference-entity.html) provides
+The [Entity API Reference](/docs/api-reference-entity) provides
 details on the static methods to be used when creating, retrieving, or updating
 entity objects.
 
 For information about recent changes to the Entity API, and examples of how to
 update your application,
-[see our v0.10 API Migration Guide](/docs/v0-10-api-migration.html#content).
+[see our v0.10 API Migration Guide](/docs/v0-10-api-migration#content).
 
 ## Introduction
 
@@ -44,8 +44,8 @@ ranges. (We are currently deprecating a previous API for accessing Entities; see
 issue
 [#839](https://github.com/facebook/draft-js/issues/839).)
 
-Using [decorators](/docs/advanced-topics-decorators.html) or
-[custom block components](/docs/advanced-topics-block-components.html), you can
+Using [decorators](/docs/advanced-topics-decorators) or
+[custom block components](/docs/advanced-topics-block-components), you can
 add rich rendering to your editor based on entity metadata.
 
 ## Creating and Retrieving Entities

--- a/docs/Advanced-Topics-Inline-Styles.md
+++ b/docs/Advanced-Topics-Inline-Styles.md
@@ -16,7 +16,7 @@ examples demonstrate complex inline style behavior in action.
 
 Within the Draft model, inline styles are represented at the character level,
 using an immutable `OrderedSet` to define the list of styles to be applied to
-each character. These styles are identified by string. (See [CharacterMetadata](/docs/api-reference-character-metadata.html)
+each character. These styles are identified by string. (See [CharacterMetadata](/docs/api-reference-character-metadata)
 for details.)
 
 For example, consider the text "Hello **world**". The first six characters of
@@ -42,7 +42,7 @@ In essence, our styles are:
 
 Now let's say that we wish to make the middle range of characters italic as well:
 He*llo* ***wo*rld**. This operation can be performed via the
-[Modifier](/docs/api-reference-modifier.html) API.
+[Modifier](/docs/api-reference-modifier) API.
 
 The end result will accommodate the overlap by including `'ITALIC'` in the
 relevant `OrderedSet` objects as well.

--- a/docs/Advanced-Topics-Issues-and-Pitfalls.md
+++ b/docs/Advanced-Topics-Issues-and-Pitfalls.md
@@ -28,16 +28,16 @@ you must always allow your `EditorState` to propagate to your `Editor`
 component without delay, and independently perform batched updates that do
 not affect the state of your `Editor` component.
 
-### Missing Draft.css
+### Missing `Draft.css`
 
 The Draft framework includes a handful of CSS resources intended for use with
-the editor, available in a single file via the build, Draft.css.
+the editor, available in a single file via the build, `Draft.css`.
 
 This CSS should be included when rendering the editor, as these styles set defaults
 for text alignment, spacing, and other important features. Without it, you may
 encounter issues with block positioning, alignment, and cursor behavior.
 
-If you choose to write your own CSS independent of Draft.css, you will most
+If you choose to write your own CSS independent of `Draft.css`, you will most
 likely need to replicate much of the default styling.
 
 ## Known Issues

--- a/docs/Advanced-Topics-Issues-and-Pitfalls.md
+++ b/docs/Advanced-Topics-Issues-and-Pitfalls.md
@@ -87,11 +87,11 @@ When using either polyfill/shim, you should include it as early as possible in
 your application's entrypoint (at the very minimum, before you import Draft).
 For instance, using
 [create-react-app](https://github.com/facebookincubator/create-react-app) and
-targeting ie11, `src/index.js` is probably a good spot to import your polyfill:
+targeting IE11, `src/index.js` is probably a good spot to import your polyfill:
 
-**src/index.js**
+**`src/index.js`**
 
-```
+```js
 import 'babel-polyfill';
 // or
 import 'es6-shim';

--- a/docs/Advanced-Topics-Nested-Lists.md
+++ b/docs/Advanced-Topics-Nested-Lists.md
@@ -9,7 +9,7 @@ depth to a list item.
 
 ## Implementation
 
-The [`RichUtils`](/docs/api-reference-rich-utils.html) module provides a handy `onTab` method that manages this
+The [`RichUtils`](/docs/api-reference-rich-utils) module provides a handy `onTab` method that manages this
 behavior, and should be sufficient for most nested list needs. You can use
 the `onTab` prop on your `Editor` to make use of this utility.
 

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -8,7 +8,7 @@ Draft.js is a framework for building rich text editors in React, powered by an i
 
 Draft.js allows you to build any type of rich text input, whether you're only looking to support a few inline text styles or building a complex text editor for composing long-form articles.
 
-Draft.js was introduced at [React.js Conf](https://conf2016.reactjs.org/schedule.html#rich-text-editing-with-react) in February 2016.
+Draft.js was introduced at [React.js Conf](https://conf2016.reactjs.org/schedule#rich-text-editing-with-react) in February 2016.
 
 <iframe width="650" height="365" src="https://www.youtube.com/embed/feUYwoLhE_4" frameborder="0" allowfullscreen></iframe>
 
@@ -30,7 +30,7 @@ npm install draft-js react react-dom babel-polyfill
 yarn add draft-js react react-dom es6-shim
 ```
 
-Learn more about [using a shim with Draft](/docs/advanced-topics-issues-and-pitfalls.html#polyfills).
+Learn more about [using a shim with Draft](/docs/advanced-topics-issues-and-pitfalls#polyfills).
 
 ## API Changes Notice
 
@@ -98,6 +98,6 @@ Because Draft.js supports unicode, you must have the following meta tag in the `
 <meta charset="utf-8" />
 ```
 
-`Draft.css` should be included when rendering the editor. Learn more about [why](/docs/advanced-topics-issues-and-pitfalls.html#missing-draftcss).
+`Draft.css` should be included when rendering the editor. Learn more about [why](/docs/advanced-topics-issues-and-pitfalls#missing-draftcss).
 
 Next, let's go into the basics of the API and learn what else you can do with Draft.js.

--- a/docs/QuickStart-API-Basics.md
+++ b/docs/QuickStart-API-Basics.md
@@ -42,12 +42,11 @@ The top-level component can maintain control over the input state via this
 
 In a React rich text scenario, however, there are two clear problems:
 
-1. A string of plaintext is insufficient to represent the complex state of
-a rich editor.
+1. A string of plaintext is insufficient to represent the complex state of a rich editor.
 2. There is no such `onChange` event available for a ContentEditable element.
 
 State is therefore represented as a single immutable
-[EditorState](/docs/api-reference-editor-state.html) object, and
+[EditorState](/docs/api-reference-editor-state) object, and
 `onChange` is implemented within the `Editor` core to provide this state
 value to the top level.
 
@@ -71,5 +70,4 @@ class MyEditor extends React.Component {
 }
 ```
 
-For any edits or selection changes that occur in the editor DOM, your `onChange`
-handler will execute with the latest `EditorState` object based on those changes.
+For any edits or selection changes that occur in the editor DOM, your `onChange` handler will execute with the latest `EditorState` object based on those changes.

--- a/docs/QuickStart-Rich-Styling.md
+++ b/docs/QuickStart-Rich-Styling.md
@@ -11,18 +11,13 @@ is also available to follow along.
 
 ## EditorState: Yours to Command
 
-The previous article introduced the `EditorState` object as a snapshot of the
-full state of the editor, as provided by the `Editor` core via the
-`onChange` prop.
+The previous article introduced the `EditorState` object as a snapshot of the full state of the editor, as provided by the `Editor` core via the `onChange` prop.
 
-However, since your top-level React component is responsible for maintaining the
-state, you also have the freedom to apply changes to that `EditorState` object
-in any way you see fit.
+However, since your top-level React component is responsible for maintaining the state, you also have the freedom to apply changes to that `EditorState` object in any way you see fit.
 
-For inline and block style behavior, for example, the [`RichUtils`](/docs/api-reference-rich-utils.html) module
-provides a number of useful functions to help manipulate state.
+For inline and block style behavior, for example, the [`RichUtils`](/docs/api-reference-rich-utils) module provides a number of useful functions to help manipulate state.
 
-Similarly, the [Modifier](/docs/api-reference-modifier.html) module also provides a
+Similarly, the [Modifier](/docs/api-reference-modifier) module also provides a
 number of common operations that allow you to apply edits, including changes
 to text, styles, and more. This module is a suite of edit functions that
 compose simpler, smaller edit functions to return the desired `EditorState`
@@ -76,7 +71,7 @@ class MyEditor extends React.Component {
 > `editorState` argument represents the latest editor state as it might be
 > changed internally by draft when handling the key. Use this instance of the
 > editor state inside `handleKeyCommand`. See
-> [Advanced Topics - Key Binding](/docs/advanced-topics-key-bindings.html) for more
+> [Advanced Topics - Key Binding](/docs/advanced-topics-key-bindings) for more
 > on this, as well as details on why the function returns `handled` or `not-handled`.
 
 ## Styling Controls in UI


### PR DESCRIPTION
**Summary**

Reformat the docs in preparation for Docusaurus 2:

- Add syntax highlighting for the code blocks
- Remove `.html` from the Markdown link extensions. Docusaurus 1 allows clean URL but Docusaurus 2 doesn't, so this is necessary
- Wrap API headings in code blocks
- Change the level of some API headings so that they appear in the right table of contents

**Test Plan**

Run Docusaurus website locally and click through.

Try it out - https://draft-js-pc0wv8qnv.now.sh