### PR TITLE
convertEditorStateToRaw and convertFromRawToEditorState added

### DIFF
--- a/examples/draft-0-10-0/playground/src/App.js
+++ b/examples/draft-0-10-0/playground/src/App.js
@@ -35,6 +35,7 @@ import {
   convertFromHTML as convertFromHTMLClassic,
   convertToRaw,
   convertFromRaw,
+  convertEditorStateToRaw
 } from 'draft-js';
 
 const fromHTML = gkx('draft_refactored_html_importer')

--- a/src/Draft.js
+++ b/src/Draft.js
@@ -26,8 +26,12 @@ const DraftEntityInstance = require('DraftEntityInstance');
 const EditorState = require('EditorState');
 const KeyBindingUtil = require('KeyBindingUtil');
 const RawDraftContentState = require('RawDraftContentState');
+const RawDraftEditorState = require('RawDraftEditorState');
 const RichTextEditorUtil = require('RichTextEditorUtil');
 const SelectionState = require('SelectionState');
+
+const convertEditorStateToRaw = require('convertEditorStateToRaw');
+const convertFromRawToEditorState = require('convertFromRawToEditorState');
 
 const convertFromDraftStateToRaw = require('convertFromDraftStateToRaw');
 const convertFromRawToDraftState = require('convertFromRawToDraftState');
@@ -51,6 +55,7 @@ const DraftPublic = {
   ContentBlock,
   ContentState,
   RawDraftContentState,
+  RawDraftEditorState,
   SelectionState,
 
   AtomicBlockUtils,
@@ -62,6 +67,8 @@ const DraftPublic = {
   DefaultDraftInlineStyle,
 
   convertFromHTML,
+  convertEditorStateToRaw,
+  convertFromRawToEditorState,
   convertFromRaw: convertFromRawToDraftState,
   convertToRaw: convertFromDraftStateToRaw,
   genKey: generateRandomKey,

--- a/src/model/encoding/RawDraftEditorState.js
+++ b/src/model/encoding/RawDraftEditorState.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ * @emails oncall+draft_js
+ */
+
+'use strict';
+
+import type {RawDraftContentState} from 'RawDraftContentState';
+import type {RawDraftSelectionState} from 'RawDraftSelectionState';
+
+
+/**
+ * A type that represents a composed document as vanilla JavaScript objects,
+ * with all styles and entities represented as ranges. Corresponding entity
+ * objects are packaged as objects as well.
+ *
+ * This object is especially useful when sending the document state to the
+ * server for storage, as its representation is more concise than our
+ * immutable objects.
+ */
+export type RawDraftEditorState = {
+  rawContent: RawDraftContentState,  
+  rawSelection: RawDraftSelectionState
+};

--- a/src/model/encoding/RawDraftSelectionState.js
+++ b/src/model/encoding/RawDraftSelectionState.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ * @emails oncall+draft_js
+ */
+
+'use strict';
+
+
+/**
+ * A type that represents a composed document as vanilla JavaScript objects,
+ * with all styles and entities represented as ranges. Corresponding entity
+ * objects are packaged as objects as well.
+ *
+ * This object is especially useful when sending the document state to the
+ * server for storage, as its representation is more concise than our
+ * immutable objects.
+ */
+export type RawDraftSelectionState = {
+    anchorKey:String,
+    focusKey:String,
+    anchorOffset:Number,
+    focusOffset:Number,
+    isBackward:Boolean,
+    hasFocus:Boolean
+};

--- a/src/model/encoding/convertEditorStateToRaw.js
+++ b/src/model/encoding/convertEditorStateToRaw.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ * @emails oncall+draft_js
+ */
+
+'use strict';
+
+
+import type {RawDraftEditorState} from 'RawDraftEditorState';
+import type {EditorState} from 'EditorState';
+
+const convertFromDraftStateToRaw = require('convertFromDraftStateToRaw');
+
+
+const convertEditorStateToRaw = (
+  editorState: EditorState,
+): RawDraftEditorState => {
+
+  let selectionState = editorState.getSelection();
+
+  let rawDraftEditorState:RawDraftEditorState = {
+    rawContent: convertFromDraftStateToRaw(editorState.getCurrentContent()),  
+    rawSelection: {
+      anchorKey: selectionState.getAnchorKey(),
+      focusKey: selectionState.getFocusKey(),
+      anchorOffset: selectionState.getAnchorOffset(),
+      focusOffset: selectionState.getFocusOffset(),
+      isBackward: selectionState.getIsBackward(),
+      hasFocus: selectionState.getHasFocus(),
+    }
+  };
+
+  return rawDraftEditorState;
+};
+
+module.exports = convertEditorStateToRaw;

--- a/src/model/encoding/convertFromRawToEditorState.js
+++ b/src/model/encoding/convertFromRawToEditorState.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ * @emails oncall+draft_js
+ */
+
+'use strict';
+
+import type {RawDraftEditorState} from 'RawDraftEditorState';
+import type {ContentState} from 'ContentState';
+import type {DraftDecoratorType} from 'DraftDecoratorType';
+
+const EditorState = require('EditorState');
+const SelectionState = require('SelectionState');
+const convertFromRawToDraftState = require('convertFromRawToDraftState');
+
+
+const convertFromRawToEditorState = (
+  rawEditorState: RawDraftEditorState,
+  decorator?: ?DraftDecoratorType,
+): EditorState => {
+  
+  let contentState:ContentState = convertFromRawToDraftState(rawEditorState.rawContent);  
+  let bareEditorState:EditorState = EditorState.createWithContent(contentState, decorator);
+
+  let createdSelectionState:SelectionState = SelectionState.createFromRaw(rawEditorState.rawSelection)
+
+  let finalEditorState = EditorState.forceSelection(
+    bareEditorState,
+    createdSelectionState
+  );
+
+  return finalEditorState;
+
+};
+
+module.exports = convertFromRawToEditorState;

--- a/src/model/immutable/SelectionState.js
+++ b/src/model/immutable/SelectionState.js
@@ -12,6 +12,7 @@
 'use strict';
 
 const Immutable = require('immutable');
+import type {RawDraftEditorState} from 'RawDraftEditorState';
 
 const {Record} = Immutable;
 
@@ -144,6 +145,16 @@ class SelectionState extends SelectionStateRecord {
       focusOffset: 0,
       isBackward: false,
       hasFocus: false,
+    });
+  }
+  static createFromRaw(raw: RawDraftEditorState): SelectionState {
+    return new SelectionState({
+      anchorKey: raw.anchorKey,  
+      anchorOffset: raw.anchorOffset,
+      focusOffset: raw.focusOffset,
+      focusKey: raw.focusKey,     
+      isBackward: raw.isBackward,
+      hasFocus: raw.hasFocus,
     });
   }
 }


### PR DESCRIPTION

**Summary**

Below two utilities are added. We can now create a raw version of the EditorState and 
serialize it any where. Likewise, we can deserialize a serialized RawEditorState and create EditorState from it.

convertEditorStateToRaw(editorState): RawEditorState
convertFromRawToEditorState(editorStateRaw) : EditorState

Thanks in advance for your feedback
