### PR TITLE
Update dependabot config to try to disable dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,14 +1,26 @@
-version: 1
-update_configs:
-  - package_manager: "javascript"
-    directory: "/examples/draft-0-10-0/playground"
-    update_schedule: "monthly"
-  - package_manager: "javascript"
-    directory: "/examples/draft-0-10-0/tex"
-    update_schedule: "monthly"
-  - package_manager: "javascript"
-    directory: "/examples/draft-0-10-0/universal"
-    update_schedule: "monthly"
-  - package_manager: "javascript"
-    directory: "/"
-    update_schedule: "weekly"
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: '*'
+  - package-ecosystem: 'npm'
+    directory: '/examples/draft-0-10-0/playground'
+    schedule:
+      interval: monthly"
+    ignore:
+      - dependency-name: '*'
+  - package-ecosystem: 'npm'
+    directory: '/examples/draft-0-10-0/tex'
+    schedule:
+      interval: 'monthly'
+    ignore:
+      - dependency-name: '*'
+  - package-ecosystem: 'npm'
+    directory: '/examples/draft-0-10-0/universal'
+    schedule:
+      interval: 'monthly'
+    ignore:
+      - dependency-name: '*'


### PR DESCRIPTION
#### Summary

Given the way projects in the org are set up we can't just "turn off dependabot" for Draft.js, so giving this a shot. 

Why _try_ to turn off Dependabot in the first place? Well, Draft.js only has three actual dependencies, all of which are updated like once every two years if at all:

- `fbjs` is seldom updated
- `immutable` is hard to update given internal dependencies.
- `object-assign`, a simple utility which hasn't changed in years.

The rest are dev-dependencies, which aren't an urgent security risk given it isn't code that ships with the product.

I occasionally just go through and update all dependencies, and honestly, this is a better workflow. 

- Dependabot dependency updates are not "automatic" as straightforward for this repo since we need to sync internally. It's not like other repos where a single contributor can accept and merge the change— given our workflow with Phabricator here, one contributor needs to pull the change and find another one to accept it.  Doing a lot of dependencies at once is therefore quicker, since it only needs to be imported and reviewed once.
- Ideally we want to test these changes. Blindly updating dependencies can break things: hence why Dependabot has a ["compatibility" score](https://dependabot.com/compatibility-score/?dependency-name=eslint-config-prettier&package-manager=npm_and_yarn&previous-version=6.11.0&new-version=6.15.0) to each change. Again, this is more efficient to do all in one batch than pulling a PR per dependency and doing manually. 
- Dependabot just floods the project with PRs. This only adds noise to sift through, and makes looking through PRs seem more daunting.

Let's hope this works!


