### PR TITLE
Upgrade draft.js’ immutable.js dependency to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "fbjs": "^2.0.0",
-    "immutable": "~3.7.4",
+    "immutable": "~4.0.0-rc.12",
     "object-assign": "^4.1.1"
   },
   "peerDependencies": {

--- a/src/component/contents/DraftEditorContents-core.react.js
+++ b/src/component/contents/DraftEditorContents-core.react.js
@@ -21,6 +21,7 @@ import type {BidiDirection} from 'UnicodeBidiDirection';
 const DefaultDraftBlockRenderMap = require('DefaultDraftBlockRenderMap');
 const DraftEditorBlock = require('DraftEditorBlock.react');
 const DraftOffsetKey = require('DraftOffsetKey');
+const UnicodeBidiDirection = require('UnicodeBidiDirection');
 
 const cx = require('cx');
 const joinClasses: (
@@ -167,7 +168,7 @@ class DraftEditorContents extends React.Component<Props> {
 
       const direction = textDirectionality
         ? textDirectionality
-        : directionMap.get(key);
+        : directionMap.get(key, UnicodeBidiDirection.LTR);
       const offsetKey = DraftOffsetKey.encode(key, 0, 0);
       const componentProps = {
         contentState: content,

--- a/src/component/contents/DraftEditorContents-core.react.js
+++ b/src/component/contents/DraftEditorContents-core.react.js
@@ -12,11 +12,13 @@
 'use strict';
 
 import type {BlockNodeRecord} from 'BlockNodeRecord';
+import type {DraftBlockRenderConfig} from 'DraftBlockRenderConfig';
 import type {DraftBlockRenderMap} from 'DraftBlockRenderMap';
 import type {DraftInlineStyle} from 'DraftInlineStyle';
 import type EditorState from 'EditorState';
 import type {BidiDirection} from 'UnicodeBidiDirection';
 
+const DefaultDraftBlockRenderMap = require('DefaultDraftBlockRenderMap');
 const DraftEditorBlock = require('DraftEditorBlock.react');
 const DraftOffsetKey = require('DraftOffsetKey');
 
@@ -183,12 +185,13 @@ class DraftEditorContents extends React.Component<Props> {
         tree: editorState.getBlockTree(key),
       };
 
-      const configForType =
-        blockRenderMap.get(blockType) || blockRenderMap.get('unstyled');
+      const unstyledConfig: DraftBlockRenderConfig =
+        blockRenderMap.get('unstyled') ||
+        (DefaultDraftBlockRenderMap.get('unstyled'): any);
+      const configForType = blockRenderMap.get(blockType) || unstyledConfig;
       const wrapperTemplate = configForType.wrapper;
 
-      const Element =
-        configForType.element || blockRenderMap.get('unstyled').element;
+      const Element = configForType.element || unstyledConfig.element;
 
       const depth = block.getDepth();
       let className = '';

--- a/src/component/contents/exploration/DraftEditorBlockNode.react.js
+++ b/src/component/contents/exploration/DraftEditorBlockNode.react.js
@@ -18,6 +18,7 @@
 
 import type {BlockNodeRecord} from 'BlockNodeRecord';
 import type ContentState from 'ContentState';
+import type {DraftBlockRenderConfig} from 'DraftBlockRenderConfig';
 import type {DraftBlockRenderMap} from 'DraftBlockRenderMap';
 import type {DraftDecoratorType} from 'DraftDecoratorType';
 import type {DraftInlineStyle} from 'DraftInlineStyle';
@@ -25,6 +26,7 @@ import type EditorState from 'EditorState';
 import type SelectionState from 'SelectionState';
 import type {BidiDirection} from 'UnicodeBidiDirection';
 
+const DefaultDraftBlockRenderMap = require('DefaultDraftBlockRenderMap');
 const DraftEditorNode = require('DraftEditorNode.react');
 const DraftOffsetKey = require('DraftOffsetKey');
 const Scroll = require('Scroll');
@@ -134,12 +136,14 @@ const getDraftRenderConfig = (
   block: BlockNodeRecord,
   blockRenderMap: DraftBlockRenderMap,
 ): DraftRenderConfig => {
+  const unstyledConfig: DraftBlockRenderConfig =
+    blockRenderMap.get('unstyled') ||
+    (DefaultDraftBlockRenderMap.get('unstyled'): any);
   const configForType =
-    blockRenderMap.get(block.getType()) || blockRenderMap.get('unstyled');
+    blockRenderMap.get(block.getType()) || unstyledConfig;
 
   const wrapperTemplate = configForType.wrapper;
-  const Element =
-    configForType.element || blockRenderMap.get('unstyled').element;
+  const Element = configForType.element || unstyledConfig.element;
 
   return {
     Element,

--- a/src/component/contents/exploration/DraftEditorContentsExperimental.react.js
+++ b/src/component/contents/exploration/DraftEditorContentsExperimental.react.js
@@ -17,11 +17,13 @@
 'use strict';
 
 import type {BlockNodeRecord} from 'BlockNodeRecord';
+import type {DraftBlockRenderConfig} from 'DraftBlockRenderConfig';
 import type {DraftBlockRenderMap} from 'DraftBlockRenderMap';
 import type {DraftInlineStyle} from 'DraftInlineStyle';
 import type EditorState from 'EditorState';
 import type {BidiDirection} from 'UnicodeBidiDirection';
 
+const DefaultDraftBlockRenderMap = require('DefaultDraftBlockRenderMap');
 const DraftEditorBlockNode = require('DraftEditorBlockNode.react');
 const DraftOffsetKey = require('DraftOffsetKey');
 
@@ -142,9 +144,11 @@ class DraftEditorContentsExperimental extends React.Component<Props> {
         tree: editorState.getBlockTree(blockKey),
       };
 
+      const unstyledConfig: DraftBlockRenderConfig =
+        blockRenderMap.get('unstyled') ||
+        (DefaultDraftBlockRenderMap.get('unstyled'): any);
       const configForType =
-        blockRenderMap.get(nodeBlock.getType()) ||
-        blockRenderMap.get('unstyled');
+        blockRenderMap.get(nodeBlock.getType()) || unstyledConfig;
       const wrapperTemplate = configForType.wrapper;
       processedBlocks.push({
         /* $FlowFixMe[incompatible-type] (>=0.112.0 site=www,mobile) This

--- a/src/component/contents/exploration/DraftEditorDecoratedLeaves.react.js
+++ b/src/component/contents/exploration/DraftEditorDecoratedLeaves.react.js
@@ -18,7 +18,7 @@ import type {BlockNodeRecord} from 'BlockNodeRecord';
 import type ContentState from 'ContentState';
 import type {DraftDecoratorType} from 'DraftDecoratorType';
 import type {BidiDirection} from 'UnicodeBidiDirection';
-import type {Set} from 'immutable';
+import type {Map} from 'immutable';
 
 const DraftOffsetKey = require('DraftOffsetKey');
 const UnicodeBidi = require('UnicodeBidi');
@@ -34,7 +34,7 @@ type Props = {
   decoratorKey: string,
   direction: BidiDirection,
   text: string,
-  leafSet: Set<any>,
+  leafSet: Map<string, any>,
   ...
 };
 

--- a/src/component/contents/exploration/DraftEditorDecoratedLeaves.react.js
+++ b/src/component/contents/exploration/DraftEditorDecoratedLeaves.react.js
@@ -61,10 +61,9 @@ class DraftEditorDecoratedLeaves extends React.Component<Props> {
       0,
     );
 
-    const decoratedText = text.slice(
-      leavesForLeafSet.first().get('start'),
-      leavesForLeafSet.last().get('end'),
-    );
+    const start = leavesForLeafSet?.first()?.get('start') || 0;
+    const end = leavesForLeafSet?.last()?.get('end') || 0;
+    const decoratedText = text.slice(start, end);
 
     // Resetting dir to the same value on a child node makes Chrome/Firefox
     // confused on cursor movement. See http://jsfiddle.net/d157kLck/3/
@@ -80,7 +79,7 @@ class DraftEditorDecoratedLeaves extends React.Component<Props> {
         decoratedText={decoratedText}
         dir={dir}
         key={decoratorOffsetKey}
-        entityKey={block.getEntityAt(leafSet.get('start'))}
+        entityKey={block.getEntityAt(leafSet.get('start') || 0)}
         offsetKey={decoratorOffsetKey}>
         {children}
       </DecoratorComponent>

--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -193,7 +193,7 @@ const DraftEditorCompositionHandler = {
 
       const {start, end} = editorState
         .getBlockTree(blockKey)
-        .getIn([decoratorKey, 'leaves', leafKey]);
+        .getIn([decoratorKey, 'leaves', leafKey], {});
 
       const replacementRange = editorState.getSelection().merge({
         anchorKey: blockKey,

--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -114,7 +114,7 @@ function editOnInput(editor: DraftEditor, event: ?SyntheticInputEvent<>): void {
 
   const {start, end} = editorState
     .getBlockTree(blockKey)
-    .getIn([decoratorKey, 'leaves', leafKey]);
+    .getIn([decoratorKey, 'leaves', leafKey], {});
 
   const content = editorState.getCurrentContent();
   const block = content.getBlockForKey(blockKey);

--- a/src/component/utils/exploration/DraftTreeInvariants.js
+++ b/src/component/utils/exploration/DraftTreeInvariants.js
@@ -106,6 +106,10 @@ const DraftTreeInvariants = {
     const visitedStack = [];
     while (currentKey != null) {
       const currentNode = blockMap.get(currentKey);
+      if (currentNode == null) {
+        warning(true, '%s block should exist in block map', currentKey);
+        return false;
+      }
       const childKeys = currentNode.getChildKeys();
       const nextSiblingKey = currentNode.getNextSiblingKey();
       // if the node has children, add parent's next sibling to stack and go to children

--- a/src/component/utils/exploration/DraftTreeInvariants.js
+++ b/src/component/utils/exploration/DraftTreeInvariants.js
@@ -93,19 +93,16 @@ const DraftTreeInvariants = {
    */
   isConnectedTree(blockMap: BlockMap): boolean {
     // exactly one node has no previous sibling + no parent
-    const eligibleFirstNodes = blockMap
-      .toArray()
-      .filter(
-        block =>
-          block.getParentKey() == null && block.getPrevSiblingKey() == null,
-      );
-    if (eligibleFirstNodes.length !== 1) {
+    const eligibleFirstNodes = blockMap.filter(
+      block =>
+        block.getParentKey() == null && block.getPrevSiblingKey() == null,
+    );
+    if (eligibleFirstNodes.size !== 1) {
       warning(true, 'Tree is not connected. More or less than one first node');
       return false;
     }
-    const firstNode = eligibleFirstNodes.shift();
     let nodesSeen = 0;
-    let currentKey = firstNode.getKey();
+    let currentKey = eligibleFirstNodes.first().getKey();
     const visitedStack = [];
     while (currentKey != null) {
       const currentNode = blockMap.get(currentKey);
@@ -153,9 +150,10 @@ const DraftTreeInvariants = {
    * Checks that the block map is a connected tree with valid blocks
    */
   isValidTree(blockMap: BlockMap): boolean {
-    const blocks = blockMap.toArray();
     if (
-      !blocks.every(block => DraftTreeInvariants.isValidBlock(block, blockMap))
+      !blockMap.every(block =>
+        DraftTreeInvariants.isValidBlock(block, blockMap),
+      )
     ) {
       return false;
     }

--- a/src/component/utils/exploration/DraftTreeInvariants.js
+++ b/src/component/utils/exploration/DraftTreeInvariants.js
@@ -26,7 +26,7 @@ const DraftTreeInvariants = {
     const parentKey = block.getParentKey();
     if (parentKey != null) {
       const parent = blockMap.get(parentKey);
-      if (!parent.getChildKeys().includes(key)) {
+      if (!parent || !parent.getChildKeys().includes(key)) {
         warning(true, 'Tree is missing parent -> child pointer on %s', key);
         return false;
       }
@@ -34,7 +34,7 @@ const DraftTreeInvariants = {
 
     // is its children's parent
     const children = block.getChildKeys().map(k => blockMap.get(k));
-    if (!children.every(c => c.getParentKey() === key)) {
+    if (!children.every(c => c && c.getParentKey() === key)) {
       warning(true, 'Tree is missing child -> parent pointer on %s', key);
       return false;
     }
@@ -43,7 +43,7 @@ const DraftTreeInvariants = {
     const prevSiblingKey = block.getPrevSiblingKey();
     if (prevSiblingKey != null) {
       const prevSibling = blockMap.get(prevSiblingKey);
-      if (prevSibling.getNextSiblingKey() !== key) {
+      if (!prevSibling || prevSibling.getNextSiblingKey() !== key) {
         warning(
           true,
           "Tree is missing nextSibling pointer on %s's prevSibling",
@@ -57,7 +57,7 @@ const DraftTreeInvariants = {
     const nextSiblingKey = block.getNextSiblingKey();
     if (nextSiblingKey != null) {
       const nextSibling = blockMap.get(nextSiblingKey);
-      if (nextSibling.getPrevSiblingKey() !== key) {
+      if (!nextSibling || nextSibling.getPrevSiblingKey() !== key) {
         warning(
           true,
           "Tree is missing prevSibling pointer on %s's nextSibling",
@@ -115,7 +115,7 @@ const DraftTreeInvariants = {
         }
         const children = childKeys.map(k => blockMap.get(k));
         const firstNode = children.find(
-          block => block.getPrevSiblingKey() == null,
+          block => block && block.getPrevSiblingKey() == null,
         );
         if (firstNode == null) {
           warning(true, '%s has no first child', currentKey);

--- a/src/model/encoding/convertFromHTMLToContentBlocks.js
+++ b/src/model/encoding/convertFromHTMLToContentBlocks.js
@@ -516,8 +516,9 @@ class ContentBlocksBuilder {
       }
 
       let newStyle = style;
-      if (HTMLTagToRawInlineStyleMap.has(nodeName)) {
-        newStyle = newStyle.add(HTMLTagToRawInlineStyleMap.get(nodeName));
+      const rawInlineStyle = HTMLTagToRawInlineStyleMap.get(nodeName);
+      if (rawInlineStyle != null) {
+        newStyle = newStyle.add(rawInlineStyle);
       }
       newStyle = styleFromNodeAttributes(node, newStyle);
       const inlineStyle = detectInlineStyle(node);

--- a/src/model/immutable/ContentState.js
+++ b/src/model/immutable/ContentState.js
@@ -91,6 +91,7 @@ class ContentState extends ContentStateRecord {
   }
 
   getBlockForKey(key: string): BlockNodeRecord {
+    /* $FlowFixMe[incompatible-type] OrderedMap#get() can return undefined */
     const block: BlockNodeRecord = this.getBlockMap().get(key);
     return block;
   }

--- a/src/model/immutable/ContentState.js
+++ b/src/model/immutable/ContentState.js
@@ -128,7 +128,9 @@ class ContentState extends ContentStateRecord {
   }
 
   getBlocksAsArray(): Array<BlockNodeRecord> {
-    return this.getBlockMap().toArray();
+    return this.getBlockMap()
+      .toIndexedSeq()
+      .toArray();
   }
 
   getFirstBlock(): BlockNodeRecord {

--- a/src/model/immutable/ContentState.js
+++ b/src/model/immutable/ContentState.js
@@ -277,9 +277,9 @@ class ContentState extends ContentStateRecord {
   static fromJS(state: ContentStateRawType): ContentState {
     return new ContentState({
       ...state,
-      blockMap: OrderedMap(state.blockMap).map(
-        ContentState.createContentBlockFromJS,
-      ),
+      blockMap: state.blockMap
+        ? OrderedMap(state.blockMap).map(ContentState.createContentBlockFromJS)
+        : OrderedMap(),
       selectionBefore: new SelectionState(state.selectionBefore),
       selectionAfter: new SelectionState(state.selectionAfter),
     });

--- a/src/model/modifier/exploration/DraftTreeOperations.js
+++ b/src/model/modifier/exploration/DraftTreeOperations.js
@@ -272,8 +272,8 @@ const updateAsSiblingsChild = (
   }
   // remove the node as a child of its current parent
   const parentKey = block.getParentKey();
-  if (parentKey != null) {
-    const parent = newBlockMap.get(parentKey);
+  const parent = newBlockMap.get(parentKey || '');
+  if (parentKey != null && parent != null) {
     newBlockMap = newBlockMap.set(
       parentKey,
       parent.merge({
@@ -384,9 +384,9 @@ const moveChildUp = (blockMap: BlockMap, key: string): BlockMap => {
 
   // For both cases, also link to parent's parent
   const grandparentKey = parent.getParentKey();
-  if (grandparentKey != null) {
-    const grandparentInsertPosition = newBlockMap
-      .get(grandparentKey)
+  const grandparent = newBlockMap.get(grandparentKey || '');
+  if (grandparentKey != null && grandparent != null) {
+    const grandparentInsertPosition = grandparent
       .getChildKeys()
       .findIndex(n => n === parentKey);
     newBlockMap = updateParentChild(

--- a/src/model/modifier/exploration/DraftTreeOperations.js
+++ b/src/model/modifier/exploration/DraftTreeOperations.js
@@ -220,7 +220,7 @@ const updateAsSiblingsChild = (
   invariant(newParentKey != null, 'sibling is null');
   const newParent = blockMap.get(newParentKey);
   invariant(
-    newParent !== null && newParent.getText() === '',
+    newParent != null && newParent.getText() === '',
     'parent must be a valid node',
   );
   let newBlockMap = blockMap;
@@ -309,7 +309,7 @@ const moveChildUp = (blockMap: BlockMap, key: string): BlockMap => {
   }
 
   let parent = blockMap.get(parentKey);
-  invariant(parent !== null, 'parent must exist in block map');
+  invariant(parent != null, 'parent must exist in block map');
   let newBlockMap = blockMap;
   const childIndex = parent.getChildKeys().indexOf(key);
   invariant(
@@ -453,7 +453,7 @@ const mergeBlocks = (blockMap: BlockMap, key: string): BlockMap => {
   verifyTree(blockMap);
   // current block must be a non-leaf
   const block = blockMap.get(key);
-  invariant(block !== null, 'block must exist in block map');
+  invariant(block != null, 'block must exist in block map');
   invariant(block.getChildKeys().count() > 0, 'block must be a non-leaf');
   // next block must exist & be a non-leaf
   const nextBlockKey = block.getNextSiblingKey();

--- a/src/model/modifier/exploration/NestedRichTextEditorUtil.js
+++ b/src/model/modifier/exploration/NestedRichTextEditorUtil.js
@@ -467,9 +467,11 @@ const NestedRichTextEditorUtil: RichTextUtils = {
           depth > 0
         ) {
           let newBlockMap = onUntab(content.getBlockMap(), block);
+          const newBlock = newBlockMap.get(key);
+          invariant(newBlock != null, 'block must exist in new block map');
           newBlockMap = newBlockMap.set(
             key,
-            newBlockMap.get(key).merge({depth: depth - 1}),
+            newBlock.merge({depth: depth - 1}),
           );
           return content.merge({blockMap: newBlockMap});
         }
@@ -523,13 +525,12 @@ const onUntab = (blockMap: BlockMap, block: ContentBlockNode): BlockMap => {
         ? block.merge({parent: newBlock.getKey()})
         : block,
     );
+    const nextSibling = blockMap.get(nextSiblingKey);
+    invariant(nextSibling != null, 'block must have a next sibling here');
     // update the next/previous pointers for the children at the split
     blockMap = blockMap
       .set(key, block.merge({nextSibling: null}))
-      .set(
-        nextSiblingKey,
-        blockMap.get(nextSiblingKey).merge({prevSibling: null}),
-      );
+      .set(nextSiblingKey, nextSibling.merge({prevSibling: null}));
     const parentNextSiblingKey = parent.getNextSiblingKey();
     if (parentNextSiblingKey != null) {
       blockMap = DraftTreeOperations.updateSibling(
@@ -554,8 +555,11 @@ const onUntab = (blockMap: BlockMap, block: ContentBlockNode): BlockMap => {
     while (parent != null) {
       const children = parent.getChildKeys();
       const firstChildKey = children.first();
-      invariant(firstChildKey != null, 'parent must have at least one child');
-      const firstChild = blockMap.get(firstChildKey);
+      const firstChild = blockMap.get(firstChildKey || '');
+      invariant(
+        firstChildKey != null && firstChild != null,
+        'parent must have at least one child',
+      );
       if (firstChild.getChildKeys().count() === 0) {
         break;
       } else {

--- a/src/model/modifier/exploration/NestedRichTextEditorUtil.js
+++ b/src/model/modifier/exploration/NestedRichTextEditorUtil.js
@@ -244,7 +244,6 @@ const NestedRichTextEditorUtil: RichTextUtils = {
   currentBlockContainsLink: (editorState: EditorState): boolean => {
     const selection = editorState.getSelection();
     const contentState = editorState.getCurrentContent();
-    const entityMap = contentState.getEntityMap();
     return contentState
       .getBlockForKey(selection.getAnchorKey())
       .getCharacterList()

--- a/src/model/modifier/exploration/NestedRichTextEditorUtil.js
+++ b/src/model/modifier/exploration/NestedRichTextEditorUtil.js
@@ -168,15 +168,12 @@ const NestedRichTextEditorUtil: RichTextUtils = {
     );
 
     if (withoutBlockStyle) {
+      const blockMap = withoutBlockStyle.getBlockMap();
+      const blockType = blockMap.get(currentBlock.getKey())?.getType();
       return EditorState.push(
         editorState,
         withoutBlockStyle,
-        withoutBlockStyle
-          .getBlockMap()
-          .get(currentBlock.getKey())
-          .getType() === 'unstyled'
-          ? 'change-block-type'
-          : 'adjust-depth',
+        blockType === 'unstyled' ? 'change-block-type' : 'adjust-depth',
       );
     }
 

--- a/src/model/modifier/exploration/NestedRichTextEditorUtil.js
+++ b/src/model/modifier/exploration/NestedRichTextEditorUtil.js
@@ -487,10 +487,10 @@ const onUntab = (blockMap: BlockMap, block: ContentBlockNode): BlockMap => {
   const key = block.getKey();
   const parentKey = block.getParentKey();
   const nextSiblingKey = block.getNextSiblingKey();
-  if (parentKey == null) {
+  const parent = blockMap.get(parentKey || '');
+  if (parentKey == null || parent == null) {
     return blockMap;
   }
-  const parent = blockMap.get(parentKey);
   const existingChildren = parent.getChildKeys();
   const blockIndex = existingChildren.indexOf(key);
   if (blockIndex === 0 || blockIndex === existingChildren.count() - 1) {
@@ -577,7 +577,11 @@ const onUntab = (blockMap: BlockMap, block: ContentBlockNode): BlockMap => {
       parent != null // parent may have been deleted
         ? parent.getPrevSiblingKey()
         : null;
-    if (prevSiblingKey != null && parent.getChildKeys().count() > 0) {
+    if (
+      prevSiblingKey != null &&
+      parent != null &&
+      parent.getChildKeys().count() > 0
+    ) {
       const prevSibling = blockMap.get(prevSiblingKey);
       if (prevSibling != null && prevSibling.getChildKeys().count() > 0) {
         blockMap = DraftTreeOperations.mergeBlocks(blockMap, prevSiblingKey);

--- a/src/model/modifier/exploration/__tests__/DraftTreeOperations-test.js
+++ b/src/model/modifier/exploration/__tests__/DraftTreeOperations-test.js
@@ -115,7 +115,7 @@ test('test adding a sibling', () => {
       parent: null,
     }),
     X: newBlockMap.get('X').merge({
-      children: ['B'],
+      children: Immutable.List(['B']),
     }),
   });
   expect(newBlockMap).toMatchSnapshot();

--- a/src/model/modifier/exploration/__tests__/NestedRichTextEditorUtil-test.js
+++ b/src/model/modifier/exploration/__tests__/NestedRichTextEditorUtil-test.js
@@ -125,7 +125,10 @@ const assertNestedUtilOperation = (
 
   const expected =
     result instanceof EditorState
-      ? result.getCurrentContent().getBlockMap().toJS()
+      ? result
+          .getCurrentContent()
+          .getBlockMap()
+          .toJS()
       : result;
 
   expect(expected).toMatchSnapshot();

--- a/src/model/transaction/ContentStateInlineStyle.js
+++ b/src/model/transaction/ContentStateInlineStyle.js
@@ -19,7 +19,7 @@ const CharacterMetadata = require('CharacterMetadata');
 const {Map} = require('immutable');
 
 const ContentStateInlineStyle = {
-  add: function (
+  add: function(
     contentState: ContentState,
     selectionState: SelectionState,
     inlineStyle: string,
@@ -27,7 +27,7 @@ const ContentStateInlineStyle = {
     return modifyInlineStyle(contentState, selectionState, inlineStyle, true);
   },
 
-  remove: function (
+  remove: function(
     contentState: ContentState,
     selectionState: SelectionState,
     inlineStyle: string,

--- a/src/model/transaction/ContentStateInlineStyle.js
+++ b/src/model/transaction/ContentStateInlineStyle.js
@@ -17,6 +17,7 @@ import type SelectionState from 'SelectionState';
 const CharacterMetadata = require('CharacterMetadata');
 
 const {Map} = require('immutable');
+const invariant = require('invariant');
 
 const ContentStateInlineStyle = {
   add: function(
@@ -47,11 +48,13 @@ function modifyInlineStyle(
   const startOffset = selectionState.getStartOffset();
   const endKey = selectionState.getEndKey();
   const endOffset = selectionState.getEndOffset();
+  const endBlock = blockMap.get(endKey);
+  invariant(endBlock != null, 'selection end block must exist');
 
   const newBlocks = blockMap
     .skipUntil((_, k) => k === startKey)
     .takeUntil((_, k) => k === endKey)
-    .concat(Map([[endKey, blockMap.get(endKey)]]))
+    .concat(Map([[endKey, endBlock]]))
     .map((block, blockKey) => {
       let sliceStart;
       let sliceEnd;

--- a/src/model/transaction/ContentStateInlineStyle.js
+++ b/src/model/transaction/ContentStateInlineStyle.js
@@ -68,12 +68,14 @@ function modifyInlineStyle(
       let current;
       while (sliceStart < sliceEnd) {
         current = chars.get(sliceStart);
-        chars = chars.set(
-          sliceStart,
-          addOrRemove
-            ? CharacterMetadata.applyStyle(current, inlineStyle)
-            : CharacterMetadata.removeStyle(current, inlineStyle),
-        );
+        if (current != null) {
+          chars = chars.set(
+            sliceStart,
+            addOrRemove
+              ? CharacterMetadata.applyStyle(current, inlineStyle)
+              : CharacterMetadata.removeStyle(current, inlineStyle),
+          );
+        }
         sliceStart++;
       }
 

--- a/src/model/transaction/adjustBlockDepthForContentState.js
+++ b/src/model/transaction/adjustBlockDepthForContentState.js
@@ -14,6 +14,8 @@
 import type ContentState from 'ContentState';
 import type SelectionState from 'SelectionState';
 
+const invariant = require('invariant');
+
 function adjustBlockDepthForContentState(
   contentState: ContentState,
   selectionState: SelectionState,
@@ -23,12 +25,14 @@ function adjustBlockDepthForContentState(
   const startKey = selectionState.getStartKey();
   const endKey = selectionState.getEndKey();
   const blockMap = contentState.getBlockMap();
+  const endBlock = blockMap.get(endKey);
+  invariant(endBlock != null, 'selection end must exist in block map');
 
   const newBlocks = blockMap
     .toSeq()
     .skipUntil((_, k) => k === startKey)
     .takeUntil((_, k) => k === endKey)
-    .concat([[endKey, blockMap.get(endKey)]])
+    .concat([[endKey, endBlock]])
     .map(block => {
       let depth = block.getDepth() + adjustment;
       depth = Math.max(0, depth);

--- a/src/model/transaction/adjustBlockDepthForContentState.js
+++ b/src/model/transaction/adjustBlockDepthForContentState.js
@@ -22,8 +22,9 @@ function adjustBlockDepthForContentState(
 ): ContentState {
   const startKey = selectionState.getStartKey();
   const endKey = selectionState.getEndKey();
-  let blockMap = contentState.getBlockMap();
-  const blocks = blockMap
+  const blockMap = contentState.getBlockMap();
+
+  const newBlocks = blockMap
     .toSeq()
     .skipUntil((_, k) => k === startKey)
     .takeUntil((_, k) => k === endKey)
@@ -37,10 +38,8 @@ function adjustBlockDepthForContentState(
       return block.set('depth', depth);
     });
 
-  blockMap = blockMap.merge(blocks);
-
   return contentState.merge({
-    blockMap,
+    blockMap: blockMap.merge(newBlocks),
     selectionBefore: selectionState,
     selectionAfter: selectionState,
   });

--- a/src/model/transaction/applyEntityToContentBlock.js
+++ b/src/model/transaction/applyEntityToContentBlock.js
@@ -24,10 +24,13 @@ function applyEntityToContentBlock(
   let start = startArg;
   let characterList = contentBlock.getCharacterList();
   while (start < end) {
-    characterList = characterList.set(
-      start,
-      CharacterMetadata.applyEntity(characterList.get(start), entityKey),
-    );
+    const current = characterList.get(start);
+    if (current != null) {
+      characterList = characterList.set(
+        start,
+        CharacterMetadata.applyEntity(current, entityKey),
+      );
+    }
     start++;
   }
   return contentBlock.set('characterList', characterList);

--- a/src/model/transaction/applyEntityToContentState.js
+++ b/src/model/transaction/applyEntityToContentState.js
@@ -16,6 +16,7 @@ import type SelectionState from 'SelectionState';
 
 const applyEntityToContentBlock = require('applyEntityToContentBlock');
 const {OrderedMap} = require('immutable');
+const invariant = require('invariant');
 
 function applyEntityToContentState(
   contentState: ContentState,
@@ -27,12 +28,14 @@ function applyEntityToContentState(
   const startOffset = selectionState.getStartOffset();
   const endKey = selectionState.getEndKey();
   const endOffset = selectionState.getEndOffset();
+  const endBlock = blockMap.get(endKey);
+  invariant(endBlock != null, 'selection end must exist in block map');
 
   const newBlocks = blockMap
     .skipUntil((_, k) => k === startKey)
     .takeUntil((_, k) => k === endKey)
     .toOrderedMap()
-    .merge(OrderedMap([[endKey, blockMap.get(endKey)]]))
+    .merge(OrderedMap([[endKey, endBlock]]))
     .map((block, blockKey) => {
       const sliceStart = blockKey === startKey ? startOffset : 0;
       const sliceEnd = blockKey === endKey ? endOffset : block.getLength();

--- a/src/model/transaction/applyEntityToContentState.js
+++ b/src/model/transaction/applyEntityToContentState.js
@@ -15,7 +15,7 @@ import type ContentState from 'ContentState';
 import type SelectionState from 'SelectionState';
 
 const applyEntityToContentBlock = require('applyEntityToContentBlock');
-const Immutable = require('immutable');
+const {OrderedMap} = require('immutable');
 
 function applyEntityToContentState(
   contentState: ContentState,
@@ -32,7 +32,7 @@ function applyEntityToContentState(
     .skipUntil((_, k) => k === startKey)
     .takeUntil((_, k) => k === endKey)
     .toOrderedMap()
-    .merge(Immutable.OrderedMap([[endKey, blockMap.get(endKey)]]))
+    .merge(OrderedMap([[endKey, blockMap.get(endKey)]]))
     .map((block, blockKey) => {
       const sliceStart = blockKey === startKey ? startOffset : 0;
       const sliceEnd = blockKey === endKey ? endOffset : block.getLength();

--- a/src/model/transaction/insertFragmentIntoContentState.js
+++ b/src/model/transaction/insertFragmentIntoContentState.js
@@ -40,6 +40,7 @@ const updateExistingBlock = (
   mergeBlockData?: BlockDataMergeBehavior = 'REPLACE_WITH_NEW_DATA',
 ): ContentState => {
   const targetBlock = blockMap.get(targetKey);
+  invariant(targetBlock != null, 'target block must exist in block map');
   const text = targetBlock.getText();
   const chars = targetBlock.getCharacterList();
   const finalKey = targetKey;
@@ -219,6 +220,7 @@ const updateBlockMapLinks = (
     // update targetBlock parent child links
     if (targetParentKey) {
       const targetParent = blockMap.get(targetParentKey);
+      invariant(targetParent != null, 'target parent must exist in block map');
       const originalTargetParentChildKeys = targetParent.getChildKeys();
 
       const targetBlockIndex = originalTargetParentChildKeys.indexOf(targetKey);
@@ -249,6 +251,7 @@ const insertFragment = (
   const newBlockArr = [];
   const fragmentSize = fragment.size;
   const target = blockMap.get(targetKey);
+  invariant(target != null, 'target block must exist in block map');
   const head = fragment.first();
   const tail = fragment.last();
   const finalOffset = tail.getLength();

--- a/src/model/transaction/insertFragmentIntoContentState.js
+++ b/src/model/transaction/insertFragmentIntoContentState.js
@@ -189,15 +189,12 @@ const updateBlockMapLinks = (
       blockMapState.setIn([targetKey, 'nextSibling'], headKey);
       blockMapState.setIn([headKey, 'prevSibling'], targetKey);
     } else {
-      // update the target block that had the fragment head contents merged into it
-      blockMapState.setIn(
-        [targetKey, 'nextSibling'],
-        fragmentHeadBlock.getNextSiblingKey(),
-      );
-      blockMapState.setIn(
-        [fragmentHeadBlock.getNextSiblingKey(), 'prevSibling'],
-        targetKey,
-      );
+      const nextSiblingKey = fragmentHeadBlock.getNextSiblingKey();
+      if (nextSiblingKey != null) {
+        // update the target block that had the fragment head contents merged into it
+        blockMapState.setIn([targetKey, 'nextSibling'], nextSiblingKey);
+        blockMapState.setIn([nextSiblingKey, 'prevSibling'], targetKey);
+      }
     }
 
     // update the last root block fragment

--- a/src/model/transaction/insertTextIntoContentState.js
+++ b/src/model/transaction/insertTextIntoContentState.js
@@ -45,6 +45,7 @@ function insertTextIntoContentState(
   const key = selectionState.getStartKey();
   const offset = selectionState.getStartOffset();
   const block = blockMap.get(key);
+  invariant(block != null, 'selection start must exist in block map');
   const blockText = block.getText();
 
   const newBlock = block.merge({

--- a/src/model/transaction/modifyBlockForContentState.js
+++ b/src/model/transaction/modifyBlockForContentState.js
@@ -15,9 +15,7 @@ import type {BlockNodeRecord} from 'BlockNodeRecord';
 import type ContentState from 'ContentState';
 import type SelectionState from 'SelectionState';
 
-const Immutable = require('immutable');
-
-const {Map} = Immutable;
+const {Map} = require('immutable');
 
 function modifyBlockForContentState(
   contentState: ContentState,

--- a/src/model/transaction/modifyBlockForContentState.js
+++ b/src/model/transaction/modifyBlockForContentState.js
@@ -16,6 +16,7 @@ import type ContentState from 'ContentState';
 import type SelectionState from 'SelectionState';
 
 const {Map} = require('immutable');
+const invariant = require('invariant');
 
 function modifyBlockForContentState(
   contentState: ContentState,
@@ -25,11 +26,14 @@ function modifyBlockForContentState(
   const startKey = selectionState.getStartKey();
   const endKey = selectionState.getEndKey();
   const blockMap = contentState.getBlockMap();
+  const endBlock = blockMap.get(endKey);
+  invariant(endBlock != null, 'selection end must exist in block map');
+
   const newBlocks = blockMap
     .toSeq()
     .skipUntil((_, k) => k === startKey)
     .takeUntil((_, k) => k === endKey)
-    .concat(Map([[endKey, blockMap.get(endKey)]]))
+    .concat(Map([[endKey, endBlock]]))
     .map(operation);
 
   return contentState.merge({

--- a/src/model/transaction/randomizeBlockMapKeys.js
+++ b/src/model/transaction/randomizeBlockMapKeys.js
@@ -62,8 +62,8 @@ const randomizeContentBlockNodeKeys = (blockMap: BlockMap): BlockMap => {
             }
           }
 
-          if (parentKey && blockMapState.get(parentKey)) {
-            const parentBlock = blockMapState.get(parentKey);
+          const parentBlock = blockMapState.get(parentKey || '');
+          if (parentKey && parentBlock) {
             const parentChildrenList = parentBlock.getChildKeys();
             blockMapState.setIn(
               [parentKey, 'children'],
@@ -84,7 +84,7 @@ const randomizeContentBlockNodeKeys = (blockMap: BlockMap): BlockMap => {
               );
             }
 
-            lastRootBlock = blockMapState.get(oldKey);
+            lastRootBlock = blockMapState.get(oldKey) || lastRootBlock;
           }
 
           childrenKeys.forEach(childKey => {

--- a/src/model/transaction/randomizeBlockMapKeys.js
+++ b/src/model/transaction/randomizeBlockMapKeys.js
@@ -101,7 +101,7 @@ const randomizeContentBlockNodeKeys = (blockMap: BlockMap): BlockMap => {
         });
       })
       .toArray()
-      .map(block => [
+      .map(([_, block]) => [
         newKeysRef[block.getKey()],
         block.set('key', newKeysRef[block.getKey()]),
       ]),
@@ -110,7 +110,7 @@ const randomizeContentBlockNodeKeys = (blockMap: BlockMap): BlockMap => {
 
 const randomizeContentBlockKeys = (blockMap: BlockMap): BlockMap => {
   return OrderedMap(
-    blockMap.toArray().map(block => {
+    blockMap.toArray().map(([_, block]) => {
       const key = generateRandomKey();
       return [key, block.set('key', key)];
     }),

--- a/src/model/transaction/removeEntitiesAtEdges.js
+++ b/src/model/transaction/removeEntitiesAtEdges.js
@@ -32,6 +32,7 @@ function removeEntitiesAtEdges(
   const startKey = selectionState.getStartKey();
   const startOffset = selectionState.getStartOffset();
   const startBlock = blockMap.get(startKey);
+  invariant(startBlock != null, 'selection start must exist in block map');
   const updatedStart = removeForBlock(contentState, startBlock, startOffset);
 
   if (updatedStart !== startBlock) {
@@ -45,6 +46,7 @@ function removeEntitiesAtEdges(
     endBlock = updatedStart;
   }
 
+  invariant(endBlock != null, 'selection end must exist in block map');
   const updatedEnd = removeForBlock(contentState, endBlock, endOffset);
 
   if (updatedEnd !== endBlock) {

--- a/src/model/transaction/removeEntitiesAtEdges.js
+++ b/src/model/transaction/removeEntitiesAtEdges.js
@@ -121,7 +121,12 @@ function removeForBlock(
       let current;
       while (start < end) {
         current = chars.get(start);
-        chars = chars.set(start, CharacterMetadata.applyEntity(current, null));
+        if (current != null) {
+          chars = chars.set(
+            start,
+            CharacterMetadata.applyEntity(current, null),
+          );
+        }
         start++;
       }
       return block.set('characterList', chars);

--- a/src/model/transaction/removeRangeFromContentState.js
+++ b/src/model/transaction/removeRangeFromContentState.js
@@ -355,18 +355,21 @@ const removeRangeFromContentState = (
     endOffset === 0 &&
     endBlock.getParentKey() === startKey &&
     endBlock.getPrevSiblingKey() == null;
-  const newBlocks = shouldDeleteParent
-    ? Map([[startKey, null]])
-    : blockMap
-        .toSeq()
-        .skipUntil((_, k) => k === startKey)
-        .takeUntil((_, k) => k === endKey)
-        .filter((_, k) => parentAncestors.indexOf(k) === -1)
-        .concat(Map([[endKey, null]]))
-        .map((_, k) => {
-          return k === startKey ? modifiedStart : null;
-        });
-  let updatedBlockMap = blockMap.merge(newBlocks).filter(block => !!block);
+  let updatedBlockMap: BlockMap;
+  if (shouldDeleteParent) {
+    updatedBlockMap = blockMap.delete(startKey);
+  } else {
+    const newBlocks = blockMap
+      .toSeq()
+      .skipUntil((_, k) => k === startKey)
+      .takeUntil((_, k) => k === endKey)
+      .filter((_, k) => parentAncestors.indexOf(k) === -1)
+      .concat(Map([[endKey, null]]))
+      .map((_, k) => {
+        return k === startKey ? modifiedStart : null;
+      });
+    updatedBlockMap = blockMap.merge(newBlocks).filter(block => !!block);
+  }
 
   // Only update tree block pointers if the range is across blocks
   if (isExperimentalTreeBlock && startBlock !== endBlock) {

--- a/src/model/transaction/removeRangeFromContentState.js
+++ b/src/model/transaction/removeRangeFromContentState.js
@@ -19,9 +19,7 @@ import type SelectionState from 'SelectionState';
 const ContentBlockNode = require('ContentBlockNode');
 
 const getNextDelimiterBlockKey = require('getNextDelimiterBlockKey');
-const Immutable = require('immutable');
-
-const {List, Map} = Immutable;
+const {List, Map} = require('immutable');
 
 const transformBlock = (
   key: ?string,

--- a/src/model/transaction/removeRangeFromContentState.js
+++ b/src/model/transaction/removeRangeFromContentState.js
@@ -86,7 +86,7 @@ const getNextDelimitersBlockKeys = (
     const block = blockMap.get(nextDelimiter);
     nextDelimiters.push(nextDelimiter);
 
-    // we do not need to keep checking all root node siblings, just the first occurance
+    // we do not need to keep checking all root node siblings, just the first occurence
     nextDelimiter = block.getParentKey()
       ? getNextDelimiterBlockKey(block, blockMap)
       : null;
@@ -306,7 +306,7 @@ const removeRangeFromContentState = (
   let parentAncestors = [];
 
   if (isExperimentalTreeBlock) {
-    const endBlockchildrenKeys = endBlock.getChildKeys();
+    const endBlockChildrenKeys = endBlock.getChildKeys();
     const endBlockAncestors = getAncestorsKeys(endKey, blockMap);
 
     // endBlock has unselected siblings so we can not remove its ancestors parents
@@ -315,7 +315,7 @@ const removeRangeFromContentState = (
     }
 
     // endBlock has children so can not remove this block or any of its ancestors
-    if (!endBlockchildrenKeys.isEmpty()) {
+    if (!endBlockChildrenKeys.isEmpty()) {
       parentAncestors = parentAncestors.concat(
         endBlockAncestors.concat([endKey]),
       );

--- a/src/model/transaction/removeRangeFromContentState.js
+++ b/src/model/transaction/removeRangeFromContentState.js
@@ -20,6 +20,7 @@ const ContentBlockNode = require('ContentBlockNode');
 
 const getNextDelimiterBlockKey = require('getNextDelimiterBlockKey');
 const {List, Map} = require('immutable');
+const invariant = require('invariant');
 
 const transformBlock = (
   key: ?string,
@@ -254,6 +255,7 @@ const updateBlockMapLinks = (
       });
       if (newParentKey != null) {
         const newParent = blockMap.get(newParentKey);
+        invariant(newParent != null, 'new parent must exist in block map');
         transformBlock(newParentKey, blocks, block =>
           block.merge({
             children: newParent
@@ -295,6 +297,8 @@ const removeRangeFromContentState = (
 
   const startBlock = blockMap.get(startKey);
   const endBlock = blockMap.get(endKey);
+  invariant(startBlock != null, 'selection start must exist in block map');
+  invariant(endBlock != null, 'selection end must exist in block map');
 
   // we assume that ContentBlockNode and ContentBlocks are not mixed together
   const isExperimentalTreeBlock = startBlock instanceof ContentBlockNode;

--- a/src/model/transaction/removeRangeFromContentState.js
+++ b/src/model/transaction/removeRangeFromContentState.js
@@ -80,14 +80,15 @@ const getNextDelimitersBlockKeys = (
   }
 
   let nextDelimiter = getNextDelimiterBlockKey(block, blockMap);
-  while (nextDelimiter && blockMap.get(nextDelimiter)) {
-    const block = blockMap.get(nextDelimiter);
+  let nextBlock = blockMap.get(nextDelimiter || '');
+  while (nextDelimiter && nextBlock) {
     nextDelimiters.push(nextDelimiter);
 
     // we do not need to keep checking all root node siblings, just the first occurence
-    nextDelimiter = block.getParentKey()
-      ? getNextDelimiterBlockKey(block, blockMap)
+    nextDelimiter = nextBlock.getParentKey()
+      ? getNextDelimiterBlockKey(nextBlock, blockMap)
       : null;
+    nextBlock = blockMap.get(nextDelimiter || '');
   }
 
   return nextDelimiters;
@@ -267,8 +268,8 @@ const updateBlockMapLinks = (
       // last child of deleted parent should point to next sibling
       transformBlock(
         startBlock.getChildKeys().find(key => {
-          const block = (blockMap.get(key): ContentBlockNode);
-          return block.getNextSiblingKey() === null;
+          const block = blockMap.get(key);
+          return block && block.getNextSiblingKey() === null;
         }),
         blocks,
         block =>

--- a/src/model/transaction/removeRangeFromContentState.js
+++ b/src/model/transaction/removeRangeFromContentState.js
@@ -369,6 +369,7 @@ const removeRangeFromContentState = (
       .filter((_, k) => parentAncestors.indexOf(k) === -1)
       .concat(Map([[endKey, null]]))
       .map((_, k) => {
+        // $FlowFixMe[incompatible-return] flow expects a consistent value type
         return k === startKey ? modifiedStart : null;
       });
     updatedBlockMap = blockMap.merge(newBlocks).filter(block => !!block);

--- a/src/model/transaction/removeRangeFromContentState.js
+++ b/src/model/transaction/removeRangeFromContentState.js
@@ -105,13 +105,12 @@ const getNextValidSibling = (
 
   // note that we need to make sure we refer to the original block since this
   // function is called within a withMutations
-  let nextValidSiblingKey = originalBlockMap
-    .get(block.getKey())
-    .getNextSiblingKey();
+  const originalBlock = originalBlockMap.get(block.getKey());
+  let nextValidSiblingKey = originalBlock?.getNextSiblingKey();
 
   while (nextValidSiblingKey && !blockMap.get(nextValidSiblingKey)) {
     nextValidSiblingKey =
-      originalBlockMap.get(nextValidSiblingKey).getNextSiblingKey() || null;
+      originalBlockMap.get(nextValidSiblingKey)?.getNextSiblingKey() || null;
   }
 
   return nextValidSiblingKey;
@@ -128,13 +127,12 @@ const getPrevValidSibling = (
 
   // note that we need to make sure we refer to the original block since this
   // function is called within a withMutations
-  let prevValidSiblingKey = originalBlockMap
-    .get(block.getKey())
-    .getPrevSiblingKey();
+  const originalBlock = originalBlockMap.get(block.getKey());
+  let prevValidSiblingKey = originalBlock?.getPrevSiblingKey();
 
   while (prevValidSiblingKey && !blockMap.get(prevValidSiblingKey)) {
     prevValidSiblingKey =
-      originalBlockMap.get(prevValidSiblingKey).getPrevSiblingKey() || null;
+      originalBlockMap.get(prevValidSiblingKey)?.getPrevSiblingKey() || null;
   }
 
   return prevValidSiblingKey;

--- a/src/model/transaction/splitBlockInContentState.js
+++ b/src/model/transaction/splitBlockInContentState.js
@@ -96,6 +96,7 @@ const splitBlockInContentState = (
   const key = selectionState.getAnchorKey();
   const blockMap = contentState.getBlockMap();
   const blockToSplit = blockMap.get(key);
+  invariant(blockToSplit != null, 'Selection anchor must exist in block map.');
   const text = blockToSplit.getText();
 
   if (!text) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4669,10 +4669,10 @@ ignore@^5.0.0, ignore@^5.1.1:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
   integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
 
-immutable@~3.7.4:
-  version "3.7.6"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.7.6.tgz#13b4d3cb12befa15482a26fe1b2ebae640071e4b"
-  integrity sha1-E7TTyxK++hVIKib+Gy665kAHHks=
+immutable@~4.0.0-rc.12:
+  version "4.0.0-rc.12"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0-rc.12.tgz#ca59a7e4c19ae8d9bf74a97bdf0f6e2f2a5d0217"
+  integrity sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A==
 
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
#### Summary

this is the follow-on PR to #2955 that actually upgrades draft.js’ immutable.js dependency to v4 and isn’t compatible with v3. this branch was branched off of `immutable-4-prep` and includes 4 additional commits:

* Upgrade immutable dep from 3.7.4 → 4.0.0-rc.12 803de93
* Update use of `KeyedCollection.toArray()` to be compatible with a breaking change to its behavior (it now returns an array of `[k, v]` tuples, instead of just an array of the values, see immutable-js/immutable-js#1340) 381f5d3
* Suppress unimportant flow error due to inconsistent return type (the null values that are returned and that are inconsistent get filtered out on the next line via `.filter(block => !!block)`) a930d84
* Suppress flow error in ContentState’s `getBlockForKey` 1a5114f

for that last commit, `getBlockForKey` is annotated as always returning a `BlockNodeRecord`, but calling `.get(key)` on the blockMap can return undefined. this means the method is unsafe, but because it is so widely used and the change doesn’t have to do with changes in immutable.js v4, i made the judgement that addressing the issue is out-of-scope of this PR.

with all of these changes and with v4 of immutable.js installed, `yarn test` passes. there are some pre-existing linting errors from the prettier eslint plugin that are also in master. there are also some new flow errors pertaining to `CharacterMetadata`, but i’m not sure what to do about them. there are already 6 flow errors related to those types in `master` that seem to be the result of d0171d5bf35d1962d0bda55256f2785e9849872d, so it’s hard for me to tell if the new errors are also from that change, or if they are actual issues i need to address.

resolves #1425

#### Test Plan**

all automated tests are passing. we are manually testing these changes at my company, and i will report back here with the results of that testing.