### PR TITLE
Fix examples by building non-minified version of draft again

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -68,12 +68,7 @@ var COPYRIGHT_HEADER = `/**
  */
 `;
 
-var wpStream = null;
-
 var buildDist = function(opts) {
-  if (wpStream !== null) {
-    return wpStream;
-  }
   var webpackOpts = {
     externals: {
       immutable: {
@@ -117,7 +112,7 @@ var buildDist = function(opts) {
   if (!opts.debug) {
     webpackOpts.plugins.push(new UglifyJsPlugin());
   }
-  wpStream = webpackStream(webpackOpts, null, function(err, stats) {
+  const wpStream = webpackStream(webpackOpts, null, function(err, stats) {
     if (err) {
       throw new gulpUtil.PluginError('webpack', err);
     }


### PR DESCRIPTION
## Summary

When upgrading webpack a while back, we inadvertently broke the examples in the repo. This happened because by re-using our webpack stream, we only built the minified artifact (`Draft.min.js`) and not the non-minified one (`Draft.js`). The examples use the non-minified one.

This change doesn't cache the stream, so now there's one per artifact.

## Test plan

`yarn`, open examples, they work again.