### PR TITLE
Add eslint-plugin-fb-www to stop 'Definition for rule was not found' …

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,7 +16,7 @@ module.exports = {
   rules: {
     'prettier/prettier': ['error'],
   },
-  plugins: ['prettier'],
+  plugins: ['prettier', 'fb-www'],
   overrides: [
     {
       files: ['examples/draft-0-10-0/**', 'examples/draft-0-9-1/**'],

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "eslint-config-fbjs": "^3.1.1",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-babel": "^5.3.1",
+    "eslint-plugin-fb-www": "^1.0.3",
     "eslint-plugin-flowtype": "^5.2.0",
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-prettier": "^3.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3270,6 +3270,11 @@ eslint-plugin-babel@^5.3.1:
   dependencies:
     eslint-rule-composer "^0.3.0"
 
+eslint-plugin-fb-www@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-fb-www/-/eslint-plugin-fb-www-1.0.3.tgz#3d3934c0711c22a880c83486d5262db3a74857cb"
+  integrity sha512-X5H/nA9ZB4SfXWri+9/QBeK++oRJuA0J/lvvOp0k5SMBuQ+AVopRx7QjNN2fhSPMh2kxn1wumEaAH/W6moUcyw==
+
 eslint-plugin-flowtype@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-5.2.0.tgz#a4bef5dc18f9b2bdb41569a4ab05d73805a3d261"


### PR DESCRIPTION
Travis CI currently fails on linting suppressions for internal fb lints. This should fix the build by stopping said errors.
