### PR TITLE
Adding video-wrapper for mobile fiendly preview of the youtube video

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -29,7 +29,7 @@ function VideoContainer() {
   return (
     <div className="container text--center margin-bottom--xl margin-top--lg">
       <div className="row">
-        <div className="col">
+        <div className={`${styles.ifr-wrapper} col`}>
           <h2>Check it out in the intro video</h2>
             <iframe
               width="560"

--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -53,3 +53,11 @@ div[class^="announcementBarContent"] a:hover {
     padding: 6px 30px;
   }
 }
+
+ /* YouTube video well display in smartphones*/
+ @media only screen and (max-width: 580px) {
+  .ifr-wrapper {
+    width: 90vw;
+    height: 50.63vw;
+  }
+ }


### PR DESCRIPTION
*Before* submitting a pull request, please make sure the following is done...

1. Fork the repo and create your branch from `master`.
2. If you've added code that should be tested, add tests!
3. If you've changed APIs, update the documentation.
4. Ensure that:
  * The test suite passes (`npm test`)
  * Your code lints (`npm run lint`) and passes Flow (`npm run flow`)
  * You have followed the [testing guidelines](https://github.com/facebook/draft-js/wiki/Testing-for-Pull-Requests)
5. If you haven't already, complete the [CLA](https://code.facebook.com/cla).

Please use the simple form below as a guideline for describing your pull request, and delete these instructions.

Thanks for contributing to Draft.js!

---

#### Summary

I added a ifr-wrapper class that wraps the iframe and h2 where is the youtube video. In a less than 560px screen, the youtube video continues pretending to have the 560px dimensions and thats disturbs the page making everithing to move to the left leaving a great withe space

#### Test Plan**

[...]
