### PR TITLE
Fix flow by allowing optional chaining

### DIFF
--- a/src/.flowconfig
+++ b/src/.flowconfig
@@ -32,6 +32,7 @@ module.system.haste.paths.blacklist=.*/fbjs/node_modules/.*
 module.system.haste.paths.blacklist=.*/node_modules/invariant/.*
 
 esproposal.class_static_fields=enable
+esproposal.optional_chaining=enable
 suppress_type=$FlowIssue
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(2[0-8]\\|1[0-9]\\|[0-9]\\).[0-9]\\)? *\\).*\n
 suppress_comment=\\(.\\|\n\\)*\\$FlowExpectedError


### PR DESCRIPTION
**Summary**

Turns out the optional chaining PR (#2330) also broke flow. We should run a flow check automatically before we build, not just strip the types.

**Test Plan**

`flow .`