### PR TITLE
Fix yarn build

### DIFF
--- a/scripts/module-map.js
+++ b/scripts/module-map.js
@@ -8,7 +8,7 @@
 module.exports = Object.assign(
   {
     immutable: 'immutable',
-    React: 'react',
+    react: 'react',
     ReactDOM: 'react-dom',
     ReactDOMComet: 'react-dom',
     'object-assign': 'object-assign',


### PR DESCRIPTION
Fixes #2864

#### Summary

yarn is throwing errors where modules in lib depend on "./react".
`Module not found: Error: Can't resolve './react' in '[...]/draft-js/lib'`

With this change, the build works properly.

#### Test Plan**

Tested on MacOS Big Sur.
