### PR TITLE
Closes #1972

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -434,6 +434,7 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
             onKeyDown={this._onKeyDown}
             onKeyPress={this._onKeyPress}
             onKeyUp={this._onKeyUp}
+            onMouseDown={this._onMouseDown}
             onMouseUp={this._onMouseUp}
             onPaste={this._onPaste}
             onSelect={this._onSelect}


### PR DESCRIPTION
References https://github.com/facebook/draft-js/issues/1972. onMouseDown wasn't registered in the DraftEditor component.