### PR TITLE
Handle case in getCorrectDocumentFromNode where node is a Document

### DIFF
--- a/src/component/utils/getCorrectDocumentFromNode.js
+++ b/src/component/utils/getCorrectDocumentFromNode.js
@@ -10,6 +10,10 @@
  */
 
 function getCorrectDocumentFromNode(node: ?Node): Document {
+  if (node && node.nodeType === 9) {
+    // $FlowIgnore if nodeType is 9, node is a Document node
+    return (node: any);
+  }
   if (!node || !node.ownerDocument) {
     return document;
   }


### PR DESCRIPTION
#### Summary

when dragging a native file over a draft editor instance that is being rendered within an iframe, the [`currentTarget` of the `event` object](https://github.com/facebook/draft-js/blob/master/src/component/handlers/drag/DraftEditorDragHandler.js#L39) that gets passed to `getSelectionForEvent` from the [`onDrop` handler](https://github.com/facebook/draft-js/blob/master/src/component/handlers/drag/DraftEditorDragHandler.js#L86) in DraftEditorDragHandler.js is itself a `Document` node. as a result, it fails the [`node.ownerDocument` check](https://github.com/facebook/draft-js/blob/master/src/component/utils/getCorrectDocumentFromNode.js#L13) and returns the global `document` object instead, which results in `getSelectionForEvent` throwing when it tries to [find the ancestor offsetKey](https://github.com/facebook/draft-js/blob/master/src/component/handlers/drag/DraftEditorDragHandler.js#L59). here’s what that stacktrace looks like in my codebase:

<img width="467" alt="image" src="https://user-images.githubusercontent.com/517889/119206695-c4647500-ba50-11eb-952e-8ebe292e1157.png">

#### Test Plan**

`yarn test` is now all passing with this change. in addition, i verified that the error described above no longer occurs when i use the build that includes this change.
