### PR TITLE
Fix DOMObserver mutation data for IE

### DIFF
--- a/src/component/handlers/composition/DOMObserver.js
+++ b/src/component/handlers/composition/DOMObserver.js
@@ -110,6 +110,12 @@ class DOMObserver {
       // These events are also followed by a `childList`, which is the one
       // we are able to retrieve the offsetKey and apply the '' text.
       if (target.textContent !== '') {
+        // IE 11 considers the enter keypress that concludes the composition
+        // as an input char. This strips that newline character so the draft
+        // state does not receive spurious newlines.
+        if (USE_CHAR_DATA) {
+          return target.textContent.replace('\n', '');
+        }
         return target.textContent;
       }
     } else if (type === 'childList') {


### PR DESCRIPTION
Summary: IE 11 considers the enter keypress that concludes the composition as an input char, which ends up adding a new line to the editor. I am adding code to strip that newline character when processing the mutation event.

Differential Revision: D19141003

Before the fix (notice the \n character, it gets added to the editor):
![image](https://user-images.githubusercontent.com/1840530/71003900-440e4780-20d9-11ea-9e6a-257545fd0f05.png)

After the fix:
![image](https://user-images.githubusercontent.com/1840530/71004397-ceef4200-20d9-11ea-9197-1a42ef96295c.png)
