### PR TITLE
style(website): Removes desaturation

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -16,22 +16,6 @@
   --ifm-code-font-size: 95%;
 }
 
-.navbar {
-  filter: grayscale(100%);
-}
-
-.menu {
-  filter: grayscale(100%);
-}
-
-.hero {
-  filter: grayscale(100%);
-}
-
-.container {
-  filter: grayscale(100%);
-}
-
 .main-wrapper a:link:not(.button) {
   text-decoration: underline;
 }


### PR DESCRIPTION
**Summary**

Removes the desaturation applied to the Draft.js website and restores its original color. Fixes #2501 and remaining parts of #2494.

**Test Plan**

Manual tests with `cd website && yarn start`

## Before
<img width="1392" alt="Screen Shot 2020-07-18 at 12 23 03 PM" src="https://user-images.githubusercontent.com/860099/87850561-742cfb80-c8f1-11ea-80d0-fcbbfd5e13ff.png">

## After
<img width="1392" alt="Screen Shot 2020-07-18 at 12 22 53 PM" src="https://user-images.githubusercontent.com/860099/87850564-78591900-c8f1-11ea-85f3-855d8de491f5.png">
