### PR TITLE
chore(travis): bumps node versions used in Travis CI to 10 and 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 
 node_js:
-- 8
 - 10
+- 12
 
 sudo: false
 

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "webpack-stream": "^4.0.0"
   },
   "devEngines": {
-    "node": "8.x || 9.x || 10.x",
+    "node": "10.x || 12.x || 13.x",
     "npm": "2.x || 3.x || 5.x || 6.x"
   },
   "jest": {


### PR DESCRIPTION
**Summary**

As of January 2020, Node 8 is past Active LTS end of life. This PR removes Node 8 from the Travis CI environment config and replaces it with Node 12.

https://nodejs.org/en/about/releases/

This PR also updates supported Node versions in `package.json` to 10, 12 and 13.

**Test Plan**

Tested locally building all targets on Node 12 with [nvm](http://nvm.sh/)
```
nvm use 12
yarn
```