### PR TITLE
Remove usage of String.prototype.endsWith API as it's unavailable in …

### DIFF
--- a/src/component/contents/DraftEditorLeaf.react.js
+++ b/src/component/contents/DraftEditorLeaf.react.js
@@ -139,7 +139,7 @@ class DraftEditorLeaf extends React.Component<Props> {
     // an extra line feed character. Browsers collapse trailing newline
     // characters, which leaves the cursor in the wrong place after a
     // shift+enter. The extra character repairs this.
-    if (text.endsWith('\n') && this.props.isLast) {
+    if (text[text.lengths - 1] === '\n' && this.props.isLast) {
       text += '\n';
     }
 

--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -115,7 +115,8 @@ function editOnInput(editor: DraftEditor, e: SyntheticInputEvent<>): void {
   // we will have manually inserted an extra soft newline in DraftEditorLeaf.
   // We want to remove this extra newline for the purpose of our comparison
   // of DOM and model text.
-  if (domText.endsWith(DOUBLE_NEWLINE)) {
+  const lastSymbols = domText.slice(domText.length - DOUBLE_NEWLINE.length);
+  if (lastSymbols === DOUBLE_NEWLINE) {
     domText = domText.slice(0, -1);
   }
 


### PR DESCRIPTION
Remove usage of String.prototype.endsWith API as it's unavailable in **IE 11** :sob:
https://caniuse.com/#search=endsWith

Mostly positive, that you won't merge that ))
As you mentioned before that you don't support old browsers, but there is always hope ))
I had to try ))

Thanks for your library and have a nice day 😄 