### PR TITLE
Fix CompositionStart event did not replace the selected content

### DIFF
--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -64,6 +64,25 @@ const DraftEditorCompositionHandler = {
    */
   onCompositionStart(editor: DraftEditor): void {
     stillComposing = true;
+
+    const editorState = editor._latestEditorState;
+    if (editorState) {
+      const selection = editorState.getSelection();
+      const contentState = editorState.getCurrentContent();
+
+      if (!selection.isCollapsed()) {
+        editor.update(
+          EditorState.set(editorState, {
+            currentContent: DraftModifier.removeRange(
+              contentState,
+              selection,
+              'forward',
+            ),
+          }),
+        );
+      }
+    }
+
     startDOMObserver(editor);
   },
 


### PR DESCRIPTION
#### Summary

Automatically clear the currently selected area when you start to enter composition characters.

Resolve https://github.com/facebook/draft-js/issues/2825

#### Test Plan

[...]
