### PR TITLE
Update draft.js on website to v0.11.5

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -9,7 +9,7 @@
     "@docusaurus/core": "^2.0.0-alpha.36",
     "@docusaurus/preset-classic": "^2.0.0-alpha.36",
     "classnames": "^2.2.6",
-    "draft-js": "^0.11.4",
+    "draft-js": "0.11.5",
     "react": "^16.10.2",
     "react-dom": "^16.10.2"
   },

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -3096,10 +3096,10 @@ dot-prop@^4.1.1:
   dependencies:
     is-obj "^1.0.0"
 
-draft-js@^0.11.4:
-  version "0.11.4"
-  resolved "https://registry.yarnpkg.com/draft-js/-/draft-js-0.11.4.tgz#e48782b96b90a5c14f2cb34c164c2a1a359d8a48"
-  integrity sha512-BLZ59s0vkDj/zI8UPo9Nit/hPsl11ztDejxDCQlVbvEXJSWrTXqO6ZYgdw3hXLtuojq/URqq3wTrpnb3dvzvLA==
+draft-js@0.11.5:
+  version "0.11.5"
+  resolved "https://registry.yarnpkg.com/draft-js/-/draft-js-0.11.5.tgz#b5dd30c30c9316801ab9766d45a8f88b1cd43b2c"
+  integrity sha512-RlHcoDtblwCD6Bw2ay3D0dTLA6lH8862OcdJrHGnYrY5JjlitzSzGvGQwqqumVvbGUNDSZLD3FyNpSs4z5WIUg==
   dependencies:
     fbjs "^1.0.0"
     immutable "~3.7.4"


### PR DESCRIPTION
Draft.js v0.11.5 was released yesterday! 🎉 Let's update the website to use the new version.

## Test Plan

Ran the site. Everything seems to work.