### PR TITLE
Prevent placeholder from unnecessarily wrapping

### DIFF
--- a/src/component/base/DraftEditorPlaceholder.css
+++ b/src/component/base/DraftEditorPlaceholder.css
@@ -10,6 +10,7 @@
 .public/DraftEditorPlaceholder/root {
   color: var(fig-secondary-text);
   position: absolute;
+  width: 100%;
   z-index: 1;
 }
 


### PR DESCRIPTION
In Safari, the placeholder text sometimes wraps into multiple lines before it reaches the full width of the editor.
The addition of `width: 100%;` prevents the absolutely-positioned placeholder from trying to "shrink-wrap", which causes the unnecessarily wrapping.
Steps to reproduce:
1. Open the editor with a placeholder that takes up >50% but <100% of the editor width in Safari.
2. Type a character.
3. Press backspace.

*Before* submitting a pull request, please make sure the following is done...

1. Fork the repo and create your branch from `master`.
2. If you've added code that should be tested, add tests!
3. If you've changed APIs, update the documentation.
4. Ensure that:
  * The test suite passes (`npm test`)
  * Your code lints (`npm run lint`) and passes Flow (`npm run flow`)
  * You have followed the [testing guidelines](https://github.com/facebook/draft-js/wiki/Testing-for-Pull-Requests)
5. If you haven't already, complete the [CLA](https://code.facebook.com/cla).

Please use the simple form below as a guideline for describing your pull request.

Thanks for contributing to Draft.js!

-

**Summary**

[...]

**Test Plan**

[...]
