### PR TITLE
Fix linting, support optional catch bindings

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -48,6 +48,7 @@ var babelOptsJS = {
   plugins: [
     require('@babel/plugin-proposal-nullish-coalescing-operator'),
     require('@babel/plugin-proposal-optional-chaining'),
+    require('@babel/plugin-proposal-optional-catch-binding'),
   ],
 };
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test-ci": "cross-env NODE_ENV=test npm run lint && npm run flow && npm run test"
   },
   "dependencies": {
+    "@babel/plugin-proposal-optional-catch-binding": "^7.10.4",
     "fbjs": "^2.0.0",
     "immutable": "~3.7.4",
     "object-assign": "^4.1.1"

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -176,10 +176,7 @@ const isValidAnchor = (node: Node) => {
     // Just checking whether we can actually create a URI
     const _ = new URI(anchorNode.href);
     return true;
-    // We need our catch statements to have arguments, else
-    // UglifyJS (which we use for our OSS builds) will crash.
-    // eslint-disable-next-line fb-www/no-unused-catch-bindings
-  } catch (_) {
+  } catch {
     return false;
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -358,6 +358,14 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
 
+"@babel/plugin-proposal-optional-catch-binding@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.10.4.tgz#31c938309d24a78a49d68fdabffaa863758554dd"
+  integrity sha512-LflT6nPh+GK2MnFiKDyLiqSqVHkQnVf7hdoAvyTnnKj9xB3docGRsdPuxp6qqqW19ifK3xgc9U5/FwrSaCNX5g==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.8.0"
+
 "@babel/plugin-proposal-optional-chaining@^7.11.0":
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.11.0.tgz#de5866d0646f6afdaab8a566382fe3a221755076"
@@ -458,7 +466,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-optional-catch-binding@^7.8.3":
+"@babel/plugin-syntax-optional-catch-binding@^7.8.0", "@babel/plugin-syntax-optional-catch-binding@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz#6111a265bcfb020eb9efd0fdfd7d26402b9ed6c1"
   integrity sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==


### PR DESCRIPTION
**Summary**

Fixes an issue with linting, by allowing us to use optional catch bindings. Not doing this transform in babel breaks UglifyJS.

This should make CI pass again.

**Test Plan**

`yarn build && yarn lint`