### PR TITLE
Fix isHTMLBRElement test

### DIFF
--- a/src/component/utils/__tests__/isHTMLBRElement-test.js
+++ b/src/component/utils/__tests__/isHTMLBRElement-test.js
@@ -11,6 +11,8 @@
 
 'use strict';
 
+jest.disableAutomock();
+
 const isHTMLBRElement = require('isHTMLBRElement');
 
 test('isHTMLBRElement recognizes null', () => {


### PR DESCRIPTION
**Summary**

In the Facebook repo mirror, modules in Jest tests are not mocked, but on GitHub they are (as seen from `package.json`). That led to D18831442 passing internally in Sandcastle but failing on Travis. Not a huge deal, we can just add `jest.disableAutomock()`.

We might want to see if we can remove `"automock": true,` from the Jest config in `package.json` to have a more similar environment to Facebook's Jest config.

**Test Plan**

Travis CI should pass now.
