### PR TITLE
Update cadence for dependabot updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,8 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/examples/draft-0-10-0/"
+    update_schedule: "monthly"
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "weekly"


### PR DESCRIPTION
Updates to `examples` aren't really an issue, since this is code the user runs in it's computer only when checking out draft.js. This PR makes dependabot post PRs for it monthly.