### PR TITLE
Update link to Record in docs

### DIFF
--- a/docs/APIReference-CharacterMetadata.md
+++ b/docs/APIReference-CharacterMetadata.md
@@ -4,8 +4,8 @@ title: CharacterMetadata
 ---
 
 `CharacterMetadata` is an Immutable
-[Record](http://facebook.github.io/immutable-js/docs/#/Record/Record) that
-represents inline style and entity information for a single character.
+[Record](https://web.archive.org/web/20150623131347/http://facebook.github.io:80/immutable-js/docs/#/Record) 
+that represents inline style and entity information for a single character.
 
 `CharacterMetadata` objects are aggressively pooled and shared. If two characters
 have the same inline style and entity, they are represented with the same

--- a/docs/APIReference-ContentBlock.md
+++ b/docs/APIReference-ContentBlock.md
@@ -4,8 +4,8 @@ title: ContentBlock
 ---
 
 `ContentBlock` is an Immutable
-[Record](http://facebook.github.io/immutable-js/docs/#/Record/Record) that
-represents the full state of a single block of editor content, including:
+[Record](https://web.archive.org/web/20150623131347/http://facebook.github.io:80/immutable-js/docs/#/Record) 
+that represents the full state of a single block of editor content, including:
 
 - Plain text contents of the block
 - Type, e.g. paragraph, header, list item

--- a/docs/APIReference-ContentState.md
+++ b/docs/APIReference-ContentState.md
@@ -4,8 +4,8 @@ title: ContentState
 ---
 
 `ContentState` is an Immutable
-[Record](http://facebook.github.io/immutable-js/docs/#/Record/Record) that
-represents the full state of:
+[Record](https://web.archive.org/web/20150623131347/http://facebook.github.io:80/immutable-js/docs/#/Record) 
+that represents the full state of:
 
 - The entire **contents** of an editor: text, block and inline styles, and entity ranges.
 - Two **selection states** of an editor: before and after the rendering of these contents.

--- a/docs/APIReference-EditorState.md
+++ b/docs/APIReference-EditorState.md
@@ -5,7 +5,8 @@ title: EditorState
 
 `EditorState` is the top-level state object for the editor.
 
-It is an Immutable [Record](http://facebook.github.io/immutable-js/docs/#/Record/Record)
+It is an Immutable 
+[Record](https://web.archive.org/web/20150623131347/http://facebook.github.io:80/immutable-js/docs/#/Record)
 that represents the entire state of a Draft editor, including:
 
 - The current text content state

--- a/docs/APIReference-SelectionState.md
+++ b/docs/APIReference-SelectionState.md
@@ -3,7 +3,9 @@ id: api-reference-selection-state
 title: SelectionState
 ---
 
-`SelectionState` is an Immutable [Record](http://facebook.github.io/immutable-js/docs/#/Record/Record) that represents a selection range in the editor.
+`SelectionState` is an Immutable 
+[Record](https://web.archive.org/web/20150623131347/http://facebook.github.io:80/immutable-js/docs/#/Record) 
+that represents a selection range in the editor.
 
 The most common use for the `SelectionState` object is via `EditorState.getSelection()`,
 which provides the `SelectionState` currently being rendered in the editor.


### PR DESCRIPTION
**Summary**
Record in docs, wherever mentioned, links to http://facebook.github.io/immutable-js/docs/#/Record/Record which then redirects to https://immutable-js.github.io/immutable-js/

However, the correct link for Record is https://immutable-js.github.io/immutable-js/docs/#/Record

