### PR TITLE
Fix component header in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {Editor, EditorState} from 'draft-js';
 
-function MyEditor() {
-
-  
+class MyEditor extends React.Component {
   constructor(props) {
     super(props);
     this.state = {editorState: EditorState.createEmpty()};


### PR DESCRIPTION
#### Summary

This needs to be a class component. Looks like it got [changed by mistake](https://github.com/facebook/draft-js/commit/826f0ab5a0940542228876a645fceeb25e92fcfb#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L67-R72) in #2651 ([D24200501](https://www.internalfb.com/intern/diff/D24200501/)), which seems like it meant only to change the later example.

#### Test Plan

plopped this example into codesandbox.io, where it doesn't compile except by reverting the update to a functional component