### PR TITLE
fix: change div to span on default unstyled block

### DIFF
--- a/src/component/contents/DraftEditorBlock.react.js
+++ b/src/component/contents/DraftEditorBlock.react.js
@@ -242,12 +242,12 @@ class DraftEditorBlock extends React.Component<Props> {
     });
 
     return (
-      <div
+      <span
         data-offset-key={offsetKey}
         className={className}
         ref={ref => (this._node = ref)}>
         {this._renderChildren()}
-      </div>
+      </span>
     );
   }
 }


### PR DESCRIPTION
#### Summary

This PR changes the default tag from an `unstyled` component to be a `<span>` instead of a `<div>`. This fixes invalid DOM nesting, since `<div>` cannot be a child of `<p>`. 

The Wiki for W3 defines `<span>` as the correct pick for an `unstyled` component: 

> The <span> element doesn't mean anything on its own, but can be useful when used together with the global attributes [[ref](https://www.w3.org/html/wiki/Elements/span)]

I'm working with systems that requires content accessibility and this is important. 

Fixes #1718 and #395

#### Test Plan 

I don't have one. Maybe implementing a W3C checks.
