### PR TITLE
chore(flow): Updates flow-bin to 0.123

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-react": "^7.17.0",
     "fbjs-scripts": "^1.2.0",
-    "flow-bin": "^0.115.0",
+    "flow-bin": "^0.123.0",
     "gulp": "^4.0.2",
     "gulp-babel": "^8.0.0",
     "gulp-clean-css": "^4.2.0",

--- a/src/.flowconfig
+++ b/src/.flowconfig
@@ -51,4 +51,4 @@ unsafe-getters-setters
 ; nonstrict-import
 
 [version]
-^0.115.0
+^0.123.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -3589,10 +3589,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.0.tgz#55122b6536ea496b4b44893ee2608141d10d9916"
   integrity sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==
 
-flow-bin@^0.115.0:
-  version "0.115.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.115.0.tgz#22e3ad9e5c7198967de80138ba8a9154ff387960"
-  integrity sha512-xW+U2SrBaAr0EeLvKmXAmsdnrH6x0Io17P6yRJTNgrrV42G8KXhBAD00s6oGbTTqRyHD0nP47kyuU34zljZpaQ==
+flow-bin@^0.123.0:
+  version "0.123.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.123.0.tgz#7ba61a0b8775928cf4943ccf78eed2b1b05f7b3a"
+  integrity sha512-Ylcf8YDIM/KrqtxkPuq+f8O+6sdYA2Nuz5f+sWHlp539DatZz3YMcsO1EiXaf1C11HJgpT/3YGYe7xZ9/UZmvQ==
 
 flush-write-stream@^1.0.0, flush-write-stream@^1.0.2:
   version "1.1.1"


### PR DESCRIPTION
**Summary**

Updates flow-bin to 0.123 to keep it in sync with version used in `www`

**Test Plan**

```
→ yarn && yarn flow
Using globally installed version of Yarn
yarn install v1.12.1
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
warning " > stats-webpack-plugin@0.6.2" has unmet peer dependency "webpack@>=1.0.0".
warning " > uglifyjs-webpack-plugin@2.2.0" has unmet peer dependency "webpack@^4.0.0".
[4/4] 📃  Building fresh packages...
...
$ flow src
Launching Flow server for /Users/procidac/Development/gh/claudiopro/draft-js/src
Spawned flow server (pid=73122)
Logs will go to /private/tmp/flow/zSUserszSprocidaczSDevelopmentzSghzSclaudioprozSdraft-jszSsrc.log
Monitor logs will go to /private/tmp/flow/zSUserszSprocidaczSDevelopmentzSghzSclaudioprozSdraft-jszSsrc.monitor_log
No errors!
✨  Done in 31.18s.
```