### PR TITLE
Only build on node 14 and notify on change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: node_js
 
 node_js:
-- 10
-- 12
-- 14
+  - 14
 
 sudo: false
 
@@ -17,8 +15,7 @@ env:
   global:
     - CXX=g++-4.8
     # $GITHUB_TOKEN
-    - secure: "JOaZao55VK0+3Uf2AoPo5qOXBKEUnqwbwfHsPq5746+7zzr4WpSOleYWLCOm3cl/pMuw7MEa8cQ8MzBktvUyuqbYEl6tslqNE+IINXPlrLbZJGbz5US/doNwv6nWk679op4XJin8ZjJy3AsoP8+qRJCzGRepjiNQTT4Yq72lWEEv1ea5RN5CQNobTBJfyJ47+XK+A8Zqea8mV152LO2h0/q96Ny1YQpcG/uQj8KGjd/Gi9OEifheKYZV5YzamWF3zouchVC3uJZTfAs7zOuiz/23ej2HwUwCfE7ZlcM0EvEJ4oEKPhO7ZUt0tLw3O/xIzhIJMngyfWee+jp47SAPioyfW/mzX8S+2ma8dstFsgG7XbVpIwk4906tJFIcOLxrAocXqcSAOC+bS01rFbFzDVdh3czWF8iaSglZh6SWfgn0aAEoNSxZZJffVsxciAG13FlG0bz0MgNqZuNflwE2aN14k2rWYtgz/rpjnMQNE0p98JMuxxC4ezWQ7FwNe+k3OLqSfSiQffeOvLiOqdMQlH5KCLg/7ODtI6vvoxA3IQvYM8s0pZ7OY581aUhaBTZ/GiLGHz8fHuA4URUGNFixEyGvMr6Q1zhNvGmyHOW+vyzx4JOdM6VmW85+mY0M+qJ7TfoUJRM1A3WhvW43X2ghwou4YM35Xj2I7g4DRPEk+XE="
-
+    - secure: 'JOaZao55VK0+3Uf2AoPo5qOXBKEUnqwbwfHsPq5746+7zzr4WpSOleYWLCOm3cl/pMuw7MEa8cQ8MzBktvUyuqbYEl6tslqNE+IINXPlrLbZJGbz5US/doNwv6nWk679op4XJin8ZjJy3AsoP8+qRJCzGRepjiNQTT4Yq72lWEEv1ea5RN5CQNobTBJfyJ47+XK+A8Zqea8mV152LO2h0/q96Ny1YQpcG/uQj8KGjd/Gi9OEifheKYZV5YzamWF3zouchVC3uJZTfAs7zOuiz/23ej2HwUwCfE7ZlcM0EvEJ4oEKPhO7ZUt0tLw3O/xIzhIJMngyfWee+jp47SAPioyfW/mzX8S+2ma8dstFsgG7XbVpIwk4906tJFIcOLxrAocXqcSAOC+bS01rFbFzDVdh3czWF8iaSglZh6SWfgn0aAEoNSxZZJffVsxciAG13FlG0bz0MgNqZuNflwE2aN14k2rWYtgz/rpjnMQNE0p98JMuxxC4ezWQ7FwNe+k3OLqSfSiQffeOvLiOqdMQlH5KCLg/7ODtI6vvoxA3IQvYM8s0pZ7OY581aUhaBTZ/GiLGHz8fHuA4URUGNFixEyGvMr6Q1zhNvGmyHOW+vyzx4JOdM6VmW85+mY0M+qJ7TfoUJRM1A3WhvW43X2ghwou4YM35Xj2I7g4DRPEk+XE='
 
 addons:
   apt:
@@ -34,29 +31,29 @@ cache:
   yarn: true
 
 before_script:
-# For additional debugging when Travis inevitably gets into a bad state.
-- yarn list --depth=0
+  # For additional debugging when Travis inevitably gets into a bad state.
+  - yarn list --depth=0
 
 script:
-- |
-  if [ "$TEST_TYPE" != build_website ]
-  then
-    yarn run $TEST_TYPE
-  else
-    set -e
-    ./node_modules/.bin/gulp
-    if [ "$TRAVIS_PULL_REQUEST" = false ] && [ "$TRAVIS_BRANCH" = master ]; then
-      # Automatically publish the website
-      git config --global user.name "Travis CI"
-      git config --global user.email "travis@reactjs.org"
-      echo "machine github.com login reactjs-bot password $GITHUB_TOKEN" > ~/.netrc
-      cd website && yarn install && GIT_USER=reactjs-bot yarn deploy
+  - |
+    if [ "$TEST_TYPE" != build_website ]
+    then
+      yarn run $TEST_TYPE
     else
-      # Make sure the website builds without error
-      cd website && yarn install && yarn build
-    fi
+      set -e
+      ./node_modules/.bin/gulp
+      if [ "$TRAVIS_PULL_REQUEST" = false ] && [ "$TRAVIS_BRANCH" = master ]; then
+        # Automatically publish the website
+        git config --global user.name "Travis CI"
+        git config --global user.email "travis@reactjs.org"
+        echo "machine github.com login reactjs-bot password $GITHUB_TOKEN" > ~/.netrc
+        cd website && yarn install && GIT_USER=reactjs-bot yarn deploy
+      else
+        # Make sure the website builds without error
+        cd website && yarn install && yarn build
+      fi
 
-  fi
+    fi
 
 notifications:
   email:
@@ -64,4 +61,4 @@ notifications:
       - claudio.procida@gmail.com
       - mr.kev@me.com
     on_success: change # send a notification when the build status changes
-    on_failure: always # always send a notification
+    on_failure: change # always send a notification


### PR DESCRIPTION
This will get us quicker signal. The Travis build currently takes over half an hour, but if we built it only built on version of node it could take more like ~10min. Rarely is there any meaningful difference between the different build environments, and honestly, it's a bit of an overkill to try to officially support all of these.

As of the publishing of this PR, Node 14 is the latest LTS version of node.

I also change Travis email notifications to only notify on change. My inbox has been flooded by failures before.

Lastly, some formatting changes.

EDIT: looks like all the build jobs ran in parallel so it was done in ~3 minutes! (: 

<img width="1441" alt="Screen Shot 2020-11-02 at 3 59 04 PM" src="https://user-images.githubusercontent.com/1285131/97923933-77bf8380-1d24-11eb-8081-84f16edf98f0.png">

Also note, `lint` is expected to fail since https://github.com/facebook/draft-js/pull/2704 hasn't been merged yet.

