### PR TITLE
Fix linting issues

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -244,7 +244,6 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
         'onUpArrow',
       ].forEach(propName => {
         if (props.hasOwnProperty(propName)) {
-          // eslint-disable-next-line fb-www/no-console
           console.warn(
             `Supplying an \`${propName}\` prop to \`DraftEditor\` has ` +
               'been deprecated. If your handler needs access to the keyboard ' +
@@ -499,7 +498,6 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
    * a specified scroll position (for cases like `cut` behavior where it should
    * be restored to a known position).
    */
-  // eslint-disable-next-line fb-www/extra-arrow-initializer
   focus: (scrollPosition?: DraftScrollPosition) => void = (
     scrollPosition?: DraftScrollPosition,
   ): void => {
@@ -538,7 +536,6 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
     }
   };
 
-  // eslint-disable-next-line fb-www/extra-arrow-initializer
   blur: () => void = (): void => {
     const editorNode = this.editor;
     if (!editorNode) {
@@ -555,7 +552,6 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
    * handler module to ensure that DOM events are managed appropriately for
    * the active mode.
    */
-  // eslint-disable-next-line fb-www/extra-arrow-initializer
   setMode: DraftEditorModes => void = (mode: DraftEditorModes): void => {
     const {onPaste, onCut, onCopy} = this.props;
     const editHandler = {...handlerMap.edit};
@@ -582,7 +578,6 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
     this._handler = handler[mode];
   };
 
-  // eslint-disable-next-line fb-www/extra-arrow-initializer
   exitCurrentMode: () => void = (): void => {
     this.setMode('edit');
   };
@@ -596,7 +591,6 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
    * reconciliation occurs on a version of the DOM that is synchronized with
    * our EditorState.
    */
-  // eslint-disable-next-line fb-www/extra-arrow-initializer
   restoreEditorDOM: (scrollPosition?: DraftScrollPosition) => void = (
     scrollPosition?: DraftScrollPosition,
   ): void => {
@@ -621,7 +615,6 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
    *
    * Set the clipboard state for a cut/copy event.
    */
-  // eslint-disable-next-line fb-www/extra-arrow-initializer
   setClipboard: (?BlockMap) => void = (clipboard: ?BlockMap): void => {
     this._clipboard = clipboard;
   };
@@ -631,7 +624,6 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
    *
    * Retrieve the clipboard state for a cut/copy event.
    */
-  // eslint-disable-next-line fb-www/extra-arrow-initializer
   getClipboard: () => ?BlockMap = (): ?BlockMap => {
     return this._clipboard;
   };
@@ -645,7 +637,6 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
    * an `onChange` prop to receive state updates passed along from this
    * function.
    */
-  // eslint-disable-next-line fb-www/extra-arrow-initializer
   update: EditorState => void = (editorState: EditorState): void => {
     const onChange = this.props.onChange;
     this._latestEditorState = editorState;

--- a/src/component/handlers/edit/editOnBlur.js
+++ b/src/component/handlers/edit/editOnBlur.js
@@ -30,7 +30,7 @@ function editOnBlur(editor: DraftEditor, e: SyntheticEvent<HTMLElement>): void {
   // opposed to clicking to another tab or window).
   const {ownerDocument} = e.currentTarget;
   if (
-    !Boolean(editor.props.preserveSelectionOnBlur) &&
+    !editor.props.preserveSelectionOnBlur &&
     getActiveElement(ownerDocument) === ownerDocument.body
   ) {
     const selection: SelectionObject = ownerDocument.defaultView.getSelection();

--- a/src/component/selection/getRangeClientRects.js
+++ b/src/component/selection/getRangeClientRects.js
@@ -22,6 +22,7 @@ const isChrome = UserAgent.isBrowser('Chrome');
 // not overlap the entire node. To resolve this, we split the range at each
 // start tag and join the client rects together.
 // https://code.google.com/p/chromium/issues/detail?id=324437
+/* eslint-disable consistent-return */
 function getRangeClientRectsChrome(range: Range): Array<ClientRect> {
   const tempRange = range.cloneRange();
   const clientRects = [];

--- a/src/model/modifier/__tests__/AtomicBlockUtils-test.js
+++ b/src/model/modifier/__tests__/AtomicBlockUtils-test.js
@@ -31,9 +31,9 @@ const initialBlock = contentState.getBlockMap().first();
 const ENTITY_KEY = Entity.create('TOKEN', 'MUTABLE');
 const CHARACTER = ' ';
 
+/* eslint-disable-next-line */
 const getInvariantViolation = msg => {
   try {
-    /* eslint-disable-next-line */
     invariant(false, msg);
   } catch (e) {
     return e;

--- a/src/model/transaction/__tests__/insertFragmentIntoContentState-test.js
+++ b/src/model/transaction/__tests__/insertFragmentIntoContentState-test.js
@@ -35,9 +35,9 @@ const DEFAULT_BLOCK_CONFIG = {
 
 const initialBlock = contentState.getBlockMap().first();
 
+/* eslint-disable-next-line */
 const getInvariantViolation = msg => {
   try {
-    /* eslint-disable-next-line */
     invariant(false, msg);
   } catch (e) {
     return e;


### PR DESCRIPTION
All of the references to `fb-www` eslint rules fail when running lint. Also, there were a few small warnings for `eslint-disable` rules that just needed moved around to fix. 