### PR TITLE
Address #2413 by making Firefox follow the same behaviour as Chrome

### DIFF
--- a/src/component/handlers/edit/DraftEditorEditHandler.js
+++ b/src/component/handlers/edit/DraftEditorEditHandler.js
@@ -29,10 +29,10 @@ const onPaste = require('editOnPaste');
 const onSelect = require('editOnSelect');
 
 const isChrome = UserAgent.isBrowser('Chrome');
+const isFirefox = UserAgent.isBrowser('Firefox');
 
-const selectionHandler: (e: DraftEditor) => void = isChrome
-  ? onSelect
-  : e => {};
+const selectionHandler: (e: DraftEditor) => void =
+  isChrome || isFirefox ? onSelect : e => {};
 
 const DraftEditorEditHandler = {
   onBeforeInput,


### PR DESCRIPTION
All info is in the #2413 and this [Bugzilla issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1625475).

Noteworthy from that Bugzilla thread is [comment 16](https://bugzilla.mozilla.org/show_bug.cgi?id=1625475#c16): 

> I added a selectionchange listener to the document of Twitter, and I tried reproducing this with the STR in comment 10. Then, I confirmed that selectionchange event is fired as expected both on Firefox (Nightly) and Chrome (Release) when I click middle of the text node. So, **it might be a bug of React if the onSelect is not called as expected...**

This is worth future investigation, but for now let's just fix the bug.

EDIT: Kept reading down the thread, and [comment 21](https://bugzilla.mozilla.org/show_bug.cgi?id=1625475#c21) seems to imply this is in fact not a bug in React. Still worth investigating at some point in the future.