### PR TITLE
Update link to Immutable Map in docs

### DIFF
--- a/docs/APIReference-ContentBlock.md
+++ b/docs/APIReference-ContentBlock.md
@@ -118,7 +118,7 @@ _Properties_
 
 > Note
 >
-> Use [Immutable Map API](http://facebook.github.io/immutable-js/docs/#/Map)
+> Use [Immutable Map API](https://web.archive.org/web/20150623131347/http://facebook.github.io:80/immutable-js/docs/#/Map)
 > for the `ContentBlock` constructor or to set properties.
 
 <ul class="apiIndex">
@@ -260,7 +260,7 @@ Executes a callback for each contiguous range of entities within this `ContentBl
 
 > Note
 >
-> Use [Immutable Map API](http://facebook.github.io/immutable-js/docs/#/Map)
+> Use [Immutable Map API](https://web.archive.org/web/20150623131347/http://facebook.github.io:80/immutable-js/docs/#/Map)
 > for the `ContentBlock` constructor or to set properties.
 
 ### `key`

--- a/docs/APIReference-ContentState.md
+++ b/docs/APIReference-ContentState.md
@@ -140,7 +140,7 @@ _Methods_
 
 _Properties_
 
-> Use [Immutable Map API](http://facebook.github.io/immutable-js/docs/#/Map) to
+> Use [Immutable Map API](https://web.archive.org/web/20150623131347/http://facebook.github.io:80/immutable-js/docs/#/Map) to
 > set properties.
 >
 > **Example**
@@ -416,7 +416,7 @@ editing.
 
 ## Properties
 
-> Use [Immutable Map API](http://facebook.github.io/immutable-js/docs/#/Map) to
+> Use [Immutable Map API](https://web.archive.org/web/20150623131347/http://facebook.github.io:80/immutable-js/docs/#/Map) to
 > set properties.
 
 ### `blockMap`

--- a/docs/APIReference-SelectionState.md
+++ b/docs/APIReference-SelectionState.md
@@ -137,7 +137,7 @@ _Methods_
 
 _Properties_
 
-> Use [Immutable Map API](http://facebook.github.io/immutable-js/docs/#/Record/Record) to
+> Use [Immutable Map API](https://web.archive.org/web/20150623131347/http://facebook.github.io:80/immutable-js/docs/#/Map) to
 > set properties.
 >
 > **Example**
@@ -308,7 +308,7 @@ Returns a serialized version of the `SelectionState`. Useful for debugging.
 
 ## Properties
 
-> Use [Immutable Map API](http://facebook.github.io/immutable-js/docs/#/Record/Record) to
+> Use [Immutable Map API](https://web.archive.org/web/20150623131347/http://facebook.github.io:80/immutable-js/docs/#/Map) to
 > set properties.
 
 ```js

--- a/docs/Advanced-Topics-Custom-Block-Render.md
+++ b/docs/Advanced-Topics-Custom-Block-Render.md
@@ -35,7 +35,7 @@ by matching the Draft block render map with the matched tag.
 ## Configuring block render map
 
 Draft's default block render map can be overwritten by passing an
-[Immutable Map](http://facebook.github.io/immutable-js/docs/#/Map) to
+[Immutable Map](https://web.archive.org/web/20150623131347/http://facebook.github.io:80/immutable-js/docs/#/Map) to
 the editor blockRender props.
 
 _example of overwriting default block render map:_


### PR DESCRIPTION
**Summary**
Map in docs, wherever mentioned, links to http://facebook.github.io/immutable-js/docs/#/Map and also in some cases to http://facebook.github.io/immutable-js/docs/#/Record/Record which then redirect to https://immutable-js.github.io/immutable-js/

However, the correct link for Map is https://immutable-js.github.io/immutable-js/docs/#/Map

Draft.js uses immutable 3.7.4 which released on 18 Jun 2015 according to this commit https://github.com/immutable-js/immutable-js/commit/09f04e910bd0b891d1373eb2cb2648a0546fab3d
I have linked `Map` to the docs for that version(captured on 23 Jun 2015) through the Internet Archive.