### PR TITLE
README.md: useState value to anonymous func

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ import {Editor, EditorState} from 'draft-js';
 
 function MyEditor() {
   const [editorState, setEditorState] = React.useState(
-    EditorState.createEmpty()
+    () => EditorState.createEmpty()
   );
 
   const editor = React.useRef(null);


### PR DESCRIPTION
#### Summary

avoid EditorState.createEmpty exec on every render, changed useState(EditorState.createEmpty()) to useState(() => EditorState.createEmpty())
