### PR TITLE
Add Android to selectionHandler method

### DIFF
--- a/src/component/handlers/edit/DraftEditorEditHandler.js
+++ b/src/component/handlers/edit/DraftEditorEditHandler.js
@@ -30,9 +30,10 @@ const onSelect = require('editOnSelect');
 
 const isChrome = UserAgent.isBrowser('Chrome');
 const isFirefox = UserAgent.isBrowser('Firefox');
+const isAndroid = UserAgent.isPlatform('Android');
 
 const selectionHandler: (e: DraftEditor) => void =
-  isChrome || isFirefox ? onSelect : e => {};
+  isChrome || isFirefox || isAndroid ? onSelect : e => {};
 
 const DraftEditorEditHandler = {
   onBeforeInput,


### PR DESCRIPTION
#### Moving cursor to the middle of a word and hitting space crashes a word. 
Only on Android Gboard keyboard.
Adding screen recording gif.

![android gboard](https://user-images.githubusercontent.com/2324985/114161473-c5be6000-9930-11eb-801d-a72a4a50ee83.gif)




