### PR TITLE
Fix selection throwing when null

### DIFF
--- a/src/component/selection/getVisibleSelectionRect.js
+++ b/src/component/selection/getVisibleSelectionRect.js
@@ -24,7 +24,7 @@ const getRangeBoundingClientRect = require('getRangeBoundingClientRect');
  */
 function getVisibleSelectionRect(global: any): ?FakeClientRect {
   const selection = global.getSelection();
-  if (!selection.rangeCount) {
+  if (!selection?.rangeCount) {
     return null;
   }
 


### PR DESCRIPTION
*Before* submitting a pull request, please make sure the following is done...

1. Fork the repo and create your branch from `master`.
2. If you've added code that should be tested, add tests!
3. If you've changed APIs, update the documentation.
4. Ensure that:
  * The test suite passes (`npm test`)
  * Your code lints (`npm run lint`) and passes Flow (`npm run flow`)
  * You have followed the [testing guidelines](https://github.com/facebook/draft-js/wiki/Testing-for-Pull-Requests)
5. If you haven't already, complete the [CLA](https://code.facebook.com/cla).

Please use the simple form below as a guideline for describing your pull request, and delete these instructions.

Thanks for contributing to Draft.js!

---

#### Summary

An issue occurs while using the toolbar inline plugin, an error is thrown in the method `getVisibleSelectionRect` because the value of the selection is `null`.
The fix is to use `?.` on the existing `if test` of `selection.rangeCount` to avoid this error.