### PR TITLE
Add rules to .flowconfig for flow strict rules

### DIFF
--- a/src/.flowconfig
+++ b/src/.flowconfig
@@ -37,5 +37,17 @@ suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(2[0-8]\\|1[
 suppress_comment=\\(.\\|\n\\)*\\$FlowExpectedError
 module.name_mapper='ReactDOM' -> 'react-dom'
 
+[strict]
+deprecated-type
+sketchy-null
+unclear-type
+unsafe-getters-setters
+; Can't enable these- immutable.js raises errors
+; untyped-import
+; untyped-type-import
+; Can't enable this one- getTextContentFromFiles requires invariant.
+; The publicly-available fbjs version of invariant isn't flow strict.
+; nonstrict-import
+
 [version]
 ^0.110.1


### PR DESCRIPTION
Internally at facebook, we use `@flow strict` to define certain rules that make our codebase more reliable. I just noticed the .flowconfig for this repo doesn't include rules for `@flow strict`. We do have files in the repo annotated with strict flow, so lets configure it to get the benefits.

Unfortunatley, there's 3 rules we have enabled internally which we can't use in the repo as it exists today. I put the necessary info as a comment on the .flowconfig itself.

npm run flow -> no errors.
