### PR TITLE
Ctrl + Backspace removes extra words from URLs

### DIFF
--- a/src/model/modifier/DraftRemovableWord.js
+++ b/src/model/modifier/DraftRemovableWord.js
@@ -37,7 +37,7 @@ const CHAMELEON_CHARS = "['\u2018\u2019]";
 // "chameleon chars" also count as punctuation in this regex.
 const WHITESPACE_AND_PUNCTUATION = '\\s|(?![_])' + punctuation;
 
-var DELETE_STRING =
+const DELETE_STRING =
   '^(?:(?:' +
   WHITESPACE_AND_PUNCTUATION +
   '))|' +
@@ -53,9 +53,9 @@ var DELETE_STRING =
   '(?:(?!' +
   WHITESPACE_AND_PUNCTUATION +
   ').)';
-var DELETE_REGEX = new RegExp(DELETE_STRING);
+const DELETE_REGEX = new RegExp(DELETE_STRING);
 
-var BACKSPACE_STRING =
+const BACKSPACE_STRING =
   '(?:(?!' +
   WHITESPACE_AND_PUNCTUATION +
   ').)' +

--- a/src/model/modifier/DraftRemovableWord.js
+++ b/src/model/modifier/DraftRemovableWord.js
@@ -13,7 +13,19 @@
 
 const TokenizeUtil = require('TokenizeUtil');
 
-const punctuation = TokenizeUtil.getPunctuation();
+let punctuation = TokenizeUtil.getPunctuation();
+
+// punctuation is enhanced with '&' . Currently the punctuations are being used
+// to act as word separator. Since '&' is not a valid English punctuation it
+// is not being returned as part of the punctuation string, hence presence of &
+// in between two words is considered as part of the string.
+// For example if the string is 'value0&field1=value1&field2'
+// Backspace regex will consider 'value1&field2' as the last word of the string
+// Delete regex will consider 'value0&field1' as the first word of the string
+
+if (punctuation.indexOf('&') < 0) {
+  punctuation = [punctuation.slice(0, 1), '&', punctuation.slice(1)].join('');
+}
 
 // The apostrophe and curly single quotes behave in a curious way: when
 // surrounded on both sides by word characters, they behave as word chars; when
@@ -25,7 +37,10 @@ const CHAMELEON_CHARS = "['\u2018\u2019]";
 // "chameleon chars" also count as punctuation in this regex.
 const WHITESPACE_AND_PUNCTUATION = '\\s|(?![_])' + punctuation;
 
-const DELETE_STRING =
+var DELETE_STRING =
+  '^(?:(?:' +
+  WHITESPACE_AND_PUNCTUATION +
+  '))|' +
   '^' +
   '(?:' +
   WHITESPACE_AND_PUNCTUATION +
@@ -38,9 +53,9 @@ const DELETE_STRING =
   '(?:(?!' +
   WHITESPACE_AND_PUNCTUATION +
   ').)';
-const DELETE_REGEX = new RegExp(DELETE_STRING);
+var DELETE_REGEX = new RegExp(DELETE_STRING);
 
-const BACKSPACE_STRING =
+var BACKSPACE_STRING =
   '(?:(?!' +
   WHITESPACE_AND_PUNCTUATION +
   ').)' +
@@ -49,10 +64,12 @@ const BACKSPACE_STRING =
   '|(?!' +
   WHITESPACE_AND_PUNCTUATION +
   ').)*' +
-  '(?:' +
+  '(?!' +
   WHITESPACE_AND_PUNCTUATION +
   ')*' +
-  '$';
+  '$|(?:(?:' +
+  WHITESPACE_AND_PUNCTUATION +
+  ')$)';
 const BACKSPACE_REGEX = new RegExp(BACKSPACE_STRING);
 
 function getRemovableWord(text: string, isBackward: boolean): string {

--- a/src/model/modifier/__tests__/DraftRemovableWork-NonSnapshot-test.js
+++ b/src/model/modifier/__tests__/DraftRemovableWork-NonSnapshot-test.js
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+ui_infra
+ * @format
+ */
+
+'use strict';
+
+jest.disableAutomock();
+
+const DraftRemovableWord = require('DraftRemovableWord');
+
+let forward;
+let backward;
+
+const accents = 'th\u00e9 f\u00e0bregas';
+const arabic = '\u0637\u0638\u0639 \u063A\u063B\u063C';
+const cyrillic = '\u0430\u0448\u043e\u043a \u0431\u0414\u0416\u0426';
+const english = 'the animals';
+const halfWidthHangul = '\uffa3\uffa6\uffb0 \uffa1\uffa2\uffb2';
+const japanese = '\u4f1a\u8b70\u4e2d \u30cf\u30c3\u30b7\u30e5';
+const korean = '\ud2b8\uc704\ud130 \ud2b8\uc704\ud130';
+const withNumbers = 'f14 tomcat';
+
+beforeEach(() => {
+  jest.resetModules();
+  forward = DraftRemovableWord.getForward;
+  backward = DraftRemovableWord.getBackward;
+});
+
+test('must identify words looking forward - non snapshot - non snapshot', () => {
+  expect(forward(english)).toEqual('the');
+  expect(forward(accents)).toEqual('th\u00e9');
+  expect(forward(arabic)).toEqual('\u0637\u0638\u0639');
+  expect(forward(japanese)).toEqual('\u4f1a\u8b70\u4e2d');
+  expect(forward(korean)).toEqual('\ud2b8\uc704\ud130');
+  expect(forward(halfWidthHangul)).toEqual('\uffa3\uffa6\uffb0');
+  expect(forward(cyrillic)).toEqual('\u0430\u0448\u043e\u043a');
+  expect(forward(withNumbers)).toEqual('f14');
+});
+
+test('must identify words with apostrophes looking forward - non snapshot', () => {
+  expect(forward("you're correct.")).toEqual("you're");
+});
+
+test('must identify words with curly quotes looking forward - non snapshot', () => {
+  expect(forward('you\u2019re correct.')).toEqual('you\u2019re');
+});
+
+test('must identify punctuation with apostrophes - non snapshot', () => {
+  expect(forward("'hello'")).toEqual("'");
+  expect(backward("'hello'")).toEqual("hello'");
+  expect(forward('\u2018hello\u2019')).toEqual('\u2018');
+  expect(backward('\u2018hello\u2019')).toEqual('hello\u2019');
+
+  expect(forward("('hello')")).toEqual('(');
+  expect(backward("('hello')")).toEqual(')');
+  expect(forward(".'.")).toEqual('.');
+  expect(backward(".'.")).toEqual('.');
+});
+
+test('must identify words with underscores - non snapshot', () => {
+  expect(forward('under_score hey')).toEqual('under_score');
+  expect(backward('hey under_score')).toEqual('under_score');
+});
+
+test('must identify words led by spaces looking forward - non snapshot', () => {
+  expect(forward('  ' + english)).toEqual(' ');
+  expect(forward('    ' + accents)).toEqual(' ');
+  expect(forward('      ' + arabic)).toEqual(' ');
+});
+
+test('must identify words led by punctuation looking forward - non snapshot', () => {
+  expect(forward('.' + english)).toEqual('.');
+  expect(forward('|' + english)).toEqual('|');
+  expect(forward('^' + english)).toEqual('^');
+  expect(forward('\u060d\uFD3e\uFD3F' + english)).toEqual('\u060d');
+  expect(forward('.. .. ..' + english)).toEqual('.');
+});
+
+test('must identify punct/whitespace strings looking forward - non snapshot', () => {
+  expect(forward('    ')).toEqual(' ');
+  expect(forward('\u060d\uFD3e\uFD3F')).toEqual('\u060d');
+  expect(forward('. . . . .')).toEqual('.');
+  expect(forward('   !!!???   ')).toEqual(' ');
+});
+
+test('must identify words looking backward - non snapshot', () => {
+  expect(backward(english)).toEqual('animals');
+  expect(backward(accents)).toEqual('f\u00e0bregas');
+  expect(backward(arabic)).toEqual('\u063A\u063B\u063C');
+  expect(backward(japanese)).toEqual('\u30cf\u30c3\u30b7\u30e5');
+  expect(backward(korean)).toEqual('\ud2b8\uc704\ud130');
+  expect(backward(halfWidthHangul)).toEqual('\uffa1\uffa2\uffb2');
+  expect(backward(cyrillic)).toEqual('\u0431\u0414\u0416\u0426');
+  expect(backward(withNumbers)).toEqual('tomcat');
+});
+
+test('must identify words with apostrophes looking backward - non snapshot', () => {
+  expect(backward("you don't")).toEqual("don't");
+});
+
+test('must identify words ended by spaces looking backward - non snapshot', () => {
+  expect(backward(english + '  ')).toEqual(' ');
+  expect(backward(accents + '    ')).toEqual(' ');
+  expect(backward(arabic + '      ')).toEqual(' ');
+});
+
+test('must identify words ended by punctuation looking backward - non snapshot', () => {
+  expect(backward(english + '.')).toEqual('.');
+  expect(backward(english + '|')).toEqual('|');
+  expect(backward(english + '^')).toEqual('^');
+  expect(backward(english + '\u060d\uFD3e\uFD3F')).toEqual('\uFD3F');
+  expect(backward(english + '.. .. ..')).toEqual('.');
+});
+
+test('must identify punct/whitespace strings looking backward - non snapshot', () => {
+  expect(backward('    ')).toEqual(' ');
+  expect(backward('\u060d\uFD3e\uFD3F')).toEqual('\uFD3F');
+  expect(backward('. . . . .')).toEqual('.');
+  expect(backward('   !!!???   ')).toEqual(' ');
+});
+
+test('must identify nothing in an empty string - non snapshot', () => {
+  expect(forward('')).toEqual('');
+  expect(backward('')).toEqual('');
+});
+
+test('must identify key value param of the url - non snapshot', () => {
+  expect(forward('field1=value1')).toEqual('field1');
+  expect(backward('field1=value1')).toEqual('value1');
+  expect(forward('&field1=value1')).toEqual('&');
+  expect(backward('field1=value1&')).toEqual('&');
+  expect(forward('=value1&')).toEqual('=');
+  expect(backward('&field1=')).toEqual('=');
+});

--- a/src/model/modifier/__tests__/__snapshots__/DraftRemovableWord-test.js.snap
+++ b/src/model/modifier/__tests__/__snapshots__/DraftRemovableWord-test.js.snap
@@ -4,69 +4,69 @@ exports[`must identify nothing in an empty string 1`] = `""`;
 
 exports[`must identify nothing in an empty string 2`] = `""`;
 
-exports[`must identify punct/whitespace strings looking backward 1`] = `"    "`;
+exports[`must identify punct/whitespace strings looking backward 1`] = `" "`;
 
-exports[`must identify punct/whitespace strings looking backward 2`] = `"\\u060d\\ufd3e\\ufd3f"`;
+exports[`must identify punct/whitespace strings looking backward 2`] = `"\\ufd3f"`;
 
-exports[`must identify punct/whitespace strings looking backward 3`] = `". . . . ."`;
+exports[`must identify punct/whitespace strings looking backward 3`] = `"."`;
 
-exports[`must identify punct/whitespace strings looking backward 4`] = `"   !!!???   "`;
+exports[`must identify punct/whitespace strings looking backward 4`] = `" "`;
 
-exports[`must identify punct/whitespace strings looking forward 1`] = `"    "`;
+exports[`must identify punct/whitespace strings looking forward 1`] = `" "`;
 
-exports[`must identify punct/whitespace strings looking forward 2`] = `"\\u060d\\ufd3e\\ufd3f"`;
+exports[`must identify punct/whitespace strings looking forward 2`] = `"\\u060d"`;
 
-exports[`must identify punct/whitespace strings looking forward 3`] = `". . . . ."`;
+exports[`must identify punct/whitespace strings looking forward 3`] = `"."`;
 
-exports[`must identify punct/whitespace strings looking forward 4`] = `"   !!!???   "`;
+exports[`must identify punct/whitespace strings looking forward 4`] = `" "`;
 
-exports[`must identify punctuation with apostrophes 1`] = `"'hello"`;
+exports[`must identify punctuation with apostrophes 1`] = `"'"`;
 
 exports[`must identify punctuation with apostrophes 2`] = `"hello'"`;
 
-exports[`must identify punctuation with apostrophes 3`] = `"\\u2018hello"`;
+exports[`must identify punctuation with apostrophes 3`] = `"\\u2018"`;
 
 exports[`must identify punctuation with apostrophes 4`] = `"hello\\u2019"`;
 
-exports[`must identify punctuation with apostrophes 5`] = `"('hello"`;
+exports[`must identify punctuation with apostrophes 5`] = `"("`;
 
-exports[`must identify punctuation with apostrophes 6`] = `"hello')"`;
+exports[`must identify punctuation with apostrophes 6`] = `")"`;
 
-exports[`must identify punctuation with apostrophes 7`] = `".'."`;
+exports[`must identify punctuation with apostrophes 7`] = `"."`;
 
-exports[`must identify punctuation with apostrophes 8`] = `".'."`;
+exports[`must identify punctuation with apostrophes 8`] = `"."`;
 
-exports[`must identify words ended by punctuation looking backward 1`] = `"animals."`;
+exports[`must identify words ended by punctuation looking backward 1`] = `"."`;
 
-exports[`must identify words ended by punctuation looking backward 2`] = `"animals|"`;
+exports[`must identify words ended by punctuation looking backward 2`] = `"|"`;
 
-exports[`must identify words ended by punctuation looking backward 3`] = `"animals^"`;
+exports[`must identify words ended by punctuation looking backward 3`] = `"^"`;
 
-exports[`must identify words ended by punctuation looking backward 4`] = `"animals\\u060d\\ufd3e\\ufd3f"`;
+exports[`must identify words ended by punctuation looking backward 4`] = `"\\ufd3f"`;
 
-exports[`must identify words ended by punctuation looking backward 5`] = `"animals.. .. .."`;
+exports[`must identify words ended by punctuation looking backward 5`] = `"."`;
 
-exports[`must identify words ended by spaces looking backward 1`] = `"animals  "`;
+exports[`must identify words ended by spaces looking backward 1`] = `" "`;
 
-exports[`must identify words ended by spaces looking backward 2`] = `"f\\u00e0bregas    "`;
+exports[`must identify words ended by spaces looking backward 2`] = `" "`;
 
-exports[`must identify words ended by spaces looking backward 3`] = `"\\u063a\\u063b\\u063c      "`;
+exports[`must identify words ended by spaces looking backward 3`] = `" "`;
 
-exports[`must identify words led by punctuation looking forward 1`] = `".the"`;
+exports[`must identify words led by punctuation looking forward 1`] = `"."`;
 
-exports[`must identify words led by punctuation looking forward 2`] = `"|the"`;
+exports[`must identify words led by punctuation looking forward 2`] = `"|"`;
 
-exports[`must identify words led by punctuation looking forward 3`] = `"^the"`;
+exports[`must identify words led by punctuation looking forward 3`] = `"^"`;
 
-exports[`must identify words led by punctuation looking forward 4`] = `"\\u060d\\ufd3e\\ufd3fthe"`;
+exports[`must identify words led by punctuation looking forward 4`] = `"\\u060d"`;
 
-exports[`must identify words led by punctuation looking forward 5`] = `".. .. ..the"`;
+exports[`must identify words led by punctuation looking forward 5`] = `"."`;
 
-exports[`must identify words led by spaces looking forward 1`] = `"  the"`;
+exports[`must identify words led by spaces looking forward 1`] = `" "`;
 
-exports[`must identify words led by spaces looking forward 2`] = `"    th\\u00e9"`;
+exports[`must identify words led by spaces looking forward 2`] = `" "`;
 
-exports[`must identify words led by spaces looking forward 3`] = `"      \\u0637\\u0638\\u0639"`;
+exports[`must identify words led by spaces looking forward 3`] = `" "`;
 
 exports[`must identify words looking backward 1`] = `"animals"`;
 


### PR DESCRIPTION
**Summary**

The function getRemovableWord present in here returns a removable word based on the backspace regex or delete regex depending upon the keyboard shortcut applied. To calculate either of the regex (for example backspace regex), it creates the regex from the backspace string variable which again comprises few punctuations and whitespaces along with some regex constructs. The TokenizeUtil.getPunctuation returns a string that comprises of valid punctuations present in English and other Foreign language dictionaries. 

This punctuation string does not contain '&' as it is not part of the punctuation group. Moreover, the backspace regex that is formed considers '&' as part of the word, because of which string like 'value1&field2' is considered a single word. Due to this assumption when we try to perform Ctrl + Backspace (Option + Del in Mac), the whole word gets deleted instead of just deleting 'field2'.

The details regarding current regex and modified regex along with corresponding code change are mentioned below.

Current Backspace Regex:

(?:(?!\s|(?![_])[.,+*?$|#{}()'\^\-\[\]\\\/!@%"~=<>_:;・、。〈-】〔-〟：-？！-／［-｀｛-･⸮؟٪-٬؛،؍﴾﴿᠁।၊။‐-‧‰-⁞¡-±´-¸º»¿]).)(?:['‘’]|(?!\s|(?![_])[.,+*?$|#{}()'\^\-\[\]\\\/!@%"~=<>_:;・、。〈-】〔-〟：-？！-／［-｀｛-･⸮؟٪-٬؛،؍﴾﴿᠁।၊။‐-‧‰-⁞¡-±´-¸º»¿]).)*(?:\s|(?![_])[.,+*?$|#{}()'\^\-\[\]\\\/!@%"~=<>_:;・、。〈-】〔-〟：-？！-／［-｀｛-･⸮؟٪-٬؛،؍﴾﴿᠁।၊။‐-‧‰-⁞¡-±´-¸º»¿])*$

Modified Backspace Regex: 

(?:(?!\s|(?![_])[&.,+*?$|#{}()'\^\-\[\]\\\/!@%"~=<>_:;・、。〈-】〔-〟：-？！-／［-｀｛-･⸮؟٪-٬؛،؍﴾﴿᠁।၊။‐-‧‰-⁞¡-±´-¸º»¿]).)(?:['‘’]|(?!\s|(?![_])[&.,+*?$|#{}()'\^\-\[\]\\\/!@%"~=<>_:;・、。〈-】〔-〟：-？！-／［-｀｛-･⸮؟٪-٬؛،؍﴾﴿᠁।၊။‐-‧‰-⁞¡-±´-¸º»¿]).)*(?!\s|(?![_])[&.,+*?$|#{}()'\^\-\[\]\\\/!@%"~=<>_:;・、。〈-】〔-〟：-？！-／［-｀｛-･⸮؟٪-٬؛،؍﴾﴿᠁।၊။‐-‧‰-⁞¡-±´-¸º»¿])*$|(?:(?:\s|(?![_])[&.,+*?$|#{}()'\^\-\[\]\\\/!@%"~=<>_:;・、。〈-】〔-〟：-？！-／［-｀｛-･⸮؟٪-٬؛،؍﴾﴿᠁।၊။‐-‧‰-⁞¡-±´-¸º»¿])$)



Currently, the value of punctuation variable as returned by get punctuation function is given below.

const punctuation =  '[.,+*?$|#{}()\'\\^\\-\\[\\]\\\\\\/!@%"~=<>_:;' + "\u30FB\u3001\u3002\u3008-\u3011\u3014-\u301F\uFF1A-\uFF1F\uFF01-\uFF0F" + "\uFF3B-\uFF40\uFF5B-\uFF65\u2E2E\u061F\u066A-\u066C\u061B\u060C\u060D" + "\uFD3E\uFD3F\u1801\u0964\u104A\u104B\u2010-\u2027\u2030-\u205E" + "\xA1-\xB1\xB4-\xB8\xBA\xBB\xBF]";

The punctuation variable needs to be enhanced by adding '&' as part of it. 

Modified punctuation variable should be

const punctuation =  '[&.,+*?$|#{}()\'\\^\\-\\[\\]\\\\\\/!@%"~=<>_:;' + "\u30FB\u3001\u3002\u3008-\u3011\u3014-\u301F\uFF1A-\uFF1F\uFF01-\uFF0F" + "\uFF3B-\uFF40\uFF5B-\uFF65\u2E2E\u061F\u066A-\u066C\u061B\u060C\u060D" + "\uFD3E\uFD3F\u1801\u0964\u104A\u104B\u2010-\u2027\u2030-\u205E" + "\xA1-\xB1\xB4-\xB8\xBA\xBB\xBF]";




**Test Plan**

Automated test cases added to the library
