### PR TITLE
docs: Fix simple typo, sibbling -> sibling

### DIFF
--- a/src/component/contents/exploration/DraftEditorBlockNode.react.js
+++ b/src/component/contents/exploration/DraftEditorBlockNode.react.js
@@ -101,7 +101,7 @@ const applyWrapperElementToSiblings = (
 ): Array<React.Node> => {
   const wrappedSiblings = [];
 
-  // we check back until we find a sibbling that does not have same wrapper
+  // we check back until we find a sibling that does not have same wrapper
   for (const sibling: any of nodes.reverse()) {
     if (sibling.type !== Element) {
       break;

--- a/src/model/modifier/exploration/NestedRichTextEditorUtil.js
+++ b/src/model/modifier/exploration/NestedRichTextEditorUtil.js
@@ -156,7 +156,7 @@ const NestedRichTextEditorUtil: RichTextUtils = {
       }
     }
 
-    // if we have a next sibbling we should not allow the normal backspace
+    // if we have a next sibling we should not allow the normal backspace
     // behaviour of moving this text into its parent
     // if (currentBlock.getPrevSiblingKey()) {
     //  return editorState;


### PR DESCRIPTION
There is a small typo in src/component/contents/exploration/DraftEditorBlockNode.react.js, src/model/modifier/exploration/NestedRichTextEditorUtil.js.

Should read `sibling` rather than `sibbling`.

