### PR TITLE
Fix how we delete entire leading block

### DIFF
--- a/src/model/transaction/__tests__/__snapshots__/removeRangeFromContentState-test.js.snap
+++ b/src/model/transaction/__tests__/__snapshots__/removeRangeFromContentState-test.js.snap
@@ -1364,7 +1364,7 @@ Object {
 
 exports[`must remove from the start of A to the start of B 1`] = `
 Object {
-  "a": Object {
+  "b": Object {
     "characterList": Array [
       Object {
         "entity": "2",
@@ -1399,9 +1399,9 @@ Object {
     ],
     "data": Object {},
     "depth": 0,
-    "key": "a",
+    "key": "b",
     "text": "Bravo",
-    "type": "unstyled",
+    "type": "unordered-list-item",
   },
   "c": Object {
     "characterList": Array [
@@ -1500,7 +1500,7 @@ Object {
 
 exports[`must remove from the start of A to within B 1`] = `
 Object {
-  "a": Object {
+  "b": Object {
     "characterList": Array [
       Object {
         "entity": "2",
@@ -1517,9 +1517,9 @@ Object {
     ],
     "data": Object {},
     "depth": 0,
-    "key": "a",
+    "key": "b",
     "text": "vo",
-    "type": "unstyled",
+    "type": "unordered-list-item",
   },
   "c": Object {
     "characterList": Array [

--- a/src/model/transaction/__tests__/removeRangeFromContentState-test.js
+++ b/src/model/transaction/__tests__/removeRangeFromContentState-test.js
@@ -117,14 +117,12 @@ test('must remove to the end of the block', () => {
 });
 
 test('must remove from the start of A to the start of B', () => {
-  // Block B is removed. Its contents replace the contents of block A,
-  // while the `type` of block A is preserved.
+  // Block A is removed.
   assertRemoveRangeFromContentState(selectionState.set('focusKey', 'b'));
 });
 
 test('must remove from the start of A to within B', () => {
-  // A slice of block B contents replace the contents of block A,
-  // while the `type` of block A is preserved. Block B is removed.
+  // A slice of block B is removed. Block A is removed.
   assertRemoveRangeFromContentState(
     selectionState.merge({
       focusKey: 'b',

--- a/src/model/transaction/removeRangeFromContentState.js
+++ b/src/model/transaction/removeRangeFromContentState.js
@@ -342,7 +342,11 @@ const removeRangeFromContentState = (
       .concat(endBlock.getCharacterList().slice(endOffset));
   }
 
-  const modifiedStart = startBlock.merge({
+  const leaveEndBlock =
+    startOffset === 0 && endOffset !== endBlock.getText().length;
+  const blockToLeave = leaveEndBlock ? endBlock : startBlock;
+  const modifiedKey = leaveEndBlock ? endKey : startKey;
+  const modifiedBlock = blockToLeave.merge({
     text:
       startBlock.getText().slice(0, startOffset) +
       endBlock.getText().slice(endOffset),
@@ -366,7 +370,7 @@ const removeRangeFromContentState = (
         .filter((_, k) => parentAncestors.indexOf(k) === -1)
         .concat(Map([[endKey, null]]))
         .map((_, k) => {
-          return k === startKey ? modifiedStart : null;
+          return k === modifiedKey ? modifiedBlock : null;
         });
   let updatedBlockMap = blockMap.merge(newBlocks).filter(block => !!block);
 
@@ -384,9 +388,9 @@ const removeRangeFromContentState = (
     blockMap: updatedBlockMap,
     selectionBefore: selectionState,
     selectionAfter: selectionState.merge({
-      anchorKey: startKey,
+      anchorKey: modifiedKey,
       anchorOffset: startOffset,
-      focusKey: startKey,
+      focusKey: modifiedKey,
       focusOffset: startOffset,
       isBackward: false,
     }),


### PR DESCRIPTION
### Summary

If an entire leading block is deleted we don't want to move the remaining content to that block.  It causes block styles to change in unexpected ways for users.

### Test Plan

#### Repro Steps

1. Create editor content that contains an `h1` block with  text followed an `unstyled` block with text
2. Highlight the entire first block and part of the second
3. Press backspace

#### Expected behavior

The remainder of the second block is the only remaining text and it is `unstyled`.

#### Actual behavior

The remainder of the second block is the only remaining text and it is `h1`
