### PR TITLE
docs: in react hooks example, limit createEmpty calls

### DIFF
--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -73,7 +73,7 @@ import {Editor, EditorState} from 'draft-js';
 
 function MyEditor() {
   const [editorState, setEditorState] = React.useState(
-    EditorState.createEmpty(),
+    () => EditorState.createEmpty(),
   );
 
   return <Editor editorState={editorState} onChange={setEditorState} />;


### PR DESCRIPTION
In the React hooks example, `EditorState.createEmpty` will be called each time the component is rendered. By wrapping it in a function, it will only be called once per instance of the MyEditor component.