### PR TITLE
Fix for iOS: backspace + space deletes extra character

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -157,6 +157,7 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
   _latestEditorState: EditorState;
   _latestCommittedEditorState: EditorState;
   _pendingStateFromBeforeInput: void | EditorState;
+  _blockNextStateUpdate: boolean = false;
 
   /**
    * Define proxies that can route events to the current handler.

--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -136,6 +136,11 @@ function editOnInput(editor: DraftEditor, event: ?SyntheticInputEvent<>): void {
     domText = domText.slice(0, -1);
   }
 
+  /* $FlowFixMe[prop-missing] inputType is only defined on a draft of a
+   * standard. https://w3c.github.io/input-events/#dom-inputevent-inputtype
+   */
+  const inputType = event ? event.nativeEvent.inputType : undefined;
+
   // No change -- the DOM is up to date. Nothing to do here.
   if (domText === modelText) {
     // This can be buggy for some Android keyboards because they don't fire
@@ -145,10 +150,6 @@ function editOnInput(editor: DraftEditor, event: ?SyntheticInputEvent<>): void {
     // Newest versions of Android support the dom-inputevent-inputtype
     // and we can use the `inputType` to properly apply the state changes.
 
-    /* $FlowFixMe[prop-missing] inputType is only defined on a draft of a
-     * standard. https://w3c.github.io/input-events/#dom-inputevent-inputtype
-     */
-    const inputType = event ? event.nativeEvent.inputType : undefined;
     if (inputType) {
       const newEditorState = onInputType(inputType, editorState);
       if (newEditorState !== editorState) {
@@ -162,7 +163,6 @@ function editOnInput(editor: DraftEditor, event: ?SyntheticInputEvent<>): void {
     // This part of code is responsible for case when space button triggers
     // previous character erasure. This issue was described here
     // https://github.com/facebook/draft-js/issues/2091
-    const inputType = event ? event.nativeEvent.inputType : undefined;
     if (inputType) {
       if (inputType === 'deleteContentBackward') {
         domText = modelText;


### PR DESCRIPTION
#### Summary

Were removed bug when backspace + space delete extra character after a native autocomplete.

#### Test Plan**

It can be tested in the "playground" example in the `draft-js/examples/draft-0-10-0/playground` folder

1. Click on the editor, to focus it.
2. Start typing a word (e.g. gre).
3. Select a variant from the suggested options in the standard IOS keyboard.
4. Remove space after autocomplete word using backspace.
5. Click space and make sure that it just insert one space character and doesn't remove any character.
