### PR TITLE
Remove Jest auto mocking

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "npm": "2.x || 3.x || 5.x || 6.x"
   },
   "jest": {
-    "automock": true,
     "globals": {
       "__DEV__": true
     },

--- a/src/component/base/__tests__/DraftEditor.react-test.js
+++ b/src/component/base/__tests__/DraftEditor.react-test.js
@@ -10,8 +10,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 jest.mock('generateRandomKey');
 
 const DraftEditor = require('DraftEditor.react');

--- a/src/component/contents/__tests__/DraftEditorBlock.react-test.js
+++ b/src/component/contents/__tests__/DraftEditorBlock.react-test.js
@@ -11,7 +11,6 @@
 'use strict';
 
 jest
-  .disableAutomock()
   .mock('Style')
   .mock('getElementPosition')
   .mock('getScrollPosition')

--- a/src/component/contents/__tests__/DraftEditorContents.react-test.js
+++ b/src/component/contents/__tests__/DraftEditorContents.react-test.js
@@ -10,8 +10,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 jest.mock('generateRandomKey');
 
 const Editor = require('DraftEditor.react');

--- a/src/component/contents/__tests__/DraftEditorTextNode-test.js
+++ b/src/component/contents/__tests__/DraftEditorTextNode-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-jest.disableAutomock().mock('UserAgent');
+jest.mock('UserAgent');
 
 const BLOCK_DELIMITER_CHAR = '\n';
 const TEST_A = 'Hello';

--- a/src/component/contents/exploration/__tests__/DraftEditorBlockNode.react-test.js
+++ b/src/component/contents/exploration/__tests__/DraftEditorBlockNode.react-test.js
@@ -11,7 +11,6 @@
 'use strict';
 
 jest
-  .disableAutomock()
   .mock('Style')
   .mock('getElementPosition')
   .mock('getScrollPosition')

--- a/src/component/contents/exploration/__tests__/DraftEditorContentsExperimental.react-test.js
+++ b/src/component/contents/exploration/__tests__/DraftEditorContentsExperimental.react-test.js
@@ -10,8 +10,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 const ContentBlockNode = require('ContentBlockNode');
 const ContentState = require('ContentState');
 const DefaultDraftBlockRenderMap = require('DefaultDraftBlockRenderMap');

--- a/src/component/handlers/composition/__tests__/DraftEditorCompostionHandler-test.js
+++ b/src/component/handlers/composition/__tests__/DraftEditorCompostionHandler-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 // DraftEditorComposition uses timers to detect duplicate `compositionend`
 // events.
 jest.useFakeTimers();

--- a/src/component/handlers/edit/__tests__/editOnBeforeInput-test.js
+++ b/src/component/handlers/edit/__tests__/editOnBeforeInput-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 import type DraftEditor from 'DraftEditor.react';
 
 const CompositeDraftDecorator = require('CompositeDraftDecorator');

--- a/src/component/handlers/edit/__tests__/editOnBlur-test.js
+++ b/src/component/handlers/edit/__tests__/editOnBlur-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 const ContentBlock = require('ContentBlock');
 const ContentState = require('ContentState');
 const EditorState = require('EditorState');

--- a/src/component/handlers/edit/__tests__/editOnInput-test.js
+++ b/src/component/handlers/edit/__tests__/editOnInput-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 const ContentBlock = require('ContentBlock');
 const ContentState = require('ContentState');
 const EditorState = require('EditorState');

--- a/src/component/handlers/edit/commands/__tests__/SecondaryClipboard-test.js
+++ b/src/component/handlers/edit/commands/__tests__/SecondaryClipboard-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 jest.mock('generateRandomKey');
 
 const toggleExperimentalTreeDataSupport = enabled => {

--- a/src/component/handlers/edit/commands/__tests__/removeTextWithStrategy-test.js
+++ b/src/component/handlers/edit/commands/__tests__/removeTextWithStrategy-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 jest.mock('generateRandomKey');
 
 const toggleExperimentalTreeDataSupport = enabled => {

--- a/src/component/selection/__tests__/DraftOffsetKey-test.js
+++ b/src/component/selection/__tests__/DraftOffsetKey-test.js
@@ -9,8 +9,6 @@
  * @flow strict-local
  */
 
-jest.disableAutomock();
-
 const DraftOffsetKey = require('DraftOffsetKey');
 
 test('decodes offset key with no delimiter', () => {

--- a/src/component/selection/__tests__/getDraftEditorSelection-test.js
+++ b/src/component/selection/__tests__/getDraftEditorSelection-test.js
@@ -10,8 +10,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 const getDraftEditorSelection = require('getDraftEditorSelection');
 const getSampleSelectionMocksForTesting = require('getSampleSelectionMocksForTesting');
 const getSampleSelectionMocksForTestingNestedBlocks = require('getSampleSelectionMocksForTestingNestedBlocks');

--- a/src/component/utils/__tests__/getContentEditableContainer-test.js
+++ b/src/component/utils/__tests__/getContentEditableContainer-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 jest.mock('ReactDOM');
 
 const getContentEditableContainer = require('getContentEditableContainer');

--- a/src/component/utils/__tests__/isHTMLBRElement-test.js
+++ b/src/component/utils/__tests__/isHTMLBRElement-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 const isHTMLBRElement = require('isHTMLBRElement');
 
 test('isHTMLBRElement recognizes null', () => {

--- a/src/component/utils/exploration/__tests__/DraftTreeAdapter-test.js
+++ b/src/component/utils/exploration/__tests__/DraftTreeAdapter-test.js
@@ -10,8 +10,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 jest.mock('generateRandomKey');
 
 const DraftTreeAdapter = require('DraftTreeAdapter');

--- a/src/component/utils/exploration/__tests__/DraftTreeInvariants-test.js
+++ b/src/component/utils/exploration/__tests__/DraftTreeInvariants-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 // missing parent -> child connection
 
 const ContentBlockNode = require('ContentBlockNode');

--- a/src/model/decorators/__tests__/CompositeDraftDecorator-test.js
+++ b/src/model/decorators/__tests__/CompositeDraftDecorator-test.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-jest.disableAutomock().mock('ContentState');
+jest.mock('ContentState');
 
 const CompositeDraftDecorator = require('CompositeDraftDecorator');
 const ContentState = require('ContentState');

--- a/src/model/encoding/__tests__/DraftStringKey-test.js
+++ b/src/model/encoding/__tests__/DraftStringKey-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 const {stringify, unstringify} = require('DraftStringKey');
 
 test('must convert maybe strings to a string key', () => {

--- a/src/model/encoding/__tests__/convertFromDraftStateToRaw-test.js
+++ b/src/model/encoding/__tests__/convertFromDraftStateToRaw-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 const BlockMapBuilder = require('BlockMapBuilder');
 const CharacterMetadata = require('CharacterMetadata');
 const ContentBlock = require('ContentBlock');

--- a/src/model/encoding/__tests__/convertFromHTMLToContentBlocks-test.js
+++ b/src/model/encoding/__tests__/convertFromHTMLToContentBlocks-test.js
@@ -11,7 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
 expect.addSnapshotSerializer(require('NonASCIIStringSnapshotSerializer'));
 
 jest.mock('generateRandomKey');

--- a/src/model/encoding/__tests__/convertFromRawToDraftState-test.js
+++ b/src/model/encoding/__tests__/convertFromRawToDraftState-test.js
@@ -10,8 +10,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 jest.mock('generateRandomKey');
 
 const convertFromRawToDraftState = require('convertFromRawToDraftState');

--- a/src/model/encoding/__tests__/decodeEntityRanges-test.js
+++ b/src/model/encoding/__tests__/decodeEntityRanges-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 const decodeEntityRanges = require('decodeEntityRanges');
 
 test('must decode when no entities present', () => {

--- a/src/model/encoding/__tests__/decodeInlineStyleRanges-test.js
+++ b/src/model/encoding/__tests__/decodeInlineStyleRanges-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 const decodeInlineStyleRanges = require('decodeInlineStyleRanges');
 
 test('must decode for an unstyled block', () => {

--- a/src/model/encoding/__tests__/encodeEntityRanges-test.js
+++ b/src/model/encoding/__tests__/encodeEntityRanges-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 const ContentBlock = require('ContentBlock');
 
 const createCharacterList = require('createCharacterList');

--- a/src/model/encoding/__tests__/encodeInlineStyleRanges-test.js
+++ b/src/model/encoding/__tests__/encodeInlineStyleRanges-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 const ContentBlock = require('ContentBlock');
 const SampleDraftInlineStyle = require('SampleDraftInlineStyle');
 

--- a/src/model/encoding/__tests__/sanitizeDraftText-test.js
+++ b/src/model/encoding/__tests__/sanitizeDraftText-test.js
@@ -9,8 +9,6 @@
  * @format
  */
 
-jest.disableAutomock();
-
 const sanitizeDraftText = require('sanitizeDraftText');
 
 test('must strip trailing carriage returns', () => {

--- a/src/model/entity/__tests__/DraftEntity-test.js
+++ b/src/model/entity/__tests__/DraftEntity-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 const DraftEntity = require('DraftEntity');
 
 beforeEach(() => {

--- a/src/model/entity/__tests__/getEntityKeyForSelection-test.js
+++ b/src/model/entity/__tests__/getEntityKeyForSelection-test.js
@@ -9,8 +9,6 @@
  * @format
  */
 
-jest.disableAutomock();
-
 const getEntityKeyForSelection = require('getEntityKeyForSelection');
 const getSampleStateForTesting = require('getSampleStateForTesting');
 

--- a/src/model/immutable/__tests__/BlockTree-test.js
+++ b/src/model/immutable/__tests__/BlockTree-test.js
@@ -10,8 +10,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 const BlockTree = require('BlockTree');
 const CharacterMetadata = require('CharacterMetadata');
 const ContentBlock = require('ContentBlock');

--- a/src/model/immutable/__tests__/CharacterMetadata-test.js
+++ b/src/model/immutable/__tests__/CharacterMetadata-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 const CharacterMetadata = require('CharacterMetadata');
 const {BOLD, BOLD_ITALIC, NONE, UNDERLINE} = require('SampleDraftInlineStyle');
 

--- a/src/model/immutable/__tests__/ContentBlock-test.js
+++ b/src/model/immutable/__tests__/ContentBlock-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 const CharacterMetadata = require('CharacterMetadata');
 const ContentBlock = require('ContentBlock');
 const {BOLD} = require('SampleDraftInlineStyle');

--- a/src/model/immutable/__tests__/ContentBlockNode-test.js
+++ b/src/model/immutable/__tests__/ContentBlockNode-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 const CharacterMetadata = require('CharacterMetadata');
 const ContentBlockNode = require('ContentBlockNode');
 const {BOLD, NONE} = require('SampleDraftInlineStyle');

--- a/src/model/immutable/__tests__/ContentState-test.js
+++ b/src/model/immutable/__tests__/ContentState-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 jest.mock('SelectionState');
 
 let contentState;

--- a/src/model/immutable/__tests__/EditorBidiService-test.js
+++ b/src/model/immutable/__tests__/EditorBidiService-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 const ContentBlock = require('ContentBlock');
 const ContentState = require('ContentState');
 const EditorBidiService = require('EditorBidiService');

--- a/src/model/immutable/__tests__/EditorState-test.js
+++ b/src/model/immutable/__tests__/EditorState-test.js
@@ -10,8 +10,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 const CharacterMetadata = require('CharacterMetadata');
 const ContentBlock = require('ContentBlock');
 const ContentState = require('ContentState');

--- a/src/model/immutable/__tests__/SelectionState-test.js
+++ b/src/model/immutable/__tests__/SelectionState-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 const SelectionState = require('SelectionState');
 
 const DEFAULT_CONFIG = {

--- a/src/model/immutable/__tests__/findRangesImmutable-test.js
+++ b/src/model/immutable/__tests__/findRangesImmutable-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 const findRangesImmutable = require('findRangesImmutable');
 const Immutable = require('immutable');
 

--- a/src/model/modifier/__tests__/AtomicBlockUtils-test.js
+++ b/src/model/modifier/__tests__/AtomicBlockUtils-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 jest.mock('generateRandomKey');
 
 const AtomicBlockUtils = require('AtomicBlockUtils');

--- a/src/model/modifier/__tests__/DraftRemovableWord-test.js
+++ b/src/model/modifier/__tests__/DraftRemovableWord-test.js
@@ -11,7 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
 expect.addSnapshotSerializer(require('NonASCIIStringSnapshotSerializer'));
 
 const DraftRemovableWord = require('DraftRemovableWord');

--- a/src/model/modifier/__tests__/RichTextEditorUtil-test.js
+++ b/src/model/modifier/__tests__/RichTextEditorUtil-test.js
@@ -8,8 +8,6 @@
  * @format
  */
 
-jest.disableAutomock();
-
 const AtomicBlockUtils = require('AtomicBlockUtils');
 const DraftModifier = require('DraftModifier');
 const EditorState = require('EditorState');

--- a/src/model/modifier/exploration/__tests__/DraftTreeOperations-test.js
+++ b/src/model/modifier/exploration/__tests__/DraftTreeOperations-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 jest.mock('generateRandomKey');
 
 const ContentBlockNode = require('ContentBlockNode');

--- a/src/model/modifier/exploration/__tests__/NestedRichTextEditorUtil-test.js
+++ b/src/model/modifier/exploration/__tests__/NestedRichTextEditorUtil-test.js
@@ -8,8 +8,6 @@
  * @format
  */
 
-jest.disableAutomock();
-
 jest.mock('generateRandomKey');
 
 const AtomicBlockUtils = require('AtomicBlockUtils');

--- a/src/model/paste/__tests__/DraftPasteProcessor-test.js
+++ b/src/model/paste/__tests__/DraftPasteProcessor-test.js
@@ -10,8 +10,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 jest.mock('generateRandomKey');
 
 const DraftPasteProcessor = require('DraftPasteProcessor');

--- a/src/model/transaction/__tests__/ContentStateInlineStyle-test.js
+++ b/src/model/transaction/__tests__/ContentStateInlineStyle-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 const ContentStateInlineStyle = require('ContentStateInlineStyle');
 
 const getSampleStateForTesting = require('getSampleStateForTesting');

--- a/src/model/transaction/__tests__/applyEntityToContentBlock-test.js
+++ b/src/model/transaction/__tests__/applyEntityToContentBlock-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 const ContentBlock = require('ContentBlock');
 
 const applyEntityToContentBlock = require('applyEntityToContentBlock');

--- a/src/model/transaction/__tests__/applyEntityToContentState-test.js
+++ b/src/model/transaction/__tests__/applyEntityToContentState-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 const SelectionState = require('SelectionState');
 
 const applyEntityToContentState = require('applyEntityToContentState');

--- a/src/model/transaction/__tests__/getContentStateFragment-test.js
+++ b/src/model/transaction/__tests__/getContentStateFragment-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 jest.mock('generateRandomKey');
 
 const ContentBlock = require('ContentBlock');

--- a/src/model/transaction/__tests__/insertFragmentIntoContentState-test.js
+++ b/src/model/transaction/__tests__/insertFragmentIntoContentState-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 jest.mock('generateRandomKey');
 
 const BlockMapBuilder = require('BlockMapBuilder');

--- a/src/model/transaction/__tests__/insertIntoList-test.js
+++ b/src/model/transaction/__tests__/insertIntoList-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 const Immutable = require('immutable');
 const insertIntoList = require('insertIntoList');
 

--- a/src/model/transaction/__tests__/insertTextIntoContentState-test.js
+++ b/src/model/transaction/__tests__/insertTextIntoContentState-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 const CharacterMetadata = require('CharacterMetadata');
 const {BOLD} = require('SampleDraftInlineStyle');
 

--- a/src/model/transaction/__tests__/moveBlockInContentState-test.js
+++ b/src/model/transaction/__tests__/moveBlockInContentState-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 jest.mock('generateRandomKey');
 
 const ContentBlock = require('ContentBlock');

--- a/src/model/transaction/__tests__/randomizeBlockMapKeys-test.js
+++ b/src/model/transaction/__tests__/randomizeBlockMapKeys-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 jest.mock('generateRandomKey');
 
 const BlockMapBuilder = require('BlockMapBuilder');

--- a/src/model/transaction/__tests__/removeEntitiesAtEdges-test.js
+++ b/src/model/transaction/__tests__/removeEntitiesAtEdges-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 const applyEntityToContentBlock = require('applyEntityToContentBlock');
 const getSampleStateForTesting = require('getSampleStateForTesting');
 const removeEntitiesAtEdges = require('removeEntitiesAtEdges');

--- a/src/model/transaction/__tests__/removeRangeFromContentState-test.js
+++ b/src/model/transaction/__tests__/removeRangeFromContentState-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 const BlockMapBuilder = require('BlockMapBuilder');
 const ContentBlockNode = require('ContentBlockNode');
 const SelectionState = require('SelectionState');

--- a/src/model/transaction/__tests__/splitBlockInContentState-test.js
+++ b/src/model/transaction/__tests__/splitBlockInContentState-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 jest.mock('generateRandomKey');
 
 const BlockMapBuilder = require('BlockMapBuilder');

--- a/src/model/transaction/exploration/__tests__/getNextDelimiterBlockKey-test.js
+++ b/src/model/transaction/exploration/__tests__/getNextDelimiterBlockKey-test.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-jest.disableAutomock();
-
 jest.mock('generateRandomKey');
 
 const ContentBlock = require('ContentBlock');


### PR DESCRIPTION
**Summary**

Saw that the Travis CI is failing because of a new test (`isHTMLBRElement`) which did not explicitly disable auto mocking. In Sandcastle, Jest tests aren't automocked hence the tests passed internally but is failing on GitHub.

Since all the tests in the repo have `jest.disableAutomock()`, there's no value in having `automock: true` within `package.json`, we can remove it and save ourselves of this config discrepancy and further pain in future.

If we decide to go with this approach then #2278 can be abandoned/closed.

**Test Plan**

Travis CI should pass. Also check that Sandcastle passes.
