### PR TITLE
Remove myself (aykev) from CI emails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,10 +54,3 @@ script:
       fi
 
     fi
-
-notifications:
-  email:
-    recipients:
-      - mr.kev@me.com
-    on_success: change # send a notification when the build status changes
-    on_failure: change # always send a notification


### PR DESCRIPTION
#### Summary

Hello again Facebook! I don't work here anymore, but I never removed my email from the CI builds, so I still sometimes get blasted by these. This diff removes me; since there's no more configured recipients, I just went ahead and removed the whole notifications section from `.travis.yml`. Email notifications, in my experience, were never useful anyway— CI blocks merging and the signal makes it to Phabricator too. That was usually more than enough, and a better medium.
