### PR TITLE
Remove expanded props from child span.

### DIFF
--- a/docs/Advanced-Topics-Decorators.md
+++ b/docs/Advanced-Topics-Decorators.md
@@ -94,7 +94,7 @@ stateless components:
 ```js
 const HandleSpan = props => {
   return (
-    <span {...props} style={styles.handle}>
+    <span style={styles.handle}>
       {props.children}
     </span>
   );
@@ -102,7 +102,7 @@ const HandleSpan = props => {
 
 const HashtagSpan = props => {
   return (
-    <span {...props} style={styles.hashtag}>
+    <span style={styles.hashtag}>
       {props.children}
     </span>
   );


### PR DESCRIPTION
React is complaining about the expanded props with statements like, "React does not recognize the `contentState` prop on a...".

*Before* submitting a pull request, please make sure the following is done...

1. Fork the repo and create your branch from `master`.
2. If you've added code that should be tested, add tests!
3. If you've changed APIs, update the documentation.
4. Ensure that:
  * The test suite passes (`npm test`)
  * Your code lints (`npm run lint`) and passes Flow (`npm run flow`)
  * You have followed the [testing guidelines](https://github.com/facebook/draft-js/wiki/Testing-for-Pull-Requests)
5. If you haven't already, complete the [CLA](https://code.facebook.com/cla).

Please use the simple form below as a guideline for describing your pull request, and delete these instructions.

Thanks for contributing to Draft.js!

---

#### Summary

Remove demo code that when I cut and pasted and tried it, it complained.

#### Test Plan**

Honestly, I did not test these documentation changes.
