### PR TITLE
Fix docs links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ with [immutable-js](https://facebook.github.io/immutable-js/), offering
 an API with functional state updates and aggressively leveraging data persistence
 for scalable memory usage.
 
-[Learn how to use Draft.js in your own project.](https://draftjs.org/docs/getting-started.html)
+[Learn how to use Draft.js in your own project.](https://draftjs.org/docs/getting-started/)
 
 ## API Notice
 
@@ -164,11 +164,11 @@ comment inputs, [Notes](https://www.facebook.com/notes/), and
 | --------- | --------- | --------- | --------- | --------- | --------- |
 | IE11, Edge [1, 2]| last 2 versions| last 2 versions| last 2 versions| not fully supported [3] | not fully supported [3]
 
-[1] May need a shim or a polyfill for some syntax used in Draft.js ([docs](https://draftjs.org/docs/advanced-topics-issues-and-pitfalls.html#polyfills)).
+[1] May need a shim or a polyfill for some syntax used in Draft.js ([docs](https://draftjs.org/docs/advanced-topics-issues-and-pitfalls/#polyfills)).
 
-[2] IME inputs have known issues in these browsers, especially Korean ([docs](https://draftjs.org/docs/advanced-topics-issues-and-pitfalls.html#ime-and-internet-explorer)).
+[2] IME inputs have known issues in these browsers, especially Korean ([docs](https://draftjs.org/docs/advanced-topics-issues-and-pitfalls/#ime-and-internet-explorer)).
 
-[3] There are known issues with mobile browsers, especially on Android ([docs](https://draftjs.org/docs/advanced-topics-issues-and-pitfalls.html#mobile-not-yet-supported)).
+[3] There are known issues with mobile browsers, especially on Android ([docs](https://draftjs.org/docs/advanced-topics-issues-and-pitfalls/#mobile-not-yet-supported)).
 
 ## Resources and Ecosystem
 


### PR DESCRIPTION
**Summary**

Fixes the links in the readme pointing to the docs. The links ended in `.html` which resulted in a 404 page, this may have been a regression from the recent docusaurus update.
