### PR TITLE
Add keepPastedSoftLineBreaks option

### DIFF
--- a/docs/APIReference-Editor.md
+++ b/docs/APIReference-Editor.md
@@ -176,6 +176,22 @@ This should be used if your editor does not support rich styles.
 
 Default is `false`.
 
+### `keepPastedSoftLineBreaks`
+
+```js
+keepPastedSoftLineBreaks?: boolean
+```
+
+Set wether to interpret line breaks as distinct blocks or as soft line breaks.
+
+It means that if set to `true`, line breaks will not produce multiple blocks,
+but one with all the text. It will still habve line breaks, as if 
+they were inserted using the function `RichUtils.insertSoftNewline()`
+
+To take effect `stripPastedStyles` must also be set to `true`.
+
+Default is `false`.
+
 ## DOM and Accessibility (Optional)
 
 ### `tabIndex`

--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -145,6 +145,7 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
     readOnly: false,
     spellCheck: false,
     stripPastedStyles: false,
+    keepPastedSoftLineBreaks: false,
   };
 
   _blockSelectEvents: boolean;

--- a/src/component/base/DraftEditorProps.js
+++ b/src/component/base/DraftEditorProps.js
@@ -81,6 +81,8 @@ export type DraftEditorProps = {
   // use case should not have any block or inline styles, it is recommended
   // that you set this to `true`.
   stripPastedStyles: boolean,
+  // Set wether to interpret line breaks as distinct blocks or as soft line breaks
+  keepPastedSoftLineBreaks: boolean,
   tabIndex?: number,
   // exposed especially to help improve mobile web behaviors
   autoCapitalize?: string,
@@ -182,5 +184,6 @@ export type DraftEditorDefaultProps = {
   readOnly: boolean,
   spellCheck: boolean,
   stripPastedStyles: boolean,
+  keepPastedSoftLineBreaks: boolean,
   ...
 };

--- a/src/component/handlers/edit/editOnPaste.js
+++ b/src/component/handlers/edit/editOnPaste.js
@@ -106,7 +106,10 @@ function editOnPaste(editor: DraftEditor, e: SyntheticClipboardEvent<>): void {
   }
 
   if (text) {
-    textBlocks = splitTextIntoTextBlocks(text);
+    textBlocks =
+      editor.props.keepPastedSoftLineBreaks && editor.props.stripPastedStyles
+        ? Array(text)
+        : splitTextIntoTextBlocks(text);
   }
 
   if (!editor.props.stripPastedStyles) {


### PR DESCRIPTION
**Summary**

I was struggling with a problem that whatever text with line breaks I would paste would produce multiple blocks.

The same way that we are able to strip every style and also add soft line breaks instead of new blocks on return with
```
    function handleReturn(e, editorState) {
      const newEditorState = RichUtils.insertSoftNewline(editorState));
      ...
      
      return 'handled';
    }
```

Maybe there are more use cases (like mine) where the developer wants to interpret pasted line breaks as 'soft line breaks'.

For this I added a new property named `keepPastedSoftLineBreaks` (default: `false`), which if set to `true` the text will not be splitted.

I was trying to make it work alongside `stripPastedStyles=false`, but it seems that the HTML parser takes multiple divs as hard line breaks and I couldn't figure out how to stop it.