### PR TITLE
Move editor content inline style

### DIFF
--- a/src/component/base/DraftEditor.css
+++ b/src/component/base/DraftEditor.css
@@ -15,6 +15,12 @@
 .public/DraftEditor/content {
   height: inherit;
   text-align: initial;
+  outline: 'none';
+  /* fix parent-draggable Safari bug. #1326 */
+  user-select: text;
+  -webkit-user-select: text;
+  white-space: pre-wrap;
+  word-wrap:break-word;
 }
 
 .public/DraftEditor/content[contenteditable="true"] {
@@ -48,6 +54,10 @@
 .DraftEditor/alignLeft .public/DraftEditorPlaceholder/root {
   left: 0;
   text-align: left;
+}
+
+.public/DraftEditorPlaceholder/inner {
+  white-space: pre-wrap;
 }
 
 .DraftEditor/alignCenter .public/DraftStyleDefault/block {

--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -336,15 +336,6 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
       'DraftEditor/alignCenter': textAlignment === 'center',
     });
 
-    const contentStyle = {
-      outline: 'none',
-      // fix parent-draggable Safari bug. #1326
-      userSelect: 'text',
-      WebkitUserSelect: 'text',
-      whiteSpace: 'pre-wrap',
-      wordWrap: 'break-word',
-    };
-
     // The aria-expanded and aria-haspopup properties should only be rendered
     // for a combobox.
     /* $FlowFixMe(>=0.68.0 site=www,mobile) This comment suppresses an error
@@ -426,7 +417,6 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
             ref={this.props.editorRef}
             role={readOnly ? null : ariaRole}
             spellCheck={allowSpellCheck && this.props.spellCheck}
-            style={contentStyle}
             suppressContentEditableWarning
             tabIndex={this.props.tabIndex}>
             {/*

--- a/src/component/base/DraftEditorPlaceholder.react.js
+++ b/src/component/base/DraftEditorPlaceholder.react.js
@@ -48,16 +48,11 @@ class DraftEditorPlaceholder extends React.Component<Props> {
       'public/DraftEditorPlaceholder/hasFocus': hasFocus,
     });
 
-    const contentStyle = {
-      whiteSpace: 'pre-wrap',
-    };
-
     return (
       <div className={className}>
         <div
           className={cx('public/DraftEditorPlaceholder/inner')}
-          id={this.props.accessibilityID}
-          style={contentStyle}>
+          id={this.props.accessibilityID}>
           {this.props.text}
         </div>
       </div>


### PR DESCRIPTION
**Summary**

Moved some inline styles where the same can be accomplished in the CSS stylesheets so that Content Security Policy reports less `unsafe-inline` issues for `style-src`.

Note inline styles are still used in `draft-js/src/component/contents/DraftEditorLeaf.react.js` so this will still report CSP errors.

**Test Plan**

No functional changes & unit tests pass as a regression check.
