### PR TITLE
Add aria-required attr to DraftEditor

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -409,6 +409,7 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
             aria-labelledby={this.props.ariaLabelledBy}
             aria-multiline={this.props.ariaMultiline}
             aria-owns={readOnly ? null : this.props.ariaOwneeID}
+            aria-required={this.props.ariaRequired}
             autoCapitalize={this.props.autoCapitalize}
             autoComplete={this.props.autoComplete}
             autoCorrect={this.props.autoCorrect}

--- a/src/component/base/DraftEditorProps.js
+++ b/src/component/base/DraftEditorProps.js
@@ -106,6 +106,7 @@ export type DraftEditorProps = {
   ariaLabelledBy?: string,
   ariaMultiline?: boolean,
   ariaOwneeID?: string,
+  ariaRequired?: boolean,
   webDriverTestID?: string,
   /**
    * Cancelable event handlers, handled from the top level down. A handler


### PR DESCRIPTION
Closes: https://github.com/facebook/draft-js/issues/1696

#### Summary

`aria-required` is used to indicate that user input is required on an element before a form can be submitted. https://www.w3.org/TR/wai-aria-1.1/#aria-required 

It isn't currently possible to pass it in as a prop here so I'm just adding it in alongside the other `aria...` props. 

#### Test Plan

Tested using `npm run test && npm run lint && npm run flow`

