### PR TITLE
Update README and docs with new plans for DraftEntity API in v0.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,16 @@ for scalable memory usage.
 
 [Learn how to use Draft.js in your own project.](https://draftjs.org/docs/getting-started/)
 
+Draft.js is used in production on Facebook, including status and
+comment inputs, [Notes](https://www.facebook.com/notes/), and
+[messenger.com](https://www.messenger.com).
+
 ## API Notice
 
 Before getting started, please be aware that we recently changed the API of
-Entity storage in Draft. The latest version, `v0.10.0`, supports both the old
-and new API.  Following that up will be `v0.11.0` which will remove the old API.
-If you are interested in helping out, or tracking the progress, please follow
-[issue 839](https://github.com/facebook/draft-js/issues/839).
+Entity storage in Draft. 
+
+Previously, the old API was set to be removed in `v0.11.0`. Since, the plans have changed— `v0.11.0` still supports the old API and `v0.12.0` will remove it. Refer to [the docs](https://draftjs.org/docs/v0-10-api-migration) for more information and information on how to migrate.
 
 ## Getting Started
 
@@ -64,7 +67,9 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {Editor, EditorState} from 'draft-js';
 
-class MyEditor extends React.Component {
+function MyEditor() {
+
+  
   constructor(props) {
     super(props);
     this.state = {editorState: EditorState.createEmpty()};
@@ -113,31 +118,30 @@ Since the release of React 16.8, you can use [Hooks](https://reactjs.org/docs/ho
 
 
 ```js
-import React from 'react';
-import ReactDOM from 'react-dom';
-import {Editor, EditorState} from 'draft-js';
+import React from "react";
+import { Editor, EditorState } from "draft-js";
+import "draft-js/dist/Draft.css";
 
-function MyEditor() {
-  const [editorState, setEditorState] = React.useState(
+export default function MyEditor() {
+  const [editorState, setEditorState] = React.useState(() =>
     EditorState.createEmpty()
   );
 
   const editor = React.useRef(null);
-
   function focusEditor() {
     editor.current.focus();
   }
 
-  React.useEffect(() => {
-    focusEditor()
-  }, []);
-
   return (
-    <div onClick={focusEditor}>
+    <div
+      style={{ border: "1px solid black", minHeight: "6em", cursor: "text" }}
+      onClick={focusEditor}
+    >
       <Editor
         ref={editor}
         editorState={editorState}
-        onChange={editorState => setEditorState(editorState)}
+        onChange={setEditorState}
+        placeholder="Write something!"
       />
     </div>
   );
@@ -152,18 +156,14 @@ Because Draft.js supports unicode, you must have the following meta tag in the `
 ```html
 <meta charset="utf-8" />
 ```
-Further examples of how Draft.js can be used are provided below.
 
-### Examples
+Further examples of how Draft.js can be used are provided in the `/examples` directory of this repo.
 
-Visit http://draftjs.org/ to try out a basic rich editor example.
+### Building Draft.js
 
-The repository includes a variety of different editor examples to demonstrate
-some of the features offered by the framework.
+Draft.js is built with [Yarn](https://classic.yarnpkg.com/en/) v1. Using other package managers mgiht work, but is not officially supported.
 
-To run the examples, first build Draft.js locally. The Draft.js build is tested
-with Yarn v1 only. If you're using any other package manager and something doesn't
-work, try using yarn v1:
+To clone and build, run:
 
 ```
 git clone https://github.com/facebook/draft-js.git
@@ -172,11 +172,9 @@ yarn install
 yarn run build
 ```
 
-then open the example HTML files in your browser.
+### Examples
 
-Draft.js is used in production on Facebook, including status and
-comment inputs, [Notes](https://www.facebook.com/notes/), and
-[messenger.com](https://www.messenger.com).
+To run the examples in the `/examples` directory, first build Draft.js locally as described above. Then, open the example HTML files in your browser.
 
 ## Browser Support
 
@@ -200,7 +198,7 @@ Join our [Slack team](https://draftjs.herokuapp.com)!
 
 ## Contribute
 
-We actively welcome pull requests. Learn how to
+We welcome pull requests. Learn how to
 [contribute](https://github.com/facebook/draft-js/blob/master/CONTRIBUTING.md).
 
 ## License

--- a/docs/APIReference-APIMigration.md
+++ b/docs/APIReference-APIMigration.md
@@ -9,7 +9,9 @@ The Draft.js v0.10 release includes a change to the API for managing
 that the methods which were previously accessed on `DraftEntity` are now moved
 to the `ContentState` record.
 
-This API improvement unlocks the path for many benefits that will be available in v0.11:
+The old API was set to be permanently removed in v0.11, but will now be removed in v0.12. Make sure to migrate over!
+
+This API improvement unlocks the path for many benefits that will be available in v0.12:
 
 - DraftEntity instances and storage will be immutable.
 - DraftEntity will no longer be globally accessible.

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -35,10 +35,8 @@ Learn more about [using a shim with Draft](/docs/advanced-topics-issues-and-pitf
 ## API Changes Notice
 
 Before getting started, please be aware that we recently changed the API of
-Entity storage in Draft. The latest version, `v0.10.0`, supports both the old
-and new API. Following that up will be `v0.11.0` which will remove the old API.
-If you are interested in helping out, or tracking the progress, please follow
-[issue 839](https://github.com/facebook/draft-js/issues/839).
+Entity storage in Draft. Draft.js version `v0.10.0` and `v0.11.0` support both the old
+and new API. Following that up will be `v0.12.0` which will remove the old API.
 
 ## Usage
 


### PR DESCRIPTION
#### Summary

The old draft.js Entity API was set to be removed in `v0.11.0`, but that didn't happen so it will now occur in `v0.12.0`. This PR updates the README and website to reflect this.
