### PR TITLE
Reduce calls to restoreEditorDOM during compositions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "draft-js",
+  "name": "draft-js-composition-fix",
   "description": "A React framework for building text editors.",
-  "version": "0.11.7",
+  "version": "0.0.1",
   "keywords": [
     "draftjs",
     "editor",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "draft-js-composition-fix",
+  "name": "draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.0.1",
+  "version": "0.11.7",
   "keywords": [
     "draftjs",
     "editor",

--- a/src/component/handlers/composition/DOMObserver.js
+++ b/src/component/handlers/composition/DOMObserver.js
@@ -50,7 +50,7 @@ class DOMObserver {
   constructor(container: HTMLElement) {
     this.container = container;
     this.mutations = Map();
-    this.mustReset = false;
+    this.mutationAtLeafStart = false;
     const containerWindow = getWindowForNode(container);
     const MutationObserver = containerWindow.MutationObserver;
     if (MutationObserver && !USE_CHAR_DATA) {
@@ -98,8 +98,10 @@ class DOMObserver {
       );
     }
     const mutations = this.mutations;
+    const mutationAtLeafStart = this.mutationAtLeafStart;
     this.mutations = Map();
-    return {mutations, mustReset: this.mustReset};
+    this.mutationAtLeafStart = false;
+    return {mutations, mutationAtLeafStart};
   }
 
   registerMutations(mutations: Array<MutationRecord>): void {
@@ -128,7 +130,7 @@ class DOMObserver {
       if (addedNodes && addedNodes.length) {
         // This mutation is creating a new node, meaning it's starting
         // in a new line and the editor must be reset
-        this.mustReset = true;
+        this.mutationAtLeafStart = true;
       } else if (removedNodes && removedNodes.length) {
         // `characterData` events won't happen or are ignored when
         // removing the last character of a leaf node, what happens

--- a/src/component/handlers/composition/DOMObserver.js
+++ b/src/component/handlers/composition/DOMObserver.js
@@ -23,7 +23,7 @@ const {Map} = Immutable;
 
 type MutationRecordT =
   | MutationRecord
-  | {type: 'characterData', target: Node, removedNodes?: void};
+  | {type: 'characterData', target: Node, addedNodes?: void, removedNodes?: void};
 
 // Heavily based on Prosemirror's DOMObserver https://github.com/ProseMirror/prosemirror-view/blob/master/src/domobserver.js
 
@@ -41,6 +41,7 @@ class DOMObserver {
   observer: ?MutationObserver;
   container: HTMLElement;
   mutations: Map<string, string>;
+  mutationAtLeafStart: boolean;
   onCharData: ?({
     target: EventTarget,
     type: string,
@@ -54,11 +55,11 @@ class DOMObserver {
     const containerWindow = getWindowForNode(container);
     const MutationObserver = containerWindow.MutationObserver;
     if (MutationObserver && !USE_CHAR_DATA) {
-      this.observer = new MutationObserver((mutations) =>
+      this.observer = new MutationObserver(mutations =>
         this.registerMutations(mutations),
       );
     } else {
-      this.onCharData = (e) => {
+      this.onCharData = e => {
         invariant(
           e.target instanceof Node,
           'Expected target to be an instance of Node',

--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -240,7 +240,7 @@ const DraftEditorCompositionHandler = {
     );
     const compositionEndSelectionState = documentSelection.selectionState;
 
-    if (mustReset || mutations.size > 1) editor.restoreEditorDOM();
+    if (mustReset) editor.restoreEditorDOM();
 
     // See:
     // - https://github.com/facebook/draft-js/issues/2093

--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -153,7 +153,8 @@ const DraftEditorCompositionHandler = {
     }
 
     const lastEditorState = editor._latestEditorState;
-    const mutations = nullthrows(domObserver).stopAndFlushMutations();
+    const observerMutations = nullthrows(domObserver).stopAndFlushMutations();
+    const {mutations, mustReset} = observerMutations;
     domObserver = null;
     resolved = true;
 
@@ -239,7 +240,7 @@ const DraftEditorCompositionHandler = {
     );
     const compositionEndSelectionState = documentSelection.selectionState;
 
-    editor.restoreEditorDOM();
+    if (mustReset || mutations.size > 1) editor.restoreEditorDOM();
 
     // See:
     // - https://github.com/facebook/draft-js/issues/2093

--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -154,7 +154,8 @@ const DraftEditorCompositionHandler = {
 
     const lastEditorState = editor._latestEditorState;
     const observerMutations = nullthrows(domObserver).stopAndFlushMutations();
-    const {mutations, mustReset} = observerMutations;
+    const {mutations, mutationAtLeafStart} = observerMutations;
+    let entityKey = null;
     domObserver = null;
     resolved = true;
 
@@ -204,10 +205,7 @@ const DraftEditorCompositionHandler = {
         isBackward: false,
       });
 
-      const entityKey = getEntityKeyForSelection(
-        contentState,
-        replacementRange,
-      );
+      entityKey = getEntityKeyForSelection(contentState, replacementRange);
       const currentStyle = contentState
         .getBlockForKey(blockKey)
         .getInlineStyleAt(start);
@@ -240,6 +238,7 @@ const DraftEditorCompositionHandler = {
     );
     const compositionEndSelectionState = documentSelection.selectionState;
 
+    const mustReset = mutationAtLeafStart || entityKey !== null;
     if (mustReset) editor.restoreEditorDOM();
 
     // See:

--- a/src/component/handlers/composition/__tests__/DraftEditorCompostionHandler-test.js
+++ b/src/component/handlers/composition/__tests__/DraftEditorCompostionHandler-test.js
@@ -29,7 +29,7 @@ jest.mock('DOMObserver', () => {
   DOMObserver.prototype.start = jest.fn();
   DOMObserver.prototype.stopAndFlushMutations = jest
     .fn()
-    .mockReturnValue(Map({}));
+    .mockReturnValue({mutations: Map({})});
   return DOMObserver;
 });
 jest.mock('getContentEditableContainer');
@@ -49,7 +49,7 @@ let compositionHandler = null;
 let editor;
 
 function getEditorState(blocks) {
-  const contentBlocks = Object.keys(blocks).map((blockKey) => {
+  const contentBlocks = Object.keys(blocks).map(blockKey => {
     return new ContentBlock({
       key: blockKey,
       text: blocks[String(blockKey)],
@@ -96,7 +96,7 @@ beforeEach(() => {
     setMode: jest.fn(),
     restoreEditorDOM: jest.fn(),
     exitCurrentMode: jest.fn(),
-    update: jest.fn((state) => (editor._latestEditorState = state)),
+    update: jest.fn(state => (editor._latestEditorState = state)),
   };
 });
 
@@ -119,9 +119,9 @@ test('Can handle a single mutation', () => {
   withGlobalGetSelectionAs({}, () => {
     editor._latestEditorState = getEditorState({blockkey0: ''});
     const mutations = Map({'blockkey0-0-0': '\u79c1'});
-    require('DOMObserver').prototype.stopAndFlushMutations.mockReturnValue(
+    require('DOMObserver').prototype.stopAndFlushMutations.mockReturnValue({
       mutations,
-    );
+    });
     // $FlowExpectedError[incompatible-use]
     // $FlowExpectedError[incompatible-call]
     compositionHandler.onCompositionStart(editor);
@@ -144,9 +144,9 @@ test('Can handle mutations in multiple blocks', () => {
       'blockkey0-0-0': 'reactjs',
       'blockkey1-0-0': 'draftjs',
     });
-    require('DOMObserver').prototype.stopAndFlushMutations.mockReturnValue(
+    require('DOMObserver').prototype.stopAndFlushMutations.mockReturnValue({
       mutations,
-    );
+    });
     // $FlowExpectedError[incompatible-use]
     // $FlowExpectedError[incompatible-call]
     compositionHandler.onCompositionStart(editor);
@@ -174,9 +174,9 @@ test('Can handle mutations in the same block in multiple leaf nodes', () => {
       [`${blockKey}-0-1`]: 'draftbb',
       [`${blockKey}-0-2`]: ' graphqlccc',
     });
-    require('DOMObserver').prototype.stopAndFlushMutations.mockReturnValue(
+    require('DOMObserver').prototype.stopAndFlushMutations.mockReturnValue({
       mutations,
-    );
+    });
     // $FlowExpectedError[incompatible-use]
     // $FlowExpectedError[incompatible-call]
     compositionHandler.onCompositionStart(editor);

--- a/src/component/handlers/composition/__tests__/DraftEditorCompostionHandler-test.js
+++ b/src/component/handlers/composition/__tests__/DraftEditorCompostionHandler-test.js
@@ -49,7 +49,7 @@ let compositionHandler = null;
 let editor;
 
 function getEditorState(blocks) {
-  const contentBlocks = Object.keys(blocks).map(blockKey => {
+  const contentBlocks = Object.keys(blocks).map((blockKey) => {
     return new ContentBlock({
       key: blockKey,
       text: blocks[String(blockKey)],
@@ -96,7 +96,7 @@ beforeEach(() => {
     setMode: jest.fn(),
     restoreEditorDOM: jest.fn(),
     exitCurrentMode: jest.fn(),
-    update: jest.fn(state => (editor._latestEditorState = state)),
+    update: jest.fn((state) => (editor._latestEditorState = state)),
   };
 });
 


### PR DESCRIPTION
#### Summary
This PR tries to reduce the calls made to the `restoreEditorDom` method during compositions.

I've been experiencing some weirds issues with my custom components since version `v0.11.0`. The issue happens when typing brazilian portuguese, because we have some letters that use accents e.g., é, ê, ã, etc, so in draft-js they start a composition. Typing any of these triggers an unmount on all our custom components. It can be really troublesome if we have a custom component that does a request or some async code, as it keeps redoing it every time we type any of those letters. The same seems to be true when typing Chinese or Japanese characters as well because they also trigger compositions, as stated in #2788.

This PR attempts to mitigate this behavior by bringing back the `mustReset` flag that existed before `v0.11.0`, in the `DraftEditorCompositionHandler.js` file. The flag limits the calls to `restoreEditorDOM` method to happen only when necessary. With the current code I've identified it to be necessary when: 
- A mutation is starting a new text node 
- A composition is being resolved and the `entityKey` for the current selection is not `null`

#### Test Plan
It's possible to test the current behavior on [this code sandbox](https://codesandbox.io/s/draftjs-composition-0117-c47gs), which has the latest versions of draft-js(`0.11.7`) and a custom component with a `console.log` on the unmount component lifecycle. Everytime a composition is resolved, the `restoreEditorDOM` method is called, re-rendering the editor calling the unmount. (Can be seen on the `console` tab).

And here is another [code sandbox with this PR applied to it](https://codesandbox.io/s/draftjs-composition-fix-5rr3j). I has the same custom block in it. The unmount is limited only to specific cases.
