### PR TITLE
Fix empty styles when selection starts from empty block

### DIFF
--- a/src/model/immutable/EditorState.js
+++ b/src/model/immutable/EditorState.js
@@ -721,23 +721,69 @@ function getInlineStyleForNonCollapsedSelection(
   content: ContentState,
   selection: SelectionState,
 ): DraftInlineStyle {
-  const startKey = selection.getStartKey();
-  const startOffset = selection.getStartOffset();
-  const startBlock = content.getBlockForKey(startKey);
+  const anchorKey = selection.getAnchorKey();
+  const anchorOffset = selection.getAnchorOffset();
+  const anchorBlock = content.getBlockForKey(anchorKey);
 
   // If there is a character just inside the selection, use its style.
-  if (startOffset < startBlock.getLength()) {
-    return startBlock.getInlineStyleAt(startOffset);
+  if (anchorOffset < anchorBlock.getLength()) {
+    return anchorBlock.getInlineStyleAt(anchorOffset);
   }
 
   // Check if the selection at the end of a non-empty block. Use the last
   // style in the block.
-  if (startOffset > 0) {
-    return startBlock.getInlineStyleAt(startOffset - 1);
+  if (anchorOffset > 0) {
+    return anchorBlock.getInlineStyleAt(anchorOffset - 1);
   }
 
-  // Otherwise, look upward in the document to find the closest character.
-  return lookUpwardForInlineStyle(content, startKey);
+  if (selection.getIsBackward()) {
+    // Look upward in the document to find the closest character.
+    return lookUpwardForInlineStyle(content, anchorKey);
+  }
+
+  // Otherwise, look in the rest of the selection to find the closest
+  // character.
+  return lookRestForInlineStyle(content, selection);
+}
+
+// this is for non-collapsed selection
+function lookRestForInlineStyle(
+  content: ContentState,
+  selection: SelectionState,
+): DraftInlineStyle {
+  const blocks = content.getBlockMap();
+  const anchorKey = selection.getAnchorKey();
+  const endKey = selection.getEndKey();
+  let outOfSelection = false;
+
+  const nonEmpty = blocks
+    .skipUntil((_, k) => k === anchorKey)
+    .skip(1)
+    // we should lookup only in the selected blocks, so if this is the last
+    // selected block -- we out
+    .skipUntil((block, k) => {
+      // we don't need characters which out of the selection
+      if (outOfSelection) {
+        return false;
+      }
+      // when we reached the selection focus block
+      if (k === endKey) {
+        outOfSelection = true;
+      }
+      return block.getLength();
+    })
+    .first();
+
+  if (nonEmpty) {
+    // when this is the last block in the selection
+    if (outOfSelection) {
+      return nonEmpty.getInlineStyleAt(selection.getEndOffset() - 1);
+    }
+    return nonEmpty.getInlineStyleAt(nonEmpty.getLength() - 1);
+  }
+
+  // fallback. This is for case when all selected blocks are empty
+  return lookUpwardForInlineStyle(content, selection.getStartKey());
 }
 
 function lookUpwardForInlineStyle(

--- a/src/model/immutable/__tests__/EditorState-test.js
+++ b/src/model/immutable/__tests__/EditorState-test.js
@@ -201,8 +201,32 @@ test('looks upward through empty blocks to find a character', () => {
     rangedSelection.merge({
       anchorKey: 'emptyA',
       anchorOffset: 0,
+      focusKey: 'emptyB',
+      focusOffset: 0,
+    }),
+  );
+});
+
+test('looks through rest selected blocks to find a character when anchor block is empty', () => {
+  assertGetCurrentInlineStyle(
+    rangedSelection.merge({
+      anchorKey: 'emptyA',
+      anchorOffset: 0,
       focusKey: 'c',
       focusOffset: 3,
+      isBackward: false,
+    }),
+  );
+});
+
+test('looks through rest backward-selected blocks to find a character when anchor block is empty', () => {
+  assertGetCurrentInlineStyle(
+    new SelectionState({
+      anchorKey: 'emptyB',
+      anchorOffset: 0,
+      focusKey: 'b',
+      focusOffset: 3,
+      isBackward: true,
     }),
   );
 });
@@ -212,8 +236,8 @@ test('falls back to no style if in empty block at document start', () => {
     new SelectionState({
       anchorKey: 'emptyA',
       anchorOffset: 0,
-      focusKey: 'c',
-      focusOffset: 3,
+      focusKey: 'emptyB',
+      focusOffset: 0,
       isBackward: false,
     }),
     MULTI_BLOCK_STATE,

--- a/src/model/immutable/__tests__/__snapshots__/EditorState-test.js.snap
+++ b/src/model/immutable/__tests__/__snapshots__/EditorState-test.js.snap
@@ -20,6 +20,18 @@ Array [
 
 exports[`falls back to no style if in empty block at document start 1`] = `Array []`;
 
+exports[`looks through rest backward-selected blocks to find a character when anchor block is empty 1`] = `
+Array [
+  "BOLD",
+]
+`;
+
+exports[`looks through rest selected blocks to find a character when anchor block is empty 1`] = `
+Array [
+  "ITALIC",
+]
+`;
+
 exports[`looks upward through empty blocks to find a character 1`] = `
 Array [
   "BOLD",


### PR DESCRIPTION
**Summary**

This is the possible fix for #415 and similar.
The main change: when selection is not collapsed, we are looking styles within selection and only after we fail, we goes upward the blocks tree
