### PR TITLE
Convert html/shared/draft-js to ES6 imports/exports [1/1]

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -17,29 +17,29 @@ import type {DraftEditorModes} from 'DraftEditorModes';
 import type {DraftEditorDefaultProps, DraftEditorProps} from 'DraftEditorProps';
 import type {DraftScrollPosition} from 'DraftScrollPosition';
 
-const DefaultDraftBlockRenderMap = require('DefaultDraftBlockRenderMap');
-const DefaultDraftInlineStyle = require('DefaultDraftInlineStyle');
-const DraftEditorCompositionHandler = require('DraftEditorCompositionHandler');
-const DraftEditorContents = require('DraftEditorContents.react');
-const DraftEditorDragHandler = require('DraftEditorDragHandler');
-const DraftEditorEditHandler = require('DraftEditorEditHandler');
-const flushControlled = require('DraftEditorFlushControlled');
-const DraftEditorPlaceholder = require('DraftEditorPlaceholder.react');
-const DraftEffects = require('DraftEffects');
-const EditorState = require('EditorState');
-const React = require('React');
-const Scroll = require('Scroll');
-const Style = require('Style');
-const UserAgent = require('UserAgent');
+import DefaultDraftBlockRenderMap from 'DefaultDraftBlockRenderMap';
+import * as DefaultDraftInlineStyle from 'DefaultDraftInlineStyle';
+import * as DraftEditorCompositionHandler from 'DraftEditorCompositionHandler';
+import DraftEditorContents from 'DraftEditorContents.react';
+import * as DraftEditorDragHandler from 'DraftEditorDragHandler';
+import * as DraftEditorEditHandler from 'DraftEditorEditHandler';
+import flushControlled from 'DraftEditorFlushControlled';
+import DraftEditorPlaceholder from 'DraftEditorPlaceholder.react';
+import * as DraftEffects from 'DraftEffects';
+import EditorState from 'EditorState';
+import * as React from 'React';
+import * as Scroll from 'Scroll';
+import Style from 'Style';
+import UserAgent from 'UserAgent';
 
-const cx = require('cx');
-const generateRandomKey = require('generateRandomKey');
-const getDefaultKeyBinding = require('getDefaultKeyBinding');
-const getScrollPosition = require('getScrollPosition');
-const gkx = require('gkx');
-const invariant = require('invariant');
-const isHTMLElement = require('isHTMLElement');
-const nullthrows = require('nullthrows');
+import cx from 'cx';
+import generateRandomKey from 'generateRandomKey';
+import getDefaultKeyBinding from 'getDefaultKeyBinding';
+import getScrollPosition from 'getScrollPosition';
+import gkx from 'gkx';
+import invariant from 'invariant';
+import isHTMLElement from 'isHTMLElement';
+import nullthrows from 'nullthrows';
 
 const isIE = UserAgent.isBrowser('IE');
 
@@ -50,8 +50,14 @@ const allowSpellCheck = !isIE;
 // Define a set of handler objects to correspond to each possible `mode`
 // of editor behavior.
 const handlerMap = {
+  /* $FlowFixMe[invalid-import-star-use] Error found during ES6 imports/exports
+   * conversion. */
   edit: DraftEditorEditHandler,
+  /* $FlowFixMe[invalid-import-star-use] Error found during ES6 imports/exports
+   * conversion. */
   composite: DraftEditorCompositionHandler,
+  /* $FlowFixMe[invalid-import-star-use] Error found during ES6 imports/exports
+   * conversion. */
   drag: DraftEditorDragHandler,
   cut: null,
   render: null,
@@ -132,7 +138,10 @@ class UpdateDraftEditorFlags extends React.Component<{
  * div, and provides a wide variety of useful function props for managing the
  * state of the editor. See `DraftEditorProps` for details.
  */
-class DraftEditor extends React.Component<DraftEditorProps, State> {
+export default class DraftEditor extends React.Component<
+  DraftEditorProps,
+  State,
+> {
   static defaultProps: DraftEditorDefaultProps = {
     ariaDescribedBy: '{{editor_id_placeholder}}',
     blockRenderMap: DefaultDraftBlockRenderMap,
@@ -375,6 +384,8 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
       blockRendererFn,
       blockStyleFn,
       customStyleMap: {
+        /* $FlowFixMe[invalid-import-star-use] Error found during ES6
+         * imports/exports conversion. */
         ...DefaultDraftInlineStyle,
         ...customStyleMap,
       },
@@ -651,5 +662,3 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
     }
   };
 }
-
-module.exports = DraftEditor;

--- a/src/component/base/DraftEditorFlushControlled.js
+++ b/src/component/base/DraftEditorFlushControlled.js
@@ -9,9 +9,9 @@
  * @emails oncall+draft_js
  */
 
-const ReactDOMComet = require('ReactDOMComet');
+import * as ReactDOMComet from 'ReactDOMComet';
 
 const flushControlled: void | ((fn: () => void) => void) =
   ReactDOMComet.unstable_flushControlled;
 
-module.exports = flushControlled;
+export default flushControlled;

--- a/src/component/base/DraftEditorPlaceholder.react.js
+++ b/src/component/base/DraftEditorPlaceholder.react.js
@@ -14,9 +14,9 @@
 import type {DraftTextAlignment} from 'DraftTextAlignment';
 import type EditorState from 'EditorState';
 
-const React = require('React');
+import * as React from 'React';
 
-const cx = require('cx');
+import cx from 'cx';
 
 type Props = {
   accessibilityID: string,
@@ -32,7 +32,7 @@ type Props = {
  *
  * Override placeholder style via CSS.
  */
-class DraftEditorPlaceholder extends React.Component<Props> {
+export default class DraftEditorPlaceholder extends React.Component<Props> {
   shouldComponentUpdate(nextProps: Props): boolean {
     return (
       this.props.text !== nextProps.text ||
@@ -65,5 +65,3 @@ class DraftEditorPlaceholder extends React.Component<Props> {
     );
   }
 }
-
-module.exports = DraftEditorPlaceholder;

--- a/src/component/contents/DraftEditorBlock.react.js
+++ b/src/component/contents/DraftEditorBlock.react.js
@@ -20,21 +20,21 @@ import type SelectionState from 'SelectionState';
 import type {BidiDirection} from 'UnicodeBidiDirection';
 import type {List} from 'immutable';
 
-const DraftEditorLeaf = require('DraftEditorLeaf.react');
-const DraftOffsetKey = require('DraftOffsetKey');
-const React = require('React');
-const Scroll = require('Scroll');
-const Style = require('Style');
-const UnicodeBidi = require('UnicodeBidi');
-const UnicodeBidiDirection = require('UnicodeBidiDirection');
+import DraftEditorLeaf from 'DraftEditorLeaf.react';
+import * as DraftOffsetKey from 'DraftOffsetKey';
+import * as React from 'React';
+import * as Scroll from 'Scroll';
+import Style from 'Style';
+import * as UnicodeBidi from 'UnicodeBidi';
+import * as UnicodeBidiDirection from 'UnicodeBidiDirection';
 
-const cx = require('cx');
-const getElementPosition = require('getElementPosition');
-const getScrollPosition = require('getScrollPosition');
-const getViewportDimensions = require('getViewportDimensions');
-const invariant = require('invariant');
-const isHTMLElement = require('isHTMLElement');
-const nullthrows = require('nullthrows');
+import cx from 'cx';
+import getElementPosition from 'getElementPosition';
+import getScrollPosition from 'getScrollPosition';
+import getViewportDimensions from 'getViewportDimensions';
+import invariant from 'invariant';
+import isHTMLElement from 'isHTMLElement';
+import nullthrows from 'nullthrows';
 
 const SCROLL_BUFFER = 10;
 
@@ -72,7 +72,7 @@ const isBlockOnSelectionEdge = (
  * A `DraftEditorBlock` is able to render a given `ContentBlock` to its
  * appropriate decorator and inline style components.
  */
-class DraftEditorBlock extends React.Component<Props> {
+export default class DraftEditorBlock extends React.Component<Props> {
   _node: ?HTMLDivElement;
 
   shouldComponentUpdate(nextProps: Props): boolean {
@@ -251,5 +251,3 @@ class DraftEditorBlock extends React.Component<Props> {
     );
   }
 }
-
-module.exports = DraftEditorBlock;

--- a/src/component/contents/DraftEditorTextNode.react.js
+++ b/src/component/contents/DraftEditorTextNode.react.js
@@ -11,11 +11,11 @@
 
 'use strict';
 
-const React = require('React');
-const UserAgent = require('UserAgent');
+import * as React from 'React';
+import UserAgent from 'UserAgent';
 
-const invariant = require('invariant');
-const isElement = require('isElement');
+import invariant from 'invariant';
+import isElement from 'isElement';
 
 // In IE, spans with <br> tags render as two newlines. By rendering a span
 // with only a newline character, we can be sure to render a single line.
@@ -66,7 +66,7 @@ type Props = {children: string, ...};
  * nodes with DOM state that already matches the expectations of our immutable
  * editor state.
  */
-class DraftEditorTextNode extends React.Component<Props> {
+export default class DraftEditorTextNode extends React.Component<Props> {
   _forceFlag: boolean;
   _node: ?(HTMLSpanElement | HTMLBRElement);
 
@@ -113,5 +113,3 @@ class DraftEditorTextNode extends React.Component<Props> {
     );
   }
 }
-
-module.exports = DraftEditorTextNode;

--- a/src/component/contents/__tests__/DraftEditorTextNode-test.js
+++ b/src/component/contents/__tests__/DraftEditorTextNode-test.js
@@ -17,10 +17,10 @@ const BLOCK_DELIMITER_CHAR = '\n';
 const TEST_A = 'Hello';
 const TEST_B = ' World!';
 
-const DraftEditorTextNode = require('DraftEditorTextNode.react');
-const React = require('React');
-const ReactDOM = require('ReactDOM');
-const UserAgent = require('UserAgent');
+import DraftEditorTextNode from 'DraftEditorTextNode.react';
+import * as React from 'React';
+import * as ReactDOM from 'ReactDOM';
+import UserAgent from 'UserAgent';
 
 let container;
 

--- a/src/component/contents/exploration/DraftEditorBlockNode.react.js
+++ b/src/component/contents/exploration/DraftEditorBlockNode.react.js
@@ -25,18 +25,18 @@ import type EditorState from 'EditorState';
 import type SelectionState from 'SelectionState';
 import type {BidiDirection} from 'UnicodeBidiDirection';
 
-const DraftEditorNode = require('DraftEditorNode.react');
-const DraftOffsetKey = require('DraftOffsetKey');
-const React = require('React');
-const Scroll = require('Scroll');
-const Style = require('Style');
+import DraftEditorNode from 'DraftEditorNode.react';
+import * as DraftOffsetKey from 'DraftOffsetKey';
+import * as React from 'React';
+import * as Scroll from 'Scroll';
+import Style from 'Style';
 
-const getElementPosition = require('getElementPosition');
-const getScrollPosition = require('getScrollPosition');
-const getViewportDimensions = require('getViewportDimensions');
-const Immutable = require('immutable');
-const invariant = require('invariant');
-const isHTMLElement = require('isHTMLElement');
+import getElementPosition from 'getElementPosition';
+import getScrollPosition from 'getScrollPosition';
+import getViewportDimensions from 'getViewportDimensions';
+import Immutable from 'immutable';
+import invariant from 'invariant';
+import isHTMLElement from 'isHTMLElement';
 
 const SCROLL_BUFFER = 10;
 
@@ -202,7 +202,7 @@ const getElementPropsConfig = (
   return elementProps;
 };
 
-class DraftEditorBlockNode extends React.Component<Props> {
+export default class DraftEditorBlockNode extends React.Component<Props> {
   wrapperRef: {|current: null | Element|} = React.createRef<Element>();
 
   shouldComponentUpdate(nextProps: Props): boolean {
@@ -392,5 +392,3 @@ class DraftEditorBlockNode extends React.Component<Props> {
     return React.createElement(Element, elementProps, blockNode);
   }
 }
-
-module.exports = DraftEditorBlockNode;

--- a/src/component/contents/exploration/DraftEditorContentsExperimental.react.js
+++ b/src/component/contents/exploration/DraftEditorContentsExperimental.react.js
@@ -22,11 +22,11 @@ import type {DraftInlineStyle} from 'DraftInlineStyle';
 import type EditorState from 'EditorState';
 import type {BidiDirection} from 'UnicodeBidiDirection';
 
-const DraftEditorBlockNode = require('DraftEditorBlockNode.react');
-const DraftOffsetKey = require('DraftOffsetKey');
-const React = require('React');
+import DraftEditorBlockNode from 'DraftEditorBlockNode.react';
+import * as DraftOffsetKey from 'DraftOffsetKey';
+import * as React from 'React';
 
-const nullthrows = require('nullthrows');
+import nullthrows from 'nullthrows';
 
 type Props = {
   blockRenderMap: DraftBlockRenderMap,
@@ -49,7 +49,7 @@ type Props = {
  * (for instance, ARIA props) must be allowed to update without affecting
  * the contents of the editor.
  */
-class DraftEditorContentsExperimental extends React.Component<Props> {
+export default class DraftEditorContentsExperimental extends React.Component<Props> {
   shouldComponentUpdate(nextProps: Props): boolean {
     const prevEditorState = this.props.editorState;
     const nextEditorState = nextProps.editorState;
@@ -191,5 +191,3 @@ class DraftEditorContentsExperimental extends React.Component<Props> {
     return <div data-contents="true">{outputBlocks}</div>;
   }
 }
-
-module.exports = DraftEditorContentsExperimental;

--- a/src/component/contents/exploration/DraftEditorDecoratedLeaves.react.js
+++ b/src/component/contents/exploration/DraftEditorDecoratedLeaves.react.js
@@ -20,10 +20,10 @@ import type {DraftDecoratorType} from 'DraftDecoratorType';
 import type {BidiDirection} from 'UnicodeBidiDirection';
 import type {Set} from 'immutable';
 
-const DraftOffsetKey = require('DraftOffsetKey');
-const React = require('React');
-const UnicodeBidi = require('UnicodeBidi');
-const UnicodeBidiDirection = require('UnicodeBidiDirection');
+import * as DraftOffsetKey from 'DraftOffsetKey';
+import * as React from 'React';
+import * as UnicodeBidi from 'UnicodeBidi';
+import * as UnicodeBidiDirection from 'UnicodeBidiDirection';
 
 type Props = {
   block: BlockNodeRecord,
@@ -37,7 +37,7 @@ type Props = {
   ...
 };
 
-class DraftEditorDecoratedLeaves extends React.Component<Props> {
+export default class DraftEditorDecoratedLeaves extends React.Component<Props> {
   render(): React.Node {
     const {
       block,
@@ -86,5 +86,3 @@ class DraftEditorDecoratedLeaves extends React.Component<Props> {
     );
   }
 }
-
-module.exports = DraftEditorDecoratedLeaves;

--- a/src/component/contents/exploration/DraftEditorNode.react.js
+++ b/src/component/contents/exploration/DraftEditorNode.react.js
@@ -20,13 +20,13 @@ import type {DraftDecoratorType} from 'DraftDecoratorType';
 import type SelectionState from 'SelectionState';
 import type {BidiDirection} from 'UnicodeBidiDirection';
 
-const DraftEditorDecoratedLeaves = require('DraftEditorDecoratedLeaves.react');
-const DraftEditorLeaf = require('DraftEditorLeaf.react');
-const DraftOffsetKey = require('DraftOffsetKey');
-const Immutable = require('immutable');
-const React = require('React');
+import DraftEditorDecoratedLeaves from 'DraftEditorDecoratedLeaves.react';
+import DraftEditorLeaf from 'DraftEditorLeaf.react';
+import * as DraftOffsetKey from 'DraftOffsetKey';
+import * as React from 'React';
 
-const cx = require('cx');
+import cx from 'cx';
+import Immutable from 'immutable';
 
 const {List} = Immutable;
 
@@ -45,7 +45,7 @@ type Props = {
   ...
 };
 
-class DraftEditorNode extends React.Component<Props> {
+export default class DraftEditorNode extends React.Component<Props> {
   render(): React.Node {
     const {
       block,
@@ -127,5 +127,3 @@ class DraftEditorNode extends React.Component<Props> {
     );
   }
 }
-
-module.exports = DraftEditorNode;

--- a/src/component/handlers/composition/DOMObserver.js
+++ b/src/component/handlers/composition/DOMObserver.js
@@ -11,13 +11,13 @@
 
 'use strict';
 
-const UserAgent = require('UserAgent');
+import UserAgent from 'UserAgent';
 
-const findAncestorOffsetKey = require('findAncestorOffsetKey');
-const getWindowForNode = require('getWindowForNode');
-const Immutable = require('immutable');
-const invariant = require('invariant');
-const nullthrows = require('nullthrows');
+import findAncestorOffsetKey from 'findAncestorOffsetKey';
+import getWindowForNode from 'getWindowForNode';
+import Immutable from 'immutable';
+import invariant from 'invariant';
+import nullthrows from 'nullthrows';
 
 const {Map} = Immutable;
 
@@ -37,7 +37,7 @@ const DOM_OBSERVER_OPTIONS = {
 // IE11 has very broken mutation observers, so we also listen to DOMCharacterDataModified
 const USE_CHAR_DATA = UserAgent.isBrowser('IE <= 11');
 
-class DOMObserver {
+export default class DOMObserver {
   observer: ?MutationObserver;
   container: HTMLElement;
   mutations: Map<string, string>;
@@ -149,5 +149,3 @@ class DOMObserver {
     }
   }
 }
-
-module.exports = DOMObserver;

--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -13,18 +13,18 @@
 
 import type DraftEditor from 'DraftEditor.react';
 
-const DOMObserver = require('DOMObserver');
-const DraftModifier = require('DraftModifier');
-const DraftOffsetKey = require('DraftOffsetKey');
-const EditorState = require('EditorState');
-const Keys = require('Keys');
-const UserAgent = require('UserAgent');
+import DOMObserver from 'DOMObserver';
+import * as DraftModifier from 'DraftModifier';
+import * as DraftOffsetKey from 'DraftOffsetKey';
+import EditorState from 'EditorState';
+import Keys from 'Keys';
+import UserAgent from 'UserAgent';
 
-const editOnSelect = require('editOnSelect');
-const getContentEditableContainer = require('getContentEditableContainer');
-const getDraftEditorSelection = require('getDraftEditorSelection');
-const getEntityKeyForSelection = require('getEntityKeyForSelection');
-const nullthrows = require('nullthrows');
+import editOnSelect from 'editOnSelect';
+import getContentEditableContainer from 'getContentEditableContainer';
+import getDraftEditorSelection from 'getDraftEditorSelection';
+import getEntityKeyForSelection from 'getEntityKeyForSelection';
+import nullthrows from 'nullthrows';
 
 const isIE = UserAgent.isBrowser('IE');
 
@@ -57,194 +57,191 @@ function startDOMObserver(editor: DraftEditor) {
   }
 }
 
-const DraftEditorCompositionHandler = {
-  /**
-   * A `compositionstart` event has fired while we're still in composition
-   * mode. Continue the current composition session to prevent a re-render.
-   */
-  onCompositionStart(editor: DraftEditor): void {
-    stillComposing = true;
-    startDOMObserver(editor);
-  },
+/**
+ * A `compositionstart` event has fired while we're still in composition
+ * mode. Continue the current composition session to prevent a re-render.
+ */
+export function onCompositionStart(editor: DraftEditor): void {
+  stillComposing = true;
+  startDOMObserver(editor);
+}
 
-  /**
-   * Attempt to end the current composition session.
-   *
-   * Defer handling because browser will still insert the chars into active
-   * element after `compositionend`. If a `compositionstart` event fires
-   * before `resolveComposition` executes, our composition session will
-   * continue.
-   *
-   * The `resolved` flag is useful because certain IME interfaces fire the
-   * `compositionend` event multiple times, thus queueing up multiple attempts
-   * at handling the composition. Since handling the same composition event
-   * twice could break the DOM, we only use the first event. Example: Arabic
-   * Google Input Tools on Windows 8.1 fires `compositionend` three times.
-   */
-  onCompositionEnd(editor: DraftEditor): void {
-    resolved = false;
-    stillComposing = false;
-    setTimeout(() => {
-      if (!resolved) {
-        DraftEditorCompositionHandler.resolveComposition(editor);
-      }
-    }, RESOLVE_DELAY);
-  },
-
-  onSelect: editOnSelect,
-
-  /**
-   * In Safari, keydown events may fire when committing compositions. If
-   * the arrow keys are used to commit, prevent default so that the cursor
-   * doesn't move, otherwise it will jump back noticeably on re-render.
-   */
-  onKeyDown(editor: DraftEditor, e: SyntheticKeyboardEvent<>): void {
-    if (!stillComposing) {
-      // If a keydown event is received after compositionend but before the
-      // 20ms timer expires (ex: type option-E then backspace, or type A then
-      // backspace in 2-Set Korean), we should immediately resolve the
-      // composition and reinterpret the key press in edit mode.
-      DraftEditorCompositionHandler.resolveComposition(editor);
-      editor._onKeyDown(e);
-      return;
+/**
+ * Attempt to end the current composition session.
+ *
+ * Defer handling because browser will still insert the chars into active
+ * element after `compositionend`. If a `compositionstart` event fires
+ * before `resolveComposition` executes, our composition session will
+ * continue.
+ *
+ * The `resolved` flag is useful because certain IME interfaces fire the
+ * `compositionend` event multiple times, thus queueing up multiple attempts
+ * at handling the composition. Since handling the same composition event
+ * twice could break the DOM, we only use the first event. Example: Arabic
+ * Google Input Tools on Windows 8.1 fires `compositionend` three times.
+ */
+export function onCompositionEnd(editor: DraftEditor): void {
+  resolved = false;
+  stillComposing = false;
+  setTimeout(() => {
+    if (!resolved) {
+      resolveComposition(editor);
     }
-    if (e.which === Keys.RIGHT || e.which === Keys.LEFT) {
-      e.preventDefault();
-    }
-  },
+  }, RESOLVE_DELAY);
+}
 
-  /**
-   * Keypress events may fire when committing compositions. In Firefox,
-   * pressing RETURN commits the composition and inserts extra newline
-   * characters that we do not want. `preventDefault` allows the composition
-   * to be committed while preventing the extra characters.
-   */
-  onKeyPress(_editor: DraftEditor, e: SyntheticKeyboardEvent<>): void {
-    if (e.which === Keys.RETURN) {
-      e.preventDefault();
-    }
-  },
+export const onSelect = editOnSelect;
 
-  /**
-   * Attempt to insert composed characters into the document.
-   *
-   * If we are still in a composition session, do nothing. Otherwise, insert
-   * the characters into the document and terminate the composition session.
-   *
-   * If no characters were composed -- for instance, the user
-   * deleted all composed characters and committed nothing new --
-   * force a re-render. We also re-render when the composition occurs
-   * at the beginning of a leaf, to ensure that if the browser has
-   * created a new text node for the composition, we will discard it.
-   *
-   * Resetting innerHTML will move focus to the beginning of the editor,
-   * so we update to force it back to the correct place.
-   */
-  resolveComposition(editor: DraftEditor): void {
-    if (stillComposing) {
-      return;
-    }
+/**
+ * In Safari, keydown events may fire when committing compositions. If
+ * the arrow keys are used to commit, prevent default so that the cursor
+ * doesn't move, otherwise it will jump back noticeably on re-render.
+ */
+export function onKeyDown(
+  editor: DraftEditor,
+  e: SyntheticKeyboardEvent<>,
+): void {
+  if (!stillComposing) {
+    // If a keydown event is received after compositionend but before the
+    // 20ms timer expires (ex: type option-E then backspace, or type A then
+    // backspace in 2-Set Korean), we should immediately resolve the
+    // composition and reinterpret the key press in edit mode.
+    resolveComposition(editor);
+    editor._onKeyDown(e);
+    return;
+  }
+  if (e.which === Keys.RIGHT || e.which === Keys.LEFT) {
+    e.preventDefault();
+  }
+}
 
-    const mutations = nullthrows(domObserver).stopAndFlushMutations();
-    domObserver = null;
-    resolved = true;
+/**
+ * Keypress events may fire when committing compositions. In Firefox,
+ * pressing RETURN commits the composition and inserts extra newline
+ * characters that we do not want. `preventDefault` allows the composition
+ * to be committed while preventing the extra characters.
+ */
+export function onKeyPress(
+  _editor: DraftEditor,
+  e: SyntheticKeyboardEvent<>,
+): void {
+  if (e.which === Keys.RETURN) {
+    e.preventDefault();
+  }
+}
 
-    let editorState = EditorState.set(editor._latestEditorState, {
-      inCompositionMode: false,
+/**
+ * Attempt to insert composed characters into the document.
+ *
+ * If we are still in a composition session, do nothing. Otherwise, insert
+ * the characters into the document and terminate the composition session.
+ *
+ * If no characters were composed -- for instance, the user
+ * deleted all composed characters and committed nothing new --
+ * force a re-render. We also re-render when the composition occurs
+ * at the beginning of a leaf, to ensure that if the browser has
+ * created a new text node for the composition, we will discard it.
+ *
+ * Resetting innerHTML will move focus to the beginning of the editor,
+ * so we update to force it back to the correct place.
+ */
+export function resolveComposition(editor: DraftEditor): void {
+  if (stillComposing) {
+    return;
+  }
+
+  const mutations = nullthrows(domObserver).stopAndFlushMutations();
+  domObserver = null;
+  resolved = true;
+
+  let editorState = EditorState.set(editor._latestEditorState, {
+    inCompositionMode: false,
+  });
+
+  editor.exitCurrentMode();
+
+  if (!mutations.size) {
+    editor.update(editorState);
+    return;
+  }
+
+  // TODO, check if Facebook still needs this flag or if it could be removed.
+  // Since there can be multiple mutations providing a `composedChars` doesn't
+  // apply well on this new model.
+  // if (
+  //   gkx('draft_handlebeforeinput_composed_text') &&
+  //   editor.props.handleBeforeInput &&
+  //   isEventHandled(
+  //     editor.props.handleBeforeInput(
+  //       composedChars,
+  //       editorState,
+  //       event.timeStamp,
+  //     ),
+  //   )
+  // ) {
+  //   return;
+  // }
+
+  let contentState = editorState.getCurrentContent();
+  mutations.forEach((composedChars, offsetKey) => {
+    const {blockKey, decoratorKey, leafKey} = DraftOffsetKey.decode(offsetKey);
+
+    const {start, end} = editorState
+      .getBlockTree(blockKey)
+      .getIn([decoratorKey, 'leaves', leafKey]);
+
+    const replacementRange = editorState.getSelection().merge({
+      anchorKey: blockKey,
+      focusKey: blockKey,
+      anchorOffset: start,
+      focusOffset: end,
+      isBackward: false,
     });
 
-    editor.exitCurrentMode();
+    const entityKey = getEntityKeyForSelection(contentState, replacementRange);
+    const currentStyle = contentState
+      .getBlockForKey(blockKey)
+      .getInlineStyleAt(start);
 
-    if (!mutations.size) {
-      editor.update(editorState);
-      return;
-    }
-
-    // TODO, check if Facebook still needs this flag or if it could be removed.
-    // Since there can be multiple mutations providing a `composedChars` doesn't
-    // apply well on this new model.
-    // if (
-    //   gkx('draft_handlebeforeinput_composed_text') &&
-    //   editor.props.handleBeforeInput &&
-    //   isEventHandled(
-    //     editor.props.handleBeforeInput(
-    //       composedChars,
-    //       editorState,
-    //       event.timeStamp,
-    //     ),
-    //   )
-    // ) {
-    //   return;
-    // }
-
-    let contentState = editorState.getCurrentContent();
-    mutations.forEach((composedChars, offsetKey) => {
-      const {blockKey, decoratorKey, leafKey} = DraftOffsetKey.decode(
-        offsetKey,
-      );
-
-      const {start, end} = editorState
-        .getBlockTree(blockKey)
-        .getIn([decoratorKey, 'leaves', leafKey]);
-
-      const replacementRange = editorState.getSelection().merge({
-        anchorKey: blockKey,
-        focusKey: blockKey,
-        anchorOffset: start,
-        focusOffset: end,
-        isBackward: false,
-      });
-
-      const entityKey = getEntityKeyForSelection(
-        contentState,
-        replacementRange,
-      );
-      const currentStyle = contentState
-        .getBlockForKey(blockKey)
-        .getInlineStyleAt(start);
-
-      contentState = DraftModifier.replaceText(
-        contentState,
-        replacementRange,
-        composedChars,
-        currentStyle,
-        entityKey,
-      );
-      // We need to update the editorState so the leaf node ranges are properly
-      // updated and multiple mutations are correctly applied.
-      editorState = EditorState.set(editorState, {
-        currentContent: contentState,
-      });
+    contentState = DraftModifier.replaceText(
+      contentState,
+      replacementRange,
+      composedChars,
+      currentStyle,
+      entityKey,
+    );
+    // We need to update the editorState so the leaf node ranges are properly
+    // updated and multiple mutations are correctly applied.
+    editorState = EditorState.set(editorState, {
+      currentContent: contentState,
     });
+  });
 
-    // When we apply the text changes to the ContentState, the selection always
-    // goes to the end of the field, but it should just stay where it is
-    // after compositionEnd.
-    const documentSelection = getDraftEditorSelection(
-      editorState,
-      getContentEditableContainer(editor),
-    );
-    const compositionEndSelectionState = documentSelection.selectionState;
+  // When we apply the text changes to the ContentState, the selection always
+  // goes to the end of the field, but it should just stay where it is
+  // after compositionEnd.
+  const documentSelection = getDraftEditorSelection(
+    editorState,
+    getContentEditableContainer(editor),
+  );
+  const compositionEndSelectionState = documentSelection.selectionState;
 
-    editor.restoreEditorDOM();
+  editor.restoreEditorDOM();
 
-    // See:
-    // - https://github.com/facebook/draft-js/issues/2093
-    // - https://github.com/facebook/draft-js/pull/2094
-    // Apply this fix only in IE for now. We can test it in
-    // other browsers in the future to ensure no regressions
-    const editorStateWithUpdatedSelection = isIE
-      ? EditorState.forceSelection(editorState, compositionEndSelectionState)
-      : EditorState.acceptSelection(editorState, compositionEndSelectionState);
+  // See:
+  // - https://github.com/facebook/draft-js/issues/2093
+  // - https://github.com/facebook/draft-js/pull/2094
+  // Apply this fix only in IE for now. We can test it in
+  // other browsers in the future to ensure no regressions
+  const editorStateWithUpdatedSelection = isIE
+    ? EditorState.forceSelection(editorState, compositionEndSelectionState)
+    : EditorState.acceptSelection(editorState, compositionEndSelectionState);
 
-    editor.update(
-      EditorState.push(
-        editorStateWithUpdatedSelection,
-        contentState,
-        'insert-characters',
-      ),
-    );
-  },
-};
-
-module.exports = DraftEditorCompositionHandler;
+  editor.update(
+    EditorState.push(
+      editorStateWithUpdatedSelection,
+      contentState,
+      'insert-characters',
+    ),
+  );
+}

--- a/src/component/handlers/composition/__tests__/DraftEditorCompostionHandler-test.js
+++ b/src/component/handlers/composition/__tests__/DraftEditorCompostionHandler-test.js
@@ -15,14 +15,15 @@
 // events.
 jest.useFakeTimers();
 
-const ContentBlock = require('ContentBlock');
-const ContentState = require('ContentState');
-const EditorState = require('EditorState');
-const SelectionState = require('SelectionState');
+import ContentBlock from 'ContentBlock';
+import ContentState from 'ContentState';
+import EditorState from 'EditorState';
+import SelectionState from 'SelectionState';
 
-const convertFromHTMLToContentBlocks = require('convertFromHTMLToContentBlocks');
-const editOnCompositionStart = require('editOnCompositionStart');
-const {Map} = require('immutable');
+import convertFromHTMLToContentBlocks from 'convertFromHTMLToContentBlocks';
+import editOnCompositionStart from 'editOnCompositionStart';
+import immutable from 'immutable';
+const {Map} = immutable;
 
 jest.mock('DOMObserver', () => {
   function DOMObserver() {}

--- a/src/component/handlers/drag/DraftEditorDragHandler.js
+++ b/src/component/handlers/drag/DraftEditorDragHandler.js
@@ -14,17 +14,17 @@
 import type DraftEditor from 'DraftEditor.react';
 import type SelectionState from 'SelectionState';
 
-const DataTransfer = require('DataTransfer');
-const DraftModifier = require('DraftModifier');
-const EditorState = require('EditorState');
+import DataTransfer from 'DataTransfer';
+import * as DraftModifier from 'DraftModifier';
+import EditorState from 'EditorState';
 
-const findAncestorOffsetKey = require('findAncestorOffsetKey');
-const getCorrectDocumentFromNode = require('getCorrectDocumentFromNode');
-const getTextContentFromFiles = require('getTextContentFromFiles');
-const getUpdatedSelectionState = require('getUpdatedSelectionState');
-const getWindowForNode = require('getWindowForNode');
-const isEventHandled = require('isEventHandled');
-const nullthrows = require('nullthrows');
+import findAncestorOffsetKey from 'findAncestorOffsetKey';
+import getCorrectDocumentFromNode from 'getCorrectDocumentFromNode';
+import getTextContentFromFiles from 'getTextContentFromFiles';
+import getUpdatedSelectionState from 'getUpdatedSelectionState';
+import getWindowForNode from 'getWindowForNode';
+import isEventHandled from 'isEventHandled';
+import nullthrows from 'nullthrows';
 
 /**
  * Get a SelectionState for the supplied mouse event.
@@ -67,76 +67,70 @@ function getSelectionForEvent(
   );
 }
 
-const DraftEditorDragHandler = {
-  /**
-   * Drag originating from input terminated.
-   */
-  onDragEnd: function(editor: DraftEditor): void {
-    editor.exitCurrentMode();
-    endDrag(editor);
-  },
+/**
+ * Drag originating from input terminated.
+ */
+export function onDragEnd(editor: DraftEditor): void {
+  editor.exitCurrentMode();
+  endDrag(editor);
+}
 
-  /**
-   * Handle data being dropped.
-   */
-  onDrop: function(editor: DraftEditor, e: Object): void {
-    const data = new DataTransfer(e.nativeEvent.dataTransfer);
+/**
+ * Handle data being dropped.
+ */
+export function onDrop(editor: DraftEditor, e: Object): void {
+  const data = new DataTransfer(e.nativeEvent.dataTransfer);
 
-    const editorState: EditorState = editor._latestEditorState;
-    const dropSelection: ?SelectionState = getSelectionForEvent(
-      e.nativeEvent,
-      editorState,
-    );
+  const editorState: EditorState = editor._latestEditorState;
+  const dropSelection: ?SelectionState = getSelectionForEvent(
+    e.nativeEvent,
+    editorState,
+  );
 
-    e.preventDefault();
-    editor._dragCount = 0;
-    editor.exitCurrentMode();
+  e.preventDefault();
+  editor._dragCount = 0;
+  editor.exitCurrentMode();
 
-    if (dropSelection == null) {
-      return;
-    }
+  if (dropSelection == null) {
+    return;
+  }
 
-    const files: Array<Blob> = (data.getFiles(): any);
-    if (files.length > 0) {
-      if (
-        editor.props.handleDroppedFiles &&
-        isEventHandled(editor.props.handleDroppedFiles(dropSelection, files))
-      ) {
-        return;
-      }
-
-      /* $FlowFixMe[incompatible-call] This comment suppresses an error found
-       * DataTransfer was typed. getFiles() returns an array of <Files extends
-       * Blob>, not Blob */
-      getTextContentFromFiles(files, fileText => {
-        fileText &&
-          editor.update(
-            insertTextAtSelection(editorState, dropSelection, fileText),
-          );
-      });
-      return;
-    }
-
-    const dragType = editor._internalDrag ? 'internal' : 'external';
+  const files: Array<Blob> = (data.getFiles(): any);
+  if (files.length > 0) {
     if (
-      editor.props.handleDrop &&
-      isEventHandled(editor.props.handleDrop(dropSelection, data, dragType))
+      editor.props.handleDroppedFiles &&
+      isEventHandled(editor.props.handleDroppedFiles(dropSelection, files))
     ) {
-      // handled
-    } else if (editor._internalDrag) {
-      editor.update(moveText(editorState, dropSelection));
-    } else {
-      editor.update(
-        insertTextAtSelection(
-          editorState,
-          dropSelection,
-          (data.getText(): any),
-        ),
-      );
+      return;
     }
-    endDrag(editor);
-  },
-};
+
+    /* $FlowFixMe[incompatible-call] This comment suppresses an error found
+     * DataTransfer was typed. getFiles() returns an array of <Files extends
+     * Blob>, not Blob */
+    getTextContentFromFiles(files, fileText => {
+      fileText &&
+        editor.update(
+          insertTextAtSelection(editorState, dropSelection, fileText),
+        );
+    });
+    return;
+  }
+
+  const dragType = editor._internalDrag ? 'internal' : 'external';
+  if (
+    editor.props.handleDrop &&
+    isEventHandled(editor.props.handleDrop(dropSelection, data, dragType))
+  ) {
+    // handled
+  } else if (editor._internalDrag) {
+    editor.update(moveText(editorState, dropSelection));
+  } else {
+    editor.update(
+      insertTextAtSelection(editorState, dropSelection, (data.getText(): any)),
+    );
+  }
+  endDrag(editor);
+}
 
 function endDrag(editor) {
   editor._internalDrag = false;
@@ -184,5 +178,3 @@ function insertTextAtSelection(
   );
   return EditorState.push(editorState, newContentState, 'insert-fragment');
 }
-
-module.exports = DraftEditorDragHandler;

--- a/src/component/handlers/edit/__tests__/editOnBeforeInput-test.js
+++ b/src/component/handlers/edit/__tests__/editOnBeforeInput-test.js
@@ -13,13 +13,13 @@
 
 import type DraftEditor from 'DraftEditor.react';
 
-const CompositeDraftDecorator = require('CompositeDraftDecorator');
-const ContentBlock = require('ContentBlock');
-const ContentState = require('ContentState');
-const EditorState = require('EditorState');
-const SelectionState = require('SelectionState');
+import CompositeDraftDecorator from 'CompositeDraftDecorator';
+import ContentBlock from 'ContentBlock';
+import ContentState from 'ContentState';
+import EditorState from 'EditorState';
+import SelectionState from 'SelectionState';
 
-const onBeforeInput = require('editOnBeforeInput');
+import onBeforeInput from 'editOnBeforeInput';
 
 const DEFAULT_SELECTION = {
   anchorKey: 'a',

--- a/src/component/handlers/edit/__tests__/editOnBlur-test.js
+++ b/src/component/handlers/edit/__tests__/editOnBlur-test.js
@@ -11,11 +11,11 @@
 
 'use strict';
 
-const ContentBlock = require('ContentBlock');
-const ContentState = require('ContentState');
-const EditorState = require('EditorState');
+import ContentBlock from 'ContentBlock';
+import ContentState from 'ContentState';
+import EditorState from 'EditorState';
 
-const onBlur = require('editOnBlur');
+import onBlur from 'editOnBlur';
 
 const getEditorState = (text: string = 'Arsenal') => {
   return EditorState.createWithContent(

--- a/src/component/handlers/edit/__tests__/editOnInput-test.js
+++ b/src/component/handlers/edit/__tests__/editOnInput-test.js
@@ -11,11 +11,11 @@
 
 'use strict';
 
-const ContentBlock = require('ContentBlock');
-const ContentState = require('ContentState');
-const EditorState = require('EditorState');
+import ContentBlock from 'ContentBlock';
+import ContentState from 'ContentState';
+import EditorState from 'EditorState';
 
-const onInput = require('editOnInput');
+import onInput from 'editOnInput';
 
 jest.mock('findAncestorOffsetKey', () => jest.fn(() => 'blockkey-0-0'));
 jest.mock('keyCommandPlainBackspace', () => jest.fn(() => ({})));

--- a/src/component/handlers/edit/commands/SecondaryClipboard.js
+++ b/src/component/handlers/edit/commands/SecondaryClipboard.js
@@ -14,72 +14,64 @@
 import type {BlockMap} from 'BlockMap';
 import type SelectionState from 'SelectionState';
 
-const DraftModifier = require('DraftModifier');
-const EditorState = require('EditorState');
+import * as DraftModifier from 'DraftModifier';
+import EditorState from 'EditorState';
 
-const getContentStateFragment = require('getContentStateFragment');
-const nullthrows = require('nullthrows');
+import getContentStateFragment from 'getContentStateFragment';
+import nullthrows from 'nullthrows';
 
 let clipboard: ?BlockMap = null;
 
-/**
- * Some systems offer a "secondary" clipboard to allow quick internal cut
- * and paste behavior. For instance, Ctrl+K (cut) and Ctrl+Y (paste).
- */
-const SecondaryClipboard = {
-  cut: function(editorState: EditorState): EditorState {
-    const content = editorState.getCurrentContent();
-    const selection = editorState.getSelection();
-    let targetRange: ?SelectionState = null;
+export function cut(editorState: EditorState): EditorState {
+  const content = editorState.getCurrentContent();
+  const selection = editorState.getSelection();
+  let targetRange: ?SelectionState = null;
 
-    if (selection.isCollapsed()) {
-      const anchorKey = selection.getAnchorKey();
-      const blockEnd = content.getBlockForKey(anchorKey).getLength();
+  if (selection.isCollapsed()) {
+    const anchorKey = selection.getAnchorKey();
+    const blockEnd = content.getBlockForKey(anchorKey).getLength();
 
-      if (blockEnd === selection.getAnchorOffset()) {
-        const keyAfter = content.getKeyAfter(anchorKey);
-        if (keyAfter == null) {
-          return editorState;
-        }
-        targetRange = selection.set('focusKey', keyAfter).set('focusOffset', 0);
-      } else {
-        targetRange = selection.set('focusOffset', blockEnd);
+    if (blockEnd === selection.getAnchorOffset()) {
+      const keyAfter = content.getKeyAfter(anchorKey);
+      if (keyAfter == null) {
+        return editorState;
       }
+      targetRange = selection.set('focusKey', keyAfter).set('focusOffset', 0);
     } else {
-      targetRange = selection;
+      targetRange = selection.set('focusOffset', blockEnd);
     }
+  } else {
+    targetRange = selection;
+  }
 
-    targetRange = nullthrows(targetRange);
-    // TODO: This should actually append to the current state when doing
-    // successive ^K commands without any other cursor movement
-    clipboard = getContentStateFragment(content, targetRange);
+  targetRange = nullthrows(targetRange);
+  // TODO: This should actually append to the current state when doing
+  // successive ^K commands without any other cursor movement
+  clipboard = getContentStateFragment(content, targetRange);
 
-    const afterRemoval = DraftModifier.removeRange(
-      content,
-      targetRange,
-      'forward',
-    );
+  const afterRemoval = DraftModifier.removeRange(
+    content,
+    targetRange,
+    'forward',
+  );
 
-    if (afterRemoval === content) {
-      return editorState;
-    }
+  if (afterRemoval === content) {
+    return editorState;
+  }
 
-    return EditorState.push(editorState, afterRemoval, 'remove-range');
-  },
+  return EditorState.push(editorState, afterRemoval, 'remove-range');
+}
 
-  paste: function(editorState: EditorState): EditorState {
-    if (!clipboard) {
-      return editorState;
-    }
+export function paste(editorState: EditorState): EditorState {
+  if (!clipboard) {
+    return editorState;
+  }
 
-    const newContent = DraftModifier.replaceWithFragment(
-      editorState.getCurrentContent(),
-      editorState.getSelection(),
-      clipboard,
-    );
+  const newContent = DraftModifier.replaceWithFragment(
+    editorState.getCurrentContent(),
+    editorState.getSelection(),
+    clipboard,
+  );
 
-    return EditorState.push(editorState, newContent, 'insert-fragment');
-  },
-};
-
-module.exports = SecondaryClipboard;
+  return EditorState.push(editorState, newContent, 'insert-fragment');
+}

--- a/src/component/handlers/edit/commands/__tests__/SecondaryClipboard-test.js
+++ b/src/component/handlers/edit/commands/__tests__/SecondaryClipboard-test.js
@@ -22,14 +22,14 @@ const toggleExperimentalTreeDataSupport = enabled => {
 // Seems to be important to put this at the top
 toggleExperimentalTreeDataSupport(true);
 
-const BlockMapBuilder = require('BlockMapBuilder');
-const ContentBlockNode = require('ContentBlockNode');
-const EditorState = require('EditorState');
-const SecondaryClipboard = require('SecondaryClipboard');
-const SelectionState = require('SelectionState');
+import * as BlockMapBuilder from 'BlockMapBuilder';
+import ContentBlockNode from 'ContentBlockNode';
+import EditorState from 'EditorState';
+import * as SecondaryClipboard from 'SecondaryClipboard';
+import SelectionState from 'SelectionState';
 
-const getSampleStateForTesting = require('getSampleStateForTesting');
-const Immutable = require('immutable');
+import getSampleStateForTesting from 'getSampleStateForTesting';
+import Immutable from 'immutable';
 
 const {List} = Immutable;
 

--- a/src/component/handlers/edit/commands/__tests__/removeTextWithStrategy-test.js
+++ b/src/component/handlers/edit/commands/__tests__/removeTextWithStrategy-test.js
@@ -22,16 +22,16 @@ const toggleExperimentalTreeDataSupport = enabled => {
 // Seems to be important to put this at the top
 toggleExperimentalTreeDataSupport(true);
 
-const BlockMapBuilder = require('BlockMapBuilder');
-const ContentBlockNode = require('ContentBlockNode');
-const EditorState = require('EditorState');
-const SelectionState = require('SelectionState');
-const UnicodeUtils = require('UnicodeUtils');
+import * as BlockMapBuilder from 'BlockMapBuilder';
+import ContentBlockNode from 'ContentBlockNode';
+import EditorState from 'EditorState';
+import SelectionState from 'SelectionState';
+import * as UnicodeUtils from 'UnicodeUtils';
 
-const getSampleStateForTesting = require('getSampleStateForTesting');
-const Immutable = require('immutable');
-const moveSelectionForward = require('moveSelectionForward');
-const removeTextWithStrategy = require('removeTextWithStrategy');
+import getSampleStateForTesting from 'getSampleStateForTesting';
+import Immutable from 'immutable';
+import moveSelectionForward from 'moveSelectionForward';
+import removeTextWithStrategy from 'removeTextWithStrategy';
 
 const {List} = Immutable;
 

--- a/src/component/handlers/edit/commands/keyCommandBackspaceToStartOfLine.js
+++ b/src/component/handlers/edit/commands/keyCommandBackspaceToStartOfLine.js
@@ -13,14 +13,14 @@
 
 import type {SelectionObject} from 'DraftDOMTypes';
 
-const EditorState = require('EditorState');
+import EditorState from 'EditorState';
 
-const expandRangeToStartOfLine = require('expandRangeToStartOfLine');
-const getDraftEditorSelectionWithNodes = require('getDraftEditorSelectionWithNodes');
-const moveSelectionBackward = require('moveSelectionBackward');
-const removeTextWithStrategy = require('removeTextWithStrategy');
+import expandRangeToStartOfLine from 'expandRangeToStartOfLine';
+import getDraftEditorSelectionWithNodes from 'getDraftEditorSelectionWithNodes';
+import moveSelectionBackward from 'moveSelectionBackward';
+import removeTextWithStrategy from 'removeTextWithStrategy';
 
-function keyCommandBackspaceToStartOfLine(
+export default function keyCommandBackspaceToStartOfLine(
   editorState: EditorState,
   e: SyntheticKeyboardEvent<HTMLElement>,
 ): EditorState {
@@ -58,5 +58,3 @@ function keyCommandBackspaceToStartOfLine(
 
   return EditorState.push(editorState, afterRemoval, 'remove-range');
 }
-
-module.exports = keyCommandBackspaceToStartOfLine;

--- a/src/component/handlers/edit/commands/keyCommandBackspaceWord.js
+++ b/src/component/handlers/edit/commands/keyCommandBackspaceWord.js
@@ -11,17 +11,19 @@
 
 'use strict';
 
-const DraftRemovableWord = require('DraftRemovableWord');
-const EditorState = require('EditorState');
+import * as DraftRemovableWord from 'DraftRemovableWord';
+import EditorState from 'EditorState';
 
-const moveSelectionBackward = require('moveSelectionBackward');
-const removeTextWithStrategy = require('removeTextWithStrategy');
+import moveSelectionBackward from 'moveSelectionBackward';
+import removeTextWithStrategy from 'removeTextWithStrategy';
 
 /**
  * Delete the word that is left of the cursor, as well as any spaces or
  * punctuation after the word.
  */
-function keyCommandBackspaceWord(editorState: EditorState): EditorState {
+export default function keyCommandBackspaceWord(
+  editorState: EditorState,
+): EditorState {
   const afterRemoval = removeTextWithStrategy(
     editorState,
     strategyState => {
@@ -49,5 +51,3 @@ function keyCommandBackspaceWord(editorState: EditorState): EditorState {
 
   return EditorState.push(editorState, afterRemoval, 'remove-range');
 }
-
-module.exports = keyCommandBackspaceWord;

--- a/src/component/handlers/edit/commands/keyCommandDeleteWord.js
+++ b/src/component/handlers/edit/commands/keyCommandDeleteWord.js
@@ -11,17 +11,19 @@
 
 'use strict';
 
-const DraftRemovableWord = require('DraftRemovableWord');
-const EditorState = require('EditorState');
+import * as DraftRemovableWord from 'DraftRemovableWord';
+import EditorState from 'EditorState';
 
-const moveSelectionForward = require('moveSelectionForward');
-const removeTextWithStrategy = require('removeTextWithStrategy');
+import moveSelectionForward from 'moveSelectionForward';
+import removeTextWithStrategy from 'removeTextWithStrategy';
 
 /**
  * Delete the word that is right of the cursor, as well as any spaces or
  * punctuation before the word.
  */
-function keyCommandDeleteWord(editorState: EditorState): EditorState {
+export default function keyCommandDeleteWord(
+  editorState: EditorState,
+): EditorState {
   const afterRemoval = removeTextWithStrategy(
     editorState,
     strategyState => {
@@ -47,5 +49,3 @@ function keyCommandDeleteWord(editorState: EditorState): EditorState {
 
   return EditorState.push(editorState, afterRemoval, 'remove-range');
 }
-
-module.exports = keyCommandDeleteWord;

--- a/src/component/handlers/edit/commands/keyCommandInsertNewline.js
+++ b/src/component/handlers/edit/commands/keyCommandInsertNewline.js
@@ -11,15 +11,15 @@
 
 'use strict';
 
-const DraftModifier = require('DraftModifier');
-const EditorState = require('EditorState');
+import * as DraftModifier from 'DraftModifier';
+import EditorState from 'EditorState';
 
-function keyCommandInsertNewline(editorState: EditorState): EditorState {
+export default function keyCommandInsertNewline(
+  editorState: EditorState,
+): EditorState {
   const contentState = DraftModifier.splitBlock(
     editorState.getCurrentContent(),
     editorState.getSelection(),
   );
   return EditorState.push(editorState, contentState, 'split-block');
 }
-
-module.exports = keyCommandInsertNewline;

--- a/src/component/handlers/edit/commands/keyCommandMoveSelectionToEndOfBlock.js
+++ b/src/component/handlers/edit/commands/keyCommandMoveSelectionToEndOfBlock.js
@@ -11,12 +11,12 @@
 
 'use strict';
 
-const EditorState = require('EditorState');
+import EditorState from 'EditorState';
 
 /**
  * See comment for `moveSelectionToStartOfBlock`.
  */
-function keyCommandMoveSelectionToEndOfBlock(
+export default function keyCommandMoveSelectionToEndOfBlock(
   editorState: EditorState,
 ): EditorState {
   const selection = editorState.getSelection();
@@ -34,5 +34,3 @@ function keyCommandMoveSelectionToEndOfBlock(
     forceSelection: true,
   });
 }
-
-module.exports = keyCommandMoveSelectionToEndOfBlock;

--- a/src/component/handlers/edit/commands/keyCommandMoveSelectionToStartOfBlock.js
+++ b/src/component/handlers/edit/commands/keyCommandMoveSelectionToStartOfBlock.js
@@ -11,14 +11,14 @@
 
 'use strict';
 
-const EditorState = require('EditorState');
+import EditorState from 'EditorState';
 
 /**
  * Collapse selection at the start of the first selected block. This is used
  * for Firefox versions that attempt to navigate forward/backward instead of
  * moving the cursor. Other browsers are able to move the cursor natively.
  */
-function keyCommandMoveSelectionToStartOfBlock(
+export default function keyCommandMoveSelectionToStartOfBlock(
   editorState: EditorState,
 ): EditorState {
   const selection = editorState.getSelection();
@@ -34,5 +34,3 @@ function keyCommandMoveSelectionToStartOfBlock(
     forceSelection: true,
   });
 }
-
-module.exports = keyCommandMoveSelectionToStartOfBlock;

--- a/src/component/handlers/edit/commands/keyCommandPlainBackspace.js
+++ b/src/component/handlers/edit/commands/keyCommandPlainBackspace.js
@@ -11,18 +11,20 @@
 
 'use strict';
 
-const EditorState = require('EditorState');
-const UnicodeUtils = require('UnicodeUtils');
+import EditorState from 'EditorState';
+import * as UnicodeUtils from 'UnicodeUtils';
 
-const moveSelectionBackward = require('moveSelectionBackward');
-const removeTextWithStrategy = require('removeTextWithStrategy');
+import moveSelectionBackward from 'moveSelectionBackward';
+import removeTextWithStrategy from 'removeTextWithStrategy';
 
 /**
  * Remove the selected range. If the cursor is collapsed, remove the preceding
  * character. This operation is Unicode-aware, so removing a single character
  * will remove a surrogate pair properly as well.
  */
-function keyCommandPlainBackspace(editorState: EditorState): EditorState {
+export default function keyCommandPlainBackspace(
+  editorState: EditorState,
+): EditorState {
   const afterRemoval = removeTextWithStrategy(
     editorState,
     strategyState => {
@@ -50,5 +52,3 @@ function keyCommandPlainBackspace(editorState: EditorState): EditorState {
     selection.isCollapsed() ? 'backspace-character' : 'remove-range',
   );
 }
-
-module.exports = keyCommandPlainBackspace;

--- a/src/component/handlers/edit/commands/keyCommandPlainDelete.js
+++ b/src/component/handlers/edit/commands/keyCommandPlainDelete.js
@@ -11,18 +11,20 @@
 
 'use strict';
 
-const EditorState = require('EditorState');
-const UnicodeUtils = require('UnicodeUtils');
+import EditorState from 'EditorState';
+import * as UnicodeUtils from 'UnicodeUtils';
 
-const moveSelectionForward = require('moveSelectionForward');
-const removeTextWithStrategy = require('removeTextWithStrategy');
+import moveSelectionForward from 'moveSelectionForward';
+import removeTextWithStrategy from 'removeTextWithStrategy';
 
 /**
  * Remove the selected range. If the cursor is collapsed, remove the following
  * character. This operation is Unicode-aware, so removing a single character
  * will remove a surrogate pair properly as well.
  */
-function keyCommandPlainDelete(editorState: EditorState): EditorState {
+export default function keyCommandPlainDelete(
+  editorState: EditorState,
+): EditorState {
   const afterRemoval = removeTextWithStrategy(
     editorState,
     strategyState => {
@@ -51,5 +53,3 @@ function keyCommandPlainDelete(editorState: EditorState): EditorState {
     selection.isCollapsed() ? 'delete-character' : 'remove-range',
   );
 }
-
-module.exports = keyCommandPlainDelete;

--- a/src/component/handlers/edit/commands/keyCommandTransposeCharacters.js
+++ b/src/component/handlers/edit/commands/keyCommandTransposeCharacters.js
@@ -11,17 +11,19 @@
 
 'use strict';
 
-const DraftModifier = require('DraftModifier');
-const EditorState = require('EditorState');
+import * as DraftModifier from 'DraftModifier';
+import EditorState from 'EditorState';
 
-const getContentStateFragment = require('getContentStateFragment');
+import getContentStateFragment from 'getContentStateFragment';
 
 /**
  * Transpose the characters on either side of a collapsed cursor, or
  * if the cursor is at the end of the block, transpose the last two
  * characters.
  */
-function keyCommandTransposeCharacters(editorState: EditorState): EditorState {
+export default function keyCommandTransposeCharacters(
+  editorState: EditorState,
+): EditorState {
   const selection = editorState.getSelection();
   if (!selection.isCollapsed()) {
     return editorState;
@@ -85,5 +87,3 @@ function keyCommandTransposeCharacters(editorState: EditorState): EditorState {
 
   return EditorState.acceptSelection(newEditorState, finalSelection);
 }
-
-module.exports = keyCommandTransposeCharacters;

--- a/src/component/handlers/edit/commands/keyCommandUndo.js
+++ b/src/component/handlers/edit/commands/keyCommandUndo.js
@@ -11,9 +11,9 @@
 
 'use strict';
 
-const EditorState = require('EditorState');
+import EditorState from 'EditorState';
 
-function keyCommandUndo(
+export default function keyCommandUndo(
   e: SyntheticKeyboardEvent<>,
   editorState: EditorState,
   updateFn: (editorState: EditorState) => void,
@@ -47,5 +47,3 @@ function keyCommandUndo(
     updateFn(undoneState);
   }, 0);
 }
-
-module.exports = keyCommandUndo;

--- a/src/component/handlers/edit/commands/moveSelectionBackward.js
+++ b/src/component/handlers/edit/commands/moveSelectionBackward.js
@@ -14,7 +14,7 @@
 import type EditorState from 'EditorState';
 import type SelectionState from 'SelectionState';
 
-const warning = require('warning');
+import warning from 'warning';
 
 /**
  * Given a collapsed selection, move the focus `maxDistance` backward within
@@ -24,7 +24,7 @@ const warning = require('warning');
  * This function is not Unicode-aware, so surrogate pairs will be treated
  * as having length 2.
  */
-function moveSelectionBackward(
+export default function moveSelectionBackward(
   editorState: EditorState,
   maxDistance: number,
 ): SelectionState {
@@ -60,5 +60,3 @@ function moveSelectionBackward(
     isBackward: true,
   });
 }
-
-module.exports = moveSelectionBackward;

--- a/src/component/handlers/edit/commands/moveSelectionForward.js
+++ b/src/component/handlers/edit/commands/moveSelectionForward.js
@@ -14,7 +14,7 @@
 import type EditorState from 'EditorState';
 import type SelectionState from 'SelectionState';
 
-const warning = require('warning');
+import warning from 'warning';
 
 /**
  * Given a collapsed selection, move the focus `maxDistance` forward within
@@ -24,7 +24,7 @@ const warning = require('warning');
  * This function is not Unicode-aware, so surrogate pairs will be treated
  * as having length 2.
  */
-function moveSelectionForward(
+export default function moveSelectionForward(
   editorState: EditorState,
   maxDistance: number,
 ): SelectionState {
@@ -52,5 +52,3 @@ function moveSelectionForward(
 
   return selection.merge({focusKey, focusOffset});
 }
-
-module.exports = moveSelectionForward;

--- a/src/component/handlers/edit/commands/removeTextWithStrategy.js
+++ b/src/component/handlers/edit/commands/removeTextWithStrategy.js
@@ -16,9 +16,9 @@ import type {DraftRemovalDirection} from 'DraftRemovalDirection';
 import type EditorState from 'EditorState';
 import type SelectionState from 'SelectionState';
 
-const DraftModifier = require('DraftModifier');
+import * as DraftModifier from 'DraftModifier';
 
-const gkx = require('gkx');
+import gkx from 'gkx';
 
 const experimentalTreeDataSupport = gkx('draft_tree_data_support');
 
@@ -26,7 +26,7 @@ const experimentalTreeDataSupport = gkx('draft_tree_data_support');
  * For a collapsed selection state, remove text based on the specified strategy.
  * If the selection state is not collapsed, remove the entire selected range.
  */
-function removeTextWithStrategy(
+export default function removeTextWithStrategy(
   editorState: EditorState,
   strategy: (editorState: EditorState) => SelectionState,
   direction: DraftRemovalDirection,
@@ -77,5 +77,3 @@ function removeTextWithStrategy(
   }
   return DraftModifier.removeRange(content, target, direction);
 }
-
-module.exports = removeTextWithStrategy;

--- a/src/component/handlers/edit/editOnBeforeInput.js
+++ b/src/component/handlers/edit/editOnBeforeInput.js
@@ -14,15 +14,15 @@
 import type DraftEditor from 'DraftEditor.react';
 import type {DraftInlineStyle} from 'DraftInlineStyle';
 
-const DraftModifier = require('DraftModifier');
-const EditorState = require('EditorState');
-const UserAgent = require('UserAgent');
+import * as DraftModifier from 'DraftModifier';
+import EditorState from 'EditorState';
+import UserAgent from 'UserAgent';
 
-const getEntityKeyForSelection = require('getEntityKeyForSelection');
-const isEventHandled = require('isEventHandled');
-const isSelectionAtLeafStart = require('isSelectionAtLeafStart');
-const nullthrows = require('nullthrows');
-const setImmediate = require('setImmediate');
+import getEntityKeyForSelection from 'getEntityKeyForSelection';
+import isEventHandled from 'isEventHandled';
+import isSelectionAtLeafStart from 'isSelectionAtLeafStart';
+import nullthrows from 'nullthrows';
+import setImmediate from 'setImmediate';
 
 // When nothing is focused, Firefox regards two characters, `'` and `/`, as
 // commands that should open and focus the "quickfind" search bar. This should
@@ -77,7 +77,7 @@ function replaceText(
  * preserve spellcheck highlighting, which disappears or flashes if re-render
  * occurs on the relevant text nodes.
  */
-function editOnBeforeInput(
+export default function editOnBeforeInput(
   editor: DraftEditor,
   e: SyntheticInputEvent<HTMLElement>,
 ): void {
@@ -252,5 +252,3 @@ function editOnBeforeInput(
     }
   });
 }
-
-module.exports = editOnBeforeInput;

--- a/src/component/handlers/edit/editOnBlur.js
+++ b/src/component/handlers/edit/editOnBlur.js
@@ -14,12 +14,15 @@
 import type {SelectionObject} from 'DraftDOMTypes';
 import type DraftEditor from 'DraftEditor.react';
 
-const EditorState = require('EditorState');
+import EditorState from 'EditorState';
 
-const containsNode = require('containsNode');
-const getActiveElement = require('getActiveElement');
+import containsNode from 'containsNode';
+import getActiveElement from 'getActiveElement';
 
-function editOnBlur(editor: DraftEditor, e: SyntheticEvent<HTMLElement>): void {
+export default function editOnBlur(
+  editor: DraftEditor,
+  e: SyntheticEvent<HTMLElement>,
+): void {
   // In a contentEditable element, when you select a range and then click
   // another active element, this does trigger a `blur` event but will not
   // remove the DOM selection from the contenteditable.
@@ -56,5 +59,3 @@ function editOnBlur(editor: DraftEditor, e: SyntheticEvent<HTMLElement>): void {
   editor.props.onBlur && editor.props.onBlur(e);
   editor.update(EditorState.acceptSelection(editorState, selection));
 }
-
-module.exports = editOnBlur;

--- a/src/component/handlers/edit/editOnCompositionStart.js
+++ b/src/component/handlers/edit/editOnCompositionStart.js
@@ -13,13 +13,13 @@
 
 import type DraftEditor from 'DraftEditor.react';
 
-const EditorState = require('EditorState');
+import EditorState from 'EditorState';
 
 /**
  * The user has begun using an IME input system. Switching to `composite` mode
  * allows handling composition input and disables other edit behavior.
  */
-function editOnCompositionStart(
+export default function editOnCompositionStart(
   editor: DraftEditor,
   e: SyntheticEvent<>,
 ): void {
@@ -30,5 +30,3 @@ function editOnCompositionStart(
   // Allow composition handler to interpret the compositionstart event
   editor._onCompositionStart(e);
 }
-
-module.exports = editOnCompositionStart;

--- a/src/component/handlers/edit/editOnCopy.js
+++ b/src/component/handlers/edit/editOnCopy.js
@@ -13,14 +13,17 @@
 
 import type DraftEditor from 'DraftEditor.react';
 
-const getFragmentFromSelection = require('getFragmentFromSelection');
+import getFragmentFromSelection from 'getFragmentFromSelection';
 
 /**
  * If we have a selection, create a ContentState fragment and store
  * it in our internal clipboard. Subsequent paste events will use this
  * fragment if no external clipboard data is supplied.
  */
-function editOnCopy(editor: DraftEditor, e: SyntheticClipboardEvent<>): void {
+export default function editOnCopy(
+  editor: DraftEditor,
+  e: SyntheticClipboardEvent<>,
+): void {
   const editorState = editor._latestEditorState;
   const selection = editorState.getSelection();
 
@@ -32,5 +35,3 @@ function editOnCopy(editor: DraftEditor, e: SyntheticClipboardEvent<>): void {
 
   editor.setClipboard(getFragmentFromSelection(editor._latestEditorState));
 }
-
-module.exports = editOnCopy;

--- a/src/component/handlers/edit/editOnCut.js
+++ b/src/component/handlers/edit/editOnCut.js
@@ -13,13 +13,13 @@
 
 import type DraftEditor from 'DraftEditor.react';
 
-const DraftModifier = require('DraftModifier');
-const EditorState = require('EditorState');
-const Style = require('Style');
+import * as DraftModifier from 'DraftModifier';
+import EditorState from 'EditorState';
+import Style from 'Style';
 
-const getFragmentFromSelection = require('getFragmentFromSelection');
-const getScrollPosition = require('getScrollPosition');
-const isNode = require('isInstanceOfNode');
+import getFragmentFromSelection from 'getFragmentFromSelection';
+import getScrollPosition from 'getScrollPosition';
+import isNode from 'isInstanceOfNode';
 
 /**
  * On `cut` events, native behavior is allowed to occur so that the system
@@ -30,7 +30,10 @@ const isNode = require('isInstanceOfNode');
  * In addition, we can keep a copy of the removed fragment, including all
  * styles and entities, for use as an internal paste.
  */
-function editOnCut(editor: DraftEditor, e: SyntheticClipboardEvent<>): void {
+export default function editOnCut(
+  editor: DraftEditor,
+  e: SyntheticClipboardEvent<>,
+): void {
   const editorState = editor._latestEditorState;
   const selection = editorState.getSelection();
   const element = e.target;
@@ -71,5 +74,3 @@ function removeFragment(editorState: EditorState): EditorState {
   );
   return EditorState.push(editorState, newContent, 'remove-range');
 }
-
-module.exports = editOnCut;

--- a/src/component/handlers/edit/editOnDragOver.js
+++ b/src/component/handlers/edit/editOnDragOver.js
@@ -16,9 +16,10 @@ import type DraftEditor from 'DraftEditor.react';
 /**
  * Drag behavior has begun from outside the editor element.
  */
-function editOnDragOver(editor: DraftEditor, e: SyntheticDragEvent<>): void {
+export default function editOnDragOver(
+  editor: DraftEditor,
+  e: SyntheticDragEvent<>,
+): void {
   editor.setMode('drag');
   e.preventDefault();
 }
-
-module.exports = editOnDragOver;

--- a/src/component/handlers/edit/editOnDragStart.js
+++ b/src/component/handlers/edit/editOnDragStart.js
@@ -16,9 +16,7 @@ import type DraftEditor from 'DraftEditor.react';
 /**
  * A `dragstart` event has begun within the text editor component.
  */
-function editOnDragStart(editor: DraftEditor): void {
+export default function editOnDragStart(editor: DraftEditor): void {
   editor._internalDrag = true;
   editor.setMode('drag');
 }
-
-module.exports = editOnDragStart;

--- a/src/component/handlers/edit/editOnFocus.js
+++ b/src/component/handlers/edit/editOnFocus.js
@@ -13,10 +13,13 @@
 
 import type DraftEditor from 'DraftEditor.react';
 
-const EditorState = require('EditorState');
-const UserAgent = require('UserAgent');
+import EditorState from 'EditorState';
+import UserAgent from 'UserAgent';
 
-function editOnFocus(editor: DraftEditor, e: SyntheticFocusEvent<>): void {
+export default function editOnFocus(
+  editor: DraftEditor,
+  e: SyntheticFocusEvent<>,
+): void {
   const editorState = editor._latestEditorState;
   const currentSelection = editorState.getSelection();
   if (currentSelection.getHasFocus()) {
@@ -42,5 +45,3 @@ function editOnFocus(editor: DraftEditor, e: SyntheticFocusEvent<>): void {
     editor.update(EditorState.acceptSelection(editorState, selection));
   }
 }
-
-module.exports = editOnFocus;

--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -14,15 +14,15 @@
 import type {SelectionObject} from 'DraftDOMTypes';
 import type DraftEditor from 'DraftEditor.react';
 
-const DraftModifier = require('DraftModifier');
-const DraftOffsetKey = require('DraftOffsetKey');
-const EditorState = require('EditorState');
-const UserAgent = require('UserAgent');
+import * as DraftModifier from 'DraftModifier';
+import * as DraftOffsetKey from 'DraftOffsetKey';
+import EditorState from 'EditorState';
+import UserAgent from 'UserAgent';
 
-const {notEmptyKey} = require('draftKeyUtils');
-const findAncestorOffsetKey = require('findAncestorOffsetKey');
-const keyCommandPlainBackspace = require('keyCommandPlainBackspace');
-const nullthrows = require('nullthrows');
+import {notEmptyKey} from 'draftKeyUtils';
+import findAncestorOffsetKey from 'findAncestorOffsetKey';
+import keyCommandPlainBackspace from 'keyCommandPlainBackspace';
+import nullthrows from 'nullthrows';
 
 const isGecko = UserAgent.isEngine('Gecko');
 
@@ -59,7 +59,10 @@ function onInputType(inputType: string, editorState: EditorState): EditorState {
  * when an `input` change leads to a DOM/model mismatch, the change should be
  * due to a spellcheck change, and we can incorporate it into our model.
  */
-function editOnInput(editor: DraftEditor, e: SyntheticInputEvent<>): void {
+export default function editOnInput(
+  editor: DraftEditor,
+  e: SyntheticInputEvent<>,
+): void {
   if (editor._pendingStateFromBeforeInput !== undefined) {
     editor.update(editor._pendingStateFromBeforeInput);
     editor._pendingStateFromBeforeInput = undefined;
@@ -213,5 +216,3 @@ function editOnInput(editor: DraftEditor, e: SyntheticInputEvent<>): void {
     EditorState.push(editorState, contentWithAdjustedDOMSelection, changeType),
   );
 }
-
-module.exports = editOnInput;

--- a/src/component/handlers/edit/editOnKeyDown.js
+++ b/src/component/handlers/edit/editOnKeyDown.js
@@ -14,26 +14,25 @@
 import type DraftEditor from 'DraftEditor.react';
 import type {DraftEditorCommand} from 'DraftEditorCommand';
 
-const DraftModifier = require('DraftModifier');
-const EditorState = require('EditorState');
-const KeyBindingUtil = require('KeyBindingUtil');
-const Keys = require('Keys');
-const SecondaryClipboard = require('SecondaryClipboard');
-const UserAgent = require('UserAgent');
+import * as DraftModifier from 'DraftModifier';
+import EditorState from 'EditorState';
+import {isOptionKeyCommand} from 'KeyBindingUtil';
+import Keys from 'Keys';
+import * as SecondaryClipboard from 'SecondaryClipboard';
+import UserAgent from 'UserAgent';
 
-const isEventHandled = require('isEventHandled');
-const keyCommandBackspaceToStartOfLine = require('keyCommandBackspaceToStartOfLine');
-const keyCommandBackspaceWord = require('keyCommandBackspaceWord');
-const keyCommandDeleteWord = require('keyCommandDeleteWord');
-const keyCommandInsertNewline = require('keyCommandInsertNewline');
-const keyCommandMoveSelectionToEndOfBlock = require('keyCommandMoveSelectionToEndOfBlock');
-const keyCommandMoveSelectionToStartOfBlock = require('keyCommandMoveSelectionToStartOfBlock');
-const keyCommandPlainBackspace = require('keyCommandPlainBackspace');
-const keyCommandPlainDelete = require('keyCommandPlainDelete');
-const keyCommandTransposeCharacters = require('keyCommandTransposeCharacters');
-const keyCommandUndo = require('keyCommandUndo');
+import isEventHandled from 'isEventHandled';
+import keyCommandBackspaceToStartOfLine from 'keyCommandBackspaceToStartOfLine';
+import keyCommandBackspaceWord from 'keyCommandBackspaceWord';
+import keyCommandDeleteWord from 'keyCommandDeleteWord';
+import keyCommandInsertNewline from 'keyCommandInsertNewline';
+import keyCommandMoveSelectionToEndOfBlock from 'keyCommandMoveSelectionToEndOfBlock';
+import keyCommandMoveSelectionToStartOfBlock from 'keyCommandMoveSelectionToStartOfBlock';
+import keyCommandPlainBackspace from 'keyCommandPlainBackspace';
+import keyCommandPlainDelete from 'keyCommandPlainDelete';
+import keyCommandTransposeCharacters from 'keyCommandTransposeCharacters';
+import keyCommandUndo from 'keyCommandUndo';
 
-const {isOptionKeyCommand} = KeyBindingUtil;
 const isChrome = UserAgent.isBrowser('Chrome');
 
 /**
@@ -83,7 +82,7 @@ function onKeyCommand(
  * See `getDefaultKeyBinding` for defaults. Alternatively, the top-level
  * component may provide a custom mapping via the `keyBindingFn` prop.
  */
-function editOnKeyDown(
+export default function editOnKeyDown(
   editor: DraftEditor,
   e: SyntheticKeyboardEvent<HTMLElement>,
 ): void {
@@ -202,5 +201,3 @@ function editOnKeyDown(
     editor.update(newState);
   }
 }
-
-module.exports = editOnKeyDown;

--- a/src/component/handlers/edit/editOnPaste.js
+++ b/src/component/handlers/edit/editOnPaste.js
@@ -15,23 +15,26 @@ import type {BlockMap} from 'BlockMap';
 import type DraftEditor from 'DraftEditor.react';
 import type {EntityMap} from 'EntityMap';
 
-const BlockMapBuilder = require('BlockMapBuilder');
-const CharacterMetadata = require('CharacterMetadata');
-const DataTransfer = require('DataTransfer');
-const DraftModifier = require('DraftModifier');
-const DraftPasteProcessor = require('DraftPasteProcessor');
-const EditorState = require('EditorState');
-const RichTextEditorUtil = require('RichTextEditorUtil');
+import * as BlockMapBuilder from 'BlockMapBuilder';
+import CharacterMetadata from 'CharacterMetadata';
+import DataTransfer from 'DataTransfer';
+import * as DraftModifier from 'DraftModifier';
+import * as DraftPasteProcessor from 'DraftPasteProcessor';
+import EditorState from 'EditorState';
+import RichTextEditorUtil from 'RichTextEditorUtil';
 
-const getEntityKeyForSelection = require('getEntityKeyForSelection');
-const getTextContentFromFiles = require('getTextContentFromFiles');
-const isEventHandled = require('isEventHandled');
-const splitTextIntoTextBlocks = require('splitTextIntoTextBlocks');
+import getEntityKeyForSelection from 'getEntityKeyForSelection';
+import getTextContentFromFiles from 'getTextContentFromFiles';
+import isEventHandled from 'isEventHandled';
+import splitTextIntoTextBlocks from 'splitTextIntoTextBlocks';
 
 /**
  * Paste content.
  */
-function editOnPaste(editor: DraftEditor, e: SyntheticClipboardEvent<>): void {
+export default function editOnPaste(
+  editor: DraftEditor,
+  e: SyntheticClipboardEvent<>,
+): void {
   e.preventDefault();
   const data = new DataTransfer(e.clipboardData);
 
@@ -239,5 +242,3 @@ function areTextBlocksAndClipboardEqual(
     blockMap.valueSeq().every((block, ii) => block.getText() === textBlocks[ii])
   );
 }
-
-module.exports = editOnPaste;

--- a/src/component/handlers/edit/editOnSelect.js
+++ b/src/component/handlers/edit/editOnSelect.js
@@ -13,13 +13,13 @@
 
 import type DraftEditor from 'DraftEditor.react';
 
-const DraftJsDebugLogging = require('DraftJsDebugLogging');
-const EditorState = require('EditorState');
+import * as DraftJsDebugLogging from 'DraftJsDebugLogging';
+import EditorState from 'EditorState';
 
-const getContentEditableContainer = require('getContentEditableContainer');
-const getDraftEditorSelection = require('getDraftEditorSelection');
+import getContentEditableContainer from 'getContentEditableContainer';
+import getDraftEditorSelection from 'getDraftEditorSelection';
 
-function editOnSelect(editor: DraftEditor): void {
+export default function editOnSelect(editor: DraftEditor): void {
   if (
     editor._blockSelectEvents ||
     editor._latestEditorState !== editor.props.editorState
@@ -59,5 +59,3 @@ function editOnSelect(editor: DraftEditor): void {
     editor.update(editorState);
   }
 }
-
-module.exports = editOnSelect;

--- a/src/component/handlers/edit/getFragmentFromSelection.js
+++ b/src/component/handlers/edit/getFragmentFromSelection.js
@@ -14,9 +14,11 @@
 import type {BlockMap} from 'BlockMap';
 import type EditorState from 'EditorState';
 
-const getContentStateFragment = require('getContentStateFragment');
+import getContentStateFragment from 'getContentStateFragment';
 
-function getFragmentFromSelection(editorState: EditorState): ?BlockMap {
+export default function getFragmentFromSelection(
+  editorState: EditorState,
+): ?BlockMap {
   const selectionState = editorState.getSelection();
 
   if (selectionState.isCollapsed()) {
@@ -28,5 +30,3 @@ function getFragmentFromSelection(editorState: EditorState): ?BlockMap {
     selectionState,
   );
 }
-
-module.exports = getFragmentFromSelection;

--- a/src/component/selection/DraftOffsetKey.js
+++ b/src/component/selection/DraftOffsetKey.js
@@ -15,28 +15,24 @@ import type {DraftOffsetKeyPath} from 'DraftOffsetKeyPath';
 
 const KEY_DELIMITER = '-';
 
-const DraftOffsetKey = {
-  encode: function(
-    blockKey: string,
-    decoratorKey: number,
-    leafKey: number,
-  ): string {
-    return blockKey + KEY_DELIMITER + decoratorKey + KEY_DELIMITER + leafKey;
-  },
+export function encode(
+  blockKey: string,
+  decoratorKey: number,
+  leafKey: number,
+): string {
+  return blockKey + KEY_DELIMITER + decoratorKey + KEY_DELIMITER + leafKey;
+}
 
-  decode: function(offsetKey: string): DraftOffsetKeyPath {
-    // Extracts the last two parts of offsetKey and captures the rest in blockKeyParts
-    const [leafKey, decoratorKey, ...blockKeyParts] = offsetKey
-      .split(KEY_DELIMITER)
-      .reverse();
+export function decode(offsetKey: string): DraftOffsetKeyPath {
+  // Extracts the last two parts of offsetKey and captures the rest in blockKeyParts
+  const [leafKey, decoratorKey, ...blockKeyParts] = offsetKey
+    .split(KEY_DELIMITER)
+    .reverse();
 
-    return {
-      // Recomposes the parts of blockKey after reversing them
-      blockKey: blockKeyParts.reverse().join(KEY_DELIMITER),
-      decoratorKey: parseInt(decoratorKey, 10),
-      leafKey: parseInt(leafKey, 10),
-    };
-  },
-};
-
-module.exports = DraftOffsetKey;
+  return {
+    // Recomposes the parts of blockKey after reversing them
+    blockKey: blockKeyParts.reverse().join(KEY_DELIMITER),
+    decoratorKey: parseInt(decoratorKey, 10),
+    leafKey: parseInt(leafKey, 10),
+  };
+}

--- a/src/component/selection/__tests__/DraftOffsetKey-test.js
+++ b/src/component/selection/__tests__/DraftOffsetKey-test.js
@@ -9,7 +9,7 @@
  * @flow strict-local
  */
 
-const DraftOffsetKey = require('DraftOffsetKey');
+import * as DraftOffsetKey from 'DraftOffsetKey';
 
 test('decodes offset key with no delimiter', () => {
   expect(DraftOffsetKey.decode('key-0-1')).toMatchSnapshot();

--- a/src/component/selection/expandRangeToStartOfLine.js
+++ b/src/component/selection/expandRangeToStartOfLine.js
@@ -9,11 +9,11 @@
  * @emails oncall+draft_js
  */
 
-const UnicodeUtils = require('UnicodeUtils');
+import * as UnicodeUtils from 'UnicodeUtils';
 
-const getCorrectDocumentFromNode = require('getCorrectDocumentFromNode');
-const getRangeClientRects = require('getRangeClientRects');
-const invariant = require('invariant');
+import getCorrectDocumentFromNode from 'getCorrectDocumentFromNode';
+import getRangeClientRects from 'getRangeClientRects';
+import invariant from 'invariant';
 /**
  * Return the computed line height, in pixels, for the provided element.
  */
@@ -107,7 +107,7 @@ function getNodeLength(node: Node): number {
  * Given a collapsed range, move the start position backwards as far as
  * possible while the range still spans only a single line.
  */
-function expandRangeToStartOfLine(range: Range): Range {
+export default function expandRangeToStartOfLine(range: Range): Range {
   invariant(
     range.collapsed,
     'expandRangeToStartOfLine: Provided range is not collapsed.',
@@ -206,5 +206,3 @@ function expandRangeToStartOfLine(range: Range): Range {
   range.setStart(bestContainer, bestOffset);
   return range;
 }
-
-module.exports = expandRangeToStartOfLine;

--- a/src/component/selection/findAncestorOffsetKey.js
+++ b/src/component/selection/findAncestorOffsetKey.js
@@ -11,12 +11,12 @@
 
 'use strict';
 
-const getCorrectDocumentFromNode = require('getCorrectDocumentFromNode');
-const getSelectionOffsetKeyForNode = require('getSelectionOffsetKeyForNode');
+import getCorrectDocumentFromNode from 'getCorrectDocumentFromNode';
+import getSelectionOffsetKeyForNode from 'getSelectionOffsetKeyForNode';
 /**
  * Get the key from the node's nearest offset-aware ancestor.
  */
-function findAncestorOffsetKey(node: Node): ?string {
+export default function findAncestorOffsetKey(node: Node): ?string {
   let searchNode = node;
   while (
     searchNode &&
@@ -30,5 +30,3 @@ function findAncestorOffsetKey(node: Node): ?string {
   }
   return null;
 }
-
-module.exports = findAncestorOffsetKey;

--- a/src/component/selection/getDraftEditorSelection.js
+++ b/src/component/selection/getDraftEditorSelection.js
@@ -15,13 +15,13 @@ import type {DOMDerivedSelection} from 'DOMDerivedSelection';
 import type {SelectionObject} from 'DraftDOMTypes';
 import type EditorState from 'EditorState';
 
-const getDraftEditorSelectionWithNodes = require('getDraftEditorSelectionWithNodes');
+import getDraftEditorSelectionWithNodes from 'getDraftEditorSelectionWithNodes';
 
 /**
  * Convert the current selection range to an anchor/focus pair of offset keys
  * and values that can be interpreted by components.
  */
-function getDraftEditorSelection(
+export default function getDraftEditorSelection(
   editorState: EditorState,
   root: HTMLElement,
 ): DOMDerivedSelection {
@@ -57,5 +57,3 @@ function getDraftEditorSelection(
     focusOffset,
   );
 }
-
-module.exports = getDraftEditorSelection;

--- a/src/component/selection/getDraftEditorSelectionWithNodes.js
+++ b/src/component/selection/getDraftEditorSelectionWithNodes.js
@@ -14,12 +14,12 @@
 import type {DOMDerivedSelection} from 'DOMDerivedSelection';
 import type EditorState from 'EditorState';
 
-const findAncestorOffsetKey = require('findAncestorOffsetKey');
-const getSelectionOffsetKeyForNode = require('getSelectionOffsetKeyForNode');
-const getUpdatedSelectionState = require('getUpdatedSelectionState');
-const invariant = require('invariant');
-const isElement = require('isElement');
-const nullthrows = require('nullthrows');
+import findAncestorOffsetKey from 'findAncestorOffsetKey';
+import getSelectionOffsetKeyForNode from 'getSelectionOffsetKeyForNode';
+import getUpdatedSelectionState from 'getUpdatedSelectionState';
+import invariant from 'invariant';
+import isElement from 'isElement';
+import nullthrows from 'nullthrows';
 
 type SelectionPoint = {|
   key: string,
@@ -30,7 +30,7 @@ type SelectionPoint = {|
  * Convert the current selection range to an anchor/focus pair of offset keys
  * and values that can be interpreted by components.
  */
-function getDraftEditorSelectionWithNodes(
+export default function getDraftEditorSelectionWithNodes(
   editorState: EditorState,
   root: ?HTMLElement,
   anchorNode: Node,
@@ -231,5 +231,3 @@ function getTextContentLength(node: Node): number {
   const textContent = node.textContent;
   return textContent === '\n' ? 0 : textContent.length;
 }
-
-module.exports = getDraftEditorSelectionWithNodes;

--- a/src/component/selection/getRangeBoundingClientRect.js
+++ b/src/component/selection/getRangeBoundingClientRect.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const getRangeClientRects = require('getRangeClientRects');
+import getRangeClientRects from 'getRangeClientRects';
 
 export type FakeClientRect = {|
   left: number,
@@ -25,7 +25,9 @@ export type FakeClientRect = {|
 /**
  * Like range.getBoundingClientRect() but normalizes for browser bugs.
  */
-function getRangeBoundingClientRect(range: Range): FakeClientRect {
+export default function getRangeBoundingClientRect(
+  range: Range,
+): FakeClientRect {
   // "Return a DOMRect object describing the smallest rectangle that includes
   // the first rectangle in list and all of the remaining rectangles of which
   // the height or width is not zero."
@@ -66,5 +68,3 @@ function getRangeBoundingClientRect(range: Range): FakeClientRect {
     height: bottom - top,
   };
 }
-
-module.exports = getRangeBoundingClientRect;

--- a/src/component/selection/getRangeClientRects.js
+++ b/src/component/selection/getRangeClientRects.js
@@ -11,9 +11,9 @@
 
 'use strict';
 
-const UserAgent = require('UserAgent');
+import UserAgent from 'UserAgent';
 
-const invariant = require('invariant');
+import invariant from 'invariant';
 
 const isChrome = UserAgent.isBrowser('Chrome');
 
@@ -65,4 +65,4 @@ const getRangeClientRects = ((isChrome
       return Array.from(range.getClientRects());
     }): (range: Range) => Array<ClientRect>);
 
-module.exports = getRangeClientRects;
+export default getRangeClientRects;

--- a/src/component/selection/getSampleSelectionMocksForTesting.js
+++ b/src/component/selection/getSampleSelectionMocksForTesting.js
@@ -11,16 +11,16 @@
 
 'use strict';
 
-const CharacterMetadata = require('CharacterMetadata');
-const ContentBlock = require('ContentBlock');
-const ContentState = require('ContentState');
-const EditorState = require('EditorState');
-const {BOLD} = require('SampleDraftInlineStyle');
+import CharacterMetadata from 'CharacterMetadata';
+import ContentBlock from 'ContentBlock';
+import ContentState from 'ContentState';
+import EditorState from 'EditorState';
+import {BOLD} from 'SampleDraftInlineStyle';
 
-const Immutable = require('immutable');
+import Immutable from 'immutable';
 const {EMPTY} = CharacterMetadata;
 
-const getSampleSelectionMocksForTesting = (): Object => {
+export default function getSampleSelectionMocksForTesting(): Object {
   const root = document.createElement('div');
   const contents = document.createElement('div');
 
@@ -141,6 +141,4 @@ const getSampleSelectionMocksForTesting = (): Object => {
     leafChildren,
     textNodes,
   };
-};
-
-module.exports = getSampleSelectionMocksForTesting;
+}

--- a/src/component/selection/getSampleSelectionMocksForTestingNestedBlocks.js
+++ b/src/component/selection/getSampleSelectionMocksForTestingNestedBlocks.js
@@ -11,13 +11,13 @@
 
 'use strict';
 
-const ContentBlockNode = require('ContentBlockNode');
-const ContentState = require('ContentState');
-const EditorState = require('EditorState');
+import ContentBlockNode from 'ContentBlockNode';
+import ContentState from 'ContentState';
+import EditorState from 'EditorState';
 
-const Immutable = require('immutable');
+import Immutable from 'immutable';
 
-const getSampleSelectionMocksForTestingNestedBlocks = (): Object => {
+export default function getSampleSelectionMocksForTestingNestedBlocks(): Object {
   const root = document.createElement('div');
   const contents = document.createElement('div');
 
@@ -139,6 +139,4 @@ const getSampleSelectionMocksForTestingNestedBlocks = (): Object => {
     leafChildren,
     textNodes,
   };
-};
-
-module.exports = getSampleSelectionMocksForTestingNestedBlocks;
+}

--- a/src/component/selection/getSelectionOffsetKeyForNode.js
+++ b/src/component/selection/getSelectionOffsetKeyForNode.js
@@ -15,9 +15,9 @@
  * Get offset key from a node or it's child nodes. Return the first offset key
  * found on the DOM tree of given node.
  */
-const isElement = require('isElement');
+import isElement from 'isElement';
 
-function getSelectionOffsetKeyForNode(node: Node): ?string {
+export default function getSelectionOffsetKeyForNode(node: Node): ?string {
   if (isElement(node)) {
     const castedNode: Element = (node: any);
     const offsetKey = castedNode.getAttribute('data-offset-key');
@@ -35,5 +35,3 @@ function getSelectionOffsetKeyForNode(node: Node): ?string {
   }
   return null;
 }
-
-module.exports = getSelectionOffsetKeyForNode;

--- a/src/component/selection/getUpdatedSelectionState.js
+++ b/src/component/selection/getUpdatedSelectionState.js
@@ -14,11 +14,11 @@
 import type EditorState from 'EditorState';
 import type SelectionState from 'SelectionState';
 
-const DraftOffsetKey = require('DraftOffsetKey');
+import * as DraftOffsetKey from 'DraftOffsetKey';
 
-const nullthrows = require('nullthrows');
+import nullthrows from 'nullthrows';
 
-function getUpdatedSelectionState(
+export default function getUpdatedSelectionState(
   editorState: EditorState,
   anchorKey: string,
   anchorOffset: number,
@@ -109,5 +109,3 @@ function getUpdatedSelectionState(
     isBackward,
   });
 }
-
-module.exports = getUpdatedSelectionState;

--- a/src/component/selection/getVisibleSelectionRect.js
+++ b/src/component/selection/getVisibleSelectionRect.js
@@ -13,7 +13,7 @@
 
 import type {FakeClientRect} from 'getRangeBoundingClientRect';
 
-const getRangeBoundingClientRect = require('getRangeBoundingClientRect');
+import getRangeBoundingClientRect from 'getRangeBoundingClientRect';
 
 /**
  * Return the bounding ClientRect for the visible DOM selection, if any.
@@ -22,7 +22,7 @@ const getRangeBoundingClientRect = require('getRangeBoundingClientRect');
  *
  * When using from an iframe, you should pass the iframe window object
  */
-function getVisibleSelectionRect(global: any): ?FakeClientRect {
+export default function getVisibleSelectionRect(global: any): ?FakeClientRect {
   const selection = global.getSelection();
   if (!selection.rangeCount) {
     return null;
@@ -41,5 +41,3 @@ function getVisibleSelectionRect(global: any): ?FakeClientRect {
 
   return boundingRect;
 }
-
-module.exports = getVisibleSelectionRect;

--- a/src/component/selection/isSelectionAtLeafStart.js
+++ b/src/component/selection/isSelectionAtLeafStart.js
@@ -13,7 +13,9 @@
 
 import type EditorState from 'EditorState';
 
-function isSelectionAtLeafStart(editorState: EditorState): boolean {
+export default function isSelectionAtLeafStart(
+  editorState: EditorState,
+): boolean {
   const selection = editorState.getSelection();
   const anchorKey = selection.getAnchorKey();
   const blockTree = editorState.getBlockTree(anchorKey);
@@ -44,5 +46,3 @@ function isSelectionAtLeafStart(editorState: EditorState): boolean {
 
   return isAtStart;
 }
-
-module.exports = isSelectionAtLeafStart;

--- a/src/component/selection/setDraftEditorSelection.js
+++ b/src/component/selection/setDraftEditorSelection.js
@@ -14,15 +14,15 @@
 import type {SelectionObject} from 'DraftDOMTypes';
 import type SelectionState from 'SelectionState';
 
-const DraftEffects = require('DraftEffects');
-const DraftJsDebugLogging = require('DraftJsDebugLogging');
-const UserAgent = require('UserAgent');
+import * as DraftEffects from 'DraftEffects';
+import * as DraftJsDebugLogging from 'DraftJsDebugLogging';
+import UserAgent from 'UserAgent';
 
-const containsNode = require('containsNode');
-const getActiveElement = require('getActiveElement');
-const getCorrectDocumentFromNode = require('getCorrectDocumentFromNode');
-const invariant = require('invariant');
-const isElement = require('isElement');
+import containsNode from 'containsNode';
+import getActiveElement from 'getActiveElement';
+import getCorrectDocumentFromNode from 'getCorrectDocumentFromNode';
+import invariant from 'invariant';
+import isElement from 'isElement';
 
 const isIE = UserAgent.isBrowser('IE');
 
@@ -110,7 +110,7 @@ function getNodeLength(node: Node): number {
  * to programatically create a backward selection. Thus, for all IE
  * versions, we use the old IE API to create our selections.
  */
-function setDraftEditorSelection(
+export function setDraftEditorSelection(
   selectionState: SelectionState,
   node: Node,
   blockKey: string,
@@ -235,7 +235,7 @@ function setDraftEditorSelection(
 /**
  * Extend selection towards focus point.
  */
-function addFocusToSelection(
+export function addFocusToSelection(
   selection: SelectionObject,
   node: ?Node,
   offset: number,
@@ -359,8 +359,3 @@ function addPointToSelection(
     selection.addRange(range);
   }
 }
-
-module.exports = {
-  setDraftEditorSelection,
-  addFocusToSelection,
-};

--- a/src/component/utils/_DraftTestHelper.js
+++ b/src/component/utils/_DraftTestHelper.js
@@ -10,7 +10,18 @@
  */
 
 const BLACK_LIST_PROPS = ['data-reactroot'];
-const transformSnapshotProps = (
+/**
+ * This is meant to be used in combination with ReactTestRenderer
+ * to ensure compatibility with running our snapshot tests internally
+ *
+ * usage example:
+ *
+ * const blockNode = ReactTestRenderer.create(
+ *  <DraftComponentFooBar {...childProps} />,
+ * );
+ *
+ * expect(transformSnapshotProps(blockNode.toJSON())).toMatchSnapshot();
+ */ export const transformSnapshotProps = (
   node: any,
   blackList: Array<string> = BLACK_LIST_PROPS,
 ): any => {
@@ -29,21 +40,3 @@ const transformSnapshotProps = (
   }
   return node;
 };
-
-const DraftTestHelper = {
-  /**
-   * This is meant to be used in combination with ReactTestRenderer
-   * to ensure compatibility with running our snapshot tests internally
-   *
-   * usage example:
-   *
-   * const blockNode = ReactTestRenderer.create(
-   *  <DraftComponentFooBar {...childProps} />,
-   * );
-   *
-   * expect(transformSnapshotProps(blockNode.toJSON())).toMatchSnapshot();
-   */
-  transformSnapshotProps,
-};
-
-module.exports = DraftTestHelper;

--- a/src/component/utils/__tests__/isHTMLBRElement-test.js
+++ b/src/component/utils/__tests__/isHTMLBRElement-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const isHTMLBRElement = require('isHTMLBRElement');
+import isHTMLBRElement from 'isHTMLBRElement';
 
 test('isHTMLBRElement recognizes null', () => {
   expect(isHTMLBRElement(null)).toBe(false);

--- a/src/component/utils/draftKeyUtils.js
+++ b/src/component/utils/draftKeyUtils.js
@@ -13,10 +13,6 @@
 
 'use strict';
 
-function notEmptyKey(key: ?string): boolean %checks {
+export function notEmptyKey(key: ?string): boolean %checks {
   return key != null && key != '';
 }
-
-module.exports = {
-  notEmptyKey,
-};

--- a/src/component/utils/exploration/DraftTreeAdapter.js
+++ b/src/component/utils/exploration/DraftTreeAdapter.js
@@ -15,8 +15,8 @@
 import type {RawDraftContentBlock} from 'RawDraftContentBlock';
 import type {RawDraftContentState} from 'RawDraftContentState';
 
-const generateRandomKey = require('generateRandomKey');
-const invariant = require('invariant');
+import generateRandomKey from 'generateRandomKey';
+import invariant from 'invariant';
 
 const traverseInDepthOrder = (
   blocks: Array<RawDraftContentBlock>,
@@ -55,124 +55,115 @@ const addDepthToChildren = (block: RawDraftContentBlock) => {
 };
 
 /**
- * This adapter is intended to be be used as an adapter to draft tree data
- *
- * draft state <=====> draft tree state
+ * Converts from a tree raw state back to draft raw state
  */
-const DraftTreeAdapter = {
-  /**
-   * Converts from a tree raw state back to draft raw state
-   */
-  fromRawTreeStateToRawState(
-    draftTreeState: RawDraftContentState,
-  ): RawDraftContentState {
-    const {blocks} = draftTreeState;
-    const transformedBlocks = [];
+export function fromRawTreeStateToRawState(
+  draftTreeState: RawDraftContentState,
+): RawDraftContentState {
+  const {blocks} = draftTreeState;
+  const transformedBlocks = [];
 
-    invariant(Array.isArray(blocks), 'Invalid raw state');
+  invariant(Array.isArray(blocks), 'Invalid raw state');
 
-    if (!Array.isArray(blocks) || !blocks.length) {
-      return draftTreeState;
-    }
+  if (!Array.isArray(blocks) || !blocks.length) {
+    return draftTreeState;
+  }
 
-    traverseInDepthOrder(blocks, block => {
-      const newBlock = {
-        ...block,
-      };
-
-      if (isListBlock(block)) {
-        newBlock.depth = newBlock.depth || 0;
-        addDepthToChildren(block);
-
-        // if it's a non-leaf node, we don't do anything else
-        if (block.children != null && block.children.length > 0) {
-          return;
-        }
-      }
-
-      delete newBlock.children;
-
-      transformedBlocks.push(newBlock);
-    });
-
-    draftTreeState.blocks = transformedBlocks;
-
-    return {
-      ...draftTreeState,
-      blocks: transformedBlocks,
+  traverseInDepthOrder(blocks, block => {
+    const newBlock = {
+      ...block,
     };
-  },
 
-  /**
-   * Converts from draft raw state to tree draft state
-   */
-  fromRawStateToRawTreeState(
-    draftState: RawDraftContentState,
-  ): RawDraftContentState {
-    const transformedBlocks = [];
-    const parentStack = [];
+    if (isListBlock(block)) {
+      newBlock.depth = newBlock.depth || 0;
+      addDepthToChildren(block);
 
-    draftState.blocks.forEach(block => {
-      const isList = isListBlock(block);
-      const depth = block.depth || 0;
-      const treeBlock = {
-        ...block,
-        children: [],
-      };
-
-      if (!isList) {
-        transformedBlocks.push(treeBlock);
+      // if it's a non-leaf node, we don't do anything else
+      if (block.children != null && block.children.length > 0) {
         return;
       }
+    }
 
-      let lastParent = parentStack[0];
-      // block is non-nested & there are no nested blocks, directly push block
-      if (lastParent == null && depth === 0) {
-        transformedBlocks.push(treeBlock);
-        // block is first nested block or previous nested block is at a lower level
-      } else if (lastParent == null || lastParent.depth < depth - 1) {
-        // create new parent block
-        const newParent = {
-          key: generateRandomKey(),
-          text: '',
-          depth: depth - 1,
-          type: block.type,
-          children: [],
-          entityRanges: [],
-          inlineStyleRanges: [],
-        };
+    delete newBlock.children;
 
-        parentStack.unshift(newParent);
-        if (depth === 1) {
-          // add as a root-level block
-          transformedBlocks.push(newParent);
-        } else if (lastParent != null) {
-          // depth > 1 => also add as previous parent's child
-          lastParent.children.push(newParent);
-        }
-        newParent.children.push(treeBlock);
-      } else if (lastParent.depth === depth - 1) {
-        // add as child of last parent
+    transformedBlocks.push(newBlock);
+  });
+
+  draftTreeState.blocks = transformedBlocks;
+
+  return {
+    ...draftTreeState,
+    blocks: transformedBlocks,
+  };
+}
+
+/**
+ * Converts from draft raw state to tree draft state
+ */
+export function fromRawStateToRawTreeState(
+  draftState: RawDraftContentState,
+): RawDraftContentState {
+  const transformedBlocks = [];
+  const parentStack = [];
+
+  draftState.blocks.forEach(block => {
+    const isList = isListBlock(block);
+    const depth = block.depth || 0;
+    const treeBlock = {
+      ...block,
+      children: [],
+    };
+
+    if (!isList) {
+      transformedBlocks.push(treeBlock);
+      return;
+    }
+
+    let lastParent = parentStack[0];
+    // block is non-nested & there are no nested blocks, directly push block
+    if (lastParent == null && depth === 0) {
+      transformedBlocks.push(treeBlock);
+      // block is first nested block or previous nested block is at a lower level
+    } else if (lastParent == null || lastParent.depth < depth - 1) {
+      // create new parent block
+      const newParent = {
+        key: generateRandomKey(),
+        text: '',
+        depth: depth - 1,
+        type: block.type,
+        children: [],
+        entityRanges: [],
+        inlineStyleRanges: [],
+      };
+
+      parentStack.unshift(newParent);
+      if (depth === 1) {
+        // add as a root-level block
+        transformedBlocks.push(newParent);
+      } else if (lastParent != null) {
+        // depth > 1 => also add as previous parent's child
+        lastParent.children.push(newParent);
+      }
+      newParent.children.push(treeBlock);
+    } else if (lastParent.depth === depth - 1) {
+      // add as child of last parent
+      lastParent.children.push(treeBlock);
+    } else {
+      // pop out parents at levels above this one from the parent stack
+      while (lastParent != null && lastParent.depth >= depth) {
+        parentStack.shift();
+        lastParent = parentStack[0];
+      }
+      if (depth > 0) {
         lastParent.children.push(treeBlock);
       } else {
-        // pop out parents at levels above this one from the parent stack
-        while (lastParent != null && lastParent.depth >= depth) {
-          parentStack.shift();
-          lastParent = parentStack[0];
-        }
-        if (depth > 0) {
-          lastParent.children.push(treeBlock);
-        } else {
-          transformedBlocks.push(treeBlock);
-        }
+        transformedBlocks.push(treeBlock);
       }
-    });
+    }
+  });
 
-    return {
-      ...draftState,
-      blocks: transformedBlocks,
-    };
-  },
-};
-
-module.exports = DraftTreeAdapter;
+  return {
+    ...draftState,
+    blocks: transformedBlocks,
+  };
+}

--- a/src/component/utils/exploration/DraftTreeInvariants.js
+++ b/src/component/utils/exploration/DraftTreeInvariants.js
@@ -14,151 +14,154 @@
 import type {BlockMap} from 'BlockMap';
 import type ContentBlockNode from 'ContentBlockNode';
 
-const warning = require('warning');
+import warning from 'warning';
 
-const DraftTreeInvariants = {
-  /**
-   * Check if the block is valid
-   */
-  isValidBlock(block: ContentBlockNode, blockMap: BlockMap): boolean {
-    const key = block.getKey();
-    // is its parent's child
-    const parentKey = block.getParentKey();
-    if (parentKey != null) {
-      const parent = blockMap.get(parentKey);
-      if (!parent.getChildKeys().includes(key)) {
-        warning(true, 'Tree is missing parent -> child pointer on %s', key);
-        return false;
-      }
-    }
-
-    // is its children's parent
-    const children = block.getChildKeys().map(k => blockMap.get(k));
-    if (!children.every(c => c.getParentKey() === key)) {
-      warning(true, 'Tree is missing child -> parent pointer on %s', key);
+/**
+ * Check if the block is valid
+ */
+export function isValidBlock(
+  block: ContentBlockNode,
+  blockMap: BlockMap,
+): boolean {
+  const key = block.getKey();
+  // is its parent's child
+  const parentKey = block.getParentKey();
+  if (parentKey != null) {
+    const parent = blockMap.get(parentKey);
+    if (!parent.getChildKeys().includes(key)) {
+      warning(true, 'Tree is missing parent -> child pointer on %s', key);
       return false;
     }
+  }
 
-    // is its previous sibling's next sibling
-    const prevSiblingKey = block.getPrevSiblingKey();
-    if (prevSiblingKey != null) {
-      const prevSibling = blockMap.get(prevSiblingKey);
-      if (prevSibling.getNextSiblingKey() !== key) {
-        warning(
-          true,
-          "Tree is missing nextSibling pointer on %s's prevSibling",
-          key,
-        );
-        return false;
-      }
-    }
+  // is its children's parent
+  const children = block.getChildKeys().map(k => blockMap.get(k));
+  if (!children.every(c => c.getParentKey() === key)) {
+    warning(true, 'Tree is missing child -> parent pointer on %s', key);
+    return false;
+  }
 
-    // is its next sibling's previous sibling
-    const nextSiblingKey = block.getNextSiblingKey();
-    if (nextSiblingKey != null) {
-      const nextSibling = blockMap.get(nextSiblingKey);
-      if (nextSibling.getPrevSiblingKey() !== key) {
-        warning(
-          true,
-          "Tree is missing prevSibling pointer on %s's nextSibling",
-          key,
-        );
-        return false;
-      }
-    }
-
-    // no 2-node cycles
-    if (nextSiblingKey !== null && prevSiblingKey !== null) {
-      if (prevSiblingKey === nextSiblingKey) {
-        warning(true, 'Tree has a two-node cycle at %s', key);
-        return false;
-      }
-    }
-
-    // if it's a leaf node, it has text but no children
-    if (block.text != '') {
-      if (block.getChildKeys().size > 0) {
-        warning(true, 'Leaf node %s has children', key);
-        return false;
-      }
-    }
-    return true;
-  },
-
-  /**
-   * Checks that this is a connected tree on all the blocks
-   * starting from the first block, traversing nextSibling and child pointers
-   * should be a tree (preorder traversal - parent, then children)
-   * num of connected node === number of blocks
-   */
-  isConnectedTree(blockMap: BlockMap): boolean {
-    // exactly one node has no previous sibling + no parent
-    const eligibleFirstNodes = blockMap
-      .toArray()
-      .filter(
-        block =>
-          block.getParentKey() == null && block.getPrevSiblingKey() == null,
-      );
-    if (eligibleFirstNodes.length !== 1) {
-      warning(true, 'Tree is not connected. More or less than one first node');
-      return false;
-    }
-    const firstNode = eligibleFirstNodes.shift();
-    let nodesSeen = 0;
-    let currentKey = firstNode.getKey();
-    const visitedStack = [];
-    while (currentKey != null) {
-      const currentNode = blockMap.get(currentKey);
-      const childKeys = currentNode.getChildKeys();
-      const nextSiblingKey = currentNode.getNextSiblingKey();
-      // if the node has children, add parent's next sibling to stack and go to children
-      if (childKeys.size > 0) {
-        if (nextSiblingKey != null) {
-          visitedStack.unshift(nextSiblingKey);
-        }
-        const children = childKeys.map(k => blockMap.get(k));
-        const firstNode = children.find(
-          block => block.getPrevSiblingKey() == null,
-        );
-        if (firstNode == null) {
-          warning(true, '%s has no first child', currentKey);
-          return false;
-        }
-        currentKey = firstNode.getKey();
-        // TODO(T32490138): Deal with multi-node cycles here
-      } else {
-        if (currentNode.getNextSiblingKey() != null) {
-          currentKey = currentNode.getNextSiblingKey();
-        } else {
-          currentKey = visitedStack.shift();
-        }
-      }
-      nodesSeen++;
-    }
-
-    if (nodesSeen !== blockMap.size) {
+  // is its previous sibling's next sibling
+  const prevSiblingKey = block.getPrevSiblingKey();
+  if (prevSiblingKey != null) {
+    const prevSibling = blockMap.get(prevSiblingKey);
+    if (prevSibling.getNextSiblingKey() !== key) {
       warning(
         true,
-        'Tree is not connected. %s nodes were seen instead of %s',
-        nodesSeen,
-        blockMap.size,
+        "Tree is missing nextSibling pointer on %s's prevSibling",
+        key,
       );
       return false;
     }
+  }
 
-    return true;
-  },
-
-  /**
-   * Checks that the block map is a connected tree with valid blocks
-   */
-  isValidTree(blockMap: BlockMap): boolean {
-    const blocks = blockMap.toArray();
-    if (!blocks.every(block => this.isValidBlock(block, blockMap))) {
+  // is its next sibling's previous sibling
+  const nextSiblingKey = block.getNextSiblingKey();
+  if (nextSiblingKey != null) {
+    const nextSibling = blockMap.get(nextSiblingKey);
+    if (nextSibling.getPrevSiblingKey() !== key) {
+      warning(
+        true,
+        "Tree is missing prevSibling pointer on %s's nextSibling",
+        key,
+      );
       return false;
     }
-    return this.isConnectedTree(blockMap);
-  },
-};
+  }
 
-module.exports = DraftTreeInvariants;
+  // no 2-node cycles
+  if (nextSiblingKey !== null && prevSiblingKey !== null) {
+    if (prevSiblingKey === nextSiblingKey) {
+      warning(true, 'Tree has a two-node cycle at %s', key);
+      return false;
+    }
+  }
+
+  // if it's a leaf node, it has text but no children
+  if (block.text != '') {
+    if (block.getChildKeys().size > 0) {
+      warning(true, 'Leaf node %s has children', key);
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Checks that this is a connected tree on all the blocks
+ * starting from the first block, traversing nextSibling and child pointers
+ * should be a tree (preorder traversal - parent, then children)
+ * num of connected node === number of blocks
+ */
+export function isConnectedTree(blockMap: BlockMap): boolean {
+  // exactly one node has no previous sibling + no parent
+  const eligibleFirstNodes = blockMap
+    .toArray()
+    .filter(
+      block =>
+        block.getParentKey() == null && block.getPrevSiblingKey() == null,
+    );
+  if (eligibleFirstNodes.length !== 1) {
+    warning(true, 'Tree is not connected. More or less than one first node');
+    return false;
+  }
+  const firstNode = eligibleFirstNodes.shift();
+  let nodesSeen = 0;
+  let currentKey = firstNode.getKey();
+  const visitedStack = [];
+  while (currentKey != null) {
+    const currentNode = blockMap.get(currentKey);
+    const childKeys = currentNode.getChildKeys();
+    const nextSiblingKey = currentNode.getNextSiblingKey();
+    // if the node has children, add parent's next sibling to stack and go to children
+    if (childKeys.size > 0) {
+      if (nextSiblingKey != null) {
+        visitedStack.unshift(nextSiblingKey);
+      }
+      const children = childKeys.map(k => blockMap.get(k));
+      const firstNode = children.find(
+        block => block.getPrevSiblingKey() == null,
+      );
+      if (firstNode == null) {
+        warning(true, '%s has no first child', currentKey);
+        return false;
+      }
+      currentKey = firstNode.getKey();
+      // TODO(T32490138): Deal with multi-node cycles here
+    } else {
+      if (currentNode.getNextSiblingKey() != null) {
+        currentKey = currentNode.getNextSiblingKey();
+      } else {
+        currentKey = visitedStack.shift();
+      }
+    }
+    nodesSeen++;
+  }
+
+  if (nodesSeen !== blockMap.size) {
+    warning(
+      true,
+      'Tree is not connected. %s nodes were seen instead of %s',
+      nodesSeen,
+      blockMap.size,
+    );
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Checks that the block map is a connected tree with valid blocks
+ */
+export function isValidTree(blockMap: BlockMap): boolean {
+  const blocks = blockMap.toArray();
+  /* $FlowFixMe[this-in-exported-function] Error found during ES6
+   * imports/exports conversion. */
+  if (!blocks.every(block => this.isValidBlock(block, blockMap))) {
+    return false;
+  }
+  /* $FlowFixMe[this-in-exported-function] Error found during ES6
+   * imports/exports conversion. */
+  return this.isConnectedTree(blockMap);
+}

--- a/src/component/utils/exploration/__tests__/DraftTreeInvariants-test.js
+++ b/src/component/utils/exploration/__tests__/DraftTreeInvariants-test.js
@@ -13,10 +13,10 @@
 
 // missing parent -> child connection
 
-const ContentBlockNode = require('ContentBlockNode');
-const DraftTreeInvariants = require('DraftTreeInvariants');
+import ContentBlockNode from 'ContentBlockNode';
+import * as DraftTreeInvariants from 'DraftTreeInvariants';
 
-const Immutable = require('immutable');
+import Immutable from 'immutable';
 
 test('single block', () =>
   expect(

--- a/src/component/utils/getContentEditableContainer.js
+++ b/src/component/utils/getContentEditableContainer.js
@@ -13,10 +13,12 @@
 
 import type DraftEditor from 'DraftEditor.react';
 
-const invariant = require('invariant');
-const isHTMLElement = require('isHTMLElement');
+import invariant from 'invariant';
+import isHTMLElement from 'isHTMLElement';
 
-function getContentEditableContainer(editor: DraftEditor): HTMLElement {
+export default function getContentEditableContainer(
+  editor: DraftEditor,
+): HTMLElement {
   const editorNode = editor.editorContainer;
   invariant(editorNode, 'Missing editorNode');
   invariant(
@@ -26,5 +28,3 @@ function getContentEditableContainer(editor: DraftEditor): HTMLElement {
   const htmlElement = (editorNode.firstChild: any);
   return htmlElement;
 }
-
-module.exports = getContentEditableContainer;

--- a/src/component/utils/getCorrectDocumentFromNode.js
+++ b/src/component/utils/getCorrectDocumentFromNode.js
@@ -9,11 +9,9 @@
  * @emails oncall+draft_js
  */
 
-function getCorrectDocumentFromNode(node: ?Node): Document {
+export default function getCorrectDocumentFromNode(node: ?Node): Document {
   if (!node || !node.ownerDocument) {
     return document;
   }
   return node.ownerDocument;
 }
-
-module.exports = getCorrectDocumentFromNode;

--- a/src/component/utils/getDefaultKeyBinding.js
+++ b/src/component/utils/getDefaultKeyBinding.js
@@ -13,9 +13,9 @@
 
 import type {DraftEditorCommand} from 'DraftEditorCommand';
 
-const KeyBindingUtil = require('KeyBindingUtil');
-const Keys = require('Keys');
-const UserAgent = require('UserAgent');
+import {hasCommandModifier, isCtrlKeyCommand} from 'KeyBindingUtil';
+import Keys from 'Keys';
+import UserAgent from 'UserAgent';
 
 const isOSX = UserAgent.isPlatform('Mac OS X');
 
@@ -23,8 +23,6 @@ const isOSX = UserAgent.isPlatform('Mac OS X');
 // This bug was fixed in Firefox 29. Feature detection is virtually impossible
 // so we just check the version number. See #342765.
 const shouldFixFirefoxMovement = isOSX && UserAgent.isBrowser('Firefox < 29');
-
-const {hasCommandModifier, isCtrlKeyCommand} = KeyBindingUtil;
 
 function shouldRemoveWord(e: SyntheticKeyboardEvent<>): boolean {
   return (isOSX && e.altKey) || isCtrlKeyCommand(e);
@@ -58,7 +56,7 @@ function getBackspaceCommand(e: SyntheticKeyboardEvent<>): ?DraftEditorCommand {
 /**
  * Retrieve a bound key command for the given event.
  */
-function getDefaultKeyBinding(
+export default function getDefaultKeyBinding(
   e: SyntheticKeyboardEvent<>,
 ): ?DraftEditorCommand {
   switch (e.keyCode) {
@@ -110,5 +108,3 @@ function getDefaultKeyBinding(
       return null;
   }
 }
-
-module.exports = getDefaultKeyBinding;

--- a/src/component/utils/getTextContentFromFiles.js
+++ b/src/component/utils/getTextContentFromFiles.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const invariant = require('invariant');
+import invariant from 'invariant';
 
 const TEXT_CLIPPING_REGEX = /\.textClipping$/;
 
@@ -27,7 +27,7 @@ const TEXT_SIZE_UPPER_BOUND = 5000;
 /**
  * Extract the text content from a file list.
  */
-function getTextContentFromFiles(
+export default function getTextContentFromFiles(
   files: Array<File>,
   callback: (contents: string) => void,
 ): void {
@@ -80,5 +80,3 @@ function readFile(file: File, callback: (contents: string) => void): void {
   };
   reader.readAsText(file);
 }
-
-module.exports = getTextContentFromFiles;

--- a/src/component/utils/getWindowForNode.js
+++ b/src/component/utils/getWindowForNode.js
@@ -9,11 +9,9 @@
  * @emails oncall+draft_js
  */
 
-function getWindowForNode(node: ?Node): any {
+export default function getWindowForNode(node: ?Node): any {
   if (!node || !node.ownerDocument || !node.ownerDocument.defaultView) {
     return window;
   }
   return node.ownerDocument.defaultView;
 }
-
-module.exports = getWindowForNode;

--- a/src/component/utils/isElement.js
+++ b/src/component/utils/isElement.js
@@ -9,11 +9,9 @@
  * @emails oncall+draft_js
  */
 
-function isElement(node: ?Node): boolean {
+export default function isElement(node: ?Node): boolean {
   if (!node || !node.ownerDocument) {
     return false;
   }
   return node.nodeType === Node.ELEMENT_NODE;
 }
-
-module.exports = isElement;

--- a/src/component/utils/isEventHandled.js
+++ b/src/component/utils/isEventHandled.js
@@ -17,8 +17,6 @@ import type {DraftHandleValue} from 'DraftHandleValue';
  * Utility method for determining whether or not the value returned
  * from a handler indicates that it was handled.
  */
-function isEventHandled(value: DraftHandleValue): boolean {
+export default function isEventHandled(value: DraftHandleValue): boolean {
   return value === 'handled' || value === true;
 }
-
-module.exports = isEventHandled;

--- a/src/component/utils/isHTMLAnchorElement.js
+++ b/src/component/utils/isHTMLAnchorElement.js
@@ -9,13 +9,11 @@
  * @emails oncall+draft_js
  */
 
-const isElement = require('isElement');
+import isElement from 'isElement';
 
-function isHTMLAnchorElement(node: ?Node): boolean {
+export default function isHTMLAnchorElement(node: ?Node): boolean {
   if (!node || !node.ownerDocument) {
     return false;
   }
   return isElement(node) && node.nodeName === 'A';
 }
-
-module.exports = isHTMLAnchorElement;

--- a/src/component/utils/isHTMLBRElement.js
+++ b/src/component/utils/isHTMLBRElement.js
@@ -9,13 +9,11 @@
  * @emails oncall+draft_js
  */
 
-const isElement = require('isElement');
+import isElement from 'isElement';
 
-function isHTMLBRElement(node: ?Node): boolean {
+export default function isHTMLBRElement(node: ?Node): boolean {
   if (!node || !node.ownerDocument) {
     return false;
   }
   return isElement(node) && node.nodeName === 'BR';
 }
-
-module.exports = isHTMLBRElement;

--- a/src/component/utils/isHTMLElement.js
+++ b/src/component/utils/isHTMLElement.js
@@ -9,7 +9,7 @@
  * @emails oncall+draft_js
  */
 
-function isHTMLElement(node: ?Node): boolean {
+export default function isHTMLElement(node: ?Node): boolean {
   if (!node || !node.ownerDocument) {
     return false;
   }
@@ -21,5 +21,3 @@ function isHTMLElement(node: ?Node): boolean {
   }
   return false;
 }
-
-module.exports = isHTMLElement;

--- a/src/component/utils/isHTMLImageElement.js
+++ b/src/component/utils/isHTMLImageElement.js
@@ -9,13 +9,11 @@
  * @emails oncall+draft_js
  */
 
-const isElement = require('isElement');
+import isElement from 'isElement';
 
-function isHTMLImageElement(node: ?Node): boolean {
+export default function isHTMLImageElement(node: ?Node): boolean {
   if (!node || !node.ownerDocument) {
     return false;
   }
   return isElement(node) && node.nodeName === 'IMG';
 }
-
-module.exports = isHTMLImageElement;

--- a/src/component/utils/isInstanceOfNode.js
+++ b/src/component/utils/isInstanceOfNode.js
@@ -9,7 +9,7 @@
  * @emails oncall+draft_js
  */
 
-function isInstanceOfNode(target: ?EventTarget): boolean {
+export default function isInstanceOfNode(target: ?EventTarget): boolean {
   // we changed the name because of having duplicate module provider (fbjs)
   if (!target || !('ownerDocument' in target)) {
     return false;
@@ -25,5 +25,3 @@ function isInstanceOfNode(target: ?EventTarget): boolean {
   }
   return false;
 }
-
-module.exports = isInstanceOfNode;

--- a/src/component/utils/isSoftNewlineEvent.js
+++ b/src/component/utils/isSoftNewlineEvent.js
@@ -11,9 +11,11 @@
 
 'use strict';
 
-const Keys = require('Keys');
+import Keys from 'Keys';
 
-function isSoftNewlineEvent(e: SyntheticKeyboardEvent<>): boolean {
+export default function isSoftNewlineEvent(
+  e: SyntheticKeyboardEvent<>,
+): boolean {
   return (
     e.which === Keys.RETURN &&
     (e.getModifierState('Shift') ||
@@ -21,5 +23,3 @@ function isSoftNewlineEvent(e: SyntheticKeyboardEvent<>): boolean {
       e.getModifierState('Control'))
   );
 }
-
-module.exports = isSoftNewlineEvent;

--- a/src/component/utils/splitTextIntoTextBlocks.js
+++ b/src/component/utils/splitTextIntoTextBlocks.js
@@ -13,8 +13,6 @@
 
 const NEWLINE_REGEX = /\r\n?|\n/g;
 
-function splitTextIntoTextBlocks(text: string): Array<string> {
+export default function splitTextIntoTextBlocks(text: string): Array<string> {
   return text.split(NEWLINE_REGEX);
 }
-
-module.exports = splitTextIntoTextBlocks;

--- a/src/model/decorators/CompositeDraftDecorator.js
+++ b/src/model/decorators/CompositeDraftDecorator.js
@@ -15,7 +15,7 @@ import type {BlockNodeRecord} from 'BlockNodeRecord';
 import type ContentState from 'ContentState';
 import type {DraftDecorator} from 'DraftDecorator';
 
-const Immutable = require('immutable');
+import Immutable from 'immutable';
 
 const {List} = Immutable;
 
@@ -40,7 +40,7 @@ const DELIMITER = '.';
  * Thus, when a collision like this is encountered, the earlier match is
  * preserved and the new match is discarded.
  */
-class CompositeDraftDecorator {
+export default class CompositeDraftDecorator {
   _decorators: $ReadOnlyArray<DraftDecorator>;
 
   constructor(decorators: $ReadOnlyArray<DraftDecorator>) {
@@ -116,5 +116,3 @@ function occupySlice(
     targetArr[ii] = componentKey;
   }
 }
-
-module.exports = CompositeDraftDecorator;

--- a/src/model/decorators/DraftDecorator.js
+++ b/src/model/decorators/DraftDecorator.js
@@ -16,7 +16,7 @@ import type {BlockNodeRecord} from 'BlockNodeRecord';
 import type ContentState from 'ContentState';
 import type {HTMLDir} from 'UnicodeBidiDirection';
 
-const React = require('React');
+import * as React from 'React';
 
 export type DraftDecoratorStrategy = (
   block: BlockNodeRecord,

--- a/src/model/encoding/DraftStringKey.js
+++ b/src/model/encoding/DraftStringKey.js
@@ -11,14 +11,10 @@
 
 'use strict';
 
-const DraftStringKey = {
-  stringify: function(key: ?string): string {
-    return '_' + String(key);
-  },
+export function stringify(key: ?string): string {
+  return '_' + String(key);
+}
 
-  unstringify: function(key: string): string {
-    return key.slice(1);
-  },
-};
-
-module.exports = DraftStringKey;
+export function unstringify(key: string): string {
+  return key.slice(1);
+}

--- a/src/model/encoding/__tests__/DraftStringKey-test.js
+++ b/src/model/encoding/__tests__/DraftStringKey-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const {stringify, unstringify} = require('DraftStringKey');
+import {stringify, unstringify} from 'DraftStringKey';
 
 test('must convert maybe strings to a string key', () => {
   expect(stringify('anything')).toEqual('_anything');

--- a/src/model/encoding/__tests__/convertFromDraftStateToRaw-test.js
+++ b/src/model/encoding/__tests__/convertFromDraftStateToRaw-test.js
@@ -11,19 +11,19 @@
 
 'use strict';
 
-const mockUUID = require('mockUUID');
+import mockUUID from 'mockUUID';
 jest.mock('uuid', () => jest.fn(mockUUID));
 
-const BlockMapBuilder = require('BlockMapBuilder');
-const CharacterMetadata = require('CharacterMetadata');
-const ContentBlock = require('ContentBlock');
-const ContentBlockNode = require('ContentBlockNode');
-const ContentState = require('ContentState');
-const DraftEntityInstance = require('DraftEntityInstance');
+import * as BlockMapBuilder from 'BlockMapBuilder';
+import CharacterMetadata from 'CharacterMetadata';
+import ContentBlock from 'ContentBlock';
+import ContentBlockNode from 'ContentBlockNode';
+import ContentState from 'ContentState';
+import DraftEntityInstance from 'DraftEntityInstance';
 
-const convertFromDraftStateToRaw = require('convertFromDraftStateToRaw');
-const getSampleStateForTesting = require('getSampleStateForTesting');
-const Immutable = require('immutable');
+import convertFromDraftStateToRaw from 'convertFromDraftStateToRaw';
+import getSampleStateForTesting from 'getSampleStateForTesting';
+import Immutable from 'immutable';
 
 const {contentState} = getSampleStateForTesting();
 

--- a/src/model/encoding/__tests__/convertFromHTMLToContentBlocks-test.js
+++ b/src/model/encoding/__tests__/convertFromHTMLToContentBlocks-test.js
@@ -15,12 +15,12 @@ expect.addSnapshotSerializer(require('NonASCIIStringSnapshotSerializer'));
 
 jest.mock('generateRandomKey');
 
-const DefaultDraftBlockRenderMap = require('DefaultDraftBlockRenderMap');
+import DefaultDraftBlockRenderMap from 'DefaultDraftBlockRenderMap';
 
-const convertFromHTMLToContentBlocks = require('convertFromHTMLToContentBlocks');
-const cx = require('cx');
-const getSafeBodyFromHTML = require('getSafeBodyFromHTML');
-const mockUUID = require('mockUUID');
+import convertFromHTMLToContentBlocks from 'convertFromHTMLToContentBlocks';
+import cx from 'cx';
+import getSafeBodyFromHTML from 'getSafeBodyFromHTML';
+import mockUUID from 'mockUUID';
 
 const DEFAULT_CONFIG = {
   DOMBuilder: getSafeBodyFromHTML,

--- a/src/model/encoding/__tests__/decodeEntityRanges-test.js
+++ b/src/model/encoding/__tests__/decodeEntityRanges-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const decodeEntityRanges = require('decodeEntityRanges');
+import decodeEntityRanges from 'decodeEntityRanges';
 
 test('must decode when no entities present', () => {
   const decoded = decodeEntityRanges(' '.repeat(20), []);

--- a/src/model/encoding/__tests__/decodeInlineStyleRanges-test.js
+++ b/src/model/encoding/__tests__/decodeInlineStyleRanges-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const decodeInlineStyleRanges = require('decodeInlineStyleRanges');
+import decodeInlineStyleRanges from 'decodeInlineStyleRanges';
 
 test('must decode for an unstyled block', () => {
   const block = {text: 'Hello', inlineStyleRanges: []};

--- a/src/model/encoding/__tests__/encodeEntityRanges-test.js
+++ b/src/model/encoding/__tests__/encodeEntityRanges-test.js
@@ -11,11 +11,11 @@
 
 'use strict';
 
-const ContentBlock = require('ContentBlock');
+import ContentBlock from 'ContentBlock';
 
-const createCharacterList = require('createCharacterList');
-const encodeEntityRanges = require('encodeEntityRanges');
-const Immutable = require('immutable');
+import createCharacterList from 'createCharacterList';
+import encodeEntityRanges from 'encodeEntityRanges';
+import Immutable from 'immutable';
 
 const {OrderedSet, Repeat} = Immutable;
 

--- a/src/model/encoding/__tests__/encodeInlineStyleRanges-test.js
+++ b/src/model/encoding/__tests__/encodeInlineStyleRanges-test.js
@@ -11,22 +11,20 @@
 
 'use strict';
 
-const ContentBlock = require('ContentBlock');
-const SampleDraftInlineStyle = require('SampleDraftInlineStyle');
-
-const createCharacterList = require('createCharacterList');
-const encodeInlineStyleRanges = require('encodeInlineStyleRanges');
-const Immutable = require('immutable');
-
-const {
+import ContentBlock from 'ContentBlock';
+import {
   BOLD,
   BOLD_ITALIC,
-  BOLD_UNDERLINE,
   BOLD_ITALIC_UNDERLINE,
+  BOLD_UNDERLINE,
   ITALIC,
   ITALIC_UNDERLINE,
   NONE,
-} = SampleDraftInlineStyle;
+} from 'SampleDraftInlineStyle';
+
+import createCharacterList from 'createCharacterList';
+import encodeInlineStyleRanges from 'encodeInlineStyleRanges';
+import Immutable from 'immutable';
 
 const {List, OrderedSet, Repeat} = Immutable;
 

--- a/src/model/encoding/__tests__/sanitizeDraftText-test.js
+++ b/src/model/encoding/__tests__/sanitizeDraftText-test.js
@@ -9,7 +9,7 @@
  * @format
  */
 
-const sanitizeDraftText = require('sanitizeDraftText');
+import sanitizeDraftText from 'sanitizeDraftText';
 
 test('must strip trailing carriage returns', () => {
   expect(sanitizeDraftText('test\u000d')).toMatchSnapshot();

--- a/src/model/encoding/convertFromDraftStateToRaw.js
+++ b/src/model/encoding/convertFromDraftStateToRaw.js
@@ -16,13 +16,13 @@ import type ContentState from 'ContentState';
 import type {RawDraftContentBlock} from 'RawDraftContentBlock';
 import type {RawDraftContentState} from 'RawDraftContentState';
 
-const ContentBlock = require('ContentBlock');
-const ContentBlockNode = require('ContentBlockNode');
-const DraftStringKey = require('DraftStringKey');
+import ContentBlock from 'ContentBlock';
+import ContentBlockNode from 'ContentBlockNode';
+import * as DraftStringKey from 'DraftStringKey';
 
-const encodeEntityRanges = require('encodeEntityRanges');
-const encodeInlineStyleRanges = require('encodeInlineStyleRanges');
-const invariant = require('invariant');
+import encodeEntityRanges from 'encodeEntityRanges';
+import encodeInlineStyleRanges from 'encodeInlineStyleRanges';
+import invariant from 'invariant';
 
 const createRawBlock = (block: BlockNodeRecord, entityStorageMap: *) => {
   return {
@@ -131,9 +131,9 @@ const encodeRawEntityMap = (
   };
 };
 
-const convertFromDraftStateToRaw = (
+export default function convertFromDraftStateToRaw(
   contentState: ContentState,
-): RawDraftContentState => {
+): RawDraftContentState {
   let rawDraftContentState = {
     entityMap: {},
     blocks: [],
@@ -146,6 +146,4 @@ const convertFromDraftStateToRaw = (
   rawDraftContentState = encodeRawEntityMap(contentState, rawDraftContentState);
 
   return rawDraftContentState;
-};
-
-module.exports = convertFromDraftStateToRaw;
+}

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -16,22 +16,25 @@ import type {DraftBlockRenderMap} from 'DraftBlockRenderMap';
 import type {DraftInlineStyle} from 'DraftInlineStyle';
 import type {EntityMap} from 'EntityMap';
 
-const CharacterMetadata = require('CharacterMetadata');
-const ContentBlock = require('ContentBlock');
-const ContentBlockNode = require('ContentBlockNode');
-const DefaultDraftBlockRenderMap = require('DefaultDraftBlockRenderMap');
-const DraftEntity = require('DraftEntity');
-const URI = require('URI');
+import CharacterMetadata from 'CharacterMetadata';
+import ContentBlock from 'ContentBlock';
+import ContentBlockNode from 'ContentBlockNode';
+import DefaultDraftBlockRenderMap from 'DefaultDraftBlockRenderMap';
+import DraftEntity from 'DraftEntity';
+import URI from 'URI';
 
-const cx = require('cx');
-const generateRandomKey = require('generateRandomKey');
-const getSafeBodyFromHTML = require('getSafeBodyFromHTML');
-const gkx = require('gkx');
-const {List, Map, OrderedSet} = require('immutable');
-const isHTMLAnchorElement = require('isHTMLAnchorElement');
-const isHTMLBRElement = require('isHTMLBRElement');
-const isHTMLElement = require('isHTMLElement');
-const isHTMLImageElement = require('isHTMLImageElement');
+import cx from 'cx';
+import generateRandomKey from 'generateRandomKey';
+import getSafeBodyFromHTML from 'getSafeBodyFromHTML';
+import gkx from 'gkx';
+import immutable from 'immutable';
+
+const {List, Map, OrderedSet} = immutable;
+
+import isHTMLAnchorElement from 'isHTMLAnchorElement';
+import isHTMLBRElement from 'isHTMLBRElement';
+import isHTMLElement from 'isHTMLElement';
+import isHTMLImageElement from 'isHTMLImageElement';
 
 const experimentalTreeDataSupport = gkx('draft_tree_data_support');
 
@@ -775,7 +778,7 @@ class ContentBlocksBuilder {
  * Converts an HTML string to an array of ContentBlocks and an EntityMap
  * suitable to initialize the internal state of a Draftjs component.
  */
-const convertFromHTMLToContentBlocks = (
+export default function convertFromHTMLToContentBlocks(
   html: string,
   DOMBuilder: Function = getSafeBodyFromHTML,
   blockRenderMap?: DraftBlockRenderMap = DefaultDraftBlockRenderMap,
@@ -783,7 +786,7 @@ const convertFromHTMLToContentBlocks = (
   contentBlocks: ?Array<BlockNodeRecord>,
   entityMap: EntityMap,
   ...
-} => {
+} {
   // Be ABSOLUTELY SURE that the dom builder you pass here won't execute
   // arbitrary code in whatever environment you're running this in. For an
   // example of how we try to do this in-browser, see getSafeBodyFromHTML.
@@ -817,6 +820,4 @@ const convertFromHTMLToContentBlocks = (
   return new ContentBlocksBuilder(blockTypeMap, disambiguate)
     .addDOMNode(safeBody)
     .getContentBlocks();
-};
-
-module.exports = convertFromHTMLToContentBlocks;
+}

--- a/src/model/encoding/convertFromRawToDraftState.js
+++ b/src/model/encoding/convertFromRawToDraftState.js
@@ -17,21 +17,21 @@ import type CharacterMetadata from 'CharacterMetadata';
 import type {RawDraftContentBlock} from 'RawDraftContentBlock';
 import type {RawDraftContentState} from 'RawDraftContentState';
 
-const ContentBlock = require('ContentBlock');
-const ContentBlockNode = require('ContentBlockNode');
-const ContentState = require('ContentState');
-const DraftEntity = require('DraftEntity');
-const DraftTreeAdapter = require('DraftTreeAdapter');
-const DraftTreeInvariants = require('DraftTreeInvariants');
-const SelectionState = require('SelectionState');
+import ContentBlock from 'ContentBlock';
+import ContentBlockNode from 'ContentBlockNode';
+import ContentState from 'ContentState';
+import DraftEntity from 'DraftEntity';
+import * as DraftTreeAdapter from 'DraftTreeAdapter';
+import * as DraftTreeInvariants from 'DraftTreeInvariants';
+import SelectionState from 'SelectionState';
 
-const createCharacterList = require('createCharacterList');
-const decodeEntityRanges = require('decodeEntityRanges');
-const decodeInlineStyleRanges = require('decodeInlineStyleRanges');
-const generateRandomKey = require('generateRandomKey');
-const gkx = require('gkx');
-const Immutable = require('immutable');
-const invariant = require('invariant');
+import createCharacterList from 'createCharacterList';
+import decodeEntityRanges from 'decodeEntityRanges';
+import decodeInlineStyleRanges from 'decodeInlineStyleRanges';
+import generateRandomKey from 'generateRandomKey';
+import gkx from 'gkx';
+import Immutable from 'immutable';
+import invariant from 'invariant';
 
 const experimentalTreeDataSupport = gkx('draft_tree_data_support');
 
@@ -260,9 +260,9 @@ const decodeRawEntityMap = (rawState: RawDraftContentState): * => {
   return entityMap;
 };
 
-const convertFromRawToDraftState = (
+export default function convertFromRawToDraftState(
   rawState: RawDraftContentState,
-): ContentState => {
+): ContentState {
   invariant(Array.isArray(rawState.blocks), 'invalid RawDraftContentState');
 
   // decode entities
@@ -282,6 +282,4 @@ const convertFromRawToDraftState = (
     selectionBefore: selectionState,
     selectionAfter: selectionState,
   });
-};
-
-module.exports = convertFromRawToDraftState;
+}

--- a/src/model/encoding/createCharacterList.js
+++ b/src/model/encoding/createCharacterList.js
@@ -13,13 +13,13 @@
 
 import type {DraftInlineStyle} from 'DraftInlineStyle';
 
-const CharacterMetadata = require('CharacterMetadata');
+import CharacterMetadata from 'CharacterMetadata';
 
-const Immutable = require('immutable');
+import Immutable from 'immutable';
 
 const {List} = Immutable;
 
-function createCharacterList(
+export default function createCharacterList(
   inlineStyles: Array<DraftInlineStyle>,
   entities: Array<?string>,
 ): List<CharacterMetadata> {
@@ -29,5 +29,3 @@ function createCharacterList(
   });
   return List(characterArray);
 }
-
-module.exports = createCharacterList;

--- a/src/model/encoding/decodeEntityRanges.js
+++ b/src/model/encoding/decodeEntityRanges.js
@@ -13,14 +13,12 @@
 
 import type {EntityRange} from 'EntityRange';
 
-const UnicodeUtils = require('UnicodeUtils');
-
-const {substr} = UnicodeUtils;
+import {substr} from 'UnicodeUtils';
 
 /**
  * Convert to native JavaScript string lengths to determine ranges.
  */
-function decodeEntityRanges(
+export default function decodeEntityRanges(
   text: string,
   ranges: Array<EntityRange>,
 ): Array<?string> {
@@ -38,5 +36,3 @@ function decodeEntityRanges(
   }
   return entities;
 }
-
-module.exports = decodeEntityRanges;

--- a/src/model/encoding/decodeInlineStyleRanges.js
+++ b/src/model/encoding/decodeInlineStyleRanges.js
@@ -14,17 +14,17 @@
 import type {DraftInlineStyle} from 'DraftInlineStyle';
 import type {InlineStyleRange} from 'InlineStyleRange';
 
-const UnicodeUtils = require('UnicodeUtils');
+import {substr} from 'UnicodeUtils';
 
-const {OrderedSet} = require('immutable');
-const {substr} = UnicodeUtils;
+import immutable from 'immutable';
+const {OrderedSet} = immutable;
 
 const EMPTY_SET = OrderedSet();
 
 /**
  * Convert to native JavaScript string lengths to determine ranges.
  */
-function decodeInlineStyleRanges(
+export default function decodeInlineStyleRanges(
   text: string,
   ranges?: Array<InlineStyleRange>,
 ): Array<DraftInlineStyle> {
@@ -41,5 +41,3 @@ function decodeInlineStyleRanges(
   }
   return styles;
 }
-
-module.exports = decodeInlineStyleRanges;

--- a/src/model/encoding/encodeEntityRanges.js
+++ b/src/model/encoding/encodeEntityRanges.js
@@ -14,15 +14,13 @@
 import type {BlockNodeRecord} from 'BlockNodeRecord';
 import type {EntityRange} from 'EntityRange';
 
-const DraftStringKey = require('DraftStringKey');
-const UnicodeUtils = require('UnicodeUtils');
-
-const {strlen} = UnicodeUtils;
+import * as DraftStringKey from 'DraftStringKey';
+import {strlen} from 'UnicodeUtils';
 
 /**
  * Convert to UTF-8 character counts for storage.
  */
-function encodeEntityRanges(
+export default function encodeEntityRanges(
   block: BlockNodeRecord,
   storageMap: Object,
 ): Array<EntityRange> {
@@ -42,5 +40,3 @@ function encodeEntityRanges(
   );
   return encoded;
 }
-
-module.exports = encodeEntityRanges;

--- a/src/model/encoding/encodeInlineStyleRanges.js
+++ b/src/model/encoding/encodeInlineStyleRanges.js
@@ -16,9 +16,9 @@ import type {DraftInlineStyle} from 'DraftInlineStyle';
 import type {InlineStyleRange} from 'InlineStyleRange';
 import type {List} from 'immutable';
 
-const UnicodeUtils = require('UnicodeUtils');
+import * as UnicodeUtils from 'UnicodeUtils';
 
-const findRangesImmutable = require('findRangesImmutable');
+import findRangesImmutable from 'findRangesImmutable';
 
 const areEqual = (a, b) => a === b;
 const isTruthy = a => !!a;
@@ -62,7 +62,7 @@ function getEncodedInlinesForType(
  * Retrieve the encoded arrays of inline styles, with each individual style
  * treated separately.
  */
-function encodeInlineStyleRanges(
+export default function encodeInlineStyleRanges(
   block: BlockNodeRecord,
 ): Array<InlineStyleRange> {
   const styleList = block
@@ -76,5 +76,3 @@ function encodeInlineStyleRanges(
 
   return Array.prototype.concat.apply(EMPTY_ARRAY, ranges.toJS());
 }
-
-module.exports = encodeInlineStyleRanges;

--- a/src/model/encoding/sanitizeDraftText.js
+++ b/src/model/encoding/sanitizeDraftText.js
@@ -13,8 +13,6 @@
 
 const REGEX_BLOCK_DELIMITER = new RegExp('\r', 'g');
 
-function sanitizeDraftText(input: string): string {
+export default function sanitizeDraftText(input: string): string {
   return input.replace(REGEX_BLOCK_DELIMITER, '');
 }
-
-module.exports = sanitizeDraftText;

--- a/src/model/entity/DraftEntity.js
+++ b/src/model/entity/DraftEntity.js
@@ -12,11 +12,11 @@
 import type {DraftEntityMutability} from 'DraftEntityMutability';
 import type {DraftEntityType} from 'DraftEntityType';
 
-const DraftEntityInstance = require('DraftEntityInstance');
+import DraftEntityInstance from 'DraftEntityInstance';
 
-const Immutable = require('immutable');
-const invariant = require('invariant');
-const uuid = require('uuid');
+import Immutable from 'immutable';
+import invariant from 'invariant';
+import uuid from 'uuid';
 
 const {Map} = Immutable;
 
@@ -270,4 +270,4 @@ const DraftEntity: DraftEntityMapObject = {
   },
 };
 
-module.exports = DraftEntity;
+export default DraftEntity;

--- a/src/model/entity/DraftEntityInstance.js
+++ b/src/model/entity/DraftEntityInstance.js
@@ -15,7 +15,7 @@
 import type {DraftEntityMutability} from 'DraftEntityMutability';
 import type {DraftEntityType} from 'DraftEntityType';
 
-const Immutable = require('immutable');
+import Immutable from 'immutable';
 
 const {Record} = Immutable;
 
@@ -36,7 +36,7 @@ const DraftEntityInstanceRecord = (Record({
  * the rendered anchor. For a mention, the ID could be used to retrieve
  * a hovercard.
  */
-class DraftEntityInstance extends DraftEntityInstanceRecord {
+export default class DraftEntityInstance extends DraftEntityInstanceRecord {
   getType(): DraftEntityType {
     return this.get('type');
   }
@@ -49,5 +49,3 @@ class DraftEntityInstance extends DraftEntityInstanceRecord {
     return this.get('data');
   }
 }
-
-module.exports = DraftEntityInstance;

--- a/src/model/entity/DraftEntityMutability.js
+++ b/src/model/entity/DraftEntityMutability.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const ComposedEntityMutability = require('ComposedEntityMutability');
+import ComposedEntityMutability from 'ComposedEntityMutability';
 
 /**
  * An enum representing the possible "mutability" options for an entity.

--- a/src/model/entity/__tests__/DraftEntity-test.js
+++ b/src/model/entity/__tests__/DraftEntity-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const DraftEntity = require('DraftEntity');
+import DraftEntity from 'DraftEntity';
 
 beforeEach(() => {
   jest.resetModules();

--- a/src/model/entity/__tests__/getEntityKeyForSelection-test.js
+++ b/src/model/entity/__tests__/getEntityKeyForSelection-test.js
@@ -9,8 +9,8 @@
  * @format
  */
 
-const getEntityKeyForSelection = require('getEntityKeyForSelection');
-const getSampleStateForTesting = require('getSampleStateForTesting');
+import getEntityKeyForSelection from 'getEntityKeyForSelection';
+import getSampleStateForTesting from 'getSampleStateForTesting';
 
 const {contentState, selectionState} = getSampleStateForTesting();
 

--- a/src/model/entity/getEntityKeyForSelection.js
+++ b/src/model/entity/getEntityKeyForSelection.js
@@ -15,14 +15,14 @@ import type ContentState from 'ContentState';
 import type {EntityMap} from 'EntityMap';
 import type SelectionState from 'SelectionState';
 
-const {notEmptyKey} = require('draftKeyUtils');
+import {notEmptyKey} from 'draftKeyUtils';
 
 /**
  * Return the entity key that should be used when inserting text for the
  * specified target selection, only if the entity is `MUTABLE`. `IMMUTABLE`
  * and `SEGMENTED` entities should not be used for insertion behavior.
  */
-function getEntityKeyForSelection(
+export default function getEntityKeyForSelection(
   contentState: ContentState,
   targetSelection: SelectionState,
 ): ?string {
@@ -64,5 +64,3 @@ function filterKey(entityMap: EntityMap, entityKey: ?string): ?string {
   }
   return null;
 }
-
-module.exports = getEntityKeyForSelection;

--- a/src/model/entity/getTextAfterNearestEntity.js
+++ b/src/model/entity/getTextAfterNearestEntity.js
@@ -17,7 +17,7 @@ import type {BlockNodeRecord} from 'BlockNodeRecord';
  * Find the string of text between the previous entity and the specified
  * offset. This allows us to narrow down search areas for regex matching.
  */
-function getTextAfterNearestEntity(
+export default function getTextAfterNearestEntity(
   block: BlockNodeRecord,
   offset: number,
 ): string {
@@ -30,5 +30,3 @@ function getTextAfterNearestEntity(
 
   return block.getText().slice(start, offset);
 }
-
-module.exports = getTextAfterNearestEntity;

--- a/src/model/immutable/BlockMapBuilder.js
+++ b/src/model/immutable/BlockMapBuilder.js
@@ -14,14 +14,10 @@
 import type {BlockMap} from 'BlockMap';
 import type {BlockNodeRecord} from 'BlockNodeRecord';
 
-const Immutable = require('immutable');
+import Immutable from 'immutable';
 
 const {OrderedMap} = Immutable;
 
-const BlockMapBuilder = {
-  createFromArray: function(blocks: Array<BlockNodeRecord>): BlockMap {
-    return OrderedMap(blocks.map(block => [block.getKey(), block]));
-  },
-};
-
-module.exports = BlockMapBuilder;
+export function createFromArray(blocks: Array<BlockNodeRecord>): BlockMap {
+  return OrderedMap(blocks.map(block => [block.getKey(), block]));
+}

--- a/src/model/immutable/CharacterMetadata.js
+++ b/src/model/immutable/CharacterMetadata.js
@@ -13,7 +13,8 @@
 
 import type {DraftInlineStyle} from 'DraftInlineStyle';
 
-const {Map, OrderedSet, Record} = require('immutable');
+import immutable from 'immutable';
+const {Map, OrderedSet, Record} = immutable;
 
 // Immutable.map is typed such that the value for every key in the map
 // must be the same type
@@ -41,7 +42,7 @@ const defaultRecord: CharacterMetadataConfig = {
 
 const CharacterMetadataRecord = (Record(defaultRecord): any);
 
-class CharacterMetadata extends CharacterMetadataRecord {
+export default class CharacterMetadata extends CharacterMetadataRecord {
   getStyle(): DraftInlineStyle {
     return this.get('style');
   }
@@ -127,5 +128,3 @@ let pool: Map<Map<any, any>, CharacterMetadata> = Map([
 ]);
 
 CharacterMetadata.EMPTY = EMPTY;
-
-module.exports = CharacterMetadata;

--- a/src/model/immutable/ContentBlock.js
+++ b/src/model/immutable/ContentBlock.js
@@ -15,10 +15,10 @@ import type {BlockNode, BlockNodeConfig, BlockNodeKey} from 'BlockNode';
 import type {DraftBlockType} from 'DraftBlockType';
 import type {DraftInlineStyle} from 'DraftInlineStyle';
 
-const CharacterMetadata = require('CharacterMetadata');
+import CharacterMetadata from 'CharacterMetadata';
 
-const findRangesImmutable = require('findRangesImmutable');
-const Immutable = require('immutable');
+import findRangesImmutable from 'findRangesImmutable';
+import Immutable from 'immutable';
 
 const {List, Map, OrderedSet, Record, Repeat} = Immutable;
 
@@ -49,7 +49,8 @@ const decorateCharacterList = (config: BlockNodeConfig): BlockNodeConfig => {
   return config;
 };
 
-class ContentBlock extends ContentBlockRecord implements BlockNode {
+export default class ContentBlock extends ContentBlockRecord
+  implements BlockNode {
   constructor(config: BlockNodeConfig) {
     super(decorateCharacterList(config));
   }
@@ -136,5 +137,3 @@ function haveEqualEntity(
 ): boolean {
   return charA.getEntity() === charB.getEntity();
 }
-
-module.exports = ContentBlock;

--- a/src/model/immutable/ContentBlockNode.js
+++ b/src/model/immutable/ContentBlockNode.js
@@ -21,10 +21,10 @@ import type {BlockNode, BlockNodeConfig, BlockNodeKey} from 'BlockNode';
 import type {DraftBlockType} from 'DraftBlockType';
 import type {DraftInlineStyle} from 'DraftInlineStyle';
 
-const CharacterMetadata = require('CharacterMetadata');
+import CharacterMetadata from 'CharacterMetadata';
 
-const findRangesImmutable = require('findRangesImmutable');
-const Immutable = require('immutable');
+import findRangesImmutable from 'findRangesImmutable';
+import Immutable from 'immutable';
 
 const {List, Map, OrderedSet, Record, Repeat} = Immutable;
 
@@ -77,7 +77,7 @@ const decorateCharacterList = (
   return config;
 };
 
-class ContentBlockNode extends (Record(defaultRecord): any)
+export default class ContentBlockNode extends (Record(defaultRecord): any)
   implements BlockNode {
   constructor(props: ContentBlockNodeConfig = defaultRecord) {
     /* eslint-disable-next-line constructor-super */
@@ -162,5 +162,3 @@ class ContentBlockNode extends (Record(defaultRecord): any)
     );
   }
 }
-
-module.exports = ContentBlockNode;

--- a/src/model/immutable/ContentState.js
+++ b/src/model/immutable/ContentState.js
@@ -20,18 +20,18 @@ import type {DraftEntityMutability} from 'DraftEntityMutability';
 import type {DraftEntityType} from 'DraftEntityType';
 import type {Map} from 'immutable';
 
-const BlockMapBuilder = require('BlockMapBuilder');
-const CharacterMetadata = require('CharacterMetadata');
-const ContentBlock = require('ContentBlock');
-const ContentBlockNode = require('ContentBlockNode');
-const DraftEntity = require('DraftEntity');
-const SelectionState = require('SelectionState');
+import * as BlockMapBuilder from 'BlockMapBuilder';
+import CharacterMetadata from 'CharacterMetadata';
+import ContentBlock from 'ContentBlock';
+import ContentBlockNode from 'ContentBlockNode';
+import DraftEntity from 'DraftEntity';
+import SelectionState from 'SelectionState';
 
-const generateRandomKey = require('generateRandomKey');
-const getOwnObjectValues = require('getOwnObjectValues');
-const gkx = require('gkx');
-const Immutable = require('immutable');
-const sanitizeDraftText = require('sanitizeDraftText');
+import generateRandomKey from 'generateRandomKey';
+import getOwnObjectValues from 'getOwnObjectValues';
+import gkx from 'gkx';
+import Immutable from 'immutable';
+import sanitizeDraftText from 'sanitizeDraftText';
 
 const {List, Record, Repeat, Map: ImmutableMap, OrderedMap} = Immutable;
 
@@ -59,7 +59,7 @@ const ContentBlockNodeRecord = gkx('draft_tree_data_support')
   ? ContentBlockNode
   : ContentBlock;
 
-class ContentState extends ContentStateRecord {
+export default class ContentState extends ContentStateRecord {
   getEntityMap(): any {
     // TODO: update this when we fully remove DraftEntity
     return DraftEntity;
@@ -264,5 +264,3 @@ class ContentState extends ContentStateRecord {
     });
   }
 }
-
-module.exports = ContentState;

--- a/src/model/immutable/DefaultDraftBlockRenderMap.js
+++ b/src/model/immutable/DefaultDraftBlockRenderMap.js
@@ -14,10 +14,11 @@
 import type {DraftBlockRenderConfig} from 'DraftBlockRenderConfig';
 import type {CoreDraftBlockType} from 'DraftBlockType';
 
-const React = require('React');
+import * as React from 'React';
 
-const cx = require('cx');
-const {Map} = require('immutable');
+import cx from 'cx';
+import immutable from 'immutable';
+const {Map} = immutable;
 
 type DefaultCoreDraftBlockRenderMap = Map<
   CoreDraftBlockType,
@@ -77,4 +78,4 @@ const DefaultDraftBlockRenderMap: DefaultCoreDraftBlockRenderMap = Map({
   },
 });
 
-module.exports = DefaultDraftBlockRenderMap;
+export default DefaultDraftBlockRenderMap;

--- a/src/model/immutable/DefaultDraftInlineStyle.js
+++ b/src/model/immutable/DefaultDraftInlineStyle.js
@@ -11,25 +11,23 @@
 
 'use strict';
 
-module.exports = {
-  BOLD: {
-    fontWeight: 'bold',
-  },
+export const BOLD = {
+  fontWeight: 'bold',
+};
 
-  CODE: {
-    fontFamily: 'monospace',
-    wordWrap: 'break-word',
-  },
+export const CODE = {
+  fontFamily: 'monospace',
+  wordWrap: 'break-word',
+};
 
-  ITALIC: {
-    fontStyle: 'italic',
-  },
+export const ITALIC = {
+  fontStyle: 'italic',
+};
 
-  STRIKETHROUGH: {
-    textDecoration: 'line-through',
-  },
+export const STRIKETHROUGH = {
+  textDecoration: 'line-through',
+};
 
-  UNDERLINE: {
-    textDecoration: 'underline',
-  },
+export const UNDERLINE = {
+  textDecoration: 'underline',
 };

--- a/src/model/immutable/DraftBlockRenderConfig.js
+++ b/src/model/immutable/DraftBlockRenderConfig.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const React = require('React');
+import * as React from 'React';
 
 export type DraftBlockRenderConfig = {
   element: string,

--- a/src/model/immutable/EditorBidiService.js
+++ b/src/model/immutable/EditorBidiService.js
@@ -13,38 +13,34 @@
 
 import type ContentState from 'ContentState';
 
-const UnicodeBidiService = require('UnicodeBidiService');
+import UnicodeBidiService from 'UnicodeBidiService';
 
-const Immutable = require('immutable');
-const nullthrows = require('nullthrows');
+import Immutable from 'immutable';
+import nullthrows from 'nullthrows';
 
 const {OrderedMap} = Immutable;
 
 let bidiService;
 
-const EditorBidiService = {
-  getDirectionMap: function(
-    content: ContentState,
-    prevBidiMap: ?OrderedMap<any, any>,
-  ): OrderedMap<any, any> {
-    if (!bidiService) {
-      bidiService = new UnicodeBidiService();
-    } else {
-      bidiService.reset();
-    }
+export function getDirectionMap(
+  content: ContentState,
+  prevBidiMap: ?OrderedMap<any, any>,
+): OrderedMap<any, any> {
+  if (!bidiService) {
+    bidiService = new UnicodeBidiService();
+  } else {
+    bidiService.reset();
+  }
 
-    const blockMap = content.getBlockMap();
-    const nextBidi = blockMap
-      .valueSeq()
-      .map(block => nullthrows(bidiService).getDirection(block.getText()));
-    const bidiMap = OrderedMap(blockMap.keySeq().zip(nextBidi));
+  const blockMap = content.getBlockMap();
+  const nextBidi = blockMap
+    .valueSeq()
+    .map(block => nullthrows(bidiService).getDirection(block.getText()));
+  const bidiMap = OrderedMap(blockMap.keySeq().zip(nextBidi));
 
-    if (prevBidiMap != null && Immutable.is(prevBidiMap, bidiMap)) {
-      return prevBidiMap;
-    }
+  if (prevBidiMap != null && Immutable.is(prevBidiMap, bidiMap)) {
+    return prevBidiMap;
+  }
 
-    return bidiMap;
-  },
-};
-
-module.exports = EditorBidiService;
+  return bidiMap;
+}

--- a/src/model/immutable/SampleDraftInlineStyle.js
+++ b/src/model/immutable/SampleDraftInlineStyle.js
@@ -11,21 +11,32 @@
 
 'use strict';
 
-const {OrderedSet} = require('immutable');
+import immutable from 'immutable';
 
-module.exports = {
-  BOLD: (OrderedSet.of('BOLD'): OrderedSet<string>),
-  BOLD_ITALIC: (OrderedSet.of('BOLD', 'ITALIC'): OrderedSet<string>),
-  BOLD_ITALIC_UNDERLINE: (OrderedSet.of(
-    'BOLD',
-    'ITALIC',
-    'UNDERLINE',
-  ): OrderedSet<string>),
-  BOLD_UNDERLINE: (OrderedSet.of('BOLD', 'UNDERLINE'): OrderedSet<string>),
-  CODE: (OrderedSet.of('CODE'): OrderedSet<string>),
-  ITALIC: (OrderedSet.of('ITALIC'): OrderedSet<string>),
-  ITALIC_UNDERLINE: (OrderedSet.of('ITALIC', 'UNDERLINE'): OrderedSet<string>),
-  NONE: (OrderedSet(): OrderedSet<string>),
-  STRIKETHROUGH: (OrderedSet.of('STRIKETHROUGH'): OrderedSet<string>),
-  UNDERLINE: (OrderedSet.of('UNDERLINE'): OrderedSet<string>),
-};
+const {OrderedSet} = immutable;
+
+export const BOLD = (OrderedSet.of('BOLD'): OrderedSet<string>);
+export const BOLD_ITALIC = (OrderedSet.of(
+  'BOLD',
+  'ITALIC',
+): OrderedSet<string>);
+export const BOLD_ITALIC_UNDERLINE = (OrderedSet.of(
+  'BOLD',
+  'ITALIC',
+  'UNDERLINE',
+): OrderedSet<string>);
+export const BOLD_UNDERLINE = (OrderedSet.of(
+  'BOLD',
+  'UNDERLINE',
+): OrderedSet<string>);
+export const CODE = (OrderedSet.of('CODE'): OrderedSet<string>);
+export const ITALIC = (OrderedSet.of('ITALIC'): OrderedSet<string>);
+export const ITALIC_UNDERLINE = (OrderedSet.of(
+  'ITALIC',
+  'UNDERLINE',
+): OrderedSet<string>);
+export const NONE = (OrderedSet(): OrderedSet<string>);
+export const STRIKETHROUGH = (OrderedSet.of(
+  'STRIKETHROUGH',
+): OrderedSet<string>);
+export const UNDERLINE = (OrderedSet.of('UNDERLINE'): OrderedSet<string>);

--- a/src/model/immutable/SelectionState.js
+++ b/src/model/immutable/SelectionState.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const Immutable = require('immutable');
+import Immutable from 'immutable';
 
 const {Record} = Immutable;
 
@@ -37,7 +37,7 @@ const defaultRecord: {
  * exports. To see the error delete this comment and run Flow. */
 const SelectionStateRecord = (Record(defaultRecord): any);
 
-class SelectionState extends SelectionStateRecord {
+export default class SelectionState extends SelectionStateRecord {
   serialize(): string {
     return (
       'Anchor: ' +
@@ -147,5 +147,3 @@ class SelectionState extends SelectionStateRecord {
     });
   }
 }
-
-module.exports = SelectionState;

--- a/src/model/immutable/__tests__/CharacterMetadata-test.js
+++ b/src/model/immutable/__tests__/CharacterMetadata-test.js
@@ -11,8 +11,8 @@
 
 'use strict';
 
-const CharacterMetadata = require('CharacterMetadata');
-const {BOLD, BOLD_ITALIC, NONE, UNDERLINE} = require('SampleDraftInlineStyle');
+import CharacterMetadata from 'CharacterMetadata';
+import {BOLD, BOLD_ITALIC, NONE, UNDERLINE} from 'SampleDraftInlineStyle';
 
 const plain = CharacterMetadata.create();
 const bold = CharacterMetadata.create({style: BOLD});

--- a/src/model/immutable/__tests__/ContentBlock-test.js
+++ b/src/model/immutable/__tests__/ContentBlock-test.js
@@ -11,11 +11,11 @@
 
 'use strict';
 
-const CharacterMetadata = require('CharacterMetadata');
-const ContentBlock = require('ContentBlock');
-const {BOLD} = require('SampleDraftInlineStyle');
+import CharacterMetadata from 'CharacterMetadata';
+import ContentBlock from 'ContentBlock';
+import {BOLD} from 'SampleDraftInlineStyle';
 
-const Immutable = require('immutable');
+import Immutable from 'immutable';
 
 const ENTITY_KEY = 'x';
 

--- a/src/model/immutable/__tests__/ContentBlockNode-test.js
+++ b/src/model/immutable/__tests__/ContentBlockNode-test.js
@@ -11,11 +11,11 @@
 
 'use strict';
 
-const CharacterMetadata = require('CharacterMetadata');
-const ContentBlockNode = require('ContentBlockNode');
-const {BOLD, NONE} = require('SampleDraftInlineStyle');
+import CharacterMetadata from 'CharacterMetadata';
+import ContentBlockNode from 'ContentBlockNode';
+import {BOLD, NONE} from 'SampleDraftInlineStyle';
 
-const Immutable = require('immutable');
+import Immutable from 'immutable';
 
 const entity_KEY = 'x';
 

--- a/src/model/immutable/__tests__/ContentState-test.js
+++ b/src/model/immutable/__tests__/ContentState-test.js
@@ -15,9 +15,9 @@ jest.mock('SelectionState');
 
 let contentState;
 
-const BlockMapBuilder = require('BlockMapBuilder');
-const ContentBlock = require('ContentBlock');
-const ContentState = require('ContentState');
+import * as BlockMapBuilder from 'BlockMapBuilder';
+import ContentBlock from 'ContentBlock';
+import ContentState from 'ContentState';
 
 const SINGLE_BLOCK = [{text: 'Lorem ipsum', key: 'a'}];
 const MULTI_BLOCK = [
@@ -26,7 +26,7 @@ const MULTI_BLOCK = [
 ];
 const ZERO_WIDTH_CHAR_BLOCK = [{text: unescape('%u200B%u200B'), key: 'a'}];
 
-const SelectionState = require('SelectionState');
+import SelectionState from 'SelectionState';
 
 const createLink = () => {
   return contentState.createEntity('LINK', 'MUTABLE', {uri: 'zombo.com'});

--- a/src/model/immutable/__tests__/EditorBidiService-test.js
+++ b/src/model/immutable/__tests__/EditorBidiService-test.js
@@ -11,11 +11,11 @@
 
 'use strict';
 
-const ContentBlock = require('ContentBlock');
-const ContentState = require('ContentState');
-const EditorBidiService = require('EditorBidiService');
+import ContentBlock from 'ContentBlock';
+import ContentState from 'ContentState';
+import * as EditorBidiService from 'EditorBidiService';
 
-const Immutable = require('immutable');
+import Immutable from 'immutable';
 
 const {OrderedMap, Seq} = Immutable;
 

--- a/src/model/immutable/__tests__/SelectionState-test.js
+++ b/src/model/immutable/__tests__/SelectionState-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const SelectionState = require('SelectionState');
+import SelectionState from 'SelectionState';
 
 const DEFAULT_CONFIG = {
   anchorKey: 'a',

--- a/src/model/immutable/__tests__/findRangesImmutable-test.js
+++ b/src/model/immutable/__tests__/findRangesImmutable-test.js
@@ -11,8 +11,8 @@
 
 'use strict';
 
-const findRangesImmutable = require('findRangesImmutable');
-const Immutable = require('immutable');
+import findRangesImmutable from 'findRangesImmutable';
+import Immutable from 'immutable';
 
 const {List} = Immutable;
 

--- a/src/model/immutable/findRangesImmutable.js
+++ b/src/model/immutable/findRangesImmutable.js
@@ -20,7 +20,7 @@ import type {List} from 'immutable';
  * When ranges are found, execute a specified `found` function to supply
  * the values to the caller.
  */
-function findRangesImmutable<T>(
+export default function findRangesImmutable<T>(
   haystack: List<T>,
   areEqualFn: (a: T, b: T) => boolean,
   filterFn: (value: T) => boolean,
@@ -44,5 +44,3 @@ function findRangesImmutable<T>(
 
   filterFn(haystack.last()) && foundFn(cursor, haystack.count());
 }
-
-module.exports = findRangesImmutable;

--- a/src/model/keys/generateRandomKey.js
+++ b/src/model/keys/generateRandomKey.js
@@ -14,7 +14,7 @@
 const seenKeys = {};
 const MULTIPLIER = Math.pow(2, 24);
 
-function generateRandomKey(): string {
+export default function generateRandomKey(): string {
   let key;
   while (key === undefined || seenKeys.hasOwnProperty(key) || !isNaN(+key)) {
     key = Math.floor(Math.random() * MULTIPLIER).toString(32);
@@ -22,5 +22,3 @@ function generateRandomKey(): string {
   seenKeys[key] = true;
   return key;
 }
-
-module.exports = generateRandomKey;

--- a/src/model/keys/mockUUID.js
+++ b/src/model/keys/mockUUID.js
@@ -13,8 +13,6 @@
 
 let counter = 0;
 
-function mockUUID(): string {
+export default function mockUUID(): string {
   return '' + ++counter;
 }
-
-module.exports = mockUUID;

--- a/src/model/modifier/AtomicBlockUtils.js
+++ b/src/model/modifier/AtomicBlockUtils.js
@@ -15,17 +15,17 @@ import type {BlockNodeRecord} from 'BlockNodeRecord';
 import type {DraftInsertionType} from 'DraftInsertionType';
 import type SelectionState from 'SelectionState';
 
-const BlockMapBuilder = require('BlockMapBuilder');
-const CharacterMetadata = require('CharacterMetadata');
-const ContentBlock = require('ContentBlock');
-const ContentBlockNode = require('ContentBlockNode');
-const DraftModifier = require('DraftModifier');
-const EditorState = require('EditorState');
+import * as BlockMapBuilder from 'BlockMapBuilder';
+import CharacterMetadata from 'CharacterMetadata';
+import ContentBlock from 'ContentBlock';
+import ContentBlockNode from 'ContentBlockNode';
+import * as DraftModifier from 'DraftModifier';
+import EditorState from 'EditorState';
 
-const generateRandomKey = require('generateRandomKey');
-const gkx = require('gkx');
-const Immutable = require('immutable');
-const moveBlockInContentState = require('moveBlockInContentState');
+import generateRandomKey from 'generateRandomKey';
+import gkx from 'gkx';
+import Immutable from 'immutable';
+import moveBlockInContentState from 'moveBlockInContentState';
 
 const experimentalTreeDataSupport = gkx('draft_tree_data_support');
 const ContentBlockRecord = experimentalTreeDataSupport
@@ -34,158 +34,154 @@ const ContentBlockRecord = experimentalTreeDataSupport
 
 const {List, Repeat} = Immutable;
 
-const AtomicBlockUtils = {
-  insertAtomicBlock: function(
-    editorState: EditorState,
-    entityKey: string,
-    character: string,
-  ): EditorState {
-    const contentState = editorState.getCurrentContent();
-    const selectionState = editorState.getSelection();
+export function insertAtomicBlock(
+  editorState: EditorState,
+  entityKey: string,
+  character: string,
+): EditorState {
+  const contentState = editorState.getCurrentContent();
+  const selectionState = editorState.getSelection();
 
+  const afterRemoval = DraftModifier.removeRange(
+    contentState,
+    selectionState,
+    'backward',
+  );
+
+  const targetSelection = afterRemoval.getSelectionAfter();
+  const afterSplit = DraftModifier.splitBlock(afterRemoval, targetSelection);
+  const insertionTarget = afterSplit.getSelectionAfter();
+
+  const asAtomicBlock = DraftModifier.setBlockType(
+    afterSplit,
+    insertionTarget,
+    'atomic',
+  );
+
+  const charData = CharacterMetadata.create({entity: entityKey});
+
+  let atomicBlockConfig = {
+    key: generateRandomKey(),
+    type: 'atomic',
+    text: character,
+    characterList: List(Repeat(charData, character.length)),
+  };
+
+  let atomicDividerBlockConfig = {
+    key: generateRandomKey(),
+    type: 'unstyled',
+  };
+
+  if (experimentalTreeDataSupport) {
+    atomicBlockConfig = {
+      ...atomicBlockConfig,
+      nextSibling: atomicDividerBlockConfig.key,
+    };
+    atomicDividerBlockConfig = {
+      ...atomicDividerBlockConfig,
+      prevSibling: atomicBlockConfig.key,
+    };
+  }
+
+  const fragmentArray = [
+    new ContentBlockRecord(atomicBlockConfig),
+    new ContentBlockRecord(atomicDividerBlockConfig),
+  ];
+
+  const fragment = BlockMapBuilder.createFromArray(fragmentArray);
+
+  const withAtomicBlock = DraftModifier.replaceWithFragment(
+    asAtomicBlock,
+    insertionTarget,
+    fragment,
+  );
+
+  const newContent = withAtomicBlock.merge({
+    selectionBefore: selectionState,
+    selectionAfter: withAtomicBlock.getSelectionAfter().set('hasFocus', true),
+  });
+
+  return EditorState.push(editorState, newContent, 'insert-fragment');
+}
+
+export function moveAtomicBlock(
+  editorState: EditorState,
+  atomicBlock: BlockNodeRecord,
+  targetRange: SelectionState,
+  insertionMode?: DraftInsertionType,
+): EditorState {
+  const contentState = editorState.getCurrentContent();
+  const selectionState = editorState.getSelection();
+
+  let withMovedAtomicBlock;
+
+  if (insertionMode === 'before' || insertionMode === 'after') {
+    const targetBlock = contentState.getBlockForKey(
+      insertionMode === 'before'
+        ? targetRange.getStartKey()
+        : targetRange.getEndKey(),
+    );
+
+    withMovedAtomicBlock = moveBlockInContentState(
+      contentState,
+      atomicBlock,
+      targetBlock,
+      insertionMode,
+    );
+  } else {
     const afterRemoval = DraftModifier.removeRange(
       contentState,
-      selectionState,
+      targetRange,
       'backward',
     );
 
-    const targetSelection = afterRemoval.getSelectionAfter();
-    const afterSplit = DraftModifier.splitBlock(afterRemoval, targetSelection);
-    const insertionTarget = afterSplit.getSelectionAfter();
-
-    const asAtomicBlock = DraftModifier.setBlockType(
-      afterSplit,
-      insertionTarget,
-      'atomic',
+    const selectionAfterRemoval = afterRemoval.getSelectionAfter();
+    const targetBlock = afterRemoval.getBlockForKey(
+      selectionAfterRemoval.getFocusKey(),
     );
 
-    const charData = CharacterMetadata.create({entity: entityKey});
+    if (selectionAfterRemoval.getStartOffset() === 0) {
+      withMovedAtomicBlock = moveBlockInContentState(
+        afterRemoval,
+        atomicBlock,
+        targetBlock,
+        'before',
+      );
+    } else if (
+      selectionAfterRemoval.getEndOffset() === targetBlock.getLength()
+    ) {
+      withMovedAtomicBlock = moveBlockInContentState(
+        afterRemoval,
+        atomicBlock,
+        targetBlock,
+        'after',
+      );
+    } else {
+      const afterSplit = DraftModifier.splitBlock(
+        afterRemoval,
+        selectionAfterRemoval,
+      );
 
-    let atomicBlockConfig = {
-      key: generateRandomKey(),
-      type: 'atomic',
-      text: character,
-      characterList: List(Repeat(charData, character.length)),
-    };
-
-    let atomicDividerBlockConfig = {
-      key: generateRandomKey(),
-      type: 'unstyled',
-    };
-
-    if (experimentalTreeDataSupport) {
-      atomicBlockConfig = {
-        ...atomicBlockConfig,
-        nextSibling: atomicDividerBlockConfig.key,
-      };
-      atomicDividerBlockConfig = {
-        ...atomicDividerBlockConfig,
-        prevSibling: atomicBlockConfig.key,
-      };
-    }
-
-    const fragmentArray = [
-      new ContentBlockRecord(atomicBlockConfig),
-      new ContentBlockRecord(atomicDividerBlockConfig),
-    ];
-
-    const fragment = BlockMapBuilder.createFromArray(fragmentArray);
-
-    const withAtomicBlock = DraftModifier.replaceWithFragment(
-      asAtomicBlock,
-      insertionTarget,
-      fragment,
-    );
-
-    const newContent = withAtomicBlock.merge({
-      selectionBefore: selectionState,
-      selectionAfter: withAtomicBlock.getSelectionAfter().set('hasFocus', true),
-    });
-
-    return EditorState.push(editorState, newContent, 'insert-fragment');
-  },
-
-  moveAtomicBlock: function(
-    editorState: EditorState,
-    atomicBlock: BlockNodeRecord,
-    targetRange: SelectionState,
-    insertionMode?: DraftInsertionType,
-  ): EditorState {
-    const contentState = editorState.getCurrentContent();
-    const selectionState = editorState.getSelection();
-
-    let withMovedAtomicBlock;
-
-    if (insertionMode === 'before' || insertionMode === 'after') {
-      const targetBlock = contentState.getBlockForKey(
-        insertionMode === 'before'
-          ? targetRange.getStartKey()
-          : targetRange.getEndKey(),
+      const selectionAfterSplit = afterSplit.getSelectionAfter();
+      const targetBlock = afterSplit.getBlockForKey(
+        selectionAfterSplit.getFocusKey(),
       );
 
       withMovedAtomicBlock = moveBlockInContentState(
-        contentState,
+        afterSplit,
         atomicBlock,
         targetBlock,
-        insertionMode,
+        'before',
       );
-    } else {
-      const afterRemoval = DraftModifier.removeRange(
-        contentState,
-        targetRange,
-        'backward',
-      );
-
-      const selectionAfterRemoval = afterRemoval.getSelectionAfter();
-      const targetBlock = afterRemoval.getBlockForKey(
-        selectionAfterRemoval.getFocusKey(),
-      );
-
-      if (selectionAfterRemoval.getStartOffset() === 0) {
-        withMovedAtomicBlock = moveBlockInContentState(
-          afterRemoval,
-          atomicBlock,
-          targetBlock,
-          'before',
-        );
-      } else if (
-        selectionAfterRemoval.getEndOffset() === targetBlock.getLength()
-      ) {
-        withMovedAtomicBlock = moveBlockInContentState(
-          afterRemoval,
-          atomicBlock,
-          targetBlock,
-          'after',
-        );
-      } else {
-        const afterSplit = DraftModifier.splitBlock(
-          afterRemoval,
-          selectionAfterRemoval,
-        );
-
-        const selectionAfterSplit = afterSplit.getSelectionAfter();
-        const targetBlock = afterSplit.getBlockForKey(
-          selectionAfterSplit.getFocusKey(),
-        );
-
-        withMovedAtomicBlock = moveBlockInContentState(
-          afterSplit,
-          atomicBlock,
-          targetBlock,
-          'before',
-        );
-      }
     }
+  }
 
-    const newContent = withMovedAtomicBlock.merge({
-      selectionBefore: selectionState,
-      selectionAfter: withMovedAtomicBlock
-        .getSelectionAfter()
-        .set('hasFocus', true),
-    });
+  const newContent = withMovedAtomicBlock.merge({
+    selectionBefore: selectionState,
+    selectionAfter: withMovedAtomicBlock
+      .getSelectionAfter()
+      .set('hasFocus', true),
+  });
 
-    return EditorState.push(editorState, newContent, 'move-block');
-  },
-};
-
-module.exports = AtomicBlockUtils;
+  return EditorState.push(editorState, newContent, 'move-block');
+}

--- a/src/model/modifier/DraftModifier.js
+++ b/src/model/modifier/DraftModifier.js
@@ -20,246 +20,204 @@ import type SelectionState from 'SelectionState';
 import type {Map} from 'immutable';
 import type {BlockDataMergeBehavior} from 'insertFragmentIntoContentState';
 
-const CharacterMetadata = require('CharacterMetadata');
-const ContentStateInlineStyle = require('ContentStateInlineStyle');
+import CharacterMetadata from 'CharacterMetadata';
+import * as ContentStateInlineStyle from 'ContentStateInlineStyle';
 
-const applyEntityToContentState = require('applyEntityToContentState');
-const getCharacterRemovalRange = require('getCharacterRemovalRange');
-const getContentStateFragment = require('getContentStateFragment');
-const Immutable = require('immutable');
-const insertFragmentIntoContentState = require('insertFragmentIntoContentState');
-const insertTextIntoContentState = require('insertTextIntoContentState');
-const invariant = require('invariant');
-const modifyBlockForContentState = require('modifyBlockForContentState');
-const removeEntitiesAtEdges = require('removeEntitiesAtEdges');
-const removeRangeFromContentState = require('removeRangeFromContentState');
-const splitBlockInContentState = require('splitBlockInContentState');
+import applyEntityToContentState from 'applyEntityToContentState';
+import getCharacterRemovalRange from 'getCharacterRemovalRange';
+import getContentStateFragment from 'getContentStateFragment';
+import Immutable from 'immutable';
+import insertFragmentIntoContentState from 'insertFragmentIntoContentState';
+import insertTextIntoContentState from 'insertTextIntoContentState';
+import invariant from 'invariant';
+import modifyBlockForContentState from 'modifyBlockForContentState';
+import removeEntitiesAtEdges from 'removeEntitiesAtEdges';
+import removeRangeFromContentState from 'removeRangeFromContentState';
+import splitBlockInContentState from 'splitBlockInContentState';
 
 const {OrderedSet} = Immutable;
 
-/**
- * `DraftModifier` provides a set of convenience methods that apply
- * modifications to a `ContentState` object based on a target `SelectionState`.
- *
- * Any change to a `ContentState` should be decomposable into a series of
- * transaction functions that apply the required changes and return output
- * `ContentState` objects.
- *
- * These functions encapsulate some of the most common transaction sequences.
- */
-const DraftModifier = {
-  replaceText: function(
-    contentState: ContentState,
-    rangeToReplace: SelectionState,
-    text: string,
-    inlineStyle?: DraftInlineStyle,
-    entityKey?: ?string,
-  ): ContentState {
-    const withoutEntities = removeEntitiesAtEdges(contentState, rangeToReplace);
-    const withoutText = removeRangeFromContentState(
-      withoutEntities,
-      rangeToReplace,
-    );
+export function replaceText(
+  contentState: ContentState,
+  rangeToReplace: SelectionState,
+  text: string,
+  inlineStyle?: DraftInlineStyle,
+  entityKey?: ?string,
+): ContentState {
+  const withoutEntities = removeEntitiesAtEdges(contentState, rangeToReplace);
+  const withoutText = removeRangeFromContentState(
+    withoutEntities,
+    rangeToReplace,
+  );
 
-    const character = CharacterMetadata.create({
-      style: inlineStyle || OrderedSet(),
-      entity: entityKey || null,
+  const character = CharacterMetadata.create({
+    style: inlineStyle || OrderedSet(),
+    entity: entityKey || null,
+  });
+
+  return insertTextIntoContentState(
+    withoutText,
+    withoutText.getSelectionAfter(),
+    text,
+    character,
+  );
+}
+
+export function insertText(
+  contentState: ContentState,
+  targetRange: SelectionState,
+  text: string,
+  inlineStyle?: DraftInlineStyle,
+  entityKey?: ?string,
+): ContentState {
+  invariant(
+    targetRange.isCollapsed(),
+    'Target range must be collapsed for `insertText`.',
+  );
+  return replaceText(contentState, targetRange, text, inlineStyle, entityKey);
+}
+
+export function moveText(
+  contentState: ContentState,
+  removalRange: SelectionState,
+  targetRange: SelectionState,
+): ContentState {
+  const movedFragment = getContentStateFragment(contentState, removalRange);
+
+  const afterRemoval = removeRange(contentState, removalRange, 'backward');
+
+  return replaceWithFragment(afterRemoval, targetRange, movedFragment);
+}
+
+export function replaceWithFragment(
+  contentState: ContentState,
+  targetRange: SelectionState,
+  fragment: BlockMap,
+  mergeBlockData?: BlockDataMergeBehavior = 'REPLACE_WITH_NEW_DATA',
+): ContentState {
+  const withoutEntities = removeEntitiesAtEdges(contentState, targetRange);
+  const withoutText = removeRangeFromContentState(withoutEntities, targetRange);
+
+  return insertFragmentIntoContentState(
+    withoutText,
+    withoutText.getSelectionAfter(),
+    fragment,
+    mergeBlockData,
+  );
+}
+
+export function removeRange(
+  contentState: ContentState,
+  rangeToRemove: SelectionState,
+  removalDirection: DraftRemovalDirection,
+): ContentState {
+  let startKey, endKey, startBlock, endBlock;
+  if (rangeToRemove.getIsBackward()) {
+    rangeToRemove = rangeToRemove.merge({
+      anchorKey: rangeToRemove.getFocusKey(),
+      anchorOffset: rangeToRemove.getFocusOffset(),
+      focusKey: rangeToRemove.getAnchorKey(),
+      focusOffset: rangeToRemove.getAnchorOffset(),
+      isBackward: false,
     });
+  }
+  startKey = rangeToRemove.getAnchorKey();
+  endKey = rangeToRemove.getFocusKey();
+  startBlock = contentState.getBlockForKey(startKey);
+  endBlock = contentState.getBlockForKey(endKey);
+  const startOffset = rangeToRemove.getStartOffset();
+  const endOffset = rangeToRemove.getEndOffset();
 
-    return insertTextIntoContentState(
-      withoutText,
-      withoutText.getSelectionAfter(),
-      text,
-      character,
-    );
-  },
+  const startEntityKey = startBlock.getEntityAt(startOffset);
+  const endEntityKey = endBlock.getEntityAt(endOffset - 1);
 
-  insertText: function(
-    contentState: ContentState,
-    targetRange: SelectionState,
-    text: string,
-    inlineStyle?: DraftInlineStyle,
-    entityKey?: ?string,
-  ): ContentState {
-    invariant(
-      targetRange.isCollapsed(),
-      'Target range must be collapsed for `insertText`.',
-    );
-    return DraftModifier.replaceText(
-      contentState,
-      targetRange,
-      text,
-      inlineStyle,
-      entityKey,
-    );
-  },
-
-  moveText: function(
-    contentState: ContentState,
-    removalRange: SelectionState,
-    targetRange: SelectionState,
-  ): ContentState {
-    const movedFragment = getContentStateFragment(contentState, removalRange);
-
-    const afterRemoval = DraftModifier.removeRange(
-      contentState,
-      removalRange,
-      'backward',
-    );
-
-    return DraftModifier.replaceWithFragment(
-      afterRemoval,
-      targetRange,
-      movedFragment,
-    );
-  },
-
-  replaceWithFragment: function(
-    contentState: ContentState,
-    targetRange: SelectionState,
-    fragment: BlockMap,
-    mergeBlockData?: BlockDataMergeBehavior = 'REPLACE_WITH_NEW_DATA',
-  ): ContentState {
-    const withoutEntities = removeEntitiesAtEdges(contentState, targetRange);
-    const withoutText = removeRangeFromContentState(
-      withoutEntities,
-      targetRange,
-    );
-
-    return insertFragmentIntoContentState(
-      withoutText,
-      withoutText.getSelectionAfter(),
-      fragment,
-      mergeBlockData,
-    );
-  },
-
-  removeRange: function(
-    contentState: ContentState,
-    rangeToRemove: SelectionState,
-    removalDirection: DraftRemovalDirection,
-  ): ContentState {
-    let startKey, endKey, startBlock, endBlock;
-    if (rangeToRemove.getIsBackward()) {
-      rangeToRemove = rangeToRemove.merge({
-        anchorKey: rangeToRemove.getFocusKey(),
-        anchorOffset: rangeToRemove.getFocusOffset(),
-        focusKey: rangeToRemove.getAnchorKey(),
-        focusOffset: rangeToRemove.getAnchorOffset(),
-        isBackward: false,
-      });
+  // Check whether the selection state overlaps with a single entity.
+  // If so, try to remove the appropriate substring of the entity text.
+  if (startKey === endKey) {
+    if (startEntityKey && startEntityKey === endEntityKey) {
+      const adjustedRemovalRange = getCharacterRemovalRange(
+        contentState.getEntityMap(),
+        startBlock,
+        endBlock,
+        rangeToRemove,
+        removalDirection,
+      );
+      return removeRangeFromContentState(contentState, adjustedRemovalRange);
     }
-    startKey = rangeToRemove.getAnchorKey();
-    endKey = rangeToRemove.getFocusKey();
-    startBlock = contentState.getBlockForKey(startKey);
-    endBlock = contentState.getBlockForKey(endKey);
-    const startOffset = rangeToRemove.getStartOffset();
-    const endOffset = rangeToRemove.getEndOffset();
+  }
 
-    const startEntityKey = startBlock.getEntityAt(startOffset);
-    const endEntityKey = endBlock.getEntityAt(endOffset - 1);
+  const withoutEntities = removeEntitiesAtEdges(contentState, rangeToRemove);
+  return removeRangeFromContentState(withoutEntities, rangeToRemove);
+}
 
-    // Check whether the selection state overlaps with a single entity.
-    // If so, try to remove the appropriate substring of the entity text.
-    if (startKey === endKey) {
-      if (startEntityKey && startEntityKey === endEntityKey) {
-        const adjustedRemovalRange = getCharacterRemovalRange(
-          contentState.getEntityMap(),
-          startBlock,
-          endBlock,
-          rangeToRemove,
-          removalDirection,
-        );
-        return removeRangeFromContentState(contentState, adjustedRemovalRange);
-      }
-    }
+export function splitBlock(
+  contentState: ContentState,
+  selectionState: SelectionState,
+): ContentState {
+  const withoutEntities = removeEntitiesAtEdges(contentState, selectionState);
+  const withoutText = removeRangeFromContentState(
+    withoutEntities,
+    selectionState,
+  );
 
-    const withoutEntities = removeEntitiesAtEdges(contentState, rangeToRemove);
-    return removeRangeFromContentState(withoutEntities, rangeToRemove);
-  },
+  return splitBlockInContentState(withoutText, withoutText.getSelectionAfter());
+}
 
-  splitBlock: function(
-    contentState: ContentState,
-    selectionState: SelectionState,
-  ): ContentState {
-    const withoutEntities = removeEntitiesAtEdges(contentState, selectionState);
-    const withoutText = removeRangeFromContentState(
-      withoutEntities,
-      selectionState,
-    );
+export function applyInlineStyle(
+  contentState: ContentState,
+  selectionState: SelectionState,
+  inlineStyle: string,
+): ContentState {
+  return ContentStateInlineStyle.add(contentState, selectionState, inlineStyle);
+}
 
-    return splitBlockInContentState(
-      withoutText,
-      withoutText.getSelectionAfter(),
-    );
-  },
+export function removeInlineStyle(
+  contentState: ContentState,
+  selectionState: SelectionState,
+  inlineStyle: string,
+): ContentState {
+  return ContentStateInlineStyle.remove(
+    contentState,
+    selectionState,
+    inlineStyle,
+  );
+}
 
-  applyInlineStyle: function(
-    contentState: ContentState,
-    selectionState: SelectionState,
-    inlineStyle: string,
-  ): ContentState {
-    return ContentStateInlineStyle.add(
-      contentState,
-      selectionState,
-      inlineStyle,
-    );
-  },
+export function setBlockType(
+  contentState: ContentState,
+  selectionState: SelectionState,
+  blockType: DraftBlockType,
+): ContentState {
+  return modifyBlockForContentState(contentState, selectionState, block =>
+    block.merge({type: blockType, depth: 0}),
+  );
+}
 
-  removeInlineStyle: function(
-    contentState: ContentState,
-    selectionState: SelectionState,
-    inlineStyle: string,
-  ): ContentState {
-    return ContentStateInlineStyle.remove(
-      contentState,
-      selectionState,
-      inlineStyle,
-    );
-  },
+export function setBlockData(
+  contentState: ContentState,
+  selectionState: SelectionState,
+  blockData: Map<any, any>,
+): ContentState {
+  return modifyBlockForContentState(contentState, selectionState, block =>
+    block.merge({data: blockData}),
+  );
+}
 
-  setBlockType: function(
-    contentState: ContentState,
-    selectionState: SelectionState,
-    blockType: DraftBlockType,
-  ): ContentState {
-    return modifyBlockForContentState(contentState, selectionState, block =>
-      block.merge({type: blockType, depth: 0}),
-    );
-  },
+export function mergeBlockData(
+  contentState: ContentState,
+  selectionState: SelectionState,
+  blockData: Map<any, any>,
+): ContentState {
+  return modifyBlockForContentState(contentState, selectionState, block =>
+    block.merge({data: block.getData().merge(blockData)}),
+  );
+}
 
-  setBlockData: function(
-    contentState: ContentState,
-    selectionState: SelectionState,
-    blockData: Map<any, any>,
-  ): ContentState {
-    return modifyBlockForContentState(contentState, selectionState, block =>
-      block.merge({data: blockData}),
-    );
-  },
-
-  mergeBlockData: function(
-    contentState: ContentState,
-    selectionState: SelectionState,
-    blockData: Map<any, any>,
-  ): ContentState {
-    return modifyBlockForContentState(contentState, selectionState, block =>
-      block.merge({data: block.getData().merge(blockData)}),
-    );
-  },
-
-  applyEntity: function(
-    contentState: ContentState,
-    selectionState: SelectionState,
-    entityKey: ?string,
-  ): ContentState {
-    const withoutEntities = removeEntitiesAtEdges(contentState, selectionState);
-    return applyEntityToContentState(
-      withoutEntities,
-      selectionState,
-      entityKey,
-    );
-  },
-};
-
-module.exports = DraftModifier;
+export function applyEntity(
+  contentState: ContentState,
+  selectionState: SelectionState,
+  entityKey: ?string,
+): ContentState {
+  const withoutEntities = removeEntitiesAtEdges(contentState, selectionState);
+  return applyEntityToContentState(withoutEntities, selectionState, entityKey);
+}

--- a/src/model/modifier/DraftRemovableWord.js
+++ b/src/model/modifier/DraftRemovableWord.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const TokenizeUtil = require('TokenizeUtil');
+import TokenizeUtil from 'TokenizeUtil';
 
 const punctuation = TokenizeUtil.getPunctuation();
 
@@ -62,14 +62,10 @@ function getRemovableWord(text: string, isBackward: boolean): string {
   return matches ? matches[0] : text;
 }
 
-const DraftRemovableWord = {
-  getBackward: function(text: string): string {
-    return getRemovableWord(text, true);
-  },
+export function getBackward(text: string): string {
+  return getRemovableWord(text, true);
+}
 
-  getForward: function(text: string): string {
-    return getRemovableWord(text, false);
-  },
-};
-
-module.exports = DraftRemovableWord;
+export function getForward(text: string): string {
+  return getRemovableWord(text, false);
+}

--- a/src/model/modifier/RichTextEditorUtil.js
+++ b/src/model/modifier/RichTextEditorUtil.js
@@ -18,11 +18,11 @@ import type {DataObjectForLink, RichTextUtils} from 'RichTextUtils';
 import type SelectionState from 'SelectionState';
 import type URI from 'URI';
 
-const DraftModifier = require('DraftModifier');
-const EditorState = require('EditorState');
+import * as DraftModifier from 'DraftModifier';
+import EditorState from 'EditorState';
 
-const adjustBlockDepthForContentState = require('adjustBlockDepthForContentState');
-const nullthrows = require('nullthrows');
+import adjustBlockDepthForContentState from 'adjustBlockDepthForContentState';
+import nullthrows from 'nullthrows';
 
 const RichTextEditorUtil: RichTextUtils = {
   currentBlockContainsLink: function(editorState: EditorState): boolean {
@@ -370,4 +370,4 @@ const RichTextEditorUtil: RichTextUtils = {
   },
 };
 
-module.exports = RichTextEditorUtil;
+export default RichTextEditorUtil;

--- a/src/model/modifier/__tests__/AtomicBlockUtils-test.js
+++ b/src/model/modifier/__tests__/AtomicBlockUtils-test.js
@@ -13,17 +13,17 @@
 
 jest.mock('generateRandomKey');
 
-const mockUUID = require('mockUUID');
+import mockUUID from 'mockUUID';
 jest.mock('uuid', () => mockUUID);
-const AtomicBlockUtils = require('AtomicBlockUtils');
-const BlockMapBuilder = require('BlockMapBuilder');
-const ContentBlockNode = require('ContentBlockNode');
-const Entity = require('DraftEntity');
-const EditorState = require('EditorState');
-const SelectionState = require('SelectionState');
+import * as AtomicBlockUtils from 'AtomicBlockUtils';
+import * as BlockMapBuilder from 'BlockMapBuilder';
+import ContentBlockNode from 'ContentBlockNode';
+import Entity from 'DraftEntity';
+import EditorState from 'EditorState';
+import SelectionState from 'SelectionState';
 
-const getSampleStateForTesting = require('getSampleStateForTesting');
-const invariant = require('invariant');
+import getSampleStateForTesting from 'getSampleStateForTesting';
+import invariant from 'invariant';
 
 const {editorState, contentState, selectionState} = getSampleStateForTesting();
 

--- a/src/model/modifier/__tests__/DraftRemovableWord-test.js
+++ b/src/model/modifier/__tests__/DraftRemovableWord-test.js
@@ -13,7 +13,7 @@
 
 expect.addSnapshotSerializer(require('NonASCIIStringSnapshotSerializer'));
 
-const DraftRemovableWord = require('DraftRemovableWord');
+import * as DraftRemovableWord from 'DraftRemovableWord';
 
 let forward;
 let backward;

--- a/src/model/modifier/exploration/DraftTreeOperations.js
+++ b/src/model/modifier/exploration/DraftTreeOperations.js
@@ -13,12 +13,12 @@
  */
 import type {BlockMap} from 'BlockMap';
 
-const ContentBlockNode = require('ContentBlockNode');
-const DraftTreeInvariants = require('DraftTreeInvariants');
+import ContentBlockNode from 'ContentBlockNode';
+import * as DraftTreeInvariants from 'DraftTreeInvariants';
 
-const generateRandomKey = require('generateRandomKey');
-const Immutable = require('immutable');
-const invariant = require('invariant');
+import generateRandomKey from 'generateRandomKey';
+import Immutable from 'immutable';
+import invariant from 'invariant';
 
 type SiblingInsertPosition = 'previous' | 'next';
 
@@ -37,7 +37,7 @@ const verifyTree = (tree: BlockMap): void => {
  * The block map returned by this method may not be a valid tree (siblings are
  * unaffected)
  */
-const updateParentChild = (
+export const updateParentChild = (
   blockMap: BlockMap,
   parentKey: string,
   childKey: string,
@@ -95,7 +95,7 @@ const updateParentChild = (
  * The block map returned by this method may not be a valid tree (parent/child/
  * other siblings are unaffected)
  */
-const updateSibling = (
+export const updateSibling = (
   blockMap: BlockMap,
   prevKey: string,
   nextKey: string,
@@ -123,7 +123,7 @@ const updateSibling = (
  * The block map returned by this method may not be a valid tree (siblings are
  * unaffected)
  */
-const replaceParentChild = (
+export const replaceParentChild = (
   blockMap: BlockMap,
   parentKey: string,
   existingChildKey: string,
@@ -156,7 +156,7 @@ const replaceParentChild = (
  * This operation respects the tree data invariants - it expects and returns a
  * valid tree.
  */
-const createNewParent = (blockMap: BlockMap, key: string): BlockMap => {
+export const createNewParent = (blockMap: BlockMap, key: string): BlockMap => {
   verifyTree(blockMap);
   const block = blockMap.get(key);
   invariant(block != null, 'block must exist in block map');
@@ -205,7 +205,7 @@ const createNewParent = (blockMap: BlockMap, key: string): BlockMap => {
  * This operation respects the tree data invariants - it expects and returns a
  * valid tree.
  */
-const updateAsSiblingsChild = (
+export const updateAsSiblingsChild = (
   blockMap: BlockMap,
   key: string,
   position: SiblingInsertPosition,
@@ -297,7 +297,7 @@ const updateAsSiblingsChild = (
  * This operation respects the tree data invariants - it expects and returns a
  * valid tree.
  */
-const moveChildUp = (blockMap: BlockMap, key: string): BlockMap => {
+export const moveChildUp = (blockMap: BlockMap, key: string): BlockMap => {
   verifyTree(blockMap);
   const block = blockMap.get(key);
   invariant(block != null, 'block must exist in block map');
@@ -449,7 +449,7 @@ const moveChildUp = (blockMap: BlockMap, key: string): BlockMap => {
  * This operation respects the tree data invariants - it expects and returns a
  * valid tree.
  */
-const mergeBlocks = (blockMap: BlockMap, key: string): BlockMap => {
+export const mergeBlocks = (blockMap: BlockMap, key: string): BlockMap => {
   verifyTree(blockMap);
   // current block must be a non-leaf
   const block = blockMap.get(key);
@@ -497,14 +497,4 @@ const mergeBlocks = (blockMap: BlockMap, key: string): BlockMap => {
   }
   verifyTree(newBlockMap);
   return newBlockMap;
-};
-
-module.exports = {
-  updateParentChild,
-  replaceParentChild,
-  updateSibling,
-  createNewParent,
-  updateAsSiblingsChild,
-  moveChildUp,
-  mergeBlocks,
 };

--- a/src/model/modifier/exploration/NestedRichTextEditorUtil.js
+++ b/src/model/modifier/exploration/NestedRichTextEditorUtil.js
@@ -19,15 +19,15 @@ import type {DataObjectForLink, RichTextUtils} from 'RichTextUtils';
 import type SelectionState from 'SelectionState';
 import type URI from 'URI';
 
-const ContentBlockNode = require('ContentBlockNode');
-const DraftModifier = require('DraftModifier');
-const DraftTreeOperations = require('DraftTreeOperations');
-const EditorState = require('EditorState');
-const RichTextEditorUtil = require('RichTextEditorUtil');
+import ContentBlockNode from 'ContentBlockNode';
+import * as DraftModifier from 'DraftModifier';
+import * as DraftTreeOperations from 'DraftTreeOperations';
+import EditorState from 'EditorState';
+import RichTextEditorUtil from 'RichTextEditorUtil';
 
-const adjustBlockDepthForContentState = require('adjustBlockDepthForContentState');
-const generateRandomKey = require('generateRandomKey');
-const invariant = require('invariant');
+import adjustBlockDepthForContentState from 'adjustBlockDepthForContentState';
+import generateRandomKey from 'generateRandomKey';
+import invariant from 'invariant';
 
 // Eventually we could allow to control this list by either allowing user configuration
 // and/or a schema in conjunction to DraftBlockRenderMap
@@ -588,4 +588,4 @@ const onUntab = (blockMap: BlockMap, block: ContentBlockNode): BlockMap => {
   return blockMap;
 };
 
-module.exports = NestedRichTextEditorUtil;
+export default NestedRichTextEditorUtil;

--- a/src/model/modifier/exploration/__tests__/DraftTreeOperations-test.js
+++ b/src/model/modifier/exploration/__tests__/DraftTreeOperations-test.js
@@ -13,10 +13,10 @@
 
 jest.mock('generateRandomKey');
 
-const ContentBlockNode = require('ContentBlockNode');
-const DraftTreeOperations = require('DraftTreeOperations');
+import ContentBlockNode from 'ContentBlockNode';
+import * as DraftTreeOperations from 'DraftTreeOperations';
 
-const Immutable = require('immutable');
+import Immutable from 'immutable';
 const blockMap1 = Immutable.OrderedMap({
   A: new ContentBlockNode({
     key: 'A',

--- a/src/model/modifier/getCharacterRemovalRange.js
+++ b/src/model/modifier/getCharacterRemovalRange.js
@@ -16,10 +16,10 @@ import type {DraftRemovalDirection} from 'DraftRemovalDirection';
 import type {EntityMap} from 'EntityMap';
 import type SelectionState from 'SelectionState';
 
-const DraftEntitySegments = require('DraftEntitySegments');
+import * as DraftEntitySegments from 'DraftEntitySegments';
 
-const getRangesForDraftEntity = require('getRangesForDraftEntity');
-const invariant = require('invariant');
+import getRangesForDraftEntity from 'getRangesForDraftEntity';
+import invariant from 'invariant';
 
 /**
  * Given a SelectionState and a removal direction, determine the entire range
@@ -30,7 +30,7 @@ const invariant = require('invariant');
  * range, the entire entity must be removed. The returned `SelectionState`
  * will be adjusted accordingly.
  */
-function getCharacterRemovalRange(
+export default function getCharacterRemovalRange(
   entityMap: EntityMap,
   startBlock: BlockNodeRecord,
   endBlock: BlockNodeRecord,
@@ -177,5 +177,3 @@ function getEntityRemovalRange(
     isBackward: false,
   });
 }
-
-module.exports = getCharacterRemovalRange;

--- a/src/model/modifier/getRangesForDraftEntity.js
+++ b/src/model/modifier/getRangesForDraftEntity.js
@@ -14,7 +14,7 @@
 import type {BlockNodeRecord} from 'BlockNodeRecord';
 import type {DraftRange} from 'DraftRange';
 
-const invariant = require('invariant');
+import invariant from 'invariant';
 
 /**
  * Obtain the start and end positions of the range that has the
@@ -24,7 +24,7 @@ const invariant = require('invariant');
  * method searches for the first instance of the entity key and returns
  * the subsequent range.
  */
-function getRangesForDraftEntity(
+export default function getRangesForDraftEntity(
   block: BlockNodeRecord,
   key: string,
 ): Array<DraftRange> {
@@ -40,5 +40,3 @@ function getRangesForDraftEntity(
 
   return ranges;
 }
-
-module.exports = getRangesForDraftEntity;

--- a/src/model/paste/DraftPasteProcessor.js
+++ b/src/model/paste/DraftPasteProcessor.js
@@ -17,15 +17,15 @@ import type {DraftBlockRenderMap} from 'DraftBlockRenderMap';
 import type {DraftBlockType} from 'DraftBlockType';
 import type {EntityMap} from 'EntityMap';
 
-const ContentBlock = require('ContentBlock');
-const ContentBlockNode = require('ContentBlockNode');
+import ContentBlock from 'ContentBlock';
+import ContentBlockNode from 'ContentBlockNode';
 
-const convertFromHTMLToContentBlocks = require('convertFromHTMLToContentBlocks');
-const generateRandomKey = require('generateRandomKey');
-const getSafeBodyFromHTML = require('getSafeBodyFromHTML');
-const gkx = require('gkx');
-const Immutable = require('immutable');
-const sanitizeDraftText = require('sanitizeDraftText');
+import convertFromHTMLToContentBlocks from 'convertFromHTMLToContentBlocks';
+import generateRandomKey from 'generateRandomKey';
+import getSafeBodyFromHTML from 'getSafeBodyFromHTML';
+import gkx from 'gkx';
+import Immutable from 'immutable';
+import sanitizeDraftText from 'sanitizeDraftText';
 
 const {List, Repeat} = Immutable;
 
@@ -34,58 +34,54 @@ const ContentBlockRecord = experimentalTreeDataSupport
   ? ContentBlockNode
   : ContentBlock;
 
-const DraftPasteProcessor = {
-  processHTML(
-    html: string,
-    blockRenderMap?: DraftBlockRenderMap,
-  ): ?{
-    contentBlocks: ?Array<BlockNodeRecord>,
-    entityMap: EntityMap,
-    ...
-  } {
-    return convertFromHTMLToContentBlocks(
-      html,
-      getSafeBodyFromHTML,
-      blockRenderMap,
-    );
-  },
+export function processHTML(
+  html: string,
+  blockRenderMap?: DraftBlockRenderMap,
+): ?{
+  contentBlocks: ?Array<BlockNodeRecord>,
+  entityMap: EntityMap,
+  ...
+} {
+  return convertFromHTMLToContentBlocks(
+    html,
+    getSafeBodyFromHTML,
+    blockRenderMap,
+  );
+}
 
-  processText(
-    textBlocks: Array<string>,
-    character: CharacterMetadata,
-    type: DraftBlockType,
-  ): Array<BlockNodeRecord> {
-    return textBlocks.reduce((acc, textLine, index) => {
-      textLine = sanitizeDraftText(textLine);
-      const key = generateRandomKey();
+export function processText(
+  textBlocks: Array<string>,
+  character: CharacterMetadata,
+  type: DraftBlockType,
+): Array<BlockNodeRecord> {
+  return textBlocks.reduce((acc, textLine, index) => {
+    textLine = sanitizeDraftText(textLine);
+    const key = generateRandomKey();
 
-      let blockNodeConfig = {
-        key,
-        type,
-        text: textLine,
-        characterList: List(Repeat(character, textLine.length)),
+    let blockNodeConfig = {
+      key,
+      type,
+      text: textLine,
+      characterList: List(Repeat(character, textLine.length)),
+    };
+
+    // next block updates previous block
+    if (experimentalTreeDataSupport && index !== 0) {
+      const prevSiblingIndex = index - 1;
+      // update previous block
+      const previousBlock = (acc[prevSiblingIndex] = acc[
+        prevSiblingIndex
+      ].merge({
+        nextSibling: key,
+      }));
+      blockNodeConfig = {
+        ...blockNodeConfig,
+        prevSibling: previousBlock.getKey(),
       };
+    }
 
-      // next block updates previous block
-      if (experimentalTreeDataSupport && index !== 0) {
-        const prevSiblingIndex = index - 1;
-        // update previous block
-        const previousBlock = (acc[prevSiblingIndex] = acc[
-          prevSiblingIndex
-        ].merge({
-          nextSibling: key,
-        }));
-        blockNodeConfig = {
-          ...blockNodeConfig,
-          prevSibling: previousBlock.getKey(),
-        };
-      }
+    acc.push(new ContentBlockRecord(blockNodeConfig));
 
-      acc.push(new ContentBlockRecord(blockNodeConfig));
-
-      return acc;
-    }, []);
-  },
-};
-
-module.exports = DraftPasteProcessor;
+    return acc;
+  }, []);
+}

--- a/src/model/paste/getSafeBodyFromHTML.js
+++ b/src/model/paste/getSafeBodyFromHTML.js
@@ -11,9 +11,9 @@
 
 'use strict';
 
-const UserAgent = require('UserAgent');
+import UserAgent from 'UserAgent';
 
-const invariant = require('invariant');
+import invariant from 'invariant';
 
 const isOldIE = UserAgent.isBrowser('IE <= 9');
 
@@ -21,7 +21,7 @@ const isOldIE = UserAgent.isBrowser('IE <= 9');
 // https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation.createHTMLDocument
 // https://developer.mozilla.org/en-US/Add-ons/Code_snippets/HTML_to_DOM
 
-function getSafeBodyFromHTML(html: string): ?Element {
+export default function getSafeBodyFromHTML(html: string): ?Element {
   let doc;
   let root = null;
   // Provides a safe context
@@ -37,5 +37,3 @@ function getSafeBodyFromHTML(html: string): ?Element {
   }
   return root;
 }
-
-module.exports = getSafeBodyFromHTML;

--- a/src/model/transaction/ContentStateInlineStyle.js
+++ b/src/model/transaction/ContentStateInlineStyle.js
@@ -14,26 +14,26 @@
 import type ContentState from 'ContentState';
 import type SelectionState from 'SelectionState';
 
-const CharacterMetadata = require('CharacterMetadata');
-const {Map} = require('immutable');
+import CharacterMetadata from 'CharacterMetadata';
 
-const ContentStateInlineStyle = {
-  add: function(
-    contentState: ContentState,
-    selectionState: SelectionState,
-    inlineStyle: string,
-  ): ContentState {
-    return modifyInlineStyle(contentState, selectionState, inlineStyle, true);
-  },
+import immutable from 'immutable';
 
-  remove: function(
-    contentState: ContentState,
-    selectionState: SelectionState,
-    inlineStyle: string,
-  ): ContentState {
-    return modifyInlineStyle(contentState, selectionState, inlineStyle, false);
-  },
-};
+const {Map} = immutable;
+export function add(
+  contentState: ContentState,
+  selectionState: SelectionState,
+  inlineStyle: string,
+): ContentState {
+  return modifyInlineStyle(contentState, selectionState, inlineStyle, true);
+}
+
+export function remove(
+  contentState: ContentState,
+  selectionState: SelectionState,
+  inlineStyle: string,
+): ContentState {
+  return modifyInlineStyle(contentState, selectionState, inlineStyle, false);
+}
 
 function modifyInlineStyle(
   contentState: ContentState,
@@ -85,5 +85,3 @@ function modifyInlineStyle(
     selectionAfter: selectionState,
   });
 }
-
-module.exports = ContentStateInlineStyle;

--- a/src/model/transaction/__tests__/ContentStateInlineStyle-test.js
+++ b/src/model/transaction/__tests__/ContentStateInlineStyle-test.js
@@ -11,9 +11,9 @@
 
 'use strict';
 
-const ContentStateInlineStyle = require('ContentStateInlineStyle');
+import * as ContentStateInlineStyle from 'ContentStateInlineStyle';
 
-const getSampleStateForTesting = require('getSampleStateForTesting');
+import getSampleStateForTesting from 'getSampleStateForTesting';
 
 const {contentState, selectionState} = getSampleStateForTesting();
 

--- a/src/model/transaction/__tests__/applyEntityToContentBlock-test.js
+++ b/src/model/transaction/__tests__/applyEntityToContentBlock-test.js
@@ -11,9 +11,9 @@
 
 'use strict';
 
-const ContentBlock = require('ContentBlock');
+import ContentBlock from 'ContentBlock';
 
-const applyEntityToContentBlock = require('applyEntityToContentBlock');
+import applyEntityToContentBlock from 'applyEntityToContentBlock';
 
 const sampleBlock = new ContentBlock({
   key: 'a',

--- a/src/model/transaction/__tests__/applyEntityToContentState-test.js
+++ b/src/model/transaction/__tests__/applyEntityToContentState-test.js
@@ -11,10 +11,10 @@
 
 'use strict';
 
-const SelectionState = require('SelectionState');
+import SelectionState from 'SelectionState';
 
-const applyEntityToContentState = require('applyEntityToContentState');
-const getSampleStateForTesting = require('getSampleStateForTesting');
+import applyEntityToContentState from 'applyEntityToContentState';
+import getSampleStateForTesting from 'getSampleStateForTesting';
 
 const {contentState, selectionState} = getSampleStateForTesting();
 

--- a/src/model/transaction/__tests__/getContentStateFragment-test.js
+++ b/src/model/transaction/__tests__/getContentStateFragment-test.js
@@ -13,14 +13,14 @@
 
 jest.mock('generateRandomKey');
 
-const ContentBlock = require('ContentBlock');
-const ContentBlockNode = require('ContentBlockNode');
-const ContentState = require('ContentState');
-const EditorState = require('EditorState');
-const SelectionState = require('SelectionState');
+import ContentBlock from 'ContentBlock';
+import ContentBlockNode from 'ContentBlockNode';
+import ContentState from 'ContentState';
+import EditorState from 'EditorState';
+import SelectionState from 'SelectionState';
 
-const getContentStateFragment = require('getContentStateFragment');
-const Immutable = require('immutable');
+import getContentStateFragment from 'getContentStateFragment';
+import Immutable from 'immutable';
 
 const {List} = Immutable;
 

--- a/src/model/transaction/__tests__/insertFragmentIntoContentState-test.js
+++ b/src/model/transaction/__tests__/insertFragmentIntoContentState-test.js
@@ -13,15 +13,15 @@
 
 jest.mock('generateRandomKey');
 
-const BlockMapBuilder = require('BlockMapBuilder');
-const ContentBlock = require('ContentBlock');
-const ContentBlockNode = require('ContentBlockNode');
-const SelectionState = require('SelectionState');
+import * as BlockMapBuilder from 'BlockMapBuilder';
+import ContentBlock from 'ContentBlock';
+import ContentBlockNode from 'ContentBlockNode';
+import SelectionState from 'SelectionState';
 
-const getSampleStateForTesting = require('getSampleStateForTesting');
-const Immutable = require('immutable');
-const insertFragmentIntoContentState = require('insertFragmentIntoContentState');
-const invariant = require('invariant');
+import getSampleStateForTesting from 'getSampleStateForTesting';
+import Immutable from 'immutable';
+import insertFragmentIntoContentState from 'insertFragmentIntoContentState';
+import invariant from 'invariant';
 
 const {contentState, selectionState} = getSampleStateForTesting();
 const {List, Map} = Immutable;

--- a/src/model/transaction/__tests__/insertIntoList-test.js
+++ b/src/model/transaction/__tests__/insertIntoList-test.js
@@ -11,8 +11,8 @@
 
 'use strict';
 
-const Immutable = require('immutable');
-const insertIntoList = require('insertIntoList');
+import Immutable from 'immutable';
+import insertIntoList from 'insertIntoList';
 
 const SAMPLE_LIST = Immutable.List.of(0, 1, 2, 3, 4);
 

--- a/src/model/transaction/__tests__/insertTextIntoContentState-test.js
+++ b/src/model/transaction/__tests__/insertTextIntoContentState-test.js
@@ -11,11 +11,11 @@
 
 'use strict';
 
-const CharacterMetadata = require('CharacterMetadata');
-const {BOLD} = require('SampleDraftInlineStyle');
+import CharacterMetadata from 'CharacterMetadata';
+import {BOLD} from 'SampleDraftInlineStyle';
 
-const getSampleStateForTesting = require('getSampleStateForTesting');
-const insertTextIntoContentState = require('insertTextIntoContentState');
+import getSampleStateForTesting from 'getSampleStateForTesting';
+import insertTextIntoContentState from 'insertTextIntoContentState';
 
 const {contentState, selectionState} = getSampleStateForTesting();
 

--- a/src/model/transaction/__tests__/moveBlockInContentState-test.js
+++ b/src/model/transaction/__tests__/moveBlockInContentState-test.js
@@ -13,13 +13,13 @@
 
 jest.mock('generateRandomKey');
 
-const ContentBlock = require('ContentBlock');
-const ContentBlockNode = require('ContentBlockNode');
-const ContentState = require('ContentState');
-const EditorState = require('EditorState');
+import ContentBlock from 'ContentBlock';
+import ContentBlockNode from 'ContentBlockNode';
+import ContentState from 'ContentState';
+import EditorState from 'EditorState';
 
-const Immutable = require('immutable');
-const moveBlockInContentState = require('moveBlockInContentState');
+import Immutable from 'immutable';
+import moveBlockInContentState from 'moveBlockInContentState';
 
 const {List} = Immutable;
 

--- a/src/model/transaction/__tests__/randomizeBlockMapKeys-test.js
+++ b/src/model/transaction/__tests__/randomizeBlockMapKeys-test.js
@@ -13,12 +13,12 @@
 
 jest.mock('generateRandomKey');
 
-const BlockMapBuilder = require('BlockMapBuilder');
-const ContentBlock = require('ContentBlock');
-const ContentBlockNode = require('ContentBlockNode');
+import * as BlockMapBuilder from 'BlockMapBuilder';
+import ContentBlock from 'ContentBlock';
+import ContentBlockNode from 'ContentBlockNode';
 
-const Immutable = require('immutable');
-const randomizeBlockMapKeys = require('randomizeBlockMapKeys');
+import Immutable from 'immutable';
+import randomizeBlockMapKeys from 'randomizeBlockMapKeys';
 
 const {List} = Immutable;
 

--- a/src/model/transaction/__tests__/removeEntitiesAtEdges-test.js
+++ b/src/model/transaction/__tests__/removeEntitiesAtEdges-test.js
@@ -11,9 +11,9 @@
 
 'use strict';
 
-const applyEntityToContentBlock = require('applyEntityToContentBlock');
-const getSampleStateForTesting = require('getSampleStateForTesting');
-const removeEntitiesAtEdges = require('removeEntitiesAtEdges');
+import applyEntityToContentBlock from 'applyEntityToContentBlock';
+import getSampleStateForTesting from 'getSampleStateForTesting';
+import removeEntitiesAtEdges from 'removeEntitiesAtEdges';
 
 const {contentState, selectionState} = getSampleStateForTesting();
 

--- a/src/model/transaction/__tests__/removeRangeFromContentState-test.js
+++ b/src/model/transaction/__tests__/removeRangeFromContentState-test.js
@@ -11,13 +11,13 @@
 
 'use strict';
 
-const BlockMapBuilder = require('BlockMapBuilder');
-const ContentBlockNode = require('ContentBlockNode');
-const SelectionState = require('SelectionState');
+import * as BlockMapBuilder from 'BlockMapBuilder';
+import ContentBlockNode from 'ContentBlockNode';
+import SelectionState from 'SelectionState';
 
-const getSampleStateForTesting = require('getSampleStateForTesting');
-const Immutable = require('immutable');
-const removeRangeFromContentState = require('removeRangeFromContentState');
+import getSampleStateForTesting from 'getSampleStateForTesting';
+import Immutable from 'immutable';
+import removeRangeFromContentState from 'removeRangeFromContentState';
 
 const {List} = Immutable;
 

--- a/src/model/transaction/__tests__/splitBlockInContentState-test.js
+++ b/src/model/transaction/__tests__/splitBlockInContentState-test.js
@@ -13,13 +13,13 @@
 
 jest.mock('generateRandomKey');
 
-const BlockMapBuilder = require('BlockMapBuilder');
-const ContentBlockNode = require('ContentBlockNode');
-const SelectionState = require('SelectionState');
+import * as BlockMapBuilder from 'BlockMapBuilder';
+import ContentBlockNode from 'ContentBlockNode';
+import SelectionState from 'SelectionState';
 
-const getSampleStateForTesting = require('getSampleStateForTesting');
-const Immutable = require('immutable');
-const splitBlockInContentState = require('splitBlockInContentState');
+import getSampleStateForTesting from 'getSampleStateForTesting';
+import Immutable from 'immutable';
+import splitBlockInContentState from 'splitBlockInContentState';
 
 const {List} = Immutable;
 

--- a/src/model/transaction/adjustBlockDepthForContentState.js
+++ b/src/model/transaction/adjustBlockDepthForContentState.js
@@ -14,7 +14,7 @@
 import type ContentState from 'ContentState';
 import type SelectionState from 'SelectionState';
 
-function adjustBlockDepthForContentState(
+export default function adjustBlockDepthForContentState(
   contentState: ContentState,
   selectionState: SelectionState,
   adjustment: number,
@@ -41,5 +41,3 @@ function adjustBlockDepthForContentState(
     selectionAfter: selectionState,
   });
 }
-
-module.exports = adjustBlockDepthForContentState;

--- a/src/model/transaction/applyEntityToContentBlock.js
+++ b/src/model/transaction/applyEntityToContentBlock.js
@@ -13,9 +13,9 @@
 
 import type {BlockNodeRecord} from 'BlockNodeRecord';
 
-const CharacterMetadata = require('CharacterMetadata');
+import CharacterMetadata from 'CharacterMetadata';
 
-function applyEntityToContentBlock(
+export default function applyEntityToContentBlock(
   contentBlock: BlockNodeRecord,
   startArg: number,
   end: number,
@@ -32,5 +32,3 @@ function applyEntityToContentBlock(
   }
   return contentBlock.set('characterList', characterList);
 }
-
-module.exports = applyEntityToContentBlock;

--- a/src/model/transaction/applyEntityToContentState.js
+++ b/src/model/transaction/applyEntityToContentState.js
@@ -14,10 +14,10 @@
 import type ContentState from 'ContentState';
 import type SelectionState from 'SelectionState';
 
-const applyEntityToContentBlock = require('applyEntityToContentBlock');
-const Immutable = require('immutable');
+import applyEntityToContentBlock from 'applyEntityToContentBlock';
+import Immutable from 'immutable';
 
-function applyEntityToContentState(
+export default function applyEntityToContentState(
   contentState: ContentState,
   selectionState: SelectionState,
   entityKey: ?string,
@@ -45,5 +45,3 @@ function applyEntityToContentState(
     selectionAfter: selectionState,
   });
 }
-
-module.exports = applyEntityToContentState;

--- a/src/model/transaction/exploration/__tests__/getNextDelimiterBlockKey-test.js
+++ b/src/model/transaction/exploration/__tests__/getNextDelimiterBlockKey-test.js
@@ -13,13 +13,13 @@
 
 jest.mock('generateRandomKey');
 
-const ContentBlock = require('ContentBlock');
-const ContentBlockNode = require('ContentBlockNode');
-const ContentState = require('ContentState');
-const EditorState = require('EditorState');
+import ContentBlock from 'ContentBlock';
+import ContentBlockNode from 'ContentBlockNode';
+import ContentState from 'ContentState';
+import EditorState from 'EditorState';
 
-const getNextDelimiterBlockKey = require('getNextDelimiterBlockKey');
-const Immutable = require('immutable');
+import getNextDelimiterBlockKey from 'getNextDelimiterBlockKey';
+import Immutable from 'immutable';
 
 const {List} = Immutable;
 

--- a/src/model/transaction/exploration/getNextDelimiterBlockKey.js
+++ b/src/model/transaction/exploration/getNextDelimiterBlockKey.js
@@ -15,12 +15,12 @@
 import type {BlockMap} from 'BlockMap';
 import type {BlockNodeRecord} from 'BlockNodeRecord';
 
-const ContentBlockNode = require('ContentBlockNode');
+import ContentBlockNode from 'ContentBlockNode';
 
-const getNextDelimiterBlockKey = (
+export default function getNextDelimiterBlockKey(
   block: BlockNodeRecord,
   blockMap: BlockMap,
-): ?string => {
+): ?string {
   const isExperimentalTreeBlock = block instanceof ContentBlockNode;
 
   if (!isExperimentalTreeBlock) {
@@ -53,6 +53,4 @@ const getNextDelimiterBlockKey = (
   }
 
   return nextNonDescendantBlock.getNextSiblingKey();
-};
-
-module.exports = getNextDelimiterBlockKey;
+}

--- a/src/model/transaction/getContentStateFragment.js
+++ b/src/model/transaction/getContentStateFragment.js
@@ -15,13 +15,13 @@ import type {BlockMap} from 'BlockMap';
 import type ContentState from 'ContentState';
 import type SelectionState from 'SelectionState';
 
-const randomizeBlockMapKeys = require('randomizeBlockMapKeys');
-const removeEntitiesAtEdges = require('removeEntitiesAtEdges');
+import randomizeBlockMapKeys from 'randomizeBlockMapKeys';
+import removeEntitiesAtEdges from 'removeEntitiesAtEdges';
 
-const getContentStateFragment = (
+export default function getContentStateFragment(
   contentState: ContentState,
   selectionState: SelectionState,
-): BlockMap => {
+): BlockMap {
   const startKey = selectionState.getStartKey();
   const startOffset = selectionState.getStartOffset();
   const endKey = selectionState.getEndKey();
@@ -69,6 +69,4 @@ const getContentStateFragment = (
       return block;
     }),
   );
-};
-
-module.exports = getContentStateFragment;
+}

--- a/src/model/transaction/getSampleStateForTesting.js
+++ b/src/model/transaction/getSampleStateForTesting.js
@@ -11,17 +11,16 @@
 
 'use strict';
 
-const BlockMapBuilder = require('BlockMapBuilder');
-const CharacterMetadata = require('CharacterMetadata');
-const ContentBlock = require('ContentBlock');
-const ContentState = require('ContentState');
-const EditorState = require('EditorState');
-const SampleDraftInlineStyle = require('SampleDraftInlineStyle');
-const SelectionState = require('SelectionState');
+import * as BlockMapBuilder from 'BlockMapBuilder';
+import CharacterMetadata from 'CharacterMetadata';
+import ContentBlock from 'ContentBlock';
+import ContentState from 'ContentState';
+import EditorState from 'EditorState';
+import {BOLD, ITALIC} from 'SampleDraftInlineStyle';
+import SelectionState from 'SelectionState';
 
-const Immutable = require('immutable');
+import Immutable from 'immutable';
 
-const {BOLD, ITALIC} = SampleDraftInlineStyle;
 const ENTITY_KEY = '2';
 
 const BLOCKS = [
@@ -97,12 +96,10 @@ const contentState = new ContentState({
 let editorState = EditorState.createWithContent(contentState);
 editorState = EditorState.forceSelection(editorState, selectionState);
 
-const getSampleStateForTesting = (): {|
+export default function getSampleStateForTesting(): {|
   editorState: EditorState,
   contentState: ContentState,
   selectionState: SelectionState,
-|} => {
+|} {
   return {editorState, contentState, selectionState};
-};
-
-module.exports = getSampleStateForTesting;
+}

--- a/src/model/transaction/insertFragmentIntoContentState.js
+++ b/src/model/transaction/insertFragmentIntoContentState.js
@@ -16,13 +16,13 @@ import type {BlockNodeRecord} from 'BlockNodeRecord';
 import type ContentState from 'ContentState';
 import type SelectionState from 'SelectionState';
 
-const BlockMapBuilder = require('BlockMapBuilder');
-const ContentBlockNode = require('ContentBlockNode');
+import * as BlockMapBuilder from 'BlockMapBuilder';
+import ContentBlockNode from 'ContentBlockNode';
 
-const Immutable = require('immutable');
-const insertIntoList = require('insertIntoList');
-const invariant = require('invariant');
-const randomizeBlockMapKeys = require('randomizeBlockMapKeys');
+import Immutable from 'immutable';
+import insertIntoList from 'insertIntoList';
+import invariant from 'invariant';
+import randomizeBlockMapKeys from 'randomizeBlockMapKeys';
 
 const {List} = Immutable;
 
@@ -308,12 +308,12 @@ const insertFragment = (
   });
 };
 
-const insertFragmentIntoContentState = (
+export default function insertFragmentIntoContentState(
   contentState: ContentState,
   selectionState: SelectionState,
   fragmentBlockMap: BlockMap,
   mergeBlockData?: BlockDataMergeBehavior = 'REPLACE_WITH_NEW_DATA',
-): ContentState => {
+): ContentState {
   invariant(
     selectionState.isCollapsed(),
     '`insertFragment` should only be called with a collapsed selection state.',
@@ -355,6 +355,4 @@ const insertFragmentIntoContentState = (
     targetKey,
     targetOffset,
   );
-};
-
-module.exports = insertFragmentIntoContentState;
+}

--- a/src/model/transaction/insertIntoList.js
+++ b/src/model/transaction/insertIntoList.js
@@ -16,7 +16,7 @@ import type {List} from 'immutable';
 /**
  * Maintain persistence for target list when appending and prepending.
  */
-function insertIntoList<T>(
+export default function insertIntoList<T>(
   targetListArg: List<T>,
   toInsert: List<T>,
   offset: number,
@@ -37,5 +37,3 @@ function insertIntoList<T>(
   }
   return targetList;
 }
-
-module.exports = insertIntoList;

--- a/src/model/transaction/insertTextIntoContentState.js
+++ b/src/model/transaction/insertTextIntoContentState.js
@@ -11,9 +11,9 @@
 
 'use strict';
 
-const Immutable = require('immutable');
-const insertIntoList = require('insertIntoList');
-const invariant = require('invariant');
+import Immutable from 'immutable';
+import insertIntoList from 'insertIntoList';
+import invariant from 'invariant';
 
 const {Repeat} = Immutable;
 
@@ -21,7 +21,7 @@ import type CharacterMetadata from 'CharacterMetadata';
 import type ContentState from 'ContentState';
 import type SelectionState from 'SelectionState';
 
-function insertTextIntoContentState(
+export default function insertTextIntoContentState(
   contentState: ContentState,
   selectionState: SelectionState,
   text: string,
@@ -69,5 +69,3 @@ function insertTextIntoContentState(
     }),
   });
 }
-
-module.exports = insertTextIntoContentState;

--- a/src/model/transaction/modifyBlockForContentState.js
+++ b/src/model/transaction/modifyBlockForContentState.js
@@ -15,11 +15,11 @@ import type {BlockNodeRecord} from 'BlockNodeRecord';
 import type ContentState from 'ContentState';
 import type SelectionState from 'SelectionState';
 
-const Immutable = require('immutable');
+import Immutable from 'immutable';
 
 const {Map} = Immutable;
 
-function modifyBlockForContentState(
+export default function modifyBlockForContentState(
   contentState: ContentState,
   selectionState: SelectionState,
   operation: (block: BlockNodeRecord) => BlockNodeRecord,
@@ -40,5 +40,3 @@ function modifyBlockForContentState(
     selectionAfter: selectionState,
   });
 }
-
-module.exports = modifyBlockForContentState;

--- a/src/model/transaction/moveBlockInContentState.js
+++ b/src/model/transaction/moveBlockInContentState.js
@@ -16,11 +16,11 @@ import type {BlockNodeRecord} from 'BlockNodeRecord';
 import type ContentState from 'ContentState';
 import type {DraftInsertionType} from 'DraftInsertionType';
 
-const ContentBlockNode = require('ContentBlockNode');
+import ContentBlockNode from 'ContentBlockNode';
 
-const getNextDelimiterBlockKey = require('getNextDelimiterBlockKey');
-const Immutable = require('immutable');
-const invariant = require('invariant');
+import getNextDelimiterBlockKey from 'getNextDelimiterBlockKey';
+import Immutable from 'immutable';
+import invariant from 'invariant';
 
 const {OrderedMap, List} = Immutable;
 
@@ -137,12 +137,12 @@ const updateBlockMapLinks = (
   });
 };
 
-const moveBlockInContentState = (
+export default function moveBlockInContentState(
   contentState: ContentState,
   blockToBeMoved: BlockNodeRecord,
   targetBlock: BlockNodeRecord,
   insertionMode: DraftInsertionType,
-): ContentState => {
+): ContentState {
   invariant(insertionMode !== 'replace', 'Replacing blocks is not supported.');
 
   const targetKey = targetBlock.getKey();
@@ -242,6 +242,4 @@ const moveBlockInContentState = (
       focusKey: blockKey,
     }),
   });
-};
-
-module.exports = moveBlockInContentState;
+}

--- a/src/model/transaction/randomizeBlockMapKeys.js
+++ b/src/model/transaction/randomizeBlockMapKeys.js
@@ -13,10 +13,10 @@
 
 import type {BlockMap} from 'BlockMap';
 
-const ContentBlockNode = require('ContentBlockNode');
+import ContentBlockNode from 'ContentBlockNode';
 
-const generateRandomKey = require('generateRandomKey');
-const Immutable = require('immutable');
+import generateRandomKey from 'generateRandomKey';
+import Immutable from 'immutable';
 
 const {OrderedMap} = Immutable;
 
@@ -117,7 +117,7 @@ const randomizeContentBlockKeys = (blockMap: BlockMap): BlockMap => {
   );
 };
 
-const randomizeBlockMapKeys = (blockMap: BlockMap): BlockMap => {
+export default function randomizeBlockMapKeys(blockMap: BlockMap): BlockMap {
   const isTreeBasedBlockMap = blockMap.first() instanceof ContentBlockNode;
 
   if (!isTreeBasedBlockMap) {
@@ -125,6 +125,4 @@ const randomizeBlockMapKeys = (blockMap: BlockMap): BlockMap => {
   }
 
   return randomizeContentBlockNodeKeys(blockMap);
-};
-
-module.exports = randomizeBlockMapKeys;
+}

--- a/src/model/transaction/removeEntitiesAtEdges.js
+++ b/src/model/transaction/removeEntitiesAtEdges.js
@@ -17,12 +17,12 @@ import type {EntityMap} from 'EntityMap';
 import type SelectionState from 'SelectionState';
 import type {List} from 'immutable';
 
-const CharacterMetadata = require('CharacterMetadata');
+import CharacterMetadata from 'CharacterMetadata';
 
-const findRangesImmutable = require('findRangesImmutable');
-const invariant = require('invariant');
+import findRangesImmutable from 'findRangesImmutable';
+import invariant from 'invariant';
 
-function removeEntitiesAtEdges(
+export default function removeEntitiesAtEdges(
   contentState: ContentState,
   selectionState: SelectionState,
 ): ContentState {
@@ -132,5 +132,3 @@ function removeForBlock(
 
   return block;
 }
-
-module.exports = removeEntitiesAtEdges;

--- a/src/model/transaction/removeRangeFromContentState.js
+++ b/src/model/transaction/removeRangeFromContentState.js
@@ -16,10 +16,10 @@ import type CharacterMetadata from 'CharacterMetadata';
 import type ContentState from 'ContentState';
 import type SelectionState from 'SelectionState';
 
-const ContentBlockNode = require('ContentBlockNode');
+import ContentBlockNode from 'ContentBlockNode';
 
-const getNextDelimiterBlockKey = require('getNextDelimiterBlockKey');
-const Immutable = require('immutable');
+import getNextDelimiterBlockKey from 'getNextDelimiterBlockKey';
+import Immutable from 'immutable';
 
 const {List, Map} = Immutable;
 
@@ -282,10 +282,10 @@ const updateBlockMapLinks = (
   });
 };
 
-const removeRangeFromContentState = (
+export default function removeRangeFromContentState(
   contentState: ContentState,
   selectionState: SelectionState,
-): ContentState => {
+): ContentState {
   if (selectionState.isCollapsed()) {
     return contentState;
   }
@@ -391,7 +391,7 @@ const removeRangeFromContentState = (
       isBackward: false,
     }),
   });
-};
+}
 
 /**
  * Maintain persistence for target list when removing characters on the
@@ -419,5 +419,3 @@ const removeFromList = (
   }
   return targetList;
 };
-
-module.exports = removeRangeFromContentState;

--- a/src/model/transaction/splitBlockInContentState.js
+++ b/src/model/transaction/splitBlockInContentState.js
@@ -15,12 +15,12 @@ import type {BlockMap} from 'BlockMap';
 import type ContentState from 'ContentState';
 import type SelectionState from 'SelectionState';
 
-const ContentBlockNode = require('ContentBlockNode');
+import ContentBlockNode from 'ContentBlockNode';
 
-const generateRandomKey = require('generateRandomKey');
-const Immutable = require('immutable');
-const invariant = require('invariant');
-const modifyBlockForContentState = require('modifyBlockForContentState');
+import generateRandomKey from 'generateRandomKey';
+import Immutable from 'immutable';
+import invariant from 'invariant';
+import modifyBlockForContentState from 'modifyBlockForContentState';
 
 const {List, Map} = Immutable;
 
@@ -87,10 +87,10 @@ const updateBlockMapLinks = (
   });
 };
 
-const splitBlockInContentState = (
+export default function splitBlockInContentState(
   contentState: ContentState,
   selectionState: SelectionState,
-): ContentState => {
+): ContentState {
   invariant(selectionState.isCollapsed(), 'Selection range must be collapsed.');
 
   const key = selectionState.getAnchorKey();
@@ -161,6 +161,4 @@ const splitBlockInContentState = (
       isBackward: false,
     }),
   });
-};
-
-module.exports = splitBlockInContentState;
+}


### PR DESCRIPTION
Summary:
Convert `require` and `module.exports` to instead use ES6 import/export syntax. This codemod is part of a larger project to convert all of WWW to use the new ES6 import/export syntax which will standardize and simplify JS patterns, provide greater safety guarantees and enable better tooling.

This PR is mostly to test just how much this breaks the Draft.js Github build.

bypass-lint

Differential Revision: D23249930

