### PR TITLE
[Docs]: Add Null return value type in code example

### DIFF
--- a/docs/Advanced-Topics-Key-Bindings.md
+++ b/docs/Advanced-Topics-Key-Bindings.md
@@ -44,7 +44,7 @@ First, let's define our key binding function:
 import {getDefaultKeyBinding, KeyBindingUtil} from 'draft-js';
 const {hasCommandModifier} = KeyBindingUtil;
 
-function myKeyBindingFn(e: SyntheticKeyboardEvent): string {
+function myKeyBindingFn(e: SyntheticKeyboardEvent): string | null {
   if (e.keyCode === 83 /* `S` key */ && hasCommandModifier(e)) {
     return 'myeditor-save';
   }


### PR DESCRIPTION
**Summary**

TypeScript threw this error when I attempted to copy and paste in my code:
```
Type 'null' is not assignable to type 'string'.ts(2322)
```

The `getDefaultKeyBinding()` method may return null. So I added `| null` to the return type declaration. Just thought it would help others who may also be copying/pasting the code!

**Test Plan**

No testing required.