### PR TITLE
Fix hook example

### DIFF
--- a/docs/QuickStart-API-Basics.md
+++ b/docs/QuickStart-API-Basics.md
@@ -56,9 +56,7 @@ this remains efficient due to data persistence across immutable objects.
 import {Editor, EditorState} from 'draft-js';
 
 const MyInput = () => {
-  const [editorState, setEditorState] = useState(() =>
-    EditorState.createEmpty(),
-  );
+  const [editorState, setEditorState] = useState(EditorState.createEmpty());
 
   return <Editor editorState={editorState} onChange={setEditorState} />;
 };


### PR DESCRIPTION
- hook state initial value matching class state
- fix the following error if using a function as initial state

![Screenshot from 2021-11-23 22-02-15](https://user-images.githubusercontent.com/6902134/143152559-0c313596-2125-4ffc-9cd2-9d0a1a1f4cce.png)

