### PR TITLE
enhancement(1116) | Improved style by removing boolean param in getCh…

### DIFF
--- a/src/model/modifier/__tests__/getCharacterRemovalRange-test.js
+++ b/src/model/modifier/__tests__/getCharacterRemovalRange-test.js
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+draft_js
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+const getCharacterRemovalRange = require('getCharacterRemovalRange');
+const DraftRemovableWord = require('DraftRemovableWord');
+const SelectionState = require('SelectionState');
+const convertFromRawToDraftState = require('convertFromRawToDraftState');
+
+const BLOCK_TYPE = {
+  IMMUTABLE: 'IMMUTABLE',
+  MUTABLE: 'MUTABLE',
+  SEGMENTED: 'SEGMENTED',
+};
+
+const rawContent = {
+  IMMUTABLE: {
+    blocks: [
+      {
+        key: 'firstBlock',
+        text: `This is an "immutable" entity: Superman. 
+        Deleting any characters will delete the entire entity. 
+        Adding characters will remove the entity from the range.`,
+        type: 'unstyled',
+        entityRanges: [{offset: 31, length: 8, key: 0}],
+      },
+    ],
+    entityMap: {
+      0: {
+        type: 'TOKEN',
+        mutability: 'IMMUTABLE',
+      },
+    },
+  },
+  MUTABLE: {
+    blocks: [
+      {
+        key: 'secondBlock',
+        text: `This is a "mutable" entity: Batman. 
+        Characters may be added and removed.`,
+        type: 'unstyled',
+        entityRanges: [{offset: 28, length: 6, key: 1}],
+      },
+    ],
+    entityMap: {
+      1: {
+        type: 'TOKEN',
+        mutability: 'MUTABLE',
+      },
+    },
+  },
+  SEGMENTED: {
+    blocks: [
+      {
+        key: 'thirdBlock',
+        text: `This is a "segmented" entity: Green Lantern. 
+        Deleting any characters will delete the current "segment" from the range. 
+        Adding characters will remove the entire entity from the range.`,
+        type: 'unstyled',
+        entityRanges: [{offset: 30, length: 13, key: 2}],
+      },
+    ],
+    entityMap: {
+      2: {
+        type: 'TOKEN',
+        mutability: 'SEGMENTED',
+      },
+    },
+  },
+};
+
+const results = {
+  IMMUTABLE: {
+    anchorKey: 'firstBlock',
+    anchorOffset: 31,
+    focusKey: 'firstBlock',
+    focusOffset: 39,
+    hasFocus: true,
+    isBackward: false,
+  },
+  MUTABLE: {
+    anchorKey: 'secondBlock',
+    anchorOffset: 33,
+    focusKey: 'secondBlock',
+    focusOffset: 34,
+    isBackward: false,
+    hasFocus: true,
+  },
+  SEGMENTED: {
+    anchorKey: 'thirdBlock',
+    anchorOffset: 30,
+    focusKey: 'thirdBlock',
+    focusOffset: 43,
+    isBackward: false,
+    hasFocus: true,
+  },
+};
+
+const assertCharacterRemovalRange = (
+  result,
+  selection,
+  mutability,
+  content = convertFromRawToDraftState(rawContent[mutability]),
+  backward = DraftRemovableWord.getBackward,
+) => {
+  const actualResult = getCharacterRemovalRange(
+    content.getEntityMap(),
+    content.getBlockMap().first(), //startBlock
+    content.getBlockMap().last(), //endBlock
+    selection, //rangeToRemove
+    backward, //removalDirection
+  );
+  expect(actualResult.toJS()).toStrictEqual(result);
+};
+
+/**
+ * Go-to draft-js/examples/draft-0-10-0/entity/entity.html
+ *
+ * Remove Superman from immutable block using back space
+ */
+test('must remove "Superman" from immutable entity', () => {
+  assertCharacterRemovalRange(
+    results[BLOCK_TYPE.IMMUTABLE],
+    new SelectionState(results[BLOCK_TYPE.IMMUTABLE]),
+    BLOCK_TYPE.IMMUTABLE,
+  );
+});
+
+/**
+ * Go-to draft-js/examples/draft-0-10-0/entity/entity.html
+ *
+ * Remove Batman from mutable block using back space
+ */
+test('must remove "Batman" from mutable entity', () => {
+  assertCharacterRemovalRange(
+    results[BLOCK_TYPE.MUTABLE],
+    new SelectionState(results[BLOCK_TYPE.MUTABLE]),
+    BLOCK_TYPE.MUTABLE,
+  );
+});
+
+/**
+ * Go-to draft-js/examples/draft-0-10-0/entity/entity.html
+ *
+ * Remove GREEN from segmented block using back space
+ */
+test('must remove "Green" from segmented entity', () => {
+  assertCharacterRemovalRange(
+    results[BLOCK_TYPE.SEGMENTED],
+    new SelectionState(results[BLOCK_TYPE.SEGMENTED]),
+    BLOCK_TYPE.SEGMENTED,
+  );
+});

--- a/src/model/modifier/getCharacterRemovalRange.js
+++ b/src/model/modifier/getCharacterRemovalRange.js
@@ -46,33 +46,27 @@ function getCharacterRemovalRange(
   }
   let newSelectionState = selectionState;
   if (startEntityKey && startEntityKey === endEntityKey) {
-    newSelectionState = getEntityRemovalRange(
+    newSelectionState = getEntityRemovalRangeAtStartForEntireSelection(
       entityMap,
       startBlock,
       newSelectionState,
       direction,
       startEntityKey,
-      true,
-      true,
     );
   } else if (startEntityKey && endEntityKey) {
-    const startSelectionState = getEntityRemovalRange(
+    const startSelectionState = getEntityRemovalRangeAtStartNotForEntireSelection(
       entityMap,
       startBlock,
       newSelectionState,
       direction,
       startEntityKey,
-      false,
-      true,
     );
-    const endSelectionState = getEntityRemovalRange(
+    const endSelectionState = getEntityRemovalRangeAtEnd(
       entityMap,
       endBlock,
       newSelectionState,
       direction,
       endEntityKey,
-      false,
-      false,
     );
     newSelectionState = newSelectionState.merge({
       anchorOffset: startSelectionState.getAnchorOffset(),
@@ -80,28 +74,24 @@ function getCharacterRemovalRange(
       isBackward: false,
     });
   } else if (startEntityKey) {
-    const startSelectionState = getEntityRemovalRange(
+    const startSelectionState = getEntityRemovalRangeAtStartNotForEntireSelection(
       entityMap,
       startBlock,
       newSelectionState,
       direction,
       startEntityKey,
-      false,
-      true,
     );
     newSelectionState = newSelectionState.merge({
       anchorOffset: startSelectionState.getStartOffset(),
       isBackward: false,
     });
   } else if (endEntityKey) {
-    const endSelectionState = getEntityRemovalRange(
+    const endSelectionState = getEntityRemovalRangeAtEnd(
       entityMap,
       endBlock,
       newSelectionState,
       direction,
       endEntityKey,
-      false,
-      false,
     );
     newSelectionState = newSelectionState.merge({
       focusOffset: endSelectionState.getEndOffset(),
@@ -109,6 +99,66 @@ function getCharacterRemovalRange(
     });
   }
   return newSelectionState;
+}
+
+function getEntityRemovalRangeAtStartForEntireSelection(
+  entityMap: EntityMap,
+  block: BlockNodeRecord,
+  selectionState: SelectionState,
+  direction: DraftRemovalDirection,
+  entityKey: string,
+  isEntireSelectionWithinEntity: boolean = true,
+  isEntityAtStart: boolean = true,
+): SelectionState {
+  return getEntityRemovalRange(
+    entityMap,
+    block,
+    selectionState,
+    direction,
+    entityKey,
+    isEntireSelectionWithinEntity,
+    isEntityAtStart,
+  );
+}
+
+function getEntityRemovalRangeAtStartNotForEntireSelection(
+  entityMap: EntityMap,
+  block: BlockNodeRecord,
+  selectionState: SelectionState,
+  direction: DraftRemovalDirection,
+  entityKey: string,
+  isEntireSelectionWithinEntity: boolean = false,
+  isEntityAtStart: boolean = true,
+): SelectionState {
+  return getEntityRemovalRange(
+    entityMap,
+    block,
+    selectionState,
+    direction,
+    entityKey,
+    isEntireSelectionWithinEntity,
+    isEntityAtStart,
+  );
+}
+
+function getEntityRemovalRangeAtEnd(
+  entityMap: EntityMap,
+  block: BlockNodeRecord,
+  selectionState: SelectionState,
+  direction: DraftRemovalDirection,
+  entityKey: string,
+  isEntireSelectionWithinEntity: boolean = false,
+  isEntityAtStart: boolean = false,
+): SelectionState {
+  return getEntityRemovalRange(
+    entityMap,
+    block,
+    selectionState,
+    direction,
+    entityKey,
+    isEntireSelectionWithinEntity,
+    isEntityAtStart,
+  );
 }
 
 function getEntityRemovalRange(


### PR DESCRIPTION
**Summary**
(#1116 ) | Improved style by removing boolean param in getCharacterRemovalRange.js

Give that there are 4 conditions. to improve the style I've introduced 3 new functions 

A. `getEntityRemovalRangeAtStartForEntireSelection`
B. `getEntityRemovalRangeAtStartNotForEntireSelection`
C. `getEntityRemovalRangeAtEnd`

These functions handle 4 cases.

##### Codition 1  
if `startEntityKey && startEntityKey === endEntityKey` 
AND `isEntireSelectionWithinEntity: true, isEntityAtStart: true` 
Calling function A

##### Codition 2  
else if `startEntityKey && endEntityKey` 
AND `isEntireSelectionWithinEntity: false, isEntityAtStart: true`
Calling function B

##### Codition 3 
else if `startEntityKey`
AND `isEntireSelectionWithinEntity: false, isEntityAtStart: true`
Calling function B

##### Codition 4
else `endEntityKey` 
AND  `isEntireSelectionWithinEntity: false, isEntityAtStart: false`
Call Function C

**Test Plan**

1. Manual Testing
- Tested removing Immutable, Mutable, and Segmented entities available in `examples/draft-0-10-0/entity/entity.html` by running it in the browser, works fine.

2. Unit Test
- I've introduced a file to test this model. Can be executed using following command. Covers basic unit test of model `getCharacterRemovalRange`

> `npm run test src/model/modifier/__tests__/getCharacterRemovalRange-test.js`

![image](https://user-images.githubusercontent.com/2558220/88371395-86fa7100-cdc6-11ea-86b1-51c955f29a64.png)

**Lint works fine**
> `npm run lint` 
